### PR TITLE
hw-mgmt: scripts: limit max_pwm=1 and max_tachos=4 on SN2201

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.1243) unstable; urgency=low
+hw-management (1.mlnx.7.0020.1244) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 08 Dec 2021 12:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Mon, 13 Dec 2021 12:22:00 +0300
 

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -54,6 +54,8 @@ fan_full_speed_code=20
 if [ "$board_type" == "VMOD0014" ]; then
 	i2c_bus_max=14
 	i2c_asic_bus_default=6
+	max_tachos=4
+	max_pwm=1
 fi
 
 # Get line card number by module 'sysfs' device path


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
