### PR TITLE
hw-mgmt: kernel & udev: delete thermal sensor on SN2201

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -63,7 +63,7 @@ new file mode 100644
 index 000000000..1a2103778
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
-@@ -0,0 +1,1224 @@
+@@ -0,0 +1,1221 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia sn2201 driver
@@ -586,9 +586,6 @@ index 000000000..1a2103778
 +		I2C_BOARD_INFO("24c02", 0x57),
 +	},
 +	{
-+		I2C_BOARD_INFO("lm75", 0x4a),
-+	},
-+	{
 +		I2C_BOARD_INFO("lm75", 0x4b),
 +	},
 +	{
@@ -792,31 +789,31 @@ index 000000000..1a2103778
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_aux_pwr_or_ref",
++		.label = "reset_aux_pwr_or_fu",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_main_pwr_fail",
++		.label = "reset_dc_pwr_fail",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_sw_reset",
++		.label = "reset_sw",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(4),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_fw_reset",
++		.label = "reset_fw",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_hotswap_or_wd",
++		.label = "reset_wd",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0444,
@@ -1284,7 +1281,7 @@ index 000000000..1a2103778
 +
 +module_platform_driver(nvsw_sn2201_driver);
 +
-+MODULE_AUTHOR("Claud Chang <claud.chang@deltaww.com>");
++MODULE_AUTHOR("Nvidia");
 +MODULE_DESCRIPTION("Nvidia sn2201 platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:nvsw-sn2201");

--- a/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -64,7 +64,7 @@ new file mode 100644
 index 000000000..06a257ee1
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
-@@ -0,0 +1,1224 @@
+@@ -0,0 +1,1221 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia sn2201 driver
@@ -587,9 +587,6 @@ index 000000000..06a257ee1
 +		I2C_BOARD_INFO("24c02", 0x57),
 +	},
 +	{
-+		I2C_BOARD_INFO("lm75", 0x4a),
-+	},
-+	{
 +		I2C_BOARD_INFO("lm75", 0x4b),
 +	},
 +	{
@@ -793,31 +790,31 @@ index 000000000..06a257ee1
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_aux_pwr_or_ref",
++		.label = "reset_aux_pwr_or_fu",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_main_pwr_fail",
++		.label = "reset_dc_pwr_fail",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_sw_reset",
++		.label = "reset_sw",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(4),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_fw_reset",
++		.label = "reset_fw",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_hotswap_or_wd",
++		.label = "reset_wd",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0444,
@@ -1285,7 +1282,7 @@ index 000000000..06a257ee1
 +
 +module_platform_driver(nvsw_sn2201_driver);
 +
-+MODULE_AUTHOR("Claud Chang <claud.chang@deltaww.com>");
++MODULE_AUTHOR("Nvidia");
 +MODULE_DESCRIPTION("Nvidia sn2201 platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:nvsw-sn2201");

--- a/usr/etc/hw-management-sensors/sn2201_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn2201_sensors.conf
@@ -72,10 +72,6 @@ bus "i2c-2" "i2c-1-mux (chan_id 4)"
 	ignore temp49
 
 bus "i2c-2" "i2c-1-mux (chan_id 0)"
-    chip "lm75-i2c-*-4a"
-        label temp1 "Ambient Switch Board Temp"
-
-bus "i2c-2" "i2c-1-mux (chan_id 0)"
     chip "lm75-i2c-*-4b"
         label temp1 "Ambient Port side Temp"
 

--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -61,9 +61,6 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-7/*-0049/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add fan_amb %S %p"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-7/*-0049/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm fan_amb %S %p"
 
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-*/*-004a/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add swb_amb %S %p"
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-*/*-004a/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm swb_amb %S %p"
-
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-*/*-004b/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add port_amb %S %p"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-*/*-004b/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm port_amb %S %p"
 


### PR DESCRIPTION
Thermal sensor 0x4a will be removed on the final HW of SN2201
Changes are done in nvsw-sn2201 patches of kernel 4.19, 5.10, udev rules
and appropriate sensors.conf

Change names of several reset causes.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
