### PR TITLE
hw-mgmt: pathes: 4.19: Support for multy PWM

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -123,6 +123,12 @@ Kernel-4.19
 |0130-pinctrl-intel-Allow-to-request-locked-pads.patch                   | 1bd231538c21d1cd691e71cbeeb4100fabc58068   |                                                 |                                                              |
 |0131-pinctrl-intel-Actually-disable-Tx-and-Rx-buffers-on-.patch         | e8873c0afd34beb67ec492cd648dd0095b911f65   |                                                 |                                                              |
 |0132-i2c-mlxcpld-check-correct-size-of-maximum-RECV_LEN-p.patch         | 597911287fcd13c3a4b4aa3e0a52b33d431e0a8e   |                                                 |                                                              |
+|0133-platform-x86-mlx-platform-Extend-FAN-platform-data-d.patch         |                                            |                                                 |                                                              |
+|0134-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch         | Accepted for hwmon-next                    |                                                 |                                                              |
+|0135-hwmon-mlxreg-fan-Extend-driver-to-support-multiply-P.patch         | Accepted for hwmon-next                    |                                                 |                                                              |
+|0136-hwmon-mlxreg-fan-Extend-driver-to-support-multiply-c.patch         | Accepted for hwmon-next                    |                                                 |                                                              |
+|0137-hwmon-mlxreg-fan-Fix-out-of-bounds-read-on-array-fan.patch         | Accepted for hwmon-next                    |                                                 |                                                              |
+|0138-platform-x86-mlx-platform-Add-support-for-multiply-c.patch         |                                            |                                                 |                                                              |
  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Kernel-5.10

