### PR TITLE
hw-mgmt: attributes: set delta 1100 limits

### DIFF
--- a/usr/etc/hw-management-sensors/msn3700_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn3700_sensors.conf
@@ -85,6 +85,9 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label power2 "PSU-1 12V Rail Pwr (out)"
         label curr1 "PSU-1 220V Rail Curr (in)"
         label curr2 "PSU-1 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
     chip "dps460-i2c-*-59"
         label in1 "PSU-2 220V Rail (in)"
         ignore in2
@@ -99,6 +102,9 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label power2 "PSU-2 12V Rail Pwr (out)"
         label curr1 "PSU-2 220V Rail Curr (in)"
         label curr2 "PSU-2 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"

--- a/usr/etc/hw-management-sensors/msn3800_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn3800_sensors.conf
@@ -106,6 +106,9 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label power2 "PSU-1 12V Rail Pwr (out)"
         label curr1 "PSU-1 220V Rail Curr (in)"
         label curr2 "PSU-1 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
     chip "dps460-i2c-*-59"
         label in1 "PSU-2 220V Rail (in)"
         ignore in2
@@ -120,6 +123,9 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label power2 "PSU-2 12V Rail Pwr (out)"
         label curr1 "PSU-2 220V Rail Curr (in)"
         label curr2 "PSU-2 12V Rail Curr (out)"
+        set in3_lcrit in3_crit * 0.662
+        set in3_min in3_crit * 0.745
+        set in3_max in3_crit * 0.952
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"


### PR DESCRIPTION
Set delta 1100 vout limits in lm-sensors config,
 to override bad values from PSUs.

Signed-off-by: Mykola Kostenok <c_mykolak@nvidia.com>
