### PR TITLE
hw-mgmt: patches: 5.10: Align ethtool UAPI interface with upstream

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0076-ethtool-Add-ability-to-control-transceiver-modules-p.patch
+++ b/recipes-kernel/linux/linux-5.10/0076-ethtool-Add-ability-to-control-transceiver-modules-p.patch
@@ -1,7 +1,7 @@
-From 55b0a12e873355cd3c077a2ba38c23474317fdf1 Mon Sep 17 00:00:00 2001
+From 271dea76c3adc818b642ec24de3e7fe8cc1076a1 Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@nvidia.com>
 Date: Wed, 21 Jul 2021 17:05:31 +0300
-Subject: [PATCH backport v.4.19 09/13] ethtool: Add ability to control
+Subject: [PATCH backport for v5.10 76/97] ethtool: Add ability to control
  transceiver modules' power mode
 
 Add a pair of new ethtool messages, 'ETHTOOL_MSG_MODULE_SET' and
@@ -254,13 +254,13 @@ Signed-off-by: Ido Schimmel <idosch@nvidia.com>
 ---
  Documentation/networking/ethtool-netlink.rst |  71 ++++++-
  include/linux/ethtool.h                      |  22 +++
- include/uapi/linux/ethtool.h                 |  23 +++
+ include/uapi/linux/ethtool.h                 |  28 +++
  include/uapi/linux/ethtool_netlink.h         |  22 +++
  net/ethtool/Makefile                         |   2 +-
  net/ethtool/module.c                         | 184 +++++++++++++++++++
  net/ethtool/netlink.c                        |  19 ++
  net/ethtool/netlink.h                        |   4 +
- 8 files changed, 344 insertions(+), 3 deletions(-)
+ 8 files changed, 349 insertions(+), 3 deletions(-)
  create mode 100644 net/ethtool/module.c
 
 diff --git a/Documentation/networking/ethtool-netlink.rst b/Documentation/networking/ethtool-netlink.rst
@@ -426,10 +426,22 @@ index f59504cdbe4a..2b2c65f7e753 100644
  
  int ethtool_check_ops(const struct ethtool_ops *ops);
 diff --git a/include/uapi/linux/ethtool.h b/include/uapi/linux/ethtool.h
-index cde753bb2093..ffcbc3df4ab1 100644
+index cde753bb2093..7a799291514b 100644
 --- a/include/uapi/linux/ethtool.h
 +++ b/include/uapi/linux/ethtool.h
-@@ -693,6 +693,29 @@ enum ethtool_stringset {
+@@ -649,6 +649,11 @@ enum ethtool_link_ext_substate_cable_issue {
+ 	ETHTOOL_LINK_EXT_SUBSTATE_CI_CABLE_TEST_FAILURE,
+ };
+ 
++/* More information in addition to ETHTOOL_LINK_EXT_STATE_MODULE. */
++enum ethtool_link_ext_substate_module {
++	ETHTOOL_LINK_EXT_SUBSTATE_MODULE_CMIS_NOT_READY = 1,
++};
++
+ #define ETH_GSTRING_LEN		32
+ 
+ /**
+@@ -693,6 +698,29 @@ enum ethtool_stringset {
  	ETH_SS_COUNT
  };
  
@@ -442,7 +454,7 @@ index cde753bb2093..ffcbc3df4ab1 100644
 + *	administratively down.
 + */
 +enum ethtool_module_power_mode_policy {
-+	ETHTOOL_MODULE_POWER_MODE_POLICY_HIGH,
++	ETHTOOL_MODULE_POWER_MODE_POLICY_HIGH = 1,
 +	ETHTOOL_MODULE_POWER_MODE_POLICY_AUTO,
 +};
 +

--- a/recipes-kernel/linux/linux-5.10/0080-ethtool-Add-transceiver-module-extended-states.patch
+++ b/recipes-kernel/linux/linux-5.10/0080-ethtool-Add-transceiver-module-extended-states.patch
@@ -1,7 +1,7 @@
-From 27cf01593498fca71f3eb9c896931c57bb339495 Mon Sep 17 00:00:00 2001
+From b9608ecd90edc2da45a38ec20e67f92643053a49 Mon Sep 17 00:00:00 2001
 From: Ido Schimmel <idosch@nvidia.com>
 Date: Wed, 18 Aug 2021 10:13:47 +0300
-Subject: [PATCH backport v.4.19 13/13] ethtool: Add transceiver module
+Subject: [PATCH backport for v5.10 80/97] ethtool: Add transceiver module
  extended states
 
 Add an extended state and two extended sub-states to describe link
@@ -30,8 +30,8 @@ Signed-off-by: Ido Schimmel <idosch@nvidia.com>
 ---
  Documentation/networking/ethtool-netlink.rst | 12 ++++++++++++
  include/linux/ethtool.h                      |  1 +
- include/uapi/linux/ethtool.h                 |  7 +++++++
- 3 files changed, 20 insertions(+)
+ include/uapi/linux/ethtool.h                 |  1 +
+ 3 files changed, 14 insertions(+)
 
 diff --git a/Documentation/networking/ethtool-netlink.rst b/Documentation/networking/ethtool-netlink.rst
 index 9de7c5a4baef..9403a0f7e52a 100644
@@ -76,7 +76,7 @@ index 2b2c65f7e753..e43e864404ad 100644
  	};
  };
 diff --git a/include/uapi/linux/ethtool.h b/include/uapi/linux/ethtool.h
-index ffcbc3df4ab1..d47883810114 100644
+index 7a799291514b..1a58c194b215 100644
 --- a/include/uapi/linux/ethtool.h
 +++ b/include/uapi/linux/ethtool.h
 @@ -593,6 +593,7 @@ enum ethtool_link_ext_state {
@@ -85,19 +85,6 @@ index ffcbc3df4ab1..d47883810114 100644
  	ETHTOOL_LINK_EXT_STATE_OVERHEAT,
 +	ETHTOOL_LINK_EXT_STATE_MODULE,
  };
- 
- /**
-@@ -649,6 +650,12 @@ enum ethtool_link_ext_substate_cable_issue {
- 	ETHTOOL_LINK_EXT_SUBSTATE_CI_CABLE_TEST_FAILURE,
- };
- 
-+/* More information in addition to ETHTOOL_LINK_EXT_STATE_MODULE. */
-+enum ethtool_link_ext_substate_module {
-+	ETHTOOL_LINK_EXT_SUBSTATE_MODULE_LOW_POWER_MODE = 1,
-+	ETHTOOL_LINK_EXT_SUBSTATE_MODULE_CMIS_NOT_READY,
-+};
-+
- #define ETH_GSTRING_LEN		32
  
  /**
 -- 


### PR DESCRIPTION
Update patches #0076 and #0080 to match upstream.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
