### PR TITLE
hw-mgmt: events: Move reusable functions to separate helper file

### DIFF
--- a/usr/usr/bin/hw-management-helper.sh
+++ b/usr/usr/bin/hw-management-helper.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Copyright (c) 2018 Mellanox Technologies. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+hw_management_path=/var/run/hw-management
+environment_path=$hw_management_path/environment
+alarm_path=$hw_management_path/alarm
+eeprom_path=$hw_management_path/eeprom
+led_path=$hw_management_path/led
+system_path=$hw_management_path/system
+sfp_path=$hw_management_path/sfp
+watchdog_path=$hw_management_path/watchdog
+config_path=$hw_management_path/config
+events_path=$hw_management_path/events
+thermal_path=$hw_management_path/thermal
+jtag_path=$hw_management_path/jtag
+power_path=$hw_management_path/power
+udev_ready=$hw_management_path/.udev_ready
+LOCKFILE="/var/run/hw-management-chassis.lock"
+
+i2c_bus_max=10
+lc_i2c_bus_min=34
+lc_i2c_bus_max=43
+i2c_bus_offset=0
+cpu_type=
+
+# CPU Family + CPU Model should idintify exact CPU architecture
+# IVB - Ivy-Bridge; RNG - Atom Rangeley
+# BDW - Broadwell-DE; CFL - Coffee Lake
+IVB_CPU=0x63A
+RNG_CPU=0x64D
+BDW_CPU=0x656
+CFL_CPU=0x69E
+
+log_err()
+{
+    logger -t hw-management -p daemon.err "$@"
+}
+
+log_info()
+{
+    logger -t hw-management -p daemon.info "$@"
+}
+
+check_cpu_type()
+{
+    if [ ! -f $config_path/cpu_type ]; then
+        family_num=$(grep -m1 "cpu family" /proc/cpuinfo | awk '{print $4}')
+        model_num=$(grep -m1 model /proc/cpuinfo | awk '{print $3}')
+        cpu_type=$(printf "0x%X%X" "$family_num" "$model_num")
+        echo $cpu_type > $config_path/cpu_type
+    else
+        cpu_type=$(cat $config_path/cpu_type)
+    fi  
+}
+
+find_i2c_bus()
+{
+    # Find physical bus number of Mellanox I2C controller. The default
+    # number is 1, but it could be assigned to others id numbers on
+    # systems with different CPU types.
+    for ((i=1; i<i2c_bus_max; i++)); do
+        folder=/sys/bus/i2c/devices/i2c-$i
+        if [ -d $folder ]; then
+            name=$(cut $folder/name -d' ' -f 1)
+            if [ "$name" == "i2c-mlxcpld" ]; then
+                i2c_bus_offset=$((i-1))
+                return
+            fi
+        fi
+    done
+
+    log_err "i2c-mlxcpld driver is not loaded"
+    exit 0
+}
+
+
+find_i2c_bus()
+{
+    # Find physical bus number of Mellanox I2C controller. The default
+    # number is 1, but it could be assigned to others id numbers on
+    # systems with different CPU types.
+    for ((i=1; i<i2c_bus_max; i++)); do
+        folder=/sys/bus/i2c/devices/i2c-$i
+        if [ -d $folder ]; then
+            name=$(cut $folder/name -d' ' -f 1)
+            if [ "$name" == "i2c-mlxcpld" ]; then
+                i2c_bus_offset=$((i-1))
+                return
+            fi
+        fi
+    done
+
+    log_err "i2c-mlxcpld driver is not loaded"
+    exit 0
+}
+
+lock_service_state_change()
+{
+    exec {LOCKFD}>${LOCKFILE}
+    /usr/bin/flock -x ${LOCKFD}
+    trap "/usr/bin/flock -u ${LOCKFD}" EXIT SIGINT SIGQUIT SIGTERM
+}
+
+unlock_service_state_change()
+{
+    /usr/bin/flock -u ${LOCKFD}
+}
+
+# Check if file exists and create soft link
+# $1 - file path
+# $2 - link path
+# return none
+check_n_link()
+{
+    if [ -f "$1" ];
+    then
+        ln -sf "$1" "$2"
+    fi
+}
+
+# Check if link exists and unlink it
+# $1 - link path
+# return none
+check_n_unlink()
+{
+    if [ -L "$1" ];
+    then
+        unlink "$1"
+    fi
+}

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -32,14 +32,11 @@
 #
 
 # hw-management script that is executed at the end of hw-management start.
+source hw-management-helper.sh
 
 # Local constants and paths.
 max_cpld=4
 max_fan_drwr=8
-hw_management_path=/var/run/hw-management
-config_path=$hw_management_path/config
-system_path=$hw_management_path/system
-thermal_path=/var/run/hw-management/thermal
 CPLD3_VER_DEF="0"
  
 handle_cpld_versions()

