### PR TITLE
hw-mgmt: topology: Modular system cleanup.

### DIFF
--- a/usr/lib/udev/rules.d/51-hw-management-events-modular.rules
+++ b/usr/lib/udev/rules.d/51-hw-management-events-modular.rules
@@ -37,11 +37,6 @@
 # the event handler.
 
 # I2C infrastructure.
-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-5/5-0032/i2c-mux-mlxcpld.5", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add lc_topo 1 5 %S %p"
-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-5/5-0032/i2c-mux-mlxcpld.5", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh remove lc_topo 1 5 %S %p"
-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-6/6-0032/i2c-mux-mlxcpld.6", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add lc_topo 2 6 %S %p"
-SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-6/6-0032/i2c-mux-mlxcpld.6", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh remove lc_topo 2 6 %S %p"
-# Remove the above lines after bring-up.
 SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-34/34-0032/i2c-mux-mlxcpld.34", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add lc_topo 1 34 %S %p"
 SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-34/34-0032/i2c-mux-mlxcpld.34", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh remove lc_topo 1 34 %S %p"
 SUBSYSTEM=="platform", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-35/35-0032/i2c-mux-mlxcpld.35", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add lc_topo 2 35 %S %p"

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -266,8 +266,8 @@ msn4800_base_connect_table=( mp2975 0x62 6 \
 	mp2975 0x6a 5 \
 	max11603 0x6d 6 \
 	max11603 0x64 6 \
-	tmp102 0x49 7 \
 	24c32 0x51 8 \
+	tmp102 0x49 12 \
 	max11603 0x6d 43 \
 	tmp102 0x4a 44 \
 	24c32 0x51 45)


### PR DESCRIPTION
Add fixes in topology and symbolic links.
Remove pre-bringup code.

Signed-of-by: Vadim Pasternak <vadimp@nvidia.com>
