### PR TITLE
hw-mgmt: events: Extend validation of SDK presence

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -464,7 +464,7 @@ if [ "$1" == "add" ]; then
 		if [ ! -d /sys/module/mlxsw_minimal ]; then
 			modprobe mlxsw_minimal
 		fi
-		if [ ! -f /etc/init.d/sxdkernel ]; then
+		if [ ! -f /etc/init.d/sxdkernel ] && [ ! -f /usr/lib/cumulus/sxdkernel ]; then
 			sleep 3
 			/usr/bin/hw-management.sh chipup
 		fi
@@ -696,7 +696,7 @@ elif [ "$1" == "change" ]; then
 			if [ ! -d /sys/module/mlxsw_minimal ]; then
 				modprobe mlxsw_minimal
 			fi
-			if [ ! -f /etc/init.d/sxdkernel ]; then
+			if [ ! -f /etc/init.d/sxdkernel ] && [ ! -f /usr/lib/cumulus/sxdkernel ]; then
 				sleep 3
 				/usr/bin/hw-management.sh chipup
 			fi
@@ -708,7 +708,7 @@ elif [ "$1" == "change" ]; then
 				asic_health=$(< "$4""$5"/asic1)
 			fi
 			if [ "$asic_health" -eq 2 ]; then
-				if [ ! -f /etc/init.d/sxdkernel ]; then
+				if [ ! -f /etc/init.d/sxdkernel ] && [ ! -f /usr/lib/cumulus/sxdkernel ]; then
 					sleep 3
 					/usr/bin/hw-management.sh chipup
 				fi


### PR DESCRIPTION
There are two different triggers to activate mlxsw_minimal driver:
If SDK is installed activations is trigerred by SDK udev event.
Otherwise by ASIC health event.

Extend criteria for SDK presence detection.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
