### PR TITLE
hw-mgmt: system: Change fru eeprom type to 24c512 for mqm9700 rev1 Change fru eeprom type 24c32->24c512 for mqm9700 rev1

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -275,7 +275,7 @@ mqm97xx_rev1_base_connect_table=(    max11603 0x6d 5 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c32 0x53 7 \
-			24c32 0x51 8)
+			24c512 0x51 8)
 
 msn4800_base_connect_table=( mp2975 0x62 6 \
 	mp2975 0x64 5 \


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
