### PR TITLE
hw-mgmt: patches: 5.10: platform: mellanox: Introduce support for NDR InfiniBand modular chassis

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,0 +1,135 @@
+From f2be62bb82ec85dce09ce2828778daffaf27b09a Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 27 Jan 2022 15:07:28 +0200
+Subject: [PATCH platform-next 4/4] platform: mellanox: Introduce support for
+ NDR InfiniBand modular chassis
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add support for MQM9510-N leaf and MQM9520-N spine blades for two
+flavors of NDR InfiniBand chassis:
+- MCS9500: 1,600Tb/s, 2048-port NDR InfiniBand chassis, which includes
+  32 leaves and 16 spines.
+- MCS9510: 800Tb/s, 1024-port NDR InfiniBand chassis, which includes
+  16 leaves and 8 spines.
+
+MQM9510-N leaf is Nvidia Mellanox® Quantum(TM) 2 NDR InfiniBand switch
+equipped with 64 NDR ports, 32 OSFP dual ports, Coffee Lake COMe
+module, 2 Quantum™ 2 NDR InfiniBand ASICs, 2 Power Supplies (AC) and
+with hybrid cooled (liquid and air), supporting non-blocking switching
+capacity of 2x25.6Tbps.
+MQM9520-N spine is Nvidia Mellanox® Quantum(TM) 2 NDR InfiniBand switch,
+equipped with 64 NDR ports, Coffee Lake COMe module, 2 Quantum™ 2 NDR
+InfiniBand ASICs, 2 Power Supplies (AC) and with hybrid cooled (liquid
+and air).
+
+Both leaf and spine switches are two rack unit height.
+
+New switches reuse configuration of board class "VMOD0010" with slight
+different I2C mux topology.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 64 +++++++++++++++++++++++++++++
+ 1 file changed, 64 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index b4809a6b5..be875acbc 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -239,6 +239,7 @@
+ #define MLXPLAT_CPLD_CH2_ETH_MODULAR		3
+ #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
+ #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
++#define MLXPLAT_CPLD_CH2_IB_MODULAR		18
+ 
+ /* Number of LPC attached MUX platform devices */
+ #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
+@@ -456,6 +457,34 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+ 	},
+ };
+ 
++/* Platform channels for ib modular system family */
++static const int mlxplat_ib_modular_channels[] = {
++	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
++};
++
++/* Platform IB modular mux data */
++static struct i2c_mux_reg_platform_data mlxplat_ib_modular_mux_data[] = {
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_ib_modular_channels,
++		.n_values = ARRAY_SIZE(mlxplat_ib_modular_channels),
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH2_IB_MODULAR,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.reg_size = 1,
++		.idle_in_use = 1,
++	},
++
++};
++
+ /* Platform hotplug devices */
+ static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
+ 	{
+@@ -5037,6 +5066,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_ib_modular_mux_data);
++	mlxplat_mux_data = mlxplat_ib_modular_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_ext_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_default_ng_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return 1;
++}
++
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+ 		.callback = mlxplat_dmi_default_wc_matched,
+@@ -5101,6 +5151,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0009"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_ndr_ib_modular_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI140"),
++		},
++	},
++	{
++		.callback = mlxplat_dmi_ndr_ib_modular_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_ng400_matched,
+ 		.matches = {
+-- 
+2.20.1
+


### PR DESCRIPTION
Add support for MQM9510-N leaf and MQM9520-N spine blades for two
flavors of NDR InfiniBand chassis:
- MCS9500: 1,600Tb/s, 2048-port NDR InfiniBand chassis, which includes
  32 leaves and 16 spines.
- MCS9510: 800Tb/s, 1024-port NDR InfiniBand chassis, which includes
  16 leaves and 8 spines.

MQM9510-N leaf is Nvidia MellanoxÂQuantum(TM) 2 NDR InfiniBand switch
equipped with 64 NDR ports, 32 OSFP dual ports, Coffee Lake COMe
module, 2 Quantum¢ 2 NDR InfiniBand ASICs, 2 Power Supplies (AC) and
with hybrid cooled (liquid and air), supporting non-blocking switching
capacity of 2x25.6Tbps.
MQM9520-N spine is Nvidia MellanoxÂQuantum(TM) 2 NDR InfiniBand switch,
equipped with 64 NDR ports, Coffee Lake COMe module, 2 Quantumâ2 NDR
InfiniBand ASICs, 2 Power Supplies (AC) and with hybrid cooled (liquid
and air).

Both leaf and spine switches are two rack unit height.

New switches reuse configuration of board class "VMOD0010" with slight
different I2C mux topology.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
