### PR TITLE
hw-mgmt: patches: v4.19: mlx-platform: Add support for new system XH3000

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0154-platform-x86-mlx-platform-Add-support-for-new-system.patch
+++ b/recipes-kernel/linux/linux-4.19/0154-platform-x86-mlx-platform-Add-support-for-new-system.patch
@@ -1,0 +1,96 @@
+From 692a0dbcbb7ecbfa87936935f2136f4971c27c3b Mon Sep 17 00:00:00 2001
+From: Felix Radensky <fradensky@nvidia.com>
+Date: Sun, 24 Oct 2021 16:26:40 +0000
+Subject: [PATCH] platform/x86: mlx-platform: Add support for new system XH3000
+
+Add support for new system type XH3000, which is a water cooling
+Ethernet switch blade equipped with 32x200G Ethernet ports.
+
+The system is recognized by "DMI_BOARD_NAME" and "DMI_PRODUCT_SKU" matches,
+when these fields are set to "VMOD0005" and "HI139" respectively.
+
+Signed-off-by: Felix Radensky <fradensky@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 51 +++++++++++++++++++++++++++++
+ 1 file changed, 51 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 149a2e9e9..9e1d078bb 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -2271,6 +2271,25 @@ static struct mlxreg_core_platform_data mlxplat_default_led_wc_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_led_wc_data),
+ };
+ 
++/* Platform led default data for water cooling Ethernet switch blade */
++static struct mlxreg_core_data mlxplat_mlxcpld_default_led_eth_wc_blade_data[] = {
++	{
++		.label = "status:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "status:red",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_default_led_eth_wc_blade_data = {
++	.data = mlxplat_mlxcpld_default_led_eth_wc_blade_data,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_led_eth_wc_blade_data),
++};
++
+ /* Platform led MSN21xx system family data */
+ static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_led_data[] = {
+ 	{
+@@ -4827,6 +4846,31 @@ static int __init mlxplat_dmi_default_wc_matched(const struct dmi_system_id *dmi
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_default_eth_wc_blade_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	for (i = 0; i < mlxplat_mux_num; i++) {
++		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
++		mlxplat_mux_data[i].n_values =
++				ARRAY_SIZE(mlxplat_msn21xx_channels);
++	}
++	mlxplat_hotplug = &mlxplat_mlxcpld_default_wc_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_default_led_eth_wc_blade_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng;
++
++	return 1;
++}
++
+ static int __init mlxplat_dmi_msn21xx_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+@@ -5054,6 +5098,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_PRODUCT_NAME, "MQM8700"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_default_eth_wc_blade_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0005"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI139"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_qmb7xx_matched,
+ 		.matches = {
+-- 
+2.20.1
+


### PR DESCRIPTION
Add support for new system type XH3000, which is a water cooling
Ethernet switch blade equipped with 32x200G Ethernet ports.

The system is recognized by "DMI_BOARD_NAME" and "DMI_PRODUCT_SKU" matches,
when these fields are set to "VMOD0005" and "HI139" respectively.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>
