### PR TITLE
hw-mgmt: kernel pacthes: 4.19: Modify patch #0134

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0134-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch
+++ b/recipes-kernel/linux/linux-4.19/0134-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch
@@ -109,7 +109,7 @@ index 943cb09e8583..6cb55db67be4 100644
 -		/* Return non-zero value in case only configuration is perfromed through sysfs. */
  		if (state < cur_state)
 -			return 1;
-+			return config;
++			return 0;
  
  		state = cur_state;
  	}
@@ -119,7 +119,7 @@ index 943cb09e8583..6cb55db67be4 100644
  	}
 -	/* Return non-zero value if current state has been enforced through sysfs. */
 -	return (config) ? 1 : 0;
-+	return config;
++	return 0;
  }
  
  static const struct thermal_cooling_device_ops mlxreg_fan_cooling_ops = {


### PR DESCRIPTION
Patch #0134 is modifed due to following issue.
When current cooling level is set from user space to 10 + 'n' for
configuration purpose, due to return of non-zero value, this request
is retried by user space and it is resulted in the below flow:

cat /var/run/hw-management/thermal/cooling_cur_state
8
echo 16 > /var/run/hw-management/thermal/cooling_cur_state
cat /var/run/hw-management/thermal/cooling_cur_state
6

While 16 should just set limit and not change level from 8 to 6.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
