### PR TITLE
hw-mgmt: infra: Add initial support NVIDIA HGX Vulcan Baseboard

### DIFF
--- a/usr/etc/hw-management-sensors/p2317_sensors.conf
+++ b/usr/etc/hw-management-sensors/p2317_sensors.conf
@@ -1,0 +1,45 @@
+##################################################################################
+# Copyright (c) 2020 - 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Platform specific sensors config for P2317
+##################################################################################
+
+
+# Temperature sensors
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Memory sensors
+bus "i2c-0" "SMBus I801 adapter at efa0"
+    chip "jc42-i2c-0-1c"
+        label temp1 "Ambient SODIMM Temp"
+
+    chip "jc42-i2c-0-1a"
+        label temp1 "Ambient SODIMM Temp"
+
+# NVME 
+nvme-pci-0600
+	label temp1 "Composite NVME Temp"
+        ignore temp2
+        ignore temp3
+
+# PCH
+pch_cannonlake-virtual-0
+	label temp1 "PCH Temp"
+
+# Power controllers
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "mp2975-i2c-*-6b"
+        label in1 "PMIC-6 PSU 12V Rail (vin)"
+        label in2 "PMIC-6 COMEX VCORE (out1)"
+        label in3 "PMIC-6 COMEX VCCSA (out2)"
+        label temp1 "PMIC-6 Temp"
+        label power1 "PMIC-6 COMEX Pwr (pin)"
+        label power2 "PMIC-6 COMEX Pwr (pout)"
+        label curr1 "PMIC-6 COMEX Curr (iin)"
+        label curr2 "PMIC-6 COMEX VCORE Rail Curr (out1)"
+        label curr3 "PMIC-6 COMEX VCCSA Rail Curr (out2)"
+
+
+

--- a/usr/usr/bin/hw-management-global-wp.sh
+++ b/usr/usr/bin/hw-management-global-wp.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+##################################################################################
+# Copyright (c) 2020 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+source hw-management-helpers.sh
+
+do_global_wp_release_restore()
+{
+	if [ ! -L "$system_path"/global_wp_request ] || [ ! -L "$system_path"/global_wp_response ]; then
+		return 1
+	fi
+	[ -f "$config_path"/global_wp_timeout ] && global_wp_timeout=$(< "$config_path"/global_wp_timeout);
+	[ -f "$config_path"/global_wp_wait_step ] && global_wp_wait_step=$(< "$config_path"/global_wp_wait_step);
+	if [ "$global_wp_wait_step" -gt 0 ] && [ "$global_wp_timeout" -gt 0 ]; then
+		case $1 in
+		release)
+			while [ "$global_wp_timeout" -gt 0 ]
+			do
+				# Request to disable Global Write Protection.
+				# Write Global Write Protection request.
+				echo 1 > "$system_path"/global_wp_request
+
+				# Validate if request to disable Global Write Protection was accepted.
+       	 			sleep 0.1 &
+       	 			wait $!
+
+				# Validate if request to disable Global Write Protection was accepted.
+				# Read Global Write Protection response.
+				global_wp_response=$(< "$system_path"/global_wp_response)
+				if [ "$global_wp_response" != 1 ]; then
+					global_wp_timeout=$((global_wp_timeout-global_wp_wait_step))
+					continue
+				fi
+
+				# Clear Global Write Protection request.
+				echo 0 > "$system_path"/global_wp_request
+				return 0
+			done
+			return 1
+		;;
+
+		restore)
+			# Clear Global Write Protection request.
+			echo 0 > "$system_path"/global_wp_request
+			return 0
+		;;
+		*)			
+			return 1
+		;;
+		esac
+	fi
+}
+
+__usage="
+Usage: $(basename "$0") [Options]
+
+Options:
+	release		Request to remove Global Write Protect to
+			to get grant for flashing of burnable component.
+	restore		Request to restore Global Write Protect after
+			device flashing is completed.
+"
+
+case $ACTION in
+release|restore)
+	lock_service_state_change
+	do_global_wp_release_restore "$ACTION"
+    	ret=$?
+	unlock_service_state_change
+	exit $ret
+	;;
+*)
+	echo "$__usage"
+	exit 1
+	;;
+esac
+exit 0
+

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -50,6 +50,10 @@
 #  SN38*|SN37*|SN34*|SN35*
 #  SN47*
 #  QM97*
+#  E3597
+#  SN2201
+#  XH3000
+#  P2317
 # Available options:
 # start	- load the kernel drivers required for chassis hardware management,
 #	  connect drivers to devices.
@@ -1083,6 +1087,15 @@ sn2201_specific()
 	lm_sensors_config="$lm_sensors_configs_path/sn2201_sensors.conf"
 }
 
+p2317_specific()
+{
+	echo 1 > "$config_path"/cpld_num
+	# Set time out for Global Write Protect in msec.
+	echo 2000 > "$config_path"/global_wp_timeout
+	echo 100 > "$config_path"/global_wp_wait_step
+	lm_sensors_config="$lm_sensors_configs_path/p2317_sensors.conf"
+}
+
 check_system()
 {
 	check_cpu_type
@@ -1118,6 +1131,9 @@ check_system()
 			;;
 		VMOD0014)
 			sn2201_specific
+			;;
+		VMOD0019)
+			p2317_specific
 			;;
 		*)
 			product=$(< /sys/devices/virtual/dmi/id/product_name)


### PR DESCRIPTION
Add basic infrastructure for new VMOD0019.
Add skeleton for global write protect.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
