### PR TITLE
hw-mgmt: config: Extend list of kernel modules for init

### DIFF
--- a/usr/etc/modules-load.d/hw-management-modules.conf
+++ b/usr/etc/modules-load.d/hw-management-modules.conf
@@ -13,3 +13,5 @@ at24
 xdpe12284
 mp2975
 mp2888
+i2c-mux-mlxcpld
+lm205066


### PR DESCRIPTION
Add init for modules i2c-mux-mlxcpld, lm205066.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
