### PR TITLE
kernel patches: 4.19: Add missed line in patch

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch
+++ b/recipes-kernel/linux/linux-4.19/0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch
@@ -1,8 +1,8 @@
-From 07db018b0debfbd1246a529a35d4767415338b0f Mon Sep 17 00:00:00 2001
+From 288281c9d0867821b711079baeb8af4024fc1fb8 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Tue, 6 Jul 2021 05:57:39 +0000
-Subject: [PATCH backport v4.19 040/104] platform/mellanox: mlxreg-io: Fix read
- access of n-bytes size attributes
+Subject: [PATCH 07/80] platform/mellanox: mlxreg-io: Fix read access of
+ n-bytes size attributes
 
 Fix shift argument for function rol32(). It should be provided in bits,
 while was provided in bytes.
@@ -10,22 +10,23 @@ while was provided in bytes.
 Fixes: 86148190a7db: (" platform/mellanox: mlxreg-io: Add support for complex attributes")
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlxreg-io.c | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ drivers/platform/mellanox/mlxreg-io.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
-index 6b82f5e0c1b0..475773f6dc4b 100644
+index 6b82f5e..772a8a3 100644
 --- a/drivers/platform/mellanox/mlxreg-io.c
 +++ b/drivers/platform/mellanox/mlxreg-io.c
-@@ -102,7 +102,7 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
+@@ -102,9 +102,8 @@ mlxreg_io_get_reg(void *regmap, struct mlxreg_core_data *data, u32 in_val,
  			if (ret)
  				goto access_error;
  
 -			*regval |= rol32(val, regsize * i);
 +			*regval |= rol32(val, regsize * i * 8);
  		}
- 		*regval = le32_to_cpu(*regval & regmax);
+-		*regval = le32_to_cpu(*regval & regmax);
  	}
+ 
+ access_error:
 -- 
-2.20.1
-
+2.8.4


### PR DESCRIPTION
Add missed line in patch
0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch

=======================
Fix shift argument for function rol32(). It should be provided in bits,
while was provided in bytes.

Fixes: 86148190a7db: (" platform/mellanox: mlxreg-io: Add support for complex attributes")
Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
========================

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
