### PR TITLE
hw-mgmt: sensors: Modify conf file for sensors

### DIFF
--- a/usr/etc/hw-management-sensors/msn4800_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4800_sensors.conf
@@ -4,6 +4,39 @@
 # Platform specific sensors config for SN4800
 ################################################################################
 
+# Line card power manager devices (bus is variable)
+bus "i2c-59" "i2c-34-mux (chan_id 4)"
+    chip "mp2975-i2c-59-62"
+        label in1 "Linecard PMIC-1 PSU 12V Rail (in)"
+        label in2 "Linecard PMIC-1 AGB VCORE Rail(out1)"
+        label in3 "Linecard PMIC-1 AGB 1.2V Rail(out2)"
+        ignore in4
+        label temp1 "Linecard PMIC-1 AGB VCORE_1.2V Ambient Temp 1"
+        ignore temp2
+        label power1 "Linecard PMIC-1 12V AGB VCORE_1.2V Rail Pwr (in)"
+        label power2 "Linecard PMIC-1 AGB VCORE Rail Pwr (out)"
+        label power3 "Linecard PMIC-1 AGB 1.2V Rail Pwr (out)"
+        ignore power4
+        label curr1 "Linecard PMIC-1 12V AGB VCORE_1.2V Rail Curr (in)"
+        label curr2 "Linecard PMIC-1 AGB VCORE Rail Curr (out)"
+        label curr3 "Linecard PMIC-1 AGB 1.2V Rail Curr (out)"
+        ignore curr4
+    chip "mp2975-i2c-59-64"
+        label in1 "Linecard PMIC-2 PSU 12V Rail (in)"
+        label in2 "Linecard PMIC-2 PORTS 3.3V Rail(out1)"
+        label in3 "Linecard PMIC-2 AGB 1.8V Rail(out2)"
+        ignore in4
+        label temp1 "Linecard PMIC-2 PORTS_3.3V_AGB_1.8V Ambient Temp 1"
+        ignore temp2
+        label power1 "Linecard PMIC-2 12V PORTS_3.3V_AGB_1.8V Rail Pwr (in)"
+        label power2 "Linecard PMIC-2 PORTS 3.3V Rail Pwr (out)"
+        label power3 "Linecard PMIC-2 AGB 1.8V Rail Pwr (out)"
+        ignore power4
+        label curr1 "Linecard PMIC-2 12V PORTS_3.3V_AGB_1.8V Rail Curr (in)"
+        label curr2 "Linecard PMIC-2 PORTS 3.3V Rail Curr (out)"
+        label curr3 "Linecard PMIC-2 AGB 1.8V Rail Curr (out)"
+        ignore curr4
+
 # Memory sensors
 bus "i2c-0" "SMBus I801 adapter at efa0"
     chip "jc42-i2c-0-1c"
@@ -30,7 +63,7 @@ bus "i2c-14" "i2c-1-mux (chan_id 12)"
 
 # Power controllers
 bus "i2c-5" "i2c-1-mux (chan_id 3)"
-    chip "mp2975-i2c-*-62"
+    chip "mp2975-i2c-5-62"
         label in1 "PMIC-1 PSU 12V Rail (in)"
         label in2 "PMIC-1 ASIC VCORE_MAIN Rail (out)"
         ignore in3
@@ -45,7 +78,7 @@ bus "i2c-5" "i2c-1-mux (chan_id 3)"
         label curr2 "PMIC-1 ASIC VCORE_MAIN Rail Curr (out)"
         ignore curr3 
         ignore curr4 
-    chip "mp2975-i2c-*-64"
+    chip "mp2975-i2c-5-64"
         label in1 "PMIC-2 PSU 12V Rail (in)"
         label in2 "PMIC-2 ASIC 1.8V_MAIN Rail (out1)"
         label in3 "PMIC-2 ASIC 1.2V_T0_3 Rail (out2)"
