### PR TITLE
hw-mgmt: kernel 5.10: change patch 0089 of nvsw-sn2201 driver.

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -744,6 +744,12 @@ index 000000000..06a257ee1
 +		.mode = 0644,
 +	},
 +	{
++		.label = "pwr_cycle",
++		.reg = NVSW_SN2201_PSU_CTRL_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0644,
++	},
++	{
 +		.label = "asic_health",
 +		.reg = NVSW_SN2201_SYS_STATUS_OFFSET,
 +		.mask = GENMASK(4, 3),
@@ -765,12 +771,6 @@ index 000000000..06a257ee1
 +	{
 +		.label = "mac_reset",
 +		.reg = NVSW_SN2201_SYS_RST_STATUS_OFFSET,
-+		.mask = GENMASK(7, 0) & ~BIT(2),
-+		.mode = 0644,
-+	},
-+	{
-+		.label = "pwr_cycle",
-+		.reg = NVSW_SN2201_RST_SW_CTRL_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0644,
 +	},
@@ -1289,6 +1289,5 @@ index 000000000..06a257ee1
 +MODULE_DESCRIPTION("Nvidia sn2201 platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:nvsw-sn2201");
--- 
+--
 2.20.1
-


### PR DESCRIPTION
Fix power-cycle on SN2201.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
