### PR TITLE
hw-mgmt: chassis events: Fix iio name index for linecard

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -48,6 +48,7 @@ psu1_i2c_addr=0x51
 psu2_i2c_addr=0x50
 psu3_i2c_addr=0x53
 psu4_i2c_addr=0x52
+lc_iio_dev_name_def="iio:device0"
 eeprom_name=''
 sfp_counter=0
 udev_ready=$hw_management_path/.udev_ready
@@ -393,6 +394,7 @@ if [ "$1" == "add" ]; then
 	fi
 	if [ "$2" == "a2d" ]; then
 		# Detect if it belongs to line card or to main board.
+		iio_name=$5
 		input_bus_num=$(echo "$3""$4"| xargs dirname | xargs dirname | xargs dirname | xargs basename | cut -d"-" -f2)
 		driver_dir=$(echo "$3""$4"| xargs dirname | xargs dirname | xargs dirname)/"$input_bus_num"-00"$mlxreg_lc_addr"
 		if [ -d "$driver_dir" ]; then
@@ -401,12 +403,13 @@ if [ "$1" == "add" ]; then
 				# Line card event, replace output folder.
 				find_linecard_num "$input_bus_num"
 				environment_path="$hw_management_path"/lc"$linecard_num"/environment
+				iio_name=$lc_iio_dev_name_def
 			fi
 		fi
-		ln -sf "$3""$4"/in_voltage-voltage_scale $environment_path/"$2"_"$5"_voltage_scale
+		ln -sf "$3""$4"/in_voltage-voltage_scale $environment_path/"$2"_"$iio_name"_voltage_scale
 		for i in {0..7}; do
 			if [ -f "$3""$4"/in_voltage"$i"_raw ]; then
-				ln -sf "$3""$4"/in_voltage"$i"_raw $environment_path/"$2"_"$5"_raw_"$i"
+				ln -sf "$3""$4"/in_voltage"$i"_raw $environment_path/"$2"_"$iio_name"_raw_"$i"
 			fi
 		done
 	fi


### PR DESCRIPTION
Set a2d ID value in sensor name "/lc/environment/a2d_iio:device{ID}_*"
to start from 0 for each linecard.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