@@ -107,7 +140,7 @@ bus "i2c-5" "i2c-1-mux (chan_id 3)"
         ignore curr4
         ignore curr4
 bus "i2c-56" "i2c-1-mux (chan_id 6)"
-    chip "mp2975-i2c-*-58"
+    chip "mp2975-i2c-*-6b"
         label in1 "PMIC-6 PSU 12V Rail (in1)"
         label in2 "PMIC-6 PSU 12V Rail (in2)"
         label in3 "PMIC-6 COMEX 1.8V Rail (out1)"
@@ -122,17 +155,17 @@ bus "i2c-56" "i2c-1-mux (chan_id 6)"
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "dps460-i2c-*-59"
-        label in1 "PSU-1(L) 220V Rail (in)"
+        label in1 "PSU-1(R) 220V Rail (in)"
         ignore in2
-        label in3 "PSU-1(L) 12V Rail (out)"
-        label fan1 "PSU-1(L) Fan 1"
-        label temp1 "PSU-1(L) Temp 1"
-        label temp2 "PSU-1(L) Temp 2"
-        label temp3 "PSU-1(L) Temp 3"
-        label power1 "PSU-1(L) 220V Rail Pwr (in)"
-        label power2 "PSU-1(L) 12V Rail Pwr (out)"
-        label curr1 "PSU-1(L) 220V Rail Curr (in)"
-        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+        label in3 "PSU-1(R) 12V Rail (out)"
+        label fan1 "PSU-1(R) Fan 1"
+        label temp1 "PSU-1(R) Temp 1"
+        label temp2 "PSU-1(R) Temp 2"
+        label temp3 "PSU-1(R) Temp 3"
+        label power1 "PSU-1(R) 220V Rail Pwr (in)"
+        label power2 "PSU-1(R) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(R) 220V Rail Curr (in)"
+        label curr2 "PSU-1(R) 12V Rail Curr (out)"
     chip "dps460-i2c-*-58"
         label in1 "PSU-2(R) 220V Rail (in)"
         ignore in2
@@ -146,29 +179,29 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label curr1 "PSU-2(R) 220V Rail Curr (in)"
         label curr2 "PSU-2(R) 12V Rail Curr (out)"
     chip "dps460-i2c-*-5b"
-        label in1 "PSU-3(R) 220V Rail (in)"
+        label in1 "PSU-3(L) 220V Rail (in)"
         ignore in2
-        label in3 "PSU-3(R) 12V Rail (out)"
-        label fan1 "PSU-3(R) Fan 1"
-        label temp1 "PSU-3(R) Temp 1"
-        label temp2 "PSU-3(R) Temp 2"
-        label temp3 "PSU-3(R) Temp 3"
-        label power1 "PSU-3(R) 220V Rail Pwr (in)"
-        label power2 "PSU-3(R) 12V Rail Pwr (out)"
-        label curr1 "PSU-3(R) 220V Rail Curr (in)"
-        label curr2 "PSU-3(R) 12V Rail Curr (out)"
+        label in3 "PSU-3(L) 12V Rail (out)"
+        label fan1 "PSU-3(L) Fan 1"
+        label temp1 "PSU-3(L) Temp 1"
+        label temp2 "PSU-3(L) Temp 2"
+        label temp3 "PSU-3(L) Temp 3"
+        label power1 "PSU-3(L) 220V Rail Pwr (in)"
+        label power2 "PSU-3(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-3(L) 220V Rail Curr (in)"
+        label curr2 "PSU-3(L) 12V Rail Curr (out)"
     chip "dps460-i2c-*-5a"
-        label in1 "PSU-4(R) 220V Rail (in)"
+        label in1 "PSU-4(L) 220V Rail (in)"
         ignore in2
