### PR TITLE
hw-mgmt: attributes: Fix cpld3 version reading on spc1 systems

### DIFF
--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -114,7 +114,8 @@ then
                 mst start  >/dev/null 2>&1
                 sleep 2
             fi
-            cmd='mlxreg --reg_name MSCI  -d /dev/mst/mt52100_pciconf0 -g -i "index=2" | grep version | cut -d "|" -f2'
+            mt_dev=$(find /dev/mst -name *00_pciconf0)
+            cmd='mlxreg --reg_name MSCI  -d $mt_dev -g -i "index=2" | grep version | cut -d "|" -f2'
             ver_hex=$(eval $cmd)
             if [ ! -z "$ver_hex" ]; then
                ver_dec=$(printf "%d" $ver_hex)


### PR DESCRIPTION
Fix cpld3 version reading on spc1 systems

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
