### PR TITLE
hw-mgmt: psu fw update tool: Simpify FW version reporting output

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -660,18 +660,12 @@ if [ "$1" == "add" ]; then
 		# PSU FW VER
 		mfr=$(grep MFR_NAME $eeprom_path/"$2"_vpd | awk '{print $2}')
 		if echo $mfr | grep -iq "Murata"; then
-			ps_ver=$(hw_management_psu_fw_update_murata.py -b $bus -a $psu_addr -v |
-				grep PSU | awk '{print $3}' | awk -F: '{print $2}')
-			echo $ps_ver > $fw_path/"$2"_fw
-			ps_ver=$(hw_management_psu_fw_update_murata.py -P -b $bus -a $psu_addr -v |
-				grep PSU | awk '{print $3}' | awk -F: '{print $2}')
-			echo $ps_ver > $fw_path/"$2"_fw_primary
+			hw_management_psu_fw_update_murata.py -v -b $bus -a $psu_addr > $fw_path/"$2"_fw
+			hw_management_psu_fw_update_murata.py -v -b $bus -a $psu_addr -P > $fw_path/"$2"_fw_primary
 		elif echo $mfr | grep -iq "Delta"; then
 			# Skip SN2201, FW update is not supported on this system
 			if [ "$board_type" != "VMOD0014" ]; then
-				ps_ver=$(hw_management_psu_fw_update_delta.py -b $bus -a $psu_addr -v |
-					grep PSU | awk '{print $3}' | awk -F: '{print $2}')
-				echo $ps_ver > $fw_path/"$2"_fw
+				hw_management_psu_fw_update_delta.py -v -b $bus -a $psu_addr > $fw_path/"$2"_fw
 			fi
 		fi
 

--- a/usr/usr/bin/hw_management_psu_fw_update_delta.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_delta.py
@@ -239,9 +239,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.version:
-        print("Delta FW update tool version:{}".format(TOOL_VERSION))
         fw_rev = read_mfr_fw_revision(args.i2c_bus, args.i2c_addr)
-        print("PSU FW version:{} (BUS:{}, Addr:{})".format(fw_rev, args.i2c_bus, args.i2c_addr))
+        print(fw_rev)
         exit(0)
 
     if not vars(args)['input_file']:

--- a/usr/usr/bin/hw_management_psu_fw_update_murata.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_murata.py
@@ -379,12 +379,8 @@ if __name__ == '__main__':
     # bootloader_status(i2c_bus, i2c_adr)
     # burn_fw_file(i2c_bus, i2c_addr)
     if args.version:
-        print("Murrata FW update tool version:{}".format(TOOL_VERSION))
         fw_rev = read_murata_fw_revision(args.i2c_bus, args.i2c_addr, args.primary)
-        print("PSU FW version:{} (BUS:{}, Addr:{}, primary:{})".format(fw_rev,
-                                                                       args.i2c_bus, 
-                                                                       args.i2c_addr,
-                                                                       args.primary))
+        print(fw_rev)
         exit(0)
 
     if args.reset_and_exit:


### PR DESCRIPTION
Report only PSU FW version. Remove reporting of tool version, bus,
address and MCU type to make the output easier to read and parse.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>