-        label in3 "PSU-4(R) 12V Rail (out)"
-        label fan1 "PSU-4(R) Fan 1"
-        label temp1 "PSU-4(R) Temp 1"
-        label temp2 "PSU-4(R) Temp 2"
-        label temp3 "PSU-4(R) Temp 3"
-        label power1 "PSU-4(R) 220V Rail Pwr (in)"
-        label power2 "PSU-4(R) 12V Rail Pwr (out)"
-        label curr1 "PSU-4(R) 220V Rail Curr (in)"
-        label curr2 "PSU-4(R) 12V Rail Curr (out)"
+        label in3 "PSU-4(L) 12V Rail (out)"
+        label fan1 "PSU-4(L) Fan 1"
+        label temp1 "PSU-4(L) Temp 1"
+        label temp2 "PSU-4(L) Temp 2"
+        label temp3 "PSU-4(L) Temp 3"
+        label power1 "PSU-4(L) 220V Rail Pwr (in)"
+        label power2 "PSU-4(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-4(L) 220V Rail Curr (in)"
+        label curr2 "PSU-4(L) 12V Rail Curr (out)"
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"
@@ -189,39 +222,3 @@ chip "mlxreg_fan-isa-*"
         label curr1 "Linecard Hotswap 12V_IN (iin)"
         label curr2 "Linecard Hotswap 12V (iout)"
         ignore temp1
-
-# Line card power manager devices (bus is variable)
-bus "i2c-59" "i2c-*-mux (chan_id 4)"
-    chip "mp2975-i2c-*-62"
-        label in1 "Linecard PMIC-1 PSU 12V Rail (in)"
-        label in2 "Linecard PMIC-1 AGB VCORE Rail(out1)"
-        label in3 "Linecard PMIC-1 AGB 1.2V Rail(out2)"
-        ignore in4
-        label temp1 "Linecard PMIC-1 AGB VCORE_1.2V Ambient Temp 1"
-        ignore temp2
-        label power1 "Linecard PMIC-1 12V AGB VCORE_1.2V Rail Pwr (in)"
-        label power2 "Linecard PMIC-1 AGB VCORE Rail Pwr (out)"
-        label power3 "Linecard PMIC-1 AGB 1.2V Rail Pwr (out)"
-        ignore power4
-        label curr1 "Linecard PMIC-1 12V AGB VCORE_1.2V Rail Curr (in)"
-        label curr2 "Linecard PMIC-1 AGB VCORE Rail Curr (out)"
-        label curr3 "Linecard PMIC-1 AGB 1.2V Rail Curr (out)"
-        ignore curr4
-    chip "mp2975-i2c-*-64"
-        label in1 "Linecard PMIC-2 PSU 12V Rail (in)"
-        label in2 "Linecard PMIC-2 PORTS 3.3V Rail(out1)"
-        label in3 "Linecard PMIC-2 AGB 1.8V Rail(out2)"
-        ignore in4
-        label temp1 "Linecard PMIC-2 PORTS_3.3V_AGB_1.8V Ambient Temp 1"
-        ignore temp2
-        label power1 "Linecard PMIC-2 12V PORTS_3.3V_AGB_1.8V Rail Pwr (in)"
-        label power2 "Linecard PMIC-2 PORTS 3.3V Rail Pwr (out)"
-        label power3 "Linecard PMIC-2 AGB 1.8V Rail Pwr (out)"
-        ignore power4
-        label curr1 "Linecard PMIC-2 12V PORTS_3.3V_AGB_1.8V Rail Curr (in)"
-        label curr2 "Linecard PMIC-2 PORTS 3.3V Rail Curr (out)"
-        label curr3 "Linecard PMIC-2 AGB 1.8V Rail Curr (out)"
-        ignore curr4
-
-
-


### PR DESCRIPTION
Update sensors labels for PSU.
Update labels for mp2975 devices located at addresses 0x62, 0x64.
Package lm-sensors does not provide method to distinct between
devices with the same slave address, so it is not possible to
provide custom label names for these devices.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
