### PR TITLE
hw-mgmt: config: Fix list of kernel modules init

### DIFF
--- a/usr/etc/modules-load.d/hw-management-modules.conf
+++ b/usr/etc/modules-load.d/hw-management-modules.conf
@@ -14,4 +14,4 @@ xdpe12284
 mp2975
 mp2888
 i2c-mux-mlxcpld
-lm205066
+lm25066


### PR DESCRIPTION
Fix name of hotswap driver - it is called lm25066.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
