### PR TITLE
hw-mgmt: thermal: Use default dynamic minimum thermal profile for SN4800

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -76,6 +76,10 @@ RNG_CPU=0x64D
 BDW_CPU=0x656
 CFL_CPU=0x69E
 
+board_type=$(< /sys/devices/virtual/dmi/id/board_name)
+product=$(< /sys/devices/virtual/dmi/id/product_name)
+sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+
 log_err()
 {
     logger -t hw-management -p daemon.err "$@"

--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -108,6 +108,8 @@ common_loop=20
 
 # PSU fan speed vector
 psu_fan_speed=(0x3c 0x3c 0x3c 0x3c 0x3c 0x3c 0x3c 0x46 0x50 0x5a 0x64)
+# TMP for Buffalo BU
+psu_fan_speed_full=(0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64)
 
 # Thermal tables for the minimum FAN setting per system time. It contains
 # entries with ambient temperature threshold values and relevant minimum
@@ -659,6 +661,15 @@ thermal_periodic_report()
 			set_cur_state=$cooling
 		fi
 	fi
+	# TMP for Buffalo BU
+	case $board in
+	VMOD0011)
+		ps_fan_speed=${psu_fan_speed_full[$f5]}
+		;;
+	*)
+		ps_fan_speed=${psu_fan_speed[$f5]}
+		;;
+	esac
 	ps_fan_speed=${psu_fan_speed[$f5]}
 	f5=$((f5*10))
 	f6=$((set_cur_state*10))
@@ -782,6 +793,15 @@ update_psu_fan_speed()
 				addr=$(< $config_path/psu"$i"_i2c_addr)
 				command=$(< $fan_command)
 				entry=$(< $thermal_path/cooling_cur_state)
+				# TMP for Buffalo BU
+				case $board in
+				VMOD0011)
+					speed=${psu_fan_speed_full[$entry]}
+				;;
+				*)
+					speed=${psu_fan_speed[$entry]}
+					;;
+				esac
 				speed=${psu_fan_speed[$entry]}
 				i2cset -f -y "$bus" "$addr" "$command" "$speed" wp
 			fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -910,7 +910,7 @@ msn48xx_specific()
 	local cpu_bus_offset=51
 	connect_table=(${msn4800_base_connect_table[@]})
 	add_cpu_board_to_connection_table $cpu_bus_offset
-	thermal_type=$thermal_type_full
+	thermal_type=$thermal_type_def
 	hotplug_linecards=8
 	i2c_comex_mon_bus_default=$((cpu_bus_offset+5))
 	i2c_bus_def_off_eeprom_cpu=$((cpu_bus_offset+6))
@@ -924,7 +924,7 @@ msn48xx_specific()
 	echo 4600 > $config_path/psu_fan_min
 	echo 14 > $config_path/pcie_default_i2c_bus
 	lm_sensors_config="$lm_sensors_configs_path/msn4800_sensors.conf"
-	# TMP for BU
+	# TMP for Buffalo BU
 	iorw -b 0x2004 -w -l1 -v0x3f
 }
 
@@ -1108,7 +1108,15 @@ set_config_data()
 	echo $psu2_i2c_addr > $config_path/psu2_i2c_addr
 	echo $psu3_i2c_addr > $config_path/psu3_i2c_addr
 	echo $psu4_i2c_addr > $config_path/psu4_i2c_addr
-	echo $fan_psu_default > $config_path/fan_psu_default
+	# TMP for Buffalo BU
+	case $board in
+	VMOD0011)
+		echo 0x64 > $config_path/fan_psu_default
+		;;
+	*)
+		echo $fan_psu_default > $config_path/fan_psu_default
+		;;
+	esac
 	echo $fan_command > $config_path/fan_command
 	echo 35 > $config_path/thermal_delay
 	echo $chipup_delay_default > $config_path/chipup_delay


### PR DESCRIPTION
- Use default thermal profile 60% instead of 100%.
- Use temporary WA for PSU fan speed - keep 100% until PS firmware
  is not fixed.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
