### PR TITLE
hw-mgmt: kernel patches: 4.9,4.19,5.10: Fix LED_FAN7 register reading

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0092-platform-x86-mlx-platform-Extend-FAN-and-LED-config-.patch
+++ b/recipes-kernel/linux/linux-4.19/0092-platform-x86-mlx-platform-Extend-FAN-and-LED-config-.patch
@@ -73,14 +73,14 @@ index c7a04dcbe86c..c215f4f403bd 100644
 +	{
 +		.label = "fan7:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
 +		.bit = BIT(6),
 +	},
 +	{
 +		.label = "fan7:orange",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
 +		.bit = BIT(6),
 +	},

--- a/recipes-kernel/linux/linux-4.9/0066-platform-x86-mlx-platform-Extend-FAN-and-LED-config-.patch
+++ b/recipes-kernel/linux/linux-4.9/0066-platform-x86-mlx-platform-Extend-FAN-and-LED-config-.patch
@@ -109,14 +109,14 @@ index c1d1a78..cd6c168 100644
 +	{
 +		.label = "fan7:orange",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
 +		.bit = BIT(6),
 +	},
 +	{
  		.label = "uid:blue",
  		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
- 		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
+ 		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 @@ -1906,6 +1931,20 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
  		.bit = BIT(3),
  	},

--- a/recipes-kernel/linux/linux-5.10/0065-platform-x86-mlx-platform-Extend-FAN-and-LED-config-.patch
+++ b/recipes-kernel/linux/linux-5.10/0065-platform-x86-mlx-platform-Extend-FAN-and-LED-config-.patch
@@ -73,14 +73,14 @@ index 348613d6f3f7..cbda7be7d9ff 100644
 +	{
 +		.label = "fan7:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
 +		.bit = BIT(6),
 +	},
 +	{
 +		.label = "fan7:orange",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
 +		.bit = BIT(6),
 +	},


### PR DESCRIPTION
Fix LED_FAN7 controll bits offset for system equipped with FAN7, like
"MQM97xx", which is based on Mellanox Quantum-2 ASIC. Changed controll bit from LSB
to MSB because LSB is using for Front_Fan_LED controll.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
