### PR TITLE
hw-mgmt: patches: v4.19: Rebase patches for minimal driver

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0126-mlxsw-minimal-Add-indexation-for-modules-on-for-line.patch
+++ b/recipes-kernel/linux/linux-4.19/0126-mlxsw-minimal-Add-indexation-for-modules-on-for-line.patch
@@ -1,8 +1,8 @@
-From aae52f2f583f56bac993cc387fb62085567a788f Mon Sep 17 00:00:00 2001
+From 0e193375aa2527760fc91277a7eb395aedbac58a Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
-Date: Sun, 18 Jul 2021 20:22:17 +0000
-Subject: [PATCH backport v4.19 101/104] mlxsw: minimal: Add indexation for
- modules on for line card
+Date: Thu, 23 Sep 2021 21:19:56 +0000
+Subject: [PATCH backport v.4.19 1/4] mlxsw: minimal: Add indexation for
+ modules located line cards
 
 The modules on modular system with replaceable line cards are counted
 from 1 to 128, while line card can be equipped with maximum 16 modules.
@@ -16,11 +16,11 @@ assignment.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/net/ethernet/mellanox/mlxsw/minimal.c | 14 ++++++++++----
- 1 file changed, 10 insertions(+), 4 deletions(-)
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c | 22 ++++++++++++++-----
+ 1 file changed, 16 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-index eb856936d8f9..99bb8eb792d3 100644
+index e13018380..e5b1bc90b 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
 @@ -39,6 +39,7 @@ struct mlxsw_m_area {
@@ -41,7 +41,43 @@ index eb856936d8f9..99bb8eb792d3 100644
  	return 0;
  }
  
