### PR TITLE
hw-mgmt: kernel patches: 4.9,4.19 platform/mellanox: mlxreg-io: Fix r…

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0087-platform-mellanox-mlxreg-io-Fix-read-access-of-attri.patch
+++ b/recipes-kernel/linux/linux-4.19/0087-platform-mellanox-mlxreg-io-Fix-read-access-of-attri.patch
@@ -1,0 +1,35 @@
+From 88aa1f20ddff3f18d5772531143bffa2d5fced14 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Tue, 15 Jun 2021 16:47:15 +0300
+Subject: [PATCH] platform/mellanox: mlxreg-io: Fix read access of attributes
+ of n-bytes size
+
+Fix shift argument for function rol32(). It should be provided in bits,
+while was provided in bytes.
+
+Fixes: 86148190a7db: (" platform/mellanox: mlxreg-io: Add support for complex attributes")
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index e3c0d4f..c199d6d 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -101,10 +101,8 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 			ret = regmap_read(regmap, data->reg + i, &val);
+ 			if (ret)
+ 				goto access_error;
+-
+-			*regval |= rol32(val, regsize * i);
++			*regval |= rol32(val, regsize * i * 8);
+ 		}
+-		*regval = le32_to_cpu(*regval & regmax);
+ 	}
+ 
+ access_error:
+-- 
+2.8.4
+

--- a/recipes-kernel/linux/linux-4.9/0073-platform-mellanox-mlxreg-io-Fix-read-access-of-attri.patch
+++ b/recipes-kernel/linux/linux-4.9/0073-platform-mellanox-mlxreg-io-Fix-read-access-of-attri.patch
@@ -1,0 +1,35 @@
+From 88aa1f20ddff3f18d5772531143bffa2d5fced14 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Tue, 15 Jun 2021 16:47:15 +0300
+Subject: [PATCH] platform/mellanox: mlxreg-io: Fix read access of attributes
+ of n-bytes size
+
+Fix shift argument for function rol32(). It should be provided in bits,
+while was provided in bytes.
+
+Fixes: 86148190a7db: (" platform/mellanox: mlxreg-io: Add support for complex attributes")
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index e3c0d4f..c199d6d 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -101,10 +101,8 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+ 			ret = regmap_read(regmap, data->reg + i, &val);
+ 			if (ret)
+ 				goto access_error;
+-
+-			*regval |= rol32(val, regsize * i);
++			*regval |= rol32(val, regsize * i * 8);
+ 		}
+-		*regval = le32_to_cpu(*regval & regmax);
+ 	}
+ 
+ access_error:
+-- 
+2.8.4
+


### PR DESCRIPTION
…ead access of attributes of n-bytes size

Fix shift argument for function rol32(). It should be provided in bits,
while was provided in bytes.

Fixes: 86148190a7db: (" platform/mellanox: mlxreg-io: Add support for complex attributes")
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>