### PR TITLE
hw-mgmt: patches: v4.19: Add support for systems equipped with two ASICs

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0142-platform-x86-mlx-platform-Add-support-for-systems-eq.patch
+++ b/recipes-kernel/linux/linux-4.19/0142-platform-x86-mlx-platform-Add-support-for-systems-eq.patch
@@ -1,0 +1,656 @@
+From 9569faa1c88a676c3fa970cb3dcf9340d4b711ee Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Thu, 16 Sep 2021 16:46:54 +0300
+Subject: [PATCH] platform/x86: mlx-platform: Add support for systems equipped
+ with two ASICs
+
+Motivation is to support new systems equipped with two ASICs.
+Changes includes support for:
+- the second ASIC;
+- thermal events for both ASICs, including ASIC thermal warning and critical events.
+- reset control for both ASICs, triggering reset of ASIC internal resources and
+  restarting ASIC initialization flow.
+
+New systems reuse the existing system class "VMOD0010".
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ Documentation/ABI/stable/sysfs-driver-mlxreg-io | 412 ++++++++++++++++++++++++
+ drivers/platform/x86/mlx-platform.c             |  98 +++++-
+ 2 files changed, 508 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/ABI/stable/sysfs-driver-mlxreg-io b/Documentation/ABI/stable/sysfs-driver-mlxreg-io
+index d9d117d..f7c2aee 100644
+--- a/Documentation/ABI/stable/sysfs-driver-mlxreg-io
++++ b/Documentation/ABI/stable/sysfs-driver-mlxreg-io
+@@ -21,6 +21,34 @@ Description:	These files show with which CPLD versions have been burned
+ 
+ 		The files are read only.
+ 
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/fan_dir
++Date:		December 2018
++KernelVersion:	5.0
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	This file shows the system fans direction:
++		forward direction - relevant bit is set 0;
++		reversed direction - relevant bit is set 1.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld3_version
++Date:		November 2018
++KernelVersion:	5.0
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show with which CPLD versions have been burned
++		on LED or Gearbox board.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/jtag_enable
++Date:		November 2018
++KernelVersion:	5.0
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files enable and disable the access to the JTAG domain.
++		By default access to the JTAG domain is disabled.
++
++		The file is read/write.
++
+ What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/select_iio
+ Date:		June 2018
+ KernelVersion:	4.19
+@@ -76,3 +104,387 @@ Description:	These files show the system reset cause, as following: power
+ 		reset cause.
+ 
+ 		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_comex_pwr_fail
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_from_comex
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_system
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_voltmon_upgrade_fail
++Date:		November 2018
++KernelVersion:	5.0
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show the system reset cause, as following: ComEx
++		power fail, reset from ComEx, system platform reset, reset
++		due to voltage monitor devices upgrade failure,
++		Value 1 in file means this is reset cause, 0 - otherwise.
++		Only one bit could be 1 at the same time, representing only
++		the last reset cause.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld4_version
++Date:		November 2018
++KernelVersion:	5.0
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show with which CPLD versions have been burned
++		on LED board.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_comex_thermal
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_comex_wd
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_from_asic
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_reload_bios
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_sff_wd
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_swb_wd
++Date:		June 2019
++KernelVersion:	5.3
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show the system reset cause, as following:
++		COMEX thermal shutdown; wathchdog power off or reset was derived
++		by one of the next components: COMEX, switch board or by Small Form
++		Factor mezzanine, reset requested from ASIC, reset cuased by BIOS
++		reload. Value 1 in file means this is reset cause, 0 - otherwise.
++		Only one of the above causes could be 1 at the same time, representing
++		only last reset cause.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/config1
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/config2
++Date:		January 2020
++KernelVersion:	5.6
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show system static topology identification
++		like system's static I2C topology, number and type of FPGA
++		devices within the system and so on.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_ac_pwr_fail
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_platform
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_soc
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/reset_sw_pwr_off
++Date:		January 2020
++KernelVersion:	5.6
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show the system reset causes, as following: reset
++		due to AC power failure, reset invoked from software by
++		assertion reset signal through CPLD. reset caused by signal
++		asserted by SOC through ACPI register, reset invoked from
++		software by assertion power off signal through CPLD.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/pcie_asic_reset_dis
++Date:		January 2020
++KernelVersion:	5.6
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	This file allows to retain ASIC up during PCIe root complex
++		reset, when attribute is set 1.
++
++		The file is read/write.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/vpd_wp
++Date:		January 2020
++KernelVersion:	5.6
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	This file allows to overwrite system VPD hardware wrtie
++		protection when attribute is set 1.
++
++		The file is read/write.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/voltreg_update_status
++Date:		January 2020
++KernelVersion:	5.6
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	This file exposes the configuration update status of burnable
++		voltage regulator devices. The status values are as following:
++		0 - OK; 1 - CRC failure; 2 = I2C failure; 3 - in progress.
++
++		The file is read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/ufm_version
++Date:		January 2020
++KernelVersion:	5.6
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	This file exposes the firmware version of burnable voltage
++		regulator devices.
++
++		The file is read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld1_pn
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld2_pn
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld3_pn
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld4_pn
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld1_version_min
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld2_version_min
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld3_version_min
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/cpld4_version_min
++Date:		July 2020
++KernelVersion:	5.9
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files show with which CPLD part numbers and minor
++		versions have been burned CPLD devices equipped on a
++		system.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/bios_active_image
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/bios_auth_fail
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/bios_upgrade_fail
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/bios_safe_mode
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	The files represent BIOS statuses:
++		- bios_active_image: location of current active BIOS image:
++		  0: Top, 1: Bottom.
++		  The reported value should correspond to value expected by OS
++		  in case of BIOS safe mode is 0. This bit is related to Intel
++		  top-swap feature of DualBios on the same flash.
++		- bios_auth_fail: BIOS upgrade is failed because provided BIOS
++		  image is not signed correctly.
++		- bios_upgrade_fail: BIOS upgrade is failed by some other
++		  reason not because authentication. For example due to
++		  physical SPI flash problem.
++		- bios_safe_mode:
++		  0 : BIOS is booted from a supposed active image;
++		  1 : BIOS safe mechanism was enforced by hardware
++		  (CPLD), thus BIOS is booted from supposed inactive
++		  image and it indicates that there is a problem with
++		  other image and it should be recovered.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc1_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc2_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc3_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc4_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc5_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc6_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc7_enable
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc8_enable
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files allow line cards enable state control.
++		Expected behavior:
++		When  lc{n}_enable is written 1, related line card is released
++		from the reset state, when 0 - is hold in reset state.
++
++		The files are read/write.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc1_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc2_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc3_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc4_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc5_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc6_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc7_pwr
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc8_pwr
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files switching line cards power on and off.
++		Expected behavior:
++		When  lc{n}_pwr is written 1, related line card is powered
++		on, when written 0 - powered off.
++
++		The files are read/write.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc1_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc2_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc3_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc4_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc5_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc6_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc7_rst_mask
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/lc8_rst_mask
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files clear line card reset bit enforced by ASIC, when it
++		sets it due to some abnormal ASIC behavior.
++		Expected behavior:
++		When  lc{n}_rst_mask is written 1, related line card reset bit
++		is cleared, when written 0 - no effect.
++
++		The files are read/write.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/os_ready
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	This file, when written 1, indicates that OS is taking control
++		over systems programmable devices.
++
++		The file is read only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/pm_mgmt_en
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	This file assigns power management control ownership.
++		When power management control is provided by hardware, it means
++		that hardware will automatically power off one or more line
++		cards in case system power budget is under power required for
++		feeding all powered on line cards. It could be a case, when
++		some of power units lost power good state.
++		When pm_mgmt_en is written 1, power management control by
++		software is enabled, 0 - power management control by hardware.
++		Default is 0.
++
++		The file is read/write.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/psu3_on
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/psu4_on
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files switching power supply units on and off.
++		Expected behavior:
++		When  psu3_on or psu4_on is written 1, related unit will be
++		disconnected from the power source, when written 0 - connected.
++
++		The files are write only.
++
++What:		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/shutdown_unlock
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	This file unlocks system after hardware or firmware thermal
++		shutdown, which causes locking of the all interfaces to ASIC.
++		When shutdown_unlock is written 1 and after that 0, it removes
++		locking.
++
++		The file is read/write.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/cpld1_pn
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/cpld1_version
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/cpld1_version_min
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files show with which CPLD major and minor versions
++		and part number has been burned CPLD device on line card.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/fpga1_pn
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/fpga1_version
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/fpga1_version_min
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files show with which FPGA major and minor versions
++		and part number has been burned FPGA device on line card.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/ini_wp
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/vpd_wp
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files allow to overwrite line card VPD and firmware blob
++		hardware write protection mode. When attribute is set 1 - write
++		protection is disabled, when 0 - enabled. By default both are
++		write protected.
++		If the system is in locked-down mode writing these files will
++		not be allowed.
++
++		The files are read/write.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/reset_aux_pwr_or_ref
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/reset_dc_dc_pwr_fail
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/reset_fpga_not_done
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/reset_from_chassis
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/reset_line_card
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/reset_pwr_off_from_chassis
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files show the line reset cause, as following: power
++		auxiliary outage or power refresh, DC-to-DC power failure, FPGA reset
++		failed, line card reset failed, power off from chassis.
++		Value 1 in file means this is reset cause, 0 - otherwise. Only one of
++		the above causes could be 1 at the same time, representing only last
++		reset cause.
++
++		The files are read only.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/cpld_upgrade_en
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/fpga_upgrade_en
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files allow CPLD and FPGA burning. Value 1 in file means burning
++		is enabled, 0 - otherwise.
++ 		If the system is in locked-down mode writing these files will
++		not be allowed.
++
++		The files are read/write.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/qsfp_pwr_en
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/pwr_en
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files allow to power on/off all QSFP ports and whole line card.
++		The attributes are set 1 for power on, 0 - for power off.
++
++		The files are read/write.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/agb_spi_burn_en
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/fpga_spi_burn_en
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files allow gearboxes and FPGA SPI flash burning.
++		The attributes are set 1 to enable burning, 0 - to disable.
++ 		If the system is in locked-down mode writing these files will
++		not be allowed.
++
++		The file is read/write.
++
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/max_power
++What:		/sys/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/i2c-*/*-0032/mlxreg-io.*/hwmon/hwmon*/config
++Date:		April 2021
++KernelVersion:	5.13
++Contact:	Vadim Pasternak <vadimp@nvidia.com>
++Description:	These files provide the maximum powered required for line card
++		feeding and line card configuration Id.
++
++		The files are read only.
++
++What:	/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/asic1_reset
++		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/asic2_reset
++Date:		October 2021
++KernelVersion:	5.16
++Contact:	Vadim Pasternak <vadimpmellanox.com>
++Description:	These files allow asserting asic reset, and make reinit
++		for asic internal recources
++		Expected behavior:
++		When asic1_reset is written 0: ASIC get's reset signal and start
++		to internal reset flow
++
++		The files are write only.
++
++What:                    /sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/thshtdwn_unlock
++Date:                     October 2021
++KernelVersion:  5.16
++Contact:    Vadim Pasternak vadimp@nvidia.com
++Description:    This file allows to unlock ASIC after shutdown event.
++        When system thermal shutdown is enforced by ASIC, ASIC
++        is getting locked and after system boot it will not be
++        available. Software can decide to unlock it by setting
++        this attribute to 1 and then perform system power cycle
++        by setting “pwr_cycle” attribute to 1 (power cycle of
++        main power domain).
++        Prior setting “thshtdwn_unlock” 1 it is recommended to
++        validate that system reboot cause is “reset_asic_thermal”
++        In case “thshtdwn_unlock” is not set 1, the only way to
++        release ASIC from locking - is full system power cycle
++        through the external power distribution unit.
++
++
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 143cb4f..9e11b21 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -30,6 +30,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET	0x06
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET	0x08
+ #define MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET	0x0a
++#define MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET	0x19
+ #define MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET	0x1c
+ #define MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET	0x1d
+ #define MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET	0x1e
+@@ -65,6 +66,9 @@
+ #define MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET 0x50
+ #define MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET	0x51
+ #define MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET	0x52
++#define MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET 0x53
++#define MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET	0x54
++#define MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET	0x55
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET	0x56
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET	0x57
+ #define MLXPLAT_CPLD_LPC_REG_PSU_OFFSET		0x58
+@@ -189,6 +193,7 @@
+ 					 MLXPLAT_CPLD_AGGR_MASK_LC_ACT | \
+ 					 MLXPLAT_CPLD_AGGR_MASK_LC_SDWN)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
++#define MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2	BIT(2)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
+ #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
+@@ -196,6 +201,7 @@
+ #define MLXPLAT_CPLD_PWR_EXT_MASK	GENMASK(3, 0)
+ #define MLXPLAT_CPLD_FAN_MASK		GENMASK(3, 0)
+ #define MLXPLAT_CPLD_ASIC_MASK		GENMASK(1, 0)
++#define MLXPLAT_CPLD_ASIC_THERMAL_MASK	GENMASK(3, 2)
+ #define MLXPLAT_CPLD_FAN_NG_MASK	GENMASK(6, 0)
+ #define MLXPLAT_CPLD_FAN_QMB8700_MASK	GENMASK(5, 0)
+ #define MLXPLAT_CPLD_LED_LO_NIBBLE_MASK	GENMASK(7, 4)
+@@ -567,6 +573,46 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_asic_items_data[] = {
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+ 		.mask = MLXPLAT_CPLD_ASIC_MASK,
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	}
++};
++
++static struct mlxreg_core_data mlxplat_mlxcpld_default_asic2_items_data[] = {
++	{
++		.label = "asic2",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++
++static struct mlxreg_core_data mlxplat_mlxcpld_asic_thermal_items_data[] = {
++	{
++		.label = "asic1_therm_warn",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = BIT(2),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "asic1_therm_crit",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = BIT(3),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++static struct mlxreg_core_data mlxplat_mlxcpld_asic2_thermal_items_data[] = {
++	{
++		.label = "asic2_therm_warn",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = BIT(2),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "asic2_therm_crit",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = BIT(3),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
+ 	},
+ };
+ 
+@@ -1188,11 +1234,36 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+ 		.data = mlxplat_mlxcpld_default_asic_items_data,
+ 		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+-		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
+ 		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
+ 		.inversed = 0,
+ 		.health = true,
+ 	},
++	{
++		.data = mlxplat_mlxcpld_default_asic2_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic2_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_asic_thermal_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_asic_thermal_items_data),
++		.inversed = 0,
++	},
++	{
++		.data = mlxplat_mlxcpld_asic2_thermal_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_asic2_thermal_items_data),
++		.inversed = 0,
++	},
+ };
+ 
+ static
+@@ -1202,7 +1273,7 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
+ 	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
+ 	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
+ 	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
+-	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2,
+ };
+ 
+ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+@@ -2988,6 +3059,18 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
++		.label = "asic1_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
++		.mask = GENMASK(3, 0) & ~BIT(0),
++		.mode = 0644,
++	},
++	{
++		.label = "asic2_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
++		.bit = GENMASK(2, 0),
++		.mode = 0444,
++	},
++	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -4150,6 +4233,7 @@ static struct mlxreg_core_platform_data mlxplat_mlxcpld_wd_set_type3[] = {
+ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ {
+ 	switch (reg) {
++	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED2_OFFSET:
+@@ -4173,6 +4257,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWR_EVENT_OFFSET:
+@@ -4227,6 +4313,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+@@ -4261,6 +4348,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
+@@ -4352,6 +4442,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+@@ -4384,6 +4475,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
+-- 
+2.8.4
+


### PR DESCRIPTION
platform/x86: mlx-platform: Add support for systems equipped with two ASICs

Motivation is to support new systems equipped with two ASICs.
Changes includes support for:
- the second ASIC;
- thermal events for both ASICs, including ASIC thermal warning and critical events.
- reset control for both ASICs, triggering reset of ASIC internal resources and
  restarting ASIC initialization flow.

New systems reuse the existing system class "VMOD0010".

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
