### PR TITLE
hw-mgmt: thermal: Fix cooling device enforcement criteria

### DIFF
--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -1054,9 +1054,9 @@ check_trip_min_vs_current_temp_per_type()
 	
 	for ((i=1; i<=dev_count; i+=1)); do
 		if [ -f $hw_management_path/"$subsys_path"/thermal/mlxsw-"$dev_type""$i"/thermal_zone_temp ]; then
-			trip_norm=$(< $hw_management_path/"$subsys_path"/thermal/mlxsw-"$dev_type""$i"/temp_trip_norm)
+			trip_high=$(< $hw_management_path/"$subsys_path"/thermal/mlxsw-"$dev_type""$i"/temp_trip_high)
 			temp_now=$(< $hw_management_path/"$subsys_path"/thermal/mlxsw-"$dev_type""$i"/thermal_zone_temp)
-			if [ "$temp_now" -gt 0 ] && [ "$trip_norm" -le  "$temp_now" ]; then
+			if [ "$temp_now" -gt 0 ] && [ "$trip_high" -le  "$temp_now" ]; then
 				return 1
 			fi
 		fi
@@ -1093,9 +1093,9 @@ check_trip_min_vs_current_temp()
 			fi
 		done
 	fi
-	trip_norm=$(< $temp_trip_norm)
+	trip_high=$(< $temp_trip_high)
 	temp_now=$(< $tz_temp)
-	if [ "$trip_norm" -gt  "$temp_now" ]; then
+	if [ "$trip_high" -gt  "$temp_now" ]; then
 		set_dynamic_min_pwm
 	fi
 }


### PR DESCRIPTION
Sometimes two systems with the same thermal measurement could be
inconsistently set with different cooling device speed.

It might happen at initialization time in case ASIC temperature is
above “normal” threshold. There is fan speed enforcement mechanism
in hw-management package which should move fan from full speed
(initial state) to fan dynamic minimum speed. This move is performed
in case all thermal zones for ASIC and transceivers temperatures are
below “normal” thresholds. In this case if, for example at initial
state ASIC temperature is 75C (>= normal threshold, which is is 75C),
fan will stay at full speed. And while temperature is below or equal
"normal" threshold, thermal control will not touch cooling device.

For example one system at initial state was above "normal" threshold,
while the second system was below. In this case for 2-nd system fan speed
is enforced from full speed to dynamic minimum speed, while for 1-st it
does not happen. And if for this system temperature will keep stable
trend – cooling device will not be decreased.

Moving from full speed to dynamic minimum speed should be performed
according to “high” temperature trip and not according to "normal", as
it happen now.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
