### PR TITLE
hw-mgmt: events: Fix calculation for PSU EEPROM slave address

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -566,7 +566,7 @@ if [ "$1" == "add" ]; then
 		fi
 
 		psu_addr=$(< $config_path/"$2"_i2c_addr)
-		psu_eeprom_addr=`printf '%02x\n' $(($psu_addr - 8))`
+		psu_eeprom_addr=$(printf '%02x\n' $((psu_addr - 8)))
 		eeprom_name=$2_info
 		eeprom_file=/sys/devices/platform/mlxplat/i2c_mlxcpld.1/i2c-1/i2c-$bus/$bus-00$psu_eeprom_addr/eeprom
 		# Verify if PS unit is equipped with EEPROM. If yes – connect driver.
@@ -868,7 +868,7 @@ else
 
 		if [ -L $eeprom_path/"$2"_info ] && [ -f $config_path/"$2"_eeprom_us ]; then
 			psu_addr=$(< $config_path/"$2"_i2c_addr)
-			psu_eeprom_addr=`printf '%02x\n' $(($psu_addr - 8))`
+			psu_eeprom_addr=$(printf '%02x\n' $((psu_addr - 8)))
 			echo 0x$psu_eeprom_addr > /sys/class/i2c-dev/i2c-"$bus"/device/delete_device
 			unlink $eeprom_path/"$2"_info
 			rm -rf $config_path/"$2"_eeprom_us

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -566,7 +566,7 @@ if [ "$1" == "add" ]; then
 		fi
 
 		psu_addr=$(< $config_path/"$2"_i2c_addr)
-		psu_eeprom_addr=$((${psu_addr:2:2}-8))
+		psu_eeprom_addr=`printf '%02x\n' $(($psu_addr - 8))`
 		eeprom_name=$2_info
 		eeprom_file=/sys/devices/platform/mlxplat/i2c_mlxcpld.1/i2c-1/i2c-$bus/$bus-00$psu_eeprom_addr/eeprom
 		# Verify if PS unit is equipped with EEPROM. If yes – connect driver.
@@ -868,7 +868,7 @@ else
 
 		if [ -L $eeprom_path/"$2"_info ] && [ -f $config_path/"$2"_eeprom_us ]; then
 			psu_addr=$(< $config_path/"$2"_i2c_addr)
-			psu_eeprom_addr=$((${psu_addr:2:2}-8))
+			psu_eeprom_addr=`printf '%02x\n' $(($psu_addr - 8))`
 			echo 0x$psu_eeprom_addr > /sys/class/i2c-dev/i2c-"$bus"/device/delete_device
 			unlink $eeprom_path/"$2"_info
 			rm -rf $config_path/"$2"_eeprom_us


### PR DESCRIPTION
Fix calculation of HEX slave address for PSUs 3 and 4.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