--- a/recipes-kernel/linux/linux-4.19/0133-platform-x86-mlx-platform-Extend-FAN-platform-data-d.patch
+++ b/recipes-kernel/linux/linux-4.19/0133-platform-x86-mlx-platform-Extend-FAN-platform-data-d.patch
@@ -1,0 +1,38 @@
+From 778e0b650d58850b70ca72897634feb039a89dca Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 21 Sep 2021 10:16:46 +0000
+Subject: [PATCH backport 4.19 1/6] platform/x86: mlx-platform: Extend FAN
+ platform data description
+
+Add register present entry for rotors (tachometers) 13 and 14 in
+fan description tuple.
+The purpose is to allow indication of FAN presence.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/x86/mlx-platform.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 3697b991f0da..8982251adbc7 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -3790,6 +3790,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+ 		.mask = GENMASK(7, 0),
+ 		.capability = MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET,
+ 		.bit = BIT(4),
++		.reg_prsnt = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
+ 	},
+ 	{
+ 		.label = "tacho14",
+@@ -3797,6 +3798,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+ 		.mask = GENMASK(7, 0),
+ 		.capability = MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET,
+ 		.bit = BIT(5),
++		.reg_prsnt = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
+ 	},
+ 	{
+ 		.label = "conf",
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0134-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch
+++ b/recipes-kernel/linux/linux-4.19/0134-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch
@@ -1,0 +1,128 @@
+From 188c6ee9dd1c83728eb93fb88809f72f85992264 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 16 Sep 2021 21:31:51 +0300
+Subject: [PATCH backport 4.19 1/5] hwmon: (mlxreg-fan) Return non-zero value
+ when fan current state is enforced from sysfs
+
+Fan speed minimum can be enforced from sysfs. For example, setting
+current fan speed to 20 is used to enforce fan speed to be at 100%
+speed, 19 - to be not below 90% speed, etcetera. This feature provides
+ability to limit fan speed according to some system wise
+considerations, like absence of some replaceable units or high system
+ambient temperature.
+
+Request for changing fan minimum speed is configuration request and can
+be set only through 'sysfs' write procedure. In this situation value of
+argument 'state' is above nominal fan speed maximum.
+
+Return non-zero code in this case to avoid
+thermal_cooling_device_stats_update() call, because in this case
+statistics update violates thermal statistics table range.
+The issues is observed in case kernel is configured with option
+CONFIG_THERMAL_STATISTICS.
+
+Here is the trace from KASAN:
+[  159.506659] BUG: KASAN: slab-out-of-bounds in thermal_cooling_device_stats_update+0x7d/0xb0
+[  159.516016] Read of size 4 at addr ffff888116163840 by task hw-management.s/7444
+[  159.545625] Call Trace:
+[  159.548366]  dump_stack+0x92/0xc1
+[  159.552084]  ? thermal_cooling_device_stats_update+0x7d/0xb0
+[  159.635869]  thermal_zone_device_update+0x345/0x780
+[  159.688711]  thermal_zone_device_set_mode+0x7d/0xc0
+[  159.694174]  mlxsw_thermal_modules_init+0x48f/0x590 [mlxsw_core]
+[  159.700972]  ? mlxsw_thermal_set_cur_state+0x5a0/0x5a0 [mlxsw_core]
+[  159.731827]  mlxsw_thermal_init+0x763/0x880 [mlxsw_core]
+[  160.070233] RIP: 0033:0x7fd995909970
+[  160.074239] Code: 73 01 c3 48 8b 0d 28 d5 2b 00 f7 d8 64 89 01 48 83 c8 ff c3 66 0f 1f 44 00 00 83 3d 99 2d 2c 00 00 75 10 b8 01 00 00 00 0f 05 <48> 3d 01 f0 ff ..
+[  160.095242] RSP: 002b:00007fff54f5d938 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
+[  160.103722] RAX: ffffffffffffffda RBX: 0000000000000013 RCX: 00007fd995909970
+[  160.111710] RDX: 0000000000000013 RSI: 0000000001906008 RDI: 0000000000000001
+[  160.119699] RBP: 0000000001906008 R08: 00007fd995bc9760 R09: 00007fd996210700
+[  160.127687] R10: 0000000000000073 R11: 0000000000000246 R12: 0000000000000013
+[  160.135673] R13: 0000000000000001 R14: 00007fd995bc8600 R15: 0000000000000013
+[  160.143671]
+[  160.145338] Allocated by task 2924:
+[  160.149242]  kasan_save_stack+0x19/0x40
+[  160.153541]  __kasan_kmalloc+0x7f/0xa0
+[  160.157743]  __kmalloc+0x1a2/0x2b0
+[  160.161552]  thermal_cooling_device_setup_sysfs+0xf9/0x1a0
+[  160.167687]  __thermal_cooling_device_register+0x1b5/0x500
+[  160.173833]  devm_thermal_of_cooling_device_register+0x60/0xa0
+[  160.180356]  mlxreg_fan_probe+0x474/0x5e0 [mlxreg_fan]
+[  160.248140]
+[  160.249807] The buggy address belongs to the object at ffff888116163400
+[  160.249807]  which belongs to the cache kmalloc-1k of size 1024
+[  160.263814] The buggy address is located 64 bytes to the right of
+[  160.263814]  1024-byte region [ffff888116163400, ffff888116163800)
+[  160.277536] The buggy address belongs to the page:
+[  160.282898] page:0000000012275840 refcount:1 mapcount:0 mapping:0000000000000000 index:0xffff888116167000 pfn:0x116160
+[  160.294872] head:0000000012275840 order:3 compound_mapcount:0 compound_pincount:0
+[  160.303251] flags: 0x200000000010200(slab|head|node=0|zone=2)
+[  160.309694] raw: 0200000000010200 ffffea00046f7208 ffffea0004928208 ffff88810004dbc0
+[  160.318367] raw: ffff888116167000 00000000000a0006 00000001ffffffff 0000000000000000
+[  160.327033] page dumped because: kasan: bad access detected
+[  160.333270]
+[  160.334937] Memory state around the buggy address:
+[  160.356469] >ffff888116163800: fc ..
+
+Fixes: 65afb4c8e7e4 ("hwmon: (mlxreg-fan) Add support for Mellanox FAN driver")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Link: https://lore.kernel.org/r/20210916183151.869427-1-vadimp@nvidia.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/mlxreg-fan.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index 943cb09e8583..6cb55db67be4 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -335,9 +335,8 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ {
+ 	struct mlxreg_fan *fan = cdev->devdata;
+ 	unsigned long cur_state;
+-	bool config = false;
++	int i, config = 0;
+ 	u32 regval;
+-	int i;
+ 	int err;
+ 
+ 	/*
+@@ -350,7 +349,12 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 	 * overwritten.
+ 	 */
+ 	if (state >= MLXREG_FAN_SPEED_MIN && state <= MLXREG_FAN_SPEED_MAX) {
+-		config = true;
++		/*
++		 * This is configuration change, which is only supported through sysfs.
++		 * For configuration non-zero value is to be returned to avoid thermal
++		 * statistics update.
++		 */
++		config = 1;
+ 		state -= MLXREG_FAN_MAX_STATE;
+ 		for (i = 0; i < state; i++)
+ 			fan->cooling_levels[i] = state;
+@@ -364,9 +368,8 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 		}
+ 
+ 		cur_state = MLXREG_FAN_PWM_DUTY2STATE(regval);
+-		/* Return non-zero value in case only configuration is perfromed through sysfs. */
+ 		if (state < cur_state)
+-			return 1;
++			return config;
+ 
+ 		state = cur_state;
+ 	}
+@@ -382,8 +385,7 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 		dev_err(fan->dev, "Failed to write PWM duty\n");
+ 		return err;
+ 	}
+-	/* Return non-zero value if current state has been enforced through sysfs. */
+-	return (config) ? 1 : 0;
++	return config;
+ }
+ 
+ static const struct thermal_cooling_device_ops mlxreg_fan_cooling_ops = {
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0135-hwmon-mlxreg-fan-Extend-driver-to-support-multiply-P.patch
+++ b/recipes-kernel/linux/linux-4.19/0135-hwmon-mlxreg-fan-Extend-driver-to-support-multiply-P.patch
@@ -1,0 +1,174 @@
+From 032808cb5ce4264f3811bf31edab12ac7c251ae8 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 16 Sep 2021 22:47:18 +0300
+Subject: [PATCH backport 4.19 2/5] hwmon: (mlxreg-fan) Extend driver to
+ support multiply PWM
+
+Add additional PWM attributes in order to support the systems, which
+can be equipped with up-to four PWM controllers. System capability of
+additional PWM support is validated through the reading of relevant
+registers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Link: https://lore.kernel.org/r/20210916194719.871413-3-vadimp@nvidia.com
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/mlxreg-fan.c | 52 +++++++++++++++++++++++++++++---------
+ 1 file changed, 40 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index 6cb55db67be4..c01b31818aeb 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -13,6 +13,8 @@
+ #include <linux/thermal.h>
+ 
+ #define MLXREG_FAN_MAX_TACHO		14
++#define MLXREG_FAN_MAX_PWM		4
++#define MLXREG_FAN_PWM_NOT_CONNECTED	0xff
+ #define MLXREG_FAN_MAX_STATE		10
+ #define MLXREG_FAN_MIN_DUTY		51	/* 20% */
+ #define MLXREG_FAN_MAX_DUTY		255	/* 100% */
+@@ -105,7 +107,7 @@ struct mlxreg_fan {
+ 	void *regmap;
+ 	struct mlxreg_core_platform_data *pdata;
+ 	struct mlxreg_fan_tacho tacho[MLXREG_FAN_MAX_TACHO];
+-	struct mlxreg_fan_pwm pwm;
++	struct mlxreg_fan_pwm pwm[MLXREG_FAN_MAX_PWM];
+ 	int tachos_per_drwr;
+ 	int samples;
+ 	int divider;
+@@ -119,6 +121,7 @@ mlxreg_fan_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ {
+ 	struct mlxreg_fan *fan = dev_get_drvdata(dev);
+ 	struct mlxreg_fan_tacho *tacho;
++	struct mlxreg_fan_pwm *pwm;
+ 	u32 regval;
+ 	int err;
+ 
+@@ -169,9 +172,10 @@ mlxreg_fan_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ 		break;
+ 
+ 	case hwmon_pwm:
++		pwm = &fan->pwm[channel];
+ 		switch (attr) {
+ 		case hwmon_pwm_input:
+-			err = regmap_read(fan->regmap, fan->pwm.reg, &regval);
++			err = regmap_read(fan->regmap, pwm->reg, &regval);
+ 			if (err)
+ 				return err;
+ 
+@@ -195,6 +199,7 @@ mlxreg_fan_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ 		 int channel, long val)
+ {
+ 	struct mlxreg_fan *fan = dev_get_drvdata(dev);
++	struct mlxreg_fan_pwm *pwm;
+ 
+ 	switch (type) {
+ 	case hwmon_pwm:
+@@ -203,7 +208,8 @@ mlxreg_fan_write(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ 			if (val < MLXREG_FAN_MIN_DUTY ||
+ 			    val > MLXREG_FAN_MAX_DUTY)
+ 				return -EINVAL;
+-			return regmap_write(fan->regmap, fan->pwm.reg, val);
++			pwm = &fan->pwm[channel];
++			return regmap_write(fan->regmap, pwm->reg, val);
+ 		default:
+ 			return -EOPNOTSUPP;
+ 		}
+@@ -235,7 +241,7 @@ mlxreg_fan_is_visible(const void *data, enum hwmon_sensor_types type, u32 attr,
+ 		break;
+ 
+ 	case hwmon_pwm:
+-		if (!(((struct mlxreg_fan *)data)->pwm.connected))
++		if (!(((struct mlxreg_fan *)data)->pwm[channel].connected))
+ 			return 0;
+ 
+ 		switch (attr) {
+@@ -318,7 +324,7 @@ static int mlxreg_fan_get_cur_state(struct thermal_cooling_device *cdev,
+ 	u32 regval;
+ 	int err;
+ 
+-	err = regmap_read(fan->regmap, fan->pwm.reg, &regval);
++	err = regmap_read(fan->regmap, fan->pwm[0].reg, &regval);
+ 	if (err) {
+ 		dev_err(fan->dev, "Failed to query PWM duty\n");
+ 		return err;
+@@ -361,7 +367,7 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 		for (i = state; i <= MLXREG_FAN_MAX_STATE; i++)
+ 			fan->cooling_levels[i] = i;
+ 
+-		err = regmap_read(fan->regmap, fan->pwm.reg, &regval);
++		err = regmap_read(fan->regmap, fan->pwm[0].reg, &regval);
+ 		if (err) {
+ 			dev_err(fan->dev, "Failed to query PWM duty\n");
+ 			return err;
+@@ -379,7 +385,7 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 
+ 	/* Normalize the state to the valid speed range. */
+ 	state = fan->cooling_levels[state];
+-	err = regmap_write(fan->regmap, fan->pwm.reg,
++	err = regmap_write(fan->regmap, fan->pwm[0].reg,
+ 			   MLXREG_FAN_PWM_STATE2DUTY(state));
+ 	if (err) {
+ 		dev_err(fan->dev, "Failed to write PWM duty\n");
+@@ -410,6 +416,22 @@ static int mlxreg_fan_connect_verify(struct mlxreg_fan *fan,
+ 	return !!(regval & data->bit);
+ }
+ 
++static int mlxreg_pwm_connect_verify(struct mlxreg_fan *fan,
++				     struct mlxreg_core_data *data)
++{
++	u32 regval;
++	int err;
++
++	err = regmap_read(fan->regmap, data->reg, &regval);
++	if (err) {
++		dev_err(fan->dev, "Failed to query pwm register 0x%08x\n",
++			data->reg);
++		return err;
++	}
++
++	return regval != MLXREG_FAN_PWM_NOT_CONNECTED;
++}
++
+ static int mlxreg_fan_speed_divider_get(struct mlxreg_fan *fan,
+ 					struct mlxreg_core_data *data)
+ {
+@@ -438,8 +460,8 @@ static int mlxreg_fan_speed_divider_get(struct mlxreg_fan *fan,
+ static int mlxreg_fan_config(struct mlxreg_fan *fan,
+ 			     struct mlxreg_core_platform_data *pdata)
+ {
++	int tacho_num = 0, tacho_avail = 0, pwm_num = 0, i;
+ 	struct mlxreg_core_data *data = pdata->data;
+-	int tacho_num = 0, tacho_avail = 0, i;
+ 	bool configured = false;
+ 	int err;
+ 
+@@ -469,13 +491,19 @@ static int mlxreg_fan_config(struct mlxreg_fan *fan,
+ 			fan->tacho[tacho_num++].connected = true;
+ 			tacho_avail++;
+ 		} else if (strnstr(data->label, "pwm", sizeof(data->label))) {
+-			if (fan->pwm.connected) {
+-				dev_err(fan->dev, "duplicate pwm entry: %s\n",
++			if (pwm_num == MLXREG_FAN_MAX_TACHO) {
++				dev_err(fan->dev, "too many pwm entries: %s\n",
+ 					data->label);
+ 				return -EINVAL;
+ 			}
+-			fan->pwm.reg = data->reg;
+-			fan->pwm.connected = true;
++
++			err = mlxreg_pwm_connect_verify(fan, data);
++			if (err)
++				return err;
++
++			fan->pwm[pwm_num].reg = data->reg;
++			fan->pwm[pwm_num].connected = true;
++			pwm_num++;
+ 		} else if (strnstr(data->label, "conf", sizeof(data->label))) {
+ 			if (configured) {
+ 				dev_err(fan->dev, "duplicate conf entry: %s\n",
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0136-hwmon-mlxreg-fan-Extend-driver-to-support-multiply-c.patch
+++ b/recipes-kernel/linux/linux-4.19/0136-hwmon-mlxreg-fan-Extend-driver-to-support-multiply-c.patch
@@ -1,0 +1,226 @@
+From ac5be294dc3e679fc0f0c72ed13bce5eb7bf2492 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Fri, 17 Sep 2021 00:31:28 +0300
+Subject: [PATCH backport 4.19 3/5] hwmon: (mlxreg-fan) Extend driver to
+ support multiply cooling devices
+
+Add support for additional cooling devices in order to support the
+systems, which can be equipped with up-to four PWM controllers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Signed-off-by: Guenter Roeck <linux@roeck-us.net>
+---
+ drivers/hwmon/mlxreg-fan.c | 100 +++++++++++++++++++++++++++----------
+ 1 file changed, 73 insertions(+), 27 deletions(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index c01b31818aeb..5aa00a85acb4 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -63,6 +63,8 @@
+ 					 MLXREG_FAN_MAX_DUTY,		\
+ 					 MLXREG_FAN_MAX_STATE))
+ 
++struct mlxreg_fan;
++
+ /*
+  * struct mlxreg_fan_tacho - tachometer data (internal use):
+  *
+@@ -81,12 +83,18 @@ struct mlxreg_fan_tacho {
+ /*
+  * struct mlxreg_fan_pwm - PWM data (internal use):
+  *
++ * @fan: private data;
+  * @connected: indicates if PWM is connected;
+  * @reg: register offset;
++ * @cooling: cooling device levels;
++ * @cdev: cooling device;
+  */
+ struct mlxreg_fan_pwm {
++	struct mlxreg_fan *fan;
+ 	bool connected;
+ 	u32 reg;
++	u8 cooling_levels[MLXREG_FAN_MAX_STATE + 1];
++	struct thermal_cooling_device *cdev;
+ };
+ 
+ /*
+@@ -99,8 +107,6 @@ struct mlxreg_fan_pwm {
+  * @tachos_per_drwr - number of tachometers per drawer;
+  * @samples: minimum allowed samples per pulse;
+  * @divider: divider value for tachometer RPM calculation;
+- * @cooling: cooling device levels;
+- * @cdev: cooling device;
+  */
+ struct mlxreg_fan {
+ 	struct device *dev;
+@@ -111,8 +117,6 @@ struct mlxreg_fan {
+ 	int tachos_per_drwr;
+ 	int samples;
+ 	int divider;
+-	u8 cooling_levels[MLXREG_FAN_MAX_STATE + 1];
+-	struct thermal_cooling_device *cdev;
+ };
+ 
+ static int
+@@ -283,10 +287,20 @@ static const struct hwmon_channel_info mlxreg_fan_hwmon_fan = {
+ };
+ 
+ static const u32 mlxreg_fan_hwmon_pwm_config[] = {
++	HWMON_PWM_INPUT,
++	HWMON_PWM_INPUT,
++	HWMON_PWM_INPUT,
+ 	HWMON_PWM_INPUT,
+ 	0
+ };
+ 
++static char *mlxreg_fan_name[] = {
++	"mlxreg_fan",
++	"mlxreg_fan1",
++	"mlxreg_fan2",
++	"mlxreg_fan3",
++};
++
+ static const struct hwmon_channel_info mlxreg_fan_hwmon_pwm = {
+ 	.type = hwmon_pwm,
+ 	.config = mlxreg_fan_hwmon_pwm_config,
+@@ -320,11 +334,12 @@ static int mlxreg_fan_get_cur_state(struct thermal_cooling_device *cdev,
+ 				    unsigned long *state)
+ 
+ {
+-	struct mlxreg_fan *fan = cdev->devdata;
++	struct mlxreg_fan_pwm *pwm = cdev->devdata;
++	struct mlxreg_fan *fan = pwm->fan;
+ 	u32 regval;
+ 	int err;
+ 
+-	err = regmap_read(fan->regmap, fan->pwm[0].reg, &regval);
++	err = regmap_read(fan->regmap, pwm->reg, &regval);
+ 	if (err) {
+ 		dev_err(fan->dev, "Failed to query PWM duty\n");
+ 		return err;
+@@ -339,7 +354,8 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 				    unsigned long state)
+ 
+ {
+-	struct mlxreg_fan *fan = cdev->devdata;
++	struct mlxreg_fan_pwm *pwm = cdev->devdata;
++	struct mlxreg_fan *fan = pwm->fan;
+ 	unsigned long cur_state;
+ 	int i, config = 0;
+ 	u32 regval;
+@@ -363,11 +379,11 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 		config = 1;
+ 		state -= MLXREG_FAN_MAX_STATE;
+ 		for (i = 0; i < state; i++)
+-			fan->cooling_levels[i] = state;
++			pwm->cooling_levels[i] = state;
+ 		for (i = state; i <= MLXREG_FAN_MAX_STATE; i++)
+-			fan->cooling_levels[i] = i;
++			pwm->cooling_levels[i] = i;
+ 
+-		err = regmap_read(fan->regmap, fan->pwm[0].reg, &regval);
++		err = regmap_read(fan->regmap, pwm->reg, &regval);
+ 		if (err) {
+ 			dev_err(fan->dev, "Failed to query PWM duty\n");
+ 			return err;
+@@ -384,8 +400,8 @@ static int mlxreg_fan_set_cur_state(struct thermal_cooling_device *cdev,
+ 		return -EINVAL;
+ 
+ 	/* Normalize the state to the valid speed range. */
+-	state = fan->cooling_levels[state];
+-	err = regmap_write(fan->regmap, fan->pwm[0].reg,
++	state = pwm->cooling_levels[state];
++	err = regmap_write(fan->regmap, pwm->reg,
+ 			   MLXREG_FAN_PWM_STATE2DUTY(state));
+ 	if (err) {
+ 		dev_err(fan->dev, "Failed to write PWM duty\n");
+@@ -556,15 +572,51 @@ static int mlxreg_fan_config(struct mlxreg_fan *fan,
+ 		fan->tachos_per_drwr = tacho_avail / drwr_avail;
+ 	}
+ 
+-	/* Init cooling levels per PWM state. */
+-	for (i = 0; i < MLXREG_FAN_SPEED_MIN_LEVEL; i++)
+-		fan->cooling_levels[i] = MLXREG_FAN_SPEED_MIN_LEVEL;
+-	for (i = MLXREG_FAN_SPEED_MIN_LEVEL; i <= MLXREG_FAN_MAX_STATE; i++)
+-		fan->cooling_levels[i] = i;
++	return 0;
++}
+ 
++static int mlxreg_fan_cooling_config(struct device *dev, struct mlxreg_fan *fan)
++{
++	int i, j, err;
++
++	for (i = 0; i <= MLXREG_FAN_MAX_PWM; i++) {
++		struct mlxreg_fan_pwm *pwm = &fan->pwm[i];
++
++		if (!pwm->connected)
++			continue;
++		pwm->fan = fan;
++		pwm->cdev = thermal_cooling_device_register(mlxreg_fan_name[i], pwm,
++							       &mlxreg_fan_cooling_ops);
++		if (IS_ERR(pwm->cdev)) {
++			dev_err(dev, "Failed to register cooling device\n");
++			err = PTR_ERR(pwm->cdev);
++			goto thermal_cooling_device_register_fail;
++		}
++
++		/* Init cooling levels per PWM state. */
++		for (j = 0; j < MLXREG_FAN_SPEED_MIN_LEVEL; j++)
++			pwm->cooling_levels[j] = MLXREG_FAN_SPEED_MIN_LEVEL;
++		for (j = MLXREG_FAN_SPEED_MIN_LEVEL; j <= MLXREG_FAN_MAX_STATE; j++)
++			pwm->cooling_levels[j] = j;
++	}
++thermal_cooling_device_register_fail:
++	for (i = i - 1; i >= 0; i--) {
++		if (fan->pwm[i].cdev)
++			thermal_cooling_device_unregister(fan->pwm[i].cdev);
++	}
+ 	return 0;
+ }
+ 
++static void mlxreg_fan_cooling_remove(struct mlxreg_fan *fan)
++{
++	int i;
++
++	for (i = MLXREG_FAN_MAX_PWM - 1; i >= 0; i--) {
++		if (fan->pwm[i].cdev)
++			thermal_cooling_device_unregister(fan->pwm[i].cdev);
++	}
++}
++
+ static int mlxreg_fan_probe(struct platform_device *pdev)
+ {
+ 	struct mlxreg_core_platform_data *pdata;
+@@ -600,16 +652,10 @@ static int mlxreg_fan_probe(struct platform_device *pdev)
+ 		return PTR_ERR(hwm);
+ 	}
+ 
+-	if (IS_REACHABLE(CONFIG_THERMAL)) {
+-		fan->cdev = thermal_cooling_device_register("mlxreg_fan", fan,
+-						&mlxreg_fan_cooling_ops);
+-		if (IS_ERR(fan->cdev)) {
+-			dev_err(dev, "Failed to register cooling device\n");
+-			return PTR_ERR(fan->cdev);
+-		}
+-	}
++	if (IS_REACHABLE(CONFIG_THERMAL))
++		err = mlxreg_fan_cooling_config(dev, fan);
+ 
+-	return 0;
++	return err;
+ }
+ 
+ static int mlxreg_fan_remove(struct platform_device *pdev)
+@@ -617,7 +663,7 @@ static int mlxreg_fan_remove(struct platform_device *pdev)
+ 	struct mlxreg_fan *fan = platform_get_drvdata(pdev);
+ 
+ 	if (IS_REACHABLE(CONFIG_THERMAL))
+-		thermal_cooling_device_unregister(fan->cdev);
++		mlxreg_fan_cooling_remove(fan);
+ 
+ 	return 0;
+ }
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0137-hwmon-mlxreg-fan-Fix-out-of-bounds-read-on-array-fan.patch
+++ b/recipes-kernel/linux/linux-4.19/0137-hwmon-mlxreg-fan-Fix-out-of-bounds-read-on-array-fan.patch
@@ -1,0 +1,34 @@
+From 676b45af5a595ab6529029924d94d736bdd1a8f3 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 21 Sep 2021 11:30:07 +0000
+Subject: [PATCH backport 4.19 4/5] hwmon: (mlxreg-fan): Fix out of bounds read
+ on array fan->pwm
+
+Array fan->pwm[] is MLXREG_FAN_MAX_PWM elements in size, however
+the for-loop has a off-by-one error causing index i to be out of
+range causing an out of bounds read on the array. Fix this by
+replacing the <= operator with < in the for-loop.
+
+Addresses-Coverity: ("Out-of-bounds read")
+Fixes: 35edbaab3bbf ("hwmon: (mlxreg-fan) Extend driver to support multiply cooling devices")
+Signed-off-by: Colin Ian King <colin.king@canonical.com>
+---
+ drivers/hwmon/mlxreg-fan.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index 5aa00a85acb4..0413cdd8ed2d 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -579,7 +579,7 @@ static int mlxreg_fan_cooling_config(struct device *dev, struct mlxreg_fan *fan)
+ {
+ 	int i, j, err;
+ 
+-	for (i = 0; i <= MLXREG_FAN_MAX_PWM; i++) {
++	for (i = 0; i < MLXREG_FAN_MAX_PWM; i++) {
+ 		struct mlxreg_fan_pwm *pwm = &fan->pwm[i];
+ 
+ 		if (!pwm->connected)
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0138-platform-x86-mlx-platform-Add-support-for-multiply-c.patch
+++ b/recipes-kernel/linux/linux-4.19/0138-platform-x86-mlx-platform-Add-support-for-multiply-c.patch
@@ -1,0 +1,98 @@
+From d0f2947484d48018e438481d5850f4a1654efc8c Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 19 Aug 2021 14:23:39 +0000
+Subject: [PATCH backport 4.19 5/5] platform/x86: mlx-platform: Add support for
+ multiply cooling devices
+
+Add new registers to support systems with multiply cooling devices.
+Some new systems can support up-to four cooling devices. This
+capability is detected according to the registers initial setting.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 27 +++++++++++++++++++++++++++
+ 1 file changed, 27 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 8982251adbc7..143cb4f14cb9 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -120,6 +120,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_TACHO4_OFFSET	0xe7
+ #define MLXPLAT_CPLD_LPC_REG_TACHO5_OFFSET	0xe8
+ #define MLXPLAT_CPLD_LPC_REG_TACHO6_OFFSET	0xe9
++#define MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET	0xea
+ #define MLXPLAT_CPLD_LPC_REG_TACHO7_OFFSET	0xeb
+ #define MLXPLAT_CPLD_LPC_REG_TACHO8_OFFSET	0xec
+ #define MLXPLAT_CPLD_LPC_REG_TACHO9_OFFSET	0xed
+@@ -128,6 +129,8 @@
+ #define MLXPLAT_CPLD_LPC_REG_TACHO12_OFFSET	0xf0
+ #define MLXPLAT_CPLD_LPC_REG_TACHO13_OFFSET	0xf1
+ #define MLXPLAT_CPLD_LPC_REG_TACHO14_OFFSET	0xf2
++#define MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET	0xf3
++#define MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET	0xf4
+ #define MLXPLAT_CPLD_LPC_REG_FAN_CAP1_OFFSET	0xf5
+ #define MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET	0xf6
+ #define MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET	0xf7
+@@ -3687,6 +3690,18 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+ 		.label = "pwm1",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET,
+ 	},
++	{
++		.label = "pwm2",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET,
++	},
++	{
++		.label = "pwm3",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET,
++	},
++	{
++		.label = "pwm4",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET,
++	},
+ 	{
+ 		.label = "tacho1",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET,
+@@ -4192,6 +4207,9 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
+ 		return true;
+ 	}
+@@ -4291,6 +4309,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO3_OFFSET:
+@@ -4405,6 +4426,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_TACHO3_OFFSET:
+@@ -4462,6 +4486,9 @@ static const struct reg_default mlxplat_mlxcpld_regmap_ng400[] = {
+ static const struct reg_default mlxplat_mlxcpld_regmap_eth_modular[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_GP2_OFFSET, 0x61 },
+ 	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
+-- 
+2.20.1
+


### PR DESCRIPTION
Backport patches for virtual PWM support.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
