### PR TITLE
hw-mgmt: attributes: Fix cpld4 exposing on systems with 3 cpld

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -530,9 +530,11 @@ if [ "$1" == "add" ]; then
 			done
 		fi
 		for ((i=1; i<=$(<$config_path/max_tachos); i+=1)); do
-			status=$(< $thermal_path/fan"$i"_status)
-			if [ "$status" -eq 1 ]; then
-				set_fan_direction fan"${i}" 1
+			if [ -L $thermal_path/fan"$i"_status ]; then
+				status=$(< $thermal_path/fan"$i"_status)
+				if [ "$status" -eq 1 ]; then
+					set_fan_direction fan"${i}" 1
+				fi
 			fi
 		done
 

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -66,8 +66,8 @@ fi
 if [ -z $MODE ] || [ $MODE != "compact" ]; then
 	[ -f var/log/syslog ] && cp /var/log/syslog $DUMP_FOLDER
 	[ -e /run/log/journal ] && cp -R /run/log/journal $DUMP_FOLDER/journal
-	dump_cmd "journalctl" "journalctl"
-	dump_cmd "sx_sdk --version" "sx_sdk_ver"
+	dump_cmd "journalctl" "journalctl" "45"
+	dump_cmd "sx_sdk --version" "sx_sdk_ver" "10"
 fi
 
 uname -a > $DUMP_FOLDER/sys_version

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -95,7 +95,7 @@ case $board in
 		;;
 esac
 
-timeout 20 bash -c 'until [ -L /var/run/hw-management/system/cpld1_version ]; do sleep 1; done'
+timeout 60 bash -c 'until [ -L /var/run/hw-management/system/cpld1_version ]; do sleep 1; done'
 sleep 1
 
 # Read cpld3 version with the mlxreg from mft package


### PR DESCRIPTION
Fix cpld4 exposing on systems with 3 cpld
Add fan{x}_status existing check on fan_direction set
Set timeout for "journalctl" and "sx_sdk" on debug dump generation

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
