### PR TITLE
hw-mgmt: attributes: Add cpld3 version reading from SXD driver

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -358,7 +358,7 @@ function asic_cpld_add_handler()
 		if [ "$cpld" == "cpld1" ]; then
 			ln -sf "${ASIC_I2C_PATH}"/cpld1_version $system_path/cpld3_version
 		fi
-		if [ "$cpld" == "cpld3" ]; then
+		if [ "$cpld" == "cpld3" ] && [ -f "${ASIC_I2C_PATH}"/cpld3_version ]; then
 			ln -sf "${ASIC_I2C_PATH}"/cpld3_version $system_path/cpld3_version
 		fi
 	fi


### PR DESCRIPTION
Add CPLD_PORT version reading from SXD driver on old systems like MSN24xx
and MSN27xxx.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
