### PR TITLE
hw-mgmt: attributes: Add cpld3 version reading from SXD driver

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -358,7 +358,7 @@ function asic_cpld_add_handler()
 		if [ "$cpld" == "cpld1" ]; then
 			ln -sf "${ASIC_I2C_PATH}"/cpld1_version $system_path/cpld3_version
 		fi
-		if [ "$cpld" == "cpld3" ]; then
+		if [ "$cpld" == "cpld3" ] && [ -f "${ASIC_I2C_PATH}"/cpld3_version ]; then
 			ln -sf "${ASIC_I2C_PATH}"/cpld3_version $system_path/cpld3_version
 		fi
 	fi

--- a/usr/usr/bin/sxd_read_cpld_ver.py
+++ b/usr/usr/bin/sxd_read_cpld_ver.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import time
+import sys
+import errno
+import os.path
+import argparse
+from python_sdk_api.sx_api import *
+from python_sdk_api.sxd_api import *
+
+POLL_TIME    = 5
+POLL_TIMEOUT = 60
+
+parser = argparse.ArgumentParser(description='SXD-API MSCI example')
+parser.add_argument('-c', '--command', dest='command', default=0, type=int, help='Read CPLD version command')
+parser.add_argument('-i', '--idx', dest='index', default=0, type=int, help='CPLD index')
+parser.add_argument('-s', '--strict', dest='strict', default=0, type=int, help='Print only version')
+parser.add_argument('-r', '--retry', dest='retry', default=(POLL_TIMEOUT/POLL_TIME), type=int, help='CPLD read retry count')
+args = parser.parse_args()
+msci_command = args.command
+
+retcode = 0
+if args.strict != 0:
+    print "[+] MSCI example start"
+    print "[+] Initializing register access"
+
+for i in range(0, args.retry):
+    print "Reading MSCI reg try: {}".format(i)
+    if i != 0:
+        print "wait {}sec".format(POLL_TIME)
+        time.sleep(POLL_TIME)
+
+    if not os.path.isfile("/dev/shm/dpt"):
+        print "DPT not initialised. Wait some more time ..."
+        continue
+
+    rc = sxd_access_reg_init(0, None, 4)
+    if rc != 0:
+        print "Failed to initializing register access.\nPlease check that SDK is running."
+        retcode = errno.EACCES
+        continue
+
+    meta = sxd_reg_meta_t()
+    meta.dev_id = 1
+    meta.swid = 0
+    meta.access_cmd = SXD_ACCESS_CMD_GET
+
+    msci = ku_msci_reg()
+    msci.command = msci_command
+    msci.index = args.index
+
+    if args.strict != 0:
+        print "[+] Querying meta cmd ({})".format(msci_command)
+    rc = sxd_access_reg_msci(msci, meta, 1, None, None)
+    if rc != 0:
+        retcode = rc
+        print "Failed to query MSCI register, rc: %d" % (rc)
+        continue
+
+    if args.strict != 0:
+        print "[+] Version:{}".format(msci.version)
+        print "[+] MSCI example end"
+    else:
+        print "Version:{}".format(msci.version)
+    retcode = 0
+    break
+
+sys.exit(retcode)


### PR DESCRIPTION
Add CPLD_PORT version reading from SXD driver on old systems like MSN24xx
and MSN27xxx.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
