### PR TITLE
hw-mgmg: patches: 5.10: Update register map

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0157-mlx-platform-Add-support-for-systems-equipped-with-t.patch
+++ b/recipes-kernel/linux/linux-5.10/0157-mlx-platform-Add-support-for-systems-equipped-with-t.patch
@@ -1,7 +1,7 @@
-From 28d2de6e36639b2a0e07fda5c0e4437b7274552f Mon Sep 17 00:00:00 2001
+From aa04a34cfd8679f11622704dd50f854c7f96a4d8 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 26 Jan 2022 17:16:26 +0200
-Subject: [PATCH platform-next 1/2] mlx-platform: Add support for systems
+Subject: [PATCH platform-next 1/4] mlx-platform: Add support for systems
  equipped with two ASICs
 
 Motivation is to support new systems equipped with two ASICs.
@@ -14,11 +14,11 @@ Extend driver with:
 Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
 Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 45 ++++++++++++++++++++++++++++-
- 1 file changed, 44 insertions(+), 1 deletion(-)
+ drivers/platform/x86/mlx-platform.c | 52 ++++++++++++++++++++++++++++-
+ 1 file changed, 51 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index fac4b6dcf..8b3e5192e 100644
+index fac4b6dcf..68783c489 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -34,6 +34,7 @@
@@ -107,7 +107,21 @@ index fac4b6dcf..8b3e5192e 100644
  	{
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
-@@ -4254,6 +4289,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -3214,6 +3249,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = 1,
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "asic2_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "fan_dir",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION,
+@@ -4254,6 +4296,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
@@ -116,7 +130,7 @@ index fac4b6dcf..8b3e5192e 100644
  	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWR_EVENT_OFFSET:
-@@ -4346,6 +4383,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4346,6 +4390,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
@@ -126,7 +140,7 @@ index fac4b6dcf..8b3e5192e 100644
  	case MLXPLAT_CPLD_LPC_REG_PSU_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
-@@ -4473,6 +4513,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4473,6 +4520,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:

--- a/recipes-kernel/linux/linux-5.10/0158-platform-mellanox-Introduce-support-for-COMe-NVSwitc.patch
+++ b/recipes-kernel/linux/linux-5.10/0158-platform-mellanox-Introduce-support-for-COMe-NVSwitc.patch
@@ -1,7 +1,7 @@
-From 1ccf578fca0399c7787cbd82998633f7547ebe75 Mon Sep 17 00:00:00 2001
+From 7b689a778e93d94e808362b8342663b23ae4c063 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 26 Jan 2022 20:34:32 +0200
-Subject: [PATCH platform-next 2/2] platform: mellanox: Introduce support for
+Subject: [PATCH platform-next 2/4] platform: mellanox: Introduce support for
  COMe NVSwitch management module for Vulcan chassis
 
 The Vulcan is chassis containing Nvidia's Hopper dGPU (GH100), NVswitch
@@ -19,7 +19,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 31 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 8b3e5192e..750194921 100644
+index 68783c489..683f32a0c 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -3242,6 +3242,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
@@ -35,7 +35,7 @@ index 8b3e5192e..750194921 100644
  	{
  		.label = "asic_health",
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
-@@ -4942,6 +4948,25 @@ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
+@@ -4949,6 +4955,25 @@ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -61,7 +61,7 @@ index 8b3e5192e..750194921 100644
  static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -5037,6 +5062,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5044,6 +5069,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0011"),
  		},
  	},

--- a/recipes-kernel/linux/linux-5.10/0159-platform-x86-mlx-platform-Add-support-for-new-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0159-platform-x86-mlx-platform-Add-support-for-new-system.patch
@@ -1,7 +1,7 @@
-From 714e439b96a0aa350cf197f0b8050685b37942e8 Mon Sep 17 00:00:00 2001
+From 3ec991a1cf23be46d3268d5ee91e72f4f457d058 Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Sun, 24 Oct 2021 16:26:40 +0000
-Subject: [PATCH platform-next 3/3] platform/x86: mlx-platform: Add support for
+Subject: [PATCH platform-next 3/4] platform/x86: mlx-platform: Add support for
  new system XH3000
 
 Add support for new system type XH3000, which is a water cooling
@@ -17,7 +17,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 51 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 750194921..b4809a6b5 100644
+index 683f32a0c..13d2888d7 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -2226,6 +2226,25 @@ static struct mlxreg_core_platform_data mlxplat_default_led_wc_data = {
@@ -46,7 +46,7 @@ index 750194921..b4809a6b5 100644
  /* Platform led MSN21xx system family data */
  static struct mlxreg_core_data mlxplat_mlxcpld_msn21xx_led_data[] = {
  	{
-@@ -4786,6 +4805,31 @@ static int __init mlxplat_dmi_default_wc_matched(const struct dmi_system_id *dmi
+@@ -4793,6 +4812,31 @@ static int __init mlxplat_dmi_default_wc_matched(const struct dmi_system_id *dmi
  	return 1;
  }
  
@@ -78,7 +78,7 @@ index 750194921..b4809a6b5 100644
  static int __init mlxplat_dmi_msn21xx_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -5032,6 +5076,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5039,6 +5083,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_PRODUCT_NAME, "MQM8700"),
  		},
  	},

--- a/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,4 +1,4 @@
-From 749fa62eefbde783814252f6310911b51619209c Mon Sep 17 00:00:00 2001
+From 28232d1973607a4f3c73bdd9d1a377d3860151ba Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 27 Jan 2022 15:07:28 +0200
 Subject: [PATCH platform-next 4/4] platform: mellanox: Introduce support for
@@ -28,11 +28,11 @@ different I2C mux topology and extended LED and hotplug configuration.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 255 ++++++++++++++++++++++++++++
- 1 file changed, 255 insertions(+)
+ drivers/platform/x86/mlx-platform.c | 257 ++++++++++++++++++++++++++++
+ 1 file changed, 257 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index b4809a6b5..6472a9cca 100644
+index 13d2888d7..7079e1492 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -105,6 +105,9 @@
@@ -45,7 +45,15 @@ index b4809a6b5..6472a9cca 100644
  #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
-@@ -210,6 +213,7 @@
+@@ -198,6 +201,7 @@
+ 					 MLXPLAT_CPLD_AGGR_MASK_LC_SDWN)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2	BIT(2)
++#define MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK	BIT(4)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
+ #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
+@@ -210,6 +214,7 @@
  #define MLXPLAT_CPLD_LED_LO_NIBBLE_MASK	GENMASK(7, 4)
  #define MLXPLAT_CPLD_LED_HI_NIBBLE_MASK	GENMASK(3, 0)
  #define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
@@ -53,7 +61,7 @@ index b4809a6b5..6472a9cca 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -239,6 +243,7 @@
+@@ -239,6 +244,7 @@
  #define MLXPLAT_CPLD_CH2_ETH_MODULAR		3
  #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
  #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
@@ -61,7 +69,7 @@ index b4809a6b5..6472a9cca 100644
  
  /* Number of LPC attached MUX platform devices */
  #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
-@@ -456,6 +461,34 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+@@ -456,6 +462,34 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
  	},
  };
  
@@ -96,7 +104,7 @@ index b4809a6b5..6472a9cca 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -2128,6 +2161,85 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_modular_data = {
+@@ -2128,6 +2162,86 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_modular_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
@@ -176,13 +184,14 @@ index b4809a6b5..6472a9cca 100644
 +	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
 +	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
 +	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
-+	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2 |
++		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
 +};
 +
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -2657,6 +2769,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
+@@ -2657,6 +2771,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_led_data),
  };
  
@@ -289,7 +298,7 @@ index b4809a6b5..6472a9cca 100644
  /* Platform led data for QMB8700 system */
  static struct mlxreg_core_data mlxplat_mlxcpld_qmb8700_led_data[] = {
  	{
-@@ -4338,6 +4550,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4345,6 +4559,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -298,7 +307,7 @@ index b4809a6b5..6472a9cca 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4443,6 +4657,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4450,6 +4666,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -308,7 +317,7 @@ index b4809a6b5..6472a9cca 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4573,6 +4790,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4580,6 +4799,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -318,7 +327,7 @@ index b4809a6b5..6472a9cca 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
-@@ -5037,6 +5257,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+@@ -5044,6 +5266,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -346,7 +355,7 @@ index b4809a6b5..6472a9cca 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5101,6 +5342,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5108,6 +5351,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0009"),
  		},
  	},


### PR DESCRIPTION
Update register map in patch #0157.
Rebase follwing after patches: #0158 - #0160.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
