### PR TITLE
hw-mgmt: thermal events: Fix symbolic link creation for gearboxes

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -264,11 +264,12 @@ if [ "$1" == "add" ]; then
 						*gear*)
 							lock_service_state_change
 							change_file_counter "$cpath"/gearbox_counter 1
+							gearbox_counter=`cat "$cpath"/gearbox_counter`
 							if [ "$lcmatch" == "linecard" ]; then
 								change_file_counter "$config_path"/gearbox_counter 1
 							fi
-							unlock_service_state_change
 							ln -sf "$3""$4"/temp"$i"_input "$tpath"/gearbox"$gearbox_counter"_temp_input
+							unlock_service_state_change
 							;;
 						*)
 							;;


### PR DESCRIPTION
Fix broken index for gearbox temprature symbolic link.
Read this index from gearbox counter.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