-@@ -221,11 +223,15 @@ static void mlxsw_m_port_remove(struct mlxsw_m_area *mlxsw_m_area, u8 local_port
+@@ -162,6 +164,7 @@ mlxsw_m_port_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index,
+ 	struct mlxsw_m *mlxsw_m = mlxsw_m_area->mlxsw_m;
+ 	struct mlxsw_m_port *mlxsw_m_port;
+ 	struct net_device *dev;
++	u8 port_to_area, off;
+ 	int err;
+ 
+ 	err = mlxsw_core_port_init(mlxsw_m->core, local_port, slot_index);
+@@ -177,6 +180,9 @@ mlxsw_m_port_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index,
+ 		goto err_alloc_etherdev;
+ 	}
+ 
++	/* Map local port to area index. */
++	off = mlxsw_m_area->module_off;
++	port_to_area = off ? local_port % off : local_port;
+ 	SET_NETDEV_DEV(dev, mlxsw_m->bus_info->dev);
+ 	mlxsw_m_port = netdev_priv(dev);
+ 	mlxsw_m_port->dev = dev;
+@@ -197,7 +203,7 @@ mlxsw_m_port_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index,
+ 
+ 	netif_carrier_off(dev);
+ 	mlxsw_m_port_switchdev_init(mlxsw_m_port);
+-	mlxsw_m_area->ports[local_port] = mlxsw_m_port;
++	mlxsw_m_area->ports[port_to_area] = mlxsw_m_port;
+ 	err = register_netdev(dev);
+ 	if (err) {
+ 		dev_err(mlxsw_m->bus_info->dev, "Port %d: Failed to register netdev\n",
+@@ -208,7 +214,7 @@ mlxsw_m_port_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index,
+ 	return 0;
+ 
+ err_register_netdev:
+-	mlxsw_m_area->ports[local_port] = NULL;
++	mlxsw_m_area->ports[port_to_area] = NULL;
+ 	mlxsw_m_port_switchdev_fini(mlxsw_m_port);
+ 	free_netdev(dev);
+ err_dev_addr_get:
+@@ -221,11 +227,15 @@ static void mlxsw_m_port_remove(struct mlxsw_m_area *mlxsw_m_area, u8 local_port
  {
  	struct mlxsw_m *mlxsw_m = mlxsw_m_area->mlxsw_m;
  	struct mlxsw_m_port *mlxsw_m_port;
@@ -59,7 +95,7 @@ index eb856936d8f9..99bb8eb792d3 100644
  	mlxsw_m_port_switchdev_fini(mlxsw_m_port);
  	free_netdev(mlxsw_m_port->dev);
  	mlxsw_core_port_fini(mlxsw_m->core, local_port);
-@@ -262,7 +268,7 @@ static int mlxsw_m_ports_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index
+@@ -262,7 +272,7 @@ static int mlxsw_m_ports_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index
  
  	/* Create port objects for each valid entry */
  	for (i = 0; i < mlxsw_m_area->max_ports; i++) {

--- a/recipes-kernel/linux/linux-4.19/0127-mlxsw-minimal-Obtain-maximum-number-of-slots-support.patch
+++ b/recipes-kernel/linux/linux-4.19/0127-mlxsw-minimal-Obtain-maximum-number-of-slots-support.patch
@@ -1,8 +1,8 @@
-From 5bfdfab6eeed801b2571ef0ac63d940d02761d99 Mon Sep 17 00:00:00 2001
+From 0fe6324515531410b291c6734434cd6b89e77155 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 9 Aug 2021 15:24:35 +0000
-Subject: [PATCH v4.19 backport 103/108] mlxsw: minimal: Obtain maximum number
- of slots supported by system
+Subject: [PATCH backport v.4.19 2/4] mlxsw: minimal: Obtain maximum number of
+ slots supported by system
 
 Obtain maximum slot number by query MGPIR register with 'slot_index'
 zero. This info is to be used to pre-allocate memory for maximum line
@@ -14,10 +14,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-index b1788f720..56251f0ef 100644
+index e5b1bc90b..599ccf89d 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-@@ -249,6 +249,14 @@ static int mlxsw_m_ports_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index
+@@ -253,6 +253,14 @@ static int mlxsw_m_ports_create(struct mlxsw_m_area *mlxsw_m_area, u8 slot_index
  	if (err)
  		return err;
  

--- a/recipes-kernel/linux/linux-4.19/0128-mlxsw-minimal-Add-system-event-handler.patch
+++ b/recipes-kernel/linux/linux-4.19/0128-mlxsw-minimal-Add-system-event-handler.patch
@@ -1,8 +1,7 @@
-From 963a43da5e2b8affefbad9140ebc92321e0342dd Mon Sep 17 00:00:00 2001
+From f7347c6e43b7dba0ccafe29d0d9d4a6a07d410ed Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 19 Jul 2021 16:30:00 +0000
-Subject: [PATCH backport v4.19 103/104] mlxsw: minimal: Add system event
- handler
+Subject: [PATCH backport v.4.19 3/4] mlxsw: minimal: Add system event handler
 
 Add system event handler for treating line card specific signals on
 modular system. These signals indicate line card state changes, like
@@ -17,10 +16,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 23 insertions(+)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-index eab2a216c00c..cf2a4562abc8 100644
+index 599ccf89d..903c67253 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-@@ -306,6 +306,28 @@ static void mlxsw_m_ports_remove(struct mlxsw_m_area *mlxsw_m_area)
+@@ -313,6 +313,28 @@ static void mlxsw_m_ports_remove(struct mlxsw_m_area *mlxsw_m_area)
  	kfree(mlxsw_m_area->ports);
  }
  
@@ -49,7 +48,7 @@ index eab2a216c00c..cf2a4562abc8 100644
  static int mlxsw_m_init(struct mlxsw_core *mlxsw_core,
  			const struct mlxsw_bus_info *mlxsw_bus_info)
  {
-@@ -347,6 +369,7 @@ static struct mlxsw_driver mlxsw_m_driver = {
+@@ -354,6 +376,7 @@ static struct mlxsw_driver mlxsw_m_driver = {
  	.priv_size		= sizeof(struct mlxsw_m),
  	.init			= mlxsw_m_init,
  	.fini			= mlxsw_m_fini,

--- a/recipes-kernel/linux/linux-4.19/0129-mlxsw-minimal-Add-interfaces-for-line-card-initializ.patch
+++ b/recipes-kernel/linux/linux-4.19/0129-mlxsw-minimal-Add-interfaces-for-line-card-initializ.patch
@@ -1,8 +1,8 @@
-From e9b029123f1254486faf42567b33cfdd1b627e17 Mon Sep 17 00:00:00 2001
+From d3dca533a7a54ffffb65b0a542be37164c7e44cb Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 19 Jul 2021 16:49:20 +0000
-Subject: [PATCH backport v4.19 104/104] mlxsw: minimal: Add interfaces for
- line card initialization and de-initialization
+Subject: [PATCH backport v.4.19 4/4] mlxsw: minimal: Add interfaces for line
+ card initialization and de-initialization
 
 Add callback functions for line card 'netdevice' objects initialization
 and de-initialization. Each line card is associated with the set of
@@ -18,10 +18,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 124 insertions(+)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-index cf2a4562abc8..dffbbc9e25f4 100644
+index 903c67253..f36358470 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
-@@ -328,6 +328,121 @@ static void mlxsw_m_sys_event_handler(struct mlxsw_core *mlxsw_core)
+@@ -335,6 +335,121 @@ static void mlxsw_m_sys_event_handler(struct mlxsw_core *mlxsw_core)
  	}
  }
  
@@ -143,7 +143,7 @@ index cf2a4562abc8..dffbbc9e25f4 100644
  static int mlxsw_m_init(struct mlxsw_core *mlxsw_core,
  			const struct mlxsw_bus_info *mlxsw_bus_info)
  {
-@@ -352,13 +467,22 @@ static int mlxsw_m_init(struct mlxsw_core *mlxsw_core,
+@@ -359,13 +474,22 @@ static int mlxsw_m_init(struct mlxsw_core *mlxsw_core,
  		return err;
  	}
  


### PR DESCRIPTION
Modify patch #0126 and rebase #0127 - #0129.

Signed-of-by: Vadim Pasternak <vadimp@nvidia.com>
