### PR TITLE
hw-mgmt: events: Add symbolic links for cooling current states

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -353,6 +353,15 @@ if [ "$1" == "add" ]; then
 			echo $fan_full_speed_code > $thermal_path/cooling_cur_state
 			log_info "FAN speed is set to full speed"
 		fi
+		if [ "$coolingtype" == "mlxreg_fan1" ]; then
+			ln -sf "$3""$4"/cur_state $thermal_path/cooling1_cur_state
+		fi
+		if [ "$coolingtype" == "mlxreg_fan2" ]; then
+			ln -sf "$3""$4"/cur_state $thermal_path/cooling2_cur_state
+		fi
+		if [ "$coolingtype" == "mlxreg_fan3" ]; then
+			ln -sf "$3""$4"/cur_state $thermal_path/cooling3_cur_state
+		fi
 	fi
 	if [ "$2" == "hotplug" ]; then
 		for ((i=1; i<=max_tachos; i+=1)); do
@@ -816,6 +825,9 @@ else
 	fi
 	if [ "$2" == "cooling_device" ]; then
 		check_n_unlink $thermal_path/cooling_cur_state
+		check_n_unlink $thermal_path/cooling1_cur_state
+		check_n_unlink $thermal_path/cooling2_cur_state
+		check_n_unlink $thermal_path/cooling3_cur_state
 	fi
 	if [ "$2" == "hotplug" ]; then
 		for ((i=1; i<=max_tachos; i+=1)); do


### PR DESCRIPTION
Add symbolic links for cooling objects associated with pwm1, pwm2,
pwm3 attributes.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>