### PR TITLE
hw-mgmt: events: Fix syntax on linecard events creation

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1242,7 +1242,7 @@ create_event_files()
 	fi
 	if [ $hotplug_linecards -ne 0 ]; then
 		for ((i=1; i<=hotplug_linecards; i+=1)); do
-			touch $events_path/lc"$i"_prsnt
+			touch $events_path/lc"$i"_present
 			touch $events_path/lc"$i"_verified
 			touch $events_path/lc"$i"_powered
 			touch $events_path/lc"$i"_ready


### PR DESCRIPTION
Fix syntax on linecard events creation.
Changed name lc{N}_prsnt -> lc{N}_present

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>