### PR TITLE
hw-mgmt: sensors: Modify conf file for msn4600 sensors

### DIFF
--- a/usr/etc/hw-management-sensors/msn4700_respin_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4700_respin_sensors.conf
@@ -44,8 +44,8 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
         label temp1 "PMIC-2 ASIC 1.8V_1.2V_MAIN Temp 1"
         ignore temp2
         label power1 "PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Pwr (in)"
-        label power2 "PMIC-2 ASIC 1.8V_MAIN Rail Pwr (out)"
-        ignore power3
+        label power2 "PMIC-2 ASIC 1.8V_MAIN Rail Pwr (out1)"
+        label power3 "PMIC-2 ASIC 1.2V_MAIN Rail Pwr (out2)"
         ignore power4
         label curr1 "PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Curr (in)"
         label curr2 "PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)"
@@ -59,8 +59,8 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
         label temp1 "PMIC-3 ASIC VCORE_1.8V_T0_3 Temp 1"
         ignore temp2
         label power1 "PMIC-3 12V ASIC VCORE_1.8V_T0_3 Rail Pwr (in) "
-        label power2 "PMIC-3 ASIC VCORE_T0_3 Rail Pwr (out)"
-        ignore power3
+        label power2 "PMIC-3 ASIC VCORE_T0_3 Rail Pwr (out1)"
+        label power3 "PMIC-3 ASIC 1.8V_T0_3 Rail Pwr (out2)"
         ignore power4 
         label curr1 "PMIC-3 12V ASIC VCORE_1.8V_T0_3 Rail Curr (in)"
         label curr2 "PMIC-3 ASIC VCORE_T0_3 Rail Curr (out1)"
@@ -69,13 +69,13 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
     chip "mp2975-i2c-*-6a"
         label in1 "PMIC-4 PSU 12V Rail (in)"
         label in2 "PMIC-4 ASIC VCORE_T4_7 Rail (out1)"
-        label in3 "PMIC-3 ASIC 1.8V_T4_7 Rail (out2)"
+        label in3 "PMIC-4 ASIC 1.8V_T4_7 Rail (out2)"
         ignore in4
         label temp1 "PMIC-4 ASIC VCORE_1.8V_T4_7 Temp 1"
         ignore temp2
         label power1 "PMIC-4 12V ASIC VCORE_1.8V_T4_7 Rail Pwr (in) "
-        label power2 "PMIC-4 ASIC VCORE_T4_7 Rail Pwr (out)"
-        ignore power3
+        label power2 "PMIC-4 ASIC VCORE_T4_7 Rail Pwr (out1)"
+        label power3 "PMIC-4 ASIC 1.8V_T4_7 Rail Pwr (out2)"
         ignore power4 
         label curr1 "PMIC-4 12V ASIC VCORE_1.8V_T4_7 Rail Curr (in)"
         label curr2 "PMIC-4 ASIC VCORE_T4_7 Rail Curr (out1)"
@@ -90,8 +90,8 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
         label temp1 "PMIC-5 ASIC 1.2V_T0_3_T4_7 Temp 1"
         ignore temp2
         label power1 "PMIC-5 12V ASIC 1.2V_T0_3_T4_7 Rail Pwr (in)"
-        label power2 "PMIC-5 ASIC 1.2V_T0_3 Rail Pwr (out)"
-        ignore power3
+        label power2 "PMIC-5 ASIC 1.2V_T0_3 Rail Pwr (out1)"
+        label power3 "PMIC-5 ASIC 1.2V_T4_7 Rail Pwr (out2)"
         ignore power4
         label curr1 "PMIC-5 12V ASIC 1.2V_T0_3_T4_7 Rail Curr (in)"
         label curr2 "PMIC-5 ASIC 1.2V_T0_3 Rail Curr (out1)"


### PR DESCRIPTION
Update sensors labels for msn4600 voltmon sensors located at
addresses 0x64, 0x66, 0x6a, 0x6e.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
