### PR TITLE
hw-mgmt: thermal: Add sanity check for ASIC temperature

### DIFF
--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -85,6 +85,7 @@ tz_temp=$thermal_path/mlxsw/thermal_zone_temp
 temp_trip_norm=$thermal_path/mlxsw/temp_trip_norm
 temp_trip_high=$thermal_path/mlxsw/temp_trip_high
 cooling_cur_state=$thermal_path/cooling_cur_state
+cooling_max_state=$thermal_path/cooling_max_state
 wait_for_config=120
 
 # Input parameters for the system thermal class, the number of tachometers, the
@@ -1254,6 +1255,19 @@ if [ -z "$thermal_delay" ]; then
 	wait $!
 fi
 
+asic_hot_vs_cooling_sanity()
+{
+	trip=$(< /var/run/hw-management/thermal/mlxsw/temp_trip_hot)
+	trip=$((trip+temp_tz_hyst))
+	temp_now=$(< $tz_temp)
+	cooling=$(< $cooling_cur_state)
+	cooling_max=$(< $cooling_max_state)
+	if [ "$temp_now" -gt "$trip" ] && [ "$cooling" -lt "$cooling_max" ]; then
+		log_info "FAN speed level is changed from $cooling to $cooling_max, because ASIC temparture $temp_now"
+		echo "$cooling_max" > $cooling_cur_state
+	fi
+}
+
 init_service_params()
 {
 	if [ -f $config_path/thermal_type ]; then
@@ -1372,6 +1386,8 @@ do
 	if [ $? -ne 0 ]; then
 		continue
 	fi
+	# Perform sanity check for ASI temparture versus fan speed.
+	asic_hot_vs_cooling_sanity
 	# Set PWM minimal limit.
 	# Set dynamic FAN speed minimum, depending on ambient temperature,
 	# presence of untrusted optical cables or presence of any cables

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -362,19 +362,23 @@ if [ "$1" == "add" ]; then
 		   [ "$coolingtype" == "mlxreg_fan" ] ||
 		   [ "$coolingtype" == "mlxreg_fan0" ] ||
 		   [ "$coolingtype" == "emc2305" ]; then
-			ln -sf "$3""$4"/cur_state $thermal_path/cooling_cur_state
+			check_n_link "$3""$4"/cur_state $thermal_path/cooling_cur_state
+			check_n_link "$3""$4"/max_state $thermal_path/cooling_max_state
 			# Set FAN to full speed until thermal control is started.
 			echo $fan_full_speed_code > $thermal_path/cooling_cur_state
 			log_info "FAN speed is set to full speed"
 		fi
 		if [ "$coolingtype" == "mlxreg_fan1" ]; then
-			ln -sf "$3""$4"/cur_state $thermal_path/cooling1_cur_state
+			check_n_link "$3""$4"/cur_state $thermal_path/cooling1_cur_state
+			check_n_link "$3""$4"/max_state $thermal_path/cooling1_max_state
 		fi
 		if [ "$coolingtype" == "mlxreg_fan2" ]; then
-			ln -sf "$3""$4"/cur_state $thermal_path/cooling2_cur_state
+			check_n_link "$3""$4"/cur_state $thermal_path/cooling2_cur_state
+			check_n_link "$3""$4"/max_state $thermal_path/cooling2_max_state
 		fi
 		if [ "$coolingtype" == "mlxreg_fan3" ]; then
-			ln -sf "$3""$4"/cur_state $thermal_path/cooling3_cur_state
+			check_n_link "$3""$4"/cur_state $thermal_path/cooling3_cur_state
+			check_n_link "$3""$4"/max_state $thermal_path/cooling3_max_state
 		fi
 	fi
 	if [ "$2" == "hotplug" ]; then
@@ -870,9 +874,13 @@ else
 	fi
 	if [ "$2" == "cooling_device" ]; then
 		check_n_unlink $thermal_path/cooling_cur_state
+		check_n_unlink $thermal_path/cooling_max_state
 		check_n_unlink $thermal_path/cooling1_cur_state
+		check_n_unlink $thermal_path/cooling1_max_state
 		check_n_unlink $thermal_path/cooling2_cur_state
+		check_n_unlink $thermal_path/cooling2_max_state
 		check_n_unlink $thermal_path/cooling3_cur_state
+		check_n_unlink $thermal_path/cooling3_max_state
 	fi
 	if [ "$2" == "hotplug" ]; then
 		for ((i=1; i<=max_tachos; i+=1)); do


### PR DESCRIPTION
In some marginal cases ASIC temperature can grow up too fast.
Along with it at this time user space thermal loop could decrease fan
speed according to dynamic minimum value. If it happens at the
beginning of ASIC warming up trend, it can cause kernel's cooling
control algorithm stacking in dormant state, in which kernel will stop
fan cooling level increasing. It is extremely rare scenario, but it
worth to add protection against it.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
