### PR TITLE
hw-mgmt: psu fw update tool: Allow skipping PSU redundancy check

### DIFF
--- a/usr/usr/bin/hw_management_psu_fw_update_delta.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_delta.py
@@ -234,6 +234,8 @@ if __name__ == '__main__':
     parser.add_argument('-i', "--input_file", required=False)
     required.add_argument('-b', "--i2c_bus", type=int, default=0, required=True)
     required.add_argument('-a', "--i2c_addr", type=lambda x: int(x, 0), default=0, required=True)
+    parser.add_argument('-S', "--skip_redundancy_check", type=bool, nargs='?',
+                        const=True, default=False)
     required.add_argument('-v', "--version", type=bool, nargs='?',
                         const=True, default=False)
     args = parser.parse_args()
@@ -251,6 +253,7 @@ if __name__ == '__main__':
     psu_upd_cmn.pmbus_read_mfr_model(args.i2c_bus, args.i2c_addr)
     psu_upd_cmn.pmbus_read_mfr_revision(args.i2c_bus, args.i2c_addr)
 
-    psu_upd_cmn.check_psu_redundancy(False, args.i2c_addr)
+    if not args.skip_redundancy_check:
+        psu_upd_cmn.check_psu_redundancy(False, args.i2c_addr)
 
     update_delta(args.i2c_bus, args.i2c_addr, args.input_file)

--- a/usr/usr/bin/hw_management_psu_fw_update_murata.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_murata.py
@@ -309,6 +309,10 @@ def murata_update(i2c_bus, i2c_addr, continue_update, fw_filename, primary):
         print("checksum test fails, the target microcontroller remains in BOOTLOAD Mode")
         exit(1)
 
+    if args.skip_redundancy_check:
+         print("Not checking FW version after update. Use -v option after power cycle.")
+         exit(0)
+
     # 11. Repeat steps 1-9 to upgrade remaining microcontrollers.
     # Now we updating only secondary, so nothing todo here.
     # 12. Upgrading is complete, send the POWER_SUPPLY_RESET command.


### PR DESCRIPTION
Add -S command line parameter to support skipping PSU redundancy check.
This makes it possible to update PSU FW on systems with a single active
PSU. This option already exists for Murata PSUs and is used for primary
and secondary FW update. Add it for Delta PSUs as well.

With PSU redundancy check disabled, Murata script will not perform PSU
reset after FW update, as this will cause power cycle on systems with
single active PSU.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>