### PR TITLE
hw-mgmt: patches: v4.19: Rename cooling device name

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0140-hwmon-mlxreg-fan-Rename-cooling-devices.patch
+++ b/recipes-kernel/linux/linux-4.19/0140-hwmon-mlxreg-fan-Rename-cooling-devices.patch
@@ -1,0 +1,30 @@
+From 1f5e246fe6ff9e01debd0fb8f8e8a8b4ee911c27 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 28 Sep 2021 15:21:24 +0000
+Subject: [PATCH backport v.4.19 1/2] hwmon: (mlxreg-fan) Rename cooling
+ devices
+
+Rename cooling device name for "pwm1" from "mlxreg_fan" to
+"mlxreg_fan0".
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/hwmon/mlxreg-fan.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index 7d6c2d930..4eec8726d 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -295,7 +295,7 @@ static const u32 mlxreg_fan_hwmon_pwm_config[] = {
+ };
+ 
+ static char *mlxreg_fan_name[] = {
+-	"mlxreg_fan",
++	"mlxreg_fan0",
+ 	"mlxreg_fan1",
+ 	"mlxreg_fan2",
+ 	"mlxreg_fan3",
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-4.19/0141-mlxsw-core_thermal-Rename-cooling-devices.patch
+++ b/recipes-kernel/linux/linux-4.19/0141-mlxsw-core_thermal-Rename-cooling-devices.patch
@@ -1,0 +1,30 @@
+From 9f226c091919350b088d087b5fe890ee7662e455 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 28 Sep 2021 15:23:45 +0000
+Subject: [PATCH backport v.4.19 2/2] mlxsw: core_thermal: Rename cooling
+ devices
+
+Rename cooling device name used for thermal zone binding from
+"mlxreg_fan" to "mlxreg_fan0".
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index a1a5ef04e..60187ec19 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -40,7 +40,7 @@
+ 
+ /* External cooling devices, allowed for binding to mlxsw thermal zones. */
+ static char * const mlxsw_thermal_external_allowed_cdev[] = {
+-	"mlxreg_fan",
++	"mlxreg_fan0",
+ };
+ 
+ enum mlxsw_thermal_trips {
+-- 
+2.20.1
+


### PR DESCRIPTION
Rename "mlxreg_fan" to "mlxreg_fan0".

Signed-of-by: Vadim Pasternak <vadimp@nvidia.com>
