### PR TITLE
hw-mgmt: attributes: Fix PSU power sensor attributes capability

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -119,6 +119,7 @@ psu_connect_power_sensor()
 	if [ -f "$sysfs_sensor_path"_input ];
 	then
 		ln -sf "$sysfs_sensor_path"_input "$power_path"/"$sensor_name"
+		touch "$power_path"/"$sensor_name"_capability
 		for attr_name in ${psu_sensor_attr_list[*]}
 		do
 			sysfs_sensor_attr_path="$sysfs_sensor_path"_$attr_name


### PR DESCRIPTION
Fix PSU power sensor attributes capability crating. Add empty capability file crating
even if sensor haven't additional attributes.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
