### PR TITLE
hw-mgmt: modules-load: Fix driver name

### DIFF
--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -16,7 +16,7 @@ mp2975
 mp2888
 i2c-mux-pca954x
 emc2305
-ads1015
+ti-ads1015
 powr1220
 gpio-pca953x
 pmbus


### PR DESCRIPTION
Change name 'ads1015' to 'ti-ads1015".

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
