### PR TITLE
hw-mgmt: attributes: Support PSU FW update only for specific PSU capa…

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -659,12 +659,19 @@ if [ "$1" == "add" ]; then
 
 		# PSU FW VER
 		mfr=$(grep MFR_NAME $eeprom_path/"$2"_vpd | awk '{print $2}')
+		cap=$(grep CAPACITY $eeprom_path/"$2"_vpd | awk '{print $2}')
 		if echo $mfr | grep -iq "Murata"; then
-			hw_management_psu_fw_update_murata.py -v -b $bus -a $psu_addr > $fw_path/"$2"_fw
-			hw_management_psu_fw_update_murata.py -v -b $bus -a $psu_addr -P > $fw_path/"$2"_fw_primary
+			# Support FW update only for specific Murata PSU capacities
+			if [ "$cap" == "1500" -o "$cap" == "2000" ]; then
+				hw_management_psu_fw_update_murata.py -v -b $bus -a $psu_addr > $fw_path/"$2"_fw
+				hw_management_psu_fw_update_murata.py -v -b $bus -a $psu_addr -P > $fw_path/"$2"_fw_primary
+			fi
 		elif echo $mfr | grep -iq "Delta"; then
 			# Skip SN2201, FW update is not supported on this system
-			if [ "$board_type" != "VMOD0014" ]; then
+			if [ "$board_type" == "VMOD0014" ]; then
+				true
+			# Support FW update only for specific Delta PSU capacities
+			elif [ "$cap" == "550" ]; then
 				hw_management_psu_fw_update_delta.py -v -b $bus -a $psu_addr > $fw_path/"$2"_fw
 			fi
 		fi


### PR DESCRIPTION
…cities

Restrict PSU FW update to Delta 550 and Murata 1500/2000 PSUs.
In the future the list of supported PSU vendors and capacities
may be extended.