### PR TITLE
hw-mgmt: infra: Add support for mapping PCI to I2C ASIC bus

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -575,6 +575,6 @@ SUBSYSTEM=="net", ACTION=="move", DRIVERS=="mlxsw_minimal", RUN+="/usr/bin/hw-ma
 SUBSYSTEM=="i2c", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0048", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add cpld %S %p"
 SUBSYSTEM=="i2c", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0048", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm cpld %S %p"
 # SDK
-SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sxcore add"
-SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove"
-SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="offline", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove"
+SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sxcore add %S %p"
+SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove %S %p"
+SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="offline", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove %S %p"

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -70,6 +70,7 @@ thermal_type_full=100
 
 max_tachos=14
 i2c_asic_bus_default=2
+i2c_asic2_bus_default=3
 i2c_bus_max=10
 lc_i2c_bus_min=34
 lc_i2c_bus_max=43

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -685,7 +685,7 @@ if [ "$1" == "add" ]; then
 		if [ ! -d /sys/module/mlxsw_minimal ]; then
 			modprobe mlxsw_minimal
 		fi
-		/usr/bin/hw-management.sh chipup
+		/usr/bin/hw-management.sh chipup "$4/$5"
 	fi
 	if [ "$2" == "nvme_temp" ]; then
 		dev_name=$(cat "$3""$4"/name)
@@ -988,6 +988,6 @@ else
 		rm -f $eeprom_path/"$2"_vpd
 	fi
 	if [ "$2" == "sxcore" ]; then
-		/usr/bin/hw-management.sh chipdown
+		/usr/bin/hw-management.sh chipdown "$4/$5"
 	fi
 fi


### PR DESCRIPTION
Add dynamic mapping between PCIe and I2C ASIC busses.
Support only for new coming systems.

The following attributes will be available:
/var/run/hw-management/config/
	asic_num
	asic1_i2c_bus_id
	asic2_i2c_bus_id (for systems with two ASICs)
        asic1_pci_bus_id (for new systems)
	asic2_pci_bus_id (for new systems with two ASICs)

Signed-off-by: Vadim Pasternak <vadimp@nvdia.com>