--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -71,11 +71,13 @@
 # All the sensors and statuses are exposed through the sysfs interface for the
 # user space application access.
 
+source hw-management-helper.sh
+
+set -x
+echo $@
+exec 3>&1 4>&2 >>/tmp/thermal_controll_log 2>&1
+
 # Paths to thermal sensors, device present states, thermal zone and cooling device
-hw_management_path=/var/run/hw-management
-thermal_path=$hw_management_path/thermal
-config_path=$hw_management_path/config
-system_path=$hw_management_path/system
 temp_fan_amb=$thermal_path/fan_amb
 temp_port_amb=$thermal_path/port_amb
 pwm=$thermal_path/pwm1

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -32,17 +32,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+source hw-management-helper.sh
+
 # Local variables
-hw_management_path=/var/run/hw-management
-thermal_path=$hw_management_path/thermal
-eeprom_path=$hw_management_path/eeprom
-power_path=$hw_management_path/power
-alarm_path=$hw_management_path/alarm
-config_path=$hw_management_path/config
-system_path=$hw_management_path/system
 fan_command=$config_path/fan_command
 fan_psu_default=$config_path/fan_psu_default
-events_path=$hw_management_path/events
 max_psus=4
 max_tachos=14
 max_lcs=8
@@ -50,72 +44,13 @@ min_module_gbox_ind=2
 max_module_gbox_ind=160
 min_lc_thermal_ind=1
 max_lc_thermal_ind=20
-i2c_bus_max=10
-i2c_bus_offset=0
 i2c_asic_bus_default=2
 i2c_comex_mon_bus_default=$(< $config_path/i2c_comex_mon_bus_default)
 fan_full_speed_code=20
-LOCKFILE="/var/run/hw-management-thermal.lock"
-udev_ready=$hw_management_path/.udev_ready
-IVB_CPU=0x63A
-RNG_CPU=0x64D
-BDW_CPU=0x656
-CFL_CPU=0x69E
-cpu_type=
 
-log_err()
-{
-	logger -t hw-management -p daemon.err "$@"
-}
-
-log_info()
-{
-	logger -t hw-management -p daemon.info "$@"
-}
-
-find_i2c_bus()
-{
-	# Find physical bus number of Mellanox I2C controller. The default
-	# number is 1, but it could be assigned to others id numbers on
-	# systems with different CPU types.
-	for ((i=1; i<i2c_bus_max; i++)); do
-		folder=/sys/bus/i2c/devices/i2c-$i
-		if [ -d $folder ]; then
-			name=$(cut $folder/name -d' ' -f 1)
-			if [ "$name" == "i2c-mlxcpld" ]; then
-				i2c_bus_offset=$((i-1))
-				return
-			fi
-		fi
-	done
-
-	log_err "i2c-mlxcpld driver is not loaded"
-	exit 0
-}
-
-check_cpu_type()
-{
-	if [ ! -f $config_path/cpu_type ]; then
-		family_num=$(grep -m1 "cpu family" /proc/cpuinfo | awk '{print $4}')
-		model_num=$(grep -m1 model /proc/cpuinfo | awk '{print $3}')
-		cpu_type=$(printf "0x%X%X" "$family_num" "$model_num")
-		echo $cpu_type > $config_path/cpu_type
-	else
-		cpu_type=$(cat $config_path/cpu_type)
-	fi
-}
-
-lock_service_state_change()
-{
-	exec {LOCKFD}>${LOCKFILE}
-	/usr/bin/flock -x ${LOCKFD}
-	trap "/usr/bin/flock -u ${LOCKFD}" EXIT SIGINT SIGQUIT SIGTERM
-}
-
-unlock_service_state_change()
-{
-	/usr/bin/flock -u ${LOCKFD}
-}
+set -x
+echo $@
+exec 3>&1 4>&2 >>/tmp/thermal_events_log 2>&1
 
 # Get line card number by module 'sysfs' device path
 # $1 - sys device path in, example: /sys/devices/platform/mlxplat/i2c_mlxcpld.1/i2c-1/i2c-3/3-0037/hwmon/hwmon<n>/
@@ -145,29 +80,6 @@ get_lc_id_tz()
 		return 0
 	else
 		return "${BASH_REMATCH[1]}"
-	fi
-}
-
-# Check if file exists and create soft link
-# $1 - file path
-# $2 - link path
-# return none
-check_n_link()
-{
-	if [ -f "$1" ];
-	then
-		ln -sf "$1" "$2"
-	fi
-}
-
-# Check if link exists and unlink it
-# $1 - link path
-# return none
-check_n_unlink()
-{
-	if [ -L "$1" ];
-	then
-		unlink "$1"
 	fi
 }
 


### PR DESCRIPTION
Move reusable functions from .sh scripts to separate hw-management-helper.sh file

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
