### PR TITLE
hw-mgmt: rules: Add generic rule for netdevice renaming

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -436,6 +436,7 @@ SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="add", RUN+="/usr/bin/hw-man
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm watchdog %S %p"
 
 # QSFP
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", NAME="sf$attr{phys_port_name}"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:01", KERNEL=="eth*", NAME="sfp1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:02", KERNEL=="eth*", NAME="sfp2"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:03", KERNEL=="eth*", NAME="sfp3"


### PR DESCRIPTION
Add generic rule for netdevice. This rule is supposed to work
with kernel 5.10, becasue driver has support for devlink
callback, which activates newly added rule.
Old and new rules should not impact each other.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
