### PR TITLE
hw-mgmt: attributes: Fix in*_alarm attribute for kernel 5.10

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -479,6 +479,8 @@ if [ "$1" == "add" ]; then
 				fi
 				if [ -f "$3""$4"/in"$sensor_id"_alarm ]; then
 					ln -sf "$3""$4"/in"$sensor_id"_alarm $alarm_path/"$2"_in"$i"_alarm
+				elif [ -f "$3""$4"/in"$sensor_id"_crit_alarm ]; then
+					ln -sf "$3""$4"/in"$sensor_id"_crit_alarm $alarm_path/"$2"_in"$i"_alarm
 				fi
 			fi
 			if [ -f "$3""$4"/curr"$i"_input ]; then

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -233,7 +233,7 @@ mqm97xx_base_connect_table=(	max11603 0x6d 5 \
 			tmp102 0x4a 7 \
 			24c32 0x53 7 \
 			24c32 0x51 8)
-			
+
 mqm97xx_rev0_base_connect_table=(    max11603 0x6d 5 \
 			mp2975 0x62 5 \
 			mp2888 0x66 5 \


### PR DESCRIPTION
Due to changes in pmbus infrastructure for kernel 5.10
add link in*_alarm to sysfs in*_crit_alarm instead of in*_alarm as
was for kernels 4.9, 4.19

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
