### PR TITLE
hw-mgmt: scripts: Fix FAN EEPROM insert/removal on SN2201. 		  Common i2c_bus_offset fix.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.1339) unstable; urgency=low
+hw-management (1.mlnx.7.0020.1340) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Thu, 10 Feb 2022 12:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 15 Feb 2022 12:22:00 +0300
 

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -398,30 +398,6 @@ function set_lc_fpga_combined_version()
 	echo "$str" > "$lc_path"/system/fpga
 }
 
-connect_device()
-{
-	local addr=$2
-	local bus=$3
-	if [ -f /sys/bus/i2c/devices/i2c-"$3"/new_device ]; then
-		if [ ! -d /sys/bus/i2c/devices/"$bus"-00"$addr" ] &&
-		   [ ! -d /sys/bus/i2c/devices/"$bus"-000"$addr" ]; then
-			echo "$1" "$addr" > /sys/bus/i2c/devices/i2c-"$bus"/new_device
-		fi
-	fi
-}
-
-disconnect_device()
-{
-	local addr=$2
-	local bus=$3
-	if [ -f /sys/bus/i2c/devices/i2c-"$2"/delete_device ]; then
-		if [ -d /sys/bus/i2c/devices/"$bus"-00"$addr" ] ||
-		   [ -d /sys/bus/i2c/devices/"$bus"-000"$addr" ]; then
-			echo "$1" > /sys/bus/i2c/devices/i2c-"$bus"/delete_device
-		fi
-	fi
-}
-
 function handle_hotplug_fan_event()
 {
 	local attribute=$1
@@ -455,7 +431,7 @@ function handle_hotplug_fan_event()
 		if [ "$event" -eq 1 ]; then
 			connect_device "$eeprom_type" "$addr" "$bus"
 		else
-			disconnect_device "$eeprom_type" "$addr" "$bus"
+			disconnect_device "$addr" "$bus"
 		fi
 		;;
 	*)


### PR DESCRIPTION
1. Use common helper function for connect/disconenct FAN EEPROMs on SN2201.
2. Fix common usage of i2c_bus_offset. New i2c_bus_offset attribute is added
   to hw-management config directory.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
