### PR TITLE
hw-mgmt: patches: v4.19: Add new patches for pin control and I2C

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0130-pinctrl-intel-Allow-to-request-locked-pads.patch
+++ b/recipes-kernel/linux/linux-4.19/0130-pinctrl-intel-Allow-to-request-locked-pads.patch
@@ -1,0 +1,156 @@
+From 96108dabf965809f8ba9d4814b5afd025e73dcce Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Mon, 12 Aug 2019 19:14:01 +0300
+Subject: [PATCH v4.19 backport 106/108] pinctrl: intel: Allow to request
+ locked pads
+
+Some firmwares would like to protect pads from being modified by OS
+and at the same time provide them to OS as a resource. So, the driver
+in such circumstances may request pad and may not change its state.
+
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Reviewed-by: Linus Walleij <linus.walleij@linaro.org>
+Acked-by: Mika Westerberg <mika.westerberg@linux.intel.com>
+---
+ drivers/pinctrl/intel/pinctrl-intel.c | 69 ++++++++++++++++++++-------
+ 1 file changed, 52 insertions(+), 17 deletions(-)
+
+diff --git a/drivers/pinctrl/intel/pinctrl-intel.c b/drivers/pinctrl/intel/pinctrl-intel.c
+index 89ff2795a..b2b088261 100644
+--- a/drivers/pinctrl/intel/pinctrl-intel.c
++++ b/drivers/pinctrl/intel/pinctrl-intel.c
+@@ -217,47 +217,71 @@ static bool intel_pad_acpi_mode(struct intel_pinctrl *pctrl, unsigned pin)
+ 	return !(readl(hostown) & BIT(gpp_offset));
+ }
+ 
+-static bool intel_pad_locked(struct intel_pinctrl *pctrl, unsigned pin)
++/**
++ * enum - Locking variants of the pad configuration
++ *
++ * @PAD_UNLOCKED:	pad is fully controlled by the configuration registers
++ * @PAD_LOCKED:		pad configuration registers, except TX state, are locked
++ * @PAD_LOCKED_TX:	pad configuration TX state is locked
++ * @PAD_LOCKED_FULL:	pad configuration registers are locked completely
++ *
++ * Locking is considered as read-only mode for corresponding registers and
++ * their respective fields. That said, TX state bit is locked separately from
++ * the main locking scheme.
++ */
++enum {
++	PAD_UNLOCKED	= 0,
++	PAD_LOCKED	= 1,
++	PAD_LOCKED_TX	= 2,
++	PAD_LOCKED_FULL	= PAD_LOCKED | PAD_LOCKED_TX,
++};
++
++static int intel_pad_locked(struct intel_pinctrl *pctrl, unsigned int pin)
+ {
+ 	struct intel_community *community;
+ 	const struct intel_padgroup *padgrp;
+ 	unsigned offset, gpp_offset;
+ 	u32 value;
++	int ret = PAD_UNLOCKED;
+ 
+ 	community = intel_get_community(pctrl, pin);
+ 	if (!community)
+-		return true;
++		return PAD_LOCKED_FULL;
+ 	if (!community->padcfglock_offset)
+-		return false;
++		return PAD_UNLOCKED;
+ 
+ 	padgrp = intel_community_get_padgroup(community, pin);
+ 	if (!padgrp)
+-		return true;
++		return PAD_LOCKED_FULL;
+ 
+ 	gpp_offset = padgroup_offset(padgrp, pin);
+ 
+ 	/*
+ 	 * If PADCFGLOCK and PADCFGLOCKTX bits are both clear for this pad,
+ 	 * the pad is considered unlocked. Any other case means that it is
+-	 * either fully or partially locked and we don't touch it.
++	 * either fully or partially locked.
+ 	 */
+-	offset = community->padcfglock_offset + padgrp->reg_num * 8;
++	offset = community->padcfglock_offset + 0 + padgrp->reg_num * 8;
+ 	value = readl(community->regs + offset);
+ 	if (value & BIT(gpp_offset))
+-		return true;
++		ret |= PAD_LOCKED;
+ 
+ 	offset = community->padcfglock_offset + 4 + padgrp->reg_num * 8;
+ 	value = readl(community->regs + offset);
+ 	if (value & BIT(gpp_offset))
+-		return true;
++		ret |= PAD_LOCKED_TX;
+ 
+-	return false;
++	return ret;
++}
++
++static bool intel_pad_is_unlocked(struct intel_pinctrl *pctrl, unsigned int pin)
++{
++	return (intel_pad_locked(pctrl, pin) & PAD_LOCKED) == PAD_UNLOCKED;
+ }
+ 
+ static bool intel_pad_usable(struct intel_pinctrl *pctrl, unsigned pin)
+ {
+-	return intel_pad_owned_by_host(pctrl, pin) &&
+-		!intel_pad_locked(pctrl, pin);
++	return intel_pad_owned_by_host(pctrl, pin) && intel_pad_is_unlocked(pctrl, pin);
+ }
+ 
+ static int intel_get_groups_count(struct pinctrl_dev *pctldev)
+@@ -291,7 +315,8 @@ static void intel_pin_dbg_show(struct pinctrl_dev *pctldev, struct seq_file *s,
+ 	struct intel_pinctrl *pctrl = pinctrl_dev_get_drvdata(pctldev);
+ 	void __iomem *padcfg;
+ 	u32 cfg0, cfg1, mode;
+-	bool locked, acpi;
++	int locked;
++	bool acpi;
+ 
+ 	if (!intel_pad_owned_by_host(pctrl, pin)) {
+ 		seq_puts(s, "not available");
+@@ -319,11 +344,16 @@ static void intel_pin_dbg_show(struct pinctrl_dev *pctldev, struct seq_file *s,
+ 
+ 	if (locked || acpi) {
+ 		seq_puts(s, " [");
+-		if (locked) {
++		if (locked)
+ 			seq_puts(s, "LOCKED");
+-			if (acpi)
+-				seq_puts(s, ", ");
+-		}
++		if ((locked & PAD_LOCKED_FULL) == PAD_LOCKED_TX)
++			seq_puts(s, " tx");
++		else if ((locked & PAD_LOCKED_FULL) == PAD_LOCKED_FULL)
++			seq_puts(s, " full");
++
++		if (locked && acpi)
++			seq_puts(s, ", ");
++
+ 		if (acpi)
+ 			seq_puts(s, "ACPI");
+ 		seq_puts(s, "]");
+@@ -450,11 +480,16 @@ static int intel_gpio_request_enable(struct pinctrl_dev *pctldev,
+ 
+ 	raw_spin_lock_irqsave(&pctrl->lock, flags);
+ 
+-	if (!intel_pad_usable(pctrl, pin)) {
++	if (!intel_pad_owned_by_host(pctrl, pin)) {
+ 		raw_spin_unlock_irqrestore(&pctrl->lock, flags);
+ 		return -EBUSY;
+ 	}
+ 
++	if (!intel_pad_is_unlocked(pctrl, pin)) {
++		raw_spin_unlock_irqrestore(&pctrl->lock, flags);
++		return 0;
++	}
++
+ 	padcfg0 = intel_get_padcfg(pctrl, pin, PADCFG0);
+ 
+ 	/*
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0131-pinctrl-intel-Actually-disable-Tx-and-Rx-buffers-on-.patch
+++ b/recipes-kernel/linux/linux-4.19/0131-pinctrl-intel-Actually-disable-Tx-and-Rx-buffers-on-.patch
@@ -1,0 +1,56 @@
+From 3e2c0a14b01a16e12dc4f818307b63c98057f4be Mon Sep 17 00:00:00 2001
+From: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Date: Tue, 8 Dec 2020 20:24:03 +0200
+Subject: [PATCH v4.19 backport 107/108] pinctrl: intel: Actually disable Tx
+ and Rx buffers on GPIO request
+
+Mistakenly the buffers (input and output) become enabled together for a short
+period of time during GPIO request. This is problematic, because instead of
+initial motive to disable them in the commit af7e3eeb84e2
+("pinctrl: intel: Disable input and output buffer when switching to GPIO"),
+the driven value on the pin, which might be used as an IRQ line, brings
+firmwares of some touch pads to an awkward state that needs a full power off
+to recover. Fix this, as stated in the culprit commit, by disabling the buffers.
+
+Fixes: af7e3eeb84e2 ("pinctrl: intel: Disable input and output buffer when switching to GPIO")
+BugLink: https://bugzilla.kernel.org/show_bug.cgi?id=210497
+Reported-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>
+Acked-by: Mika Westerberg <mika.westerberg@linux.intel.com>
+Tested-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>
+Tested-by: Kai-Heng Feng <kai.heng.feng@canonical.com>
+Link: https://lore.kernel.org/r/20201208182403.40435-1-andriy.shevchenko@linux.intel.com
+Signed-off-by: Linus Walleij <linus.walleij@linaro.org>
+---
+ drivers/pinctrl/intel/pinctrl-intel.c | 11 ++++++++++-
+ 1 file changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/pinctrl/intel/pinctrl-intel.c b/drivers/pinctrl/intel/pinctrl-intel.c
+index b2b088261..0230b239b 100644
+--- a/drivers/pinctrl/intel/pinctrl-intel.c
++++ b/drivers/pinctrl/intel/pinctrl-intel.c
+@@ -462,11 +462,20 @@ static void intel_gpio_set_gpio_mode(void __iomem *padcfg0)
+ {
+ 	u32 value;
+ 
++	value = readl(padcfg0);
++
+ 	/* Put the pad into GPIO mode */
+-	value = readl(padcfg0) & ~PADCFG0_PMODE_MASK;
++	value &= ~PADCFG0_PMODE_MASK;
++	value |= PADCFG0_PMODE_GPIO;
++
++	/* Disable input and output buffers */
++	value |= PADCFG0_GPIORXDIS;
++	value |= PADCFG0_GPIOTXDIS;
++
+ 	/* Disable SCI/SMI/NMI generation */
+ 	value &= ~(PADCFG0_GPIROUTIOXAPIC | PADCFG0_GPIROUTSCI);
+ 	value &= ~(PADCFG0_GPIROUTSMI | PADCFG0_GPIROUTNMI);
++
+ 	writel(value, padcfg0);
+ }
+ 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0132-i2c-mlxcpld-check-correct-size-of-maximum-RECV_LEN-p.patch
+++ b/recipes-kernel/linux/linux-4.19/0132-i2c-mlxcpld-check-correct-size-of-maximum-RECV_LEN-p.patch
@@ -1,0 +1,38 @@
+From 53ea6db0a2084499a99a2b50a30fc876816480d7 Mon Sep 17 00:00:00 2001
+From: Wolfram Sang <wsa+renesas@sang-engineering.com>
+Date: Sun, 28 Jun 2020 13:52:44 +0200
+Subject: [PATCH v4.19 backport 108/108] i2c: mlxcpld: check correct size of
+ maximum RECV_LEN packet
+
+I2C_SMBUS_BLOCK_MAX defines already the maximum number as defined in the
+SMBus 2.0 specs. I don't see a reason to add 1 here. Also, fix the errno
+to what is suggested for this error.
+
+Fixes: c9bfdc7c16cb ("i2c: mlxcpld: Add support for smbus block read transaction")
+Signed-off-by: Wolfram Sang <wsa+renesas@sang-engineering.com>
+Reviewed-by: Michael Shych <michaelsh@mellanox.com>
+Tested-by: Michael Shych <michaelsh@mellanox.com>
+Signed-off-by: Wolfram Sang <wsa@kernel.org>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 578051d09..56aa424fd 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -324,9 +324,9 @@ static int mlxcpld_i2c_wait_for_tc(struct mlxcpld_i2c_priv *priv)
+ 		if (priv->smbus_block && (val & MLXCPLD_I2C_SMBUS_BLK_BIT)) {
+ 			mlxcpld_i2c_read_comm(priv, MLXCPLD_LPCI2C_NUM_DAT_REG,
+ 					      &datalen, 1);
+-			if (unlikely(datalen > (I2C_SMBUS_BLOCK_MAX + 1))) {
++			if (unlikely(datalen > I2C_SMBUS_BLOCK_MAX)) {
+ 				dev_err(priv->dev, "Incorrect smbus block read message len\n");
+-				return -E2BIG;
++				return -EPROTO;
+ 			}
+ 		} else {
+ 			datalen = priv->xfer.data_len;
+-- 
+2.20.1
+


### PR DESCRIPTION
Backport pacthes for CFL pin control.
Backport I2C upstream patch.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
