### PR TITLE
hw-mgmt: chassis events: Fix voltmon address conflict on connecting

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -470,16 +470,22 @@ function handle_hotplug_event()
 	esac
 }
 
+# Handle i2c bus add/remove.
+# If we have some devices which should be connected to this bus - do it.
+# $1 - i2c bus full address.
+# $2 - i2c bus action type add/remove.
 function handle_i2cbus_dev_action()
 {
 	i2c_busdev_path=$1
 	i2c_busdev_action=$2
 
-	if [ ! -f $config_path/i2c_bus_connect_devs ];
+	# Check if we have devices list which should be connected to dynamic i2c buses.
+	if [ ! -f $config_path/i2c_bus_connect_devices ];
 	then
 		return
 	fi
 
+	# Extract i2c bus index.
 	i2cbus_regex="i2c-([0-9]+)$"
 	[[ $i2c_busdev_path =~ $i2cbus_regex ]]
 	if [[ -z "${BASH_REMATCH[1]}" ]]; then
@@ -488,70 +494,70 @@ function handle_i2cbus_dev_action()
 		i2cbus="${BASH_REMATCH[1]}"
 	fi
 
-	# load i2c devices list which should be connected on demand
-	declare -a asic_i2c_bus_connect_table="($(< $config_path/i2c_bus_connect_devs))"
+	# Load i2c devices list which should be connected on demand..
+	declare -a dynamic_i2c_bus_connect_table="($(< $config_path/i2c_bus_connect_devices))"
 
-	# go over all devices and check if they should be connected to the current i2c bus
-	for ((i=0; i<${#asic_i2c_bus_connect_table[@]}; i+=4)); do
-		if [ $i2cbus == "${asic_i2c_bus_connect_table[i+2]}" ];
+	# Go over all devices and check if they should be connected to the current i2c bus.
+	for ((i=0; i<${#dynamic_i2c_bus_connect_table[@]}; i+=4)); do
+		if [ $i2cbus == "${dynamic_i2c_bus_connect_table[i+2]}" ];
 		then
 			if [ "$i2c_busdev_action" == "add" ]; then
-				connect_device "${asic_i2c_bus_connect_table[i]}" "${asic_i2c_bus_connect_table[i+1]}" \
-					"${asic_i2c_bus_connect_table[i+2]}"
+				connect_device "${dynamic_i2c_bus_connect_table[i]}" "${dynamic_i2c_bus_connect_table[i+1]}" \
+					"${dynamic_i2c_bus_connect_table[i+2]}"
 			elif [ "$i2c_busdev_action" == "remove" ]; then
-				diconnect_device "${asic_i2c_bus_connect_table[i]}" "${asic_i2c_bus_connect_table[i+1]}" \
-					"${asic_i2c_bus_connect_table[i+2]}"
+				diconnect_device "${dynamic_i2c_bus_connect_table[i]}" "${dynamic_i2c_bus_connect_table[i+1]}" \
+					"${dynamic_i2c_bus_connect_table[i+2]}"
 			fi
 		fi
 	done
 }
 
-# Get voltmon sensor prefix, like voltmon{id}.
-# For name voltmonX returning name based on $config_path/i2c_bus_connect_devs file
-# for other names - just return voltmon{id} string
-# $1 - voltmon name (voltmon1,voltmon2, voltmon10, voltmonX)
+# Get voltmon sensor name prefix, like voltmon{id}.
+# For name voltmonX returning name based on $config_path/i2c_bus_connect_devices file.
+# For other names - just return voltmon{id} string.
+# $1 - voltmon name (voltmon1, voltmon2, voltmon10, voltmonX)
 # $2 - path to sensor in sysfs
-
-# return sensor index if match is found or 0 if match not found
+# return sensor index if match is found or 0 if match not found.
 function get_i2c_voltmon_prefix()
 {
 	voltmon_name=$1
-	path=$2
-
-	# Check if we need to create voltmon name based on names in i2c_bus_connect_devs
-	if [ "$voltmon_name" != "voltmon_nameX" ];
+	i2c_busdev_path=$2
+	
+	# Check if we have devices list which can be connected with name translation.
+	if [  -f $config_path/i2c_bus_connect_devices ];
 	then
-		echo "$voltmon_name"
-		return
-	fi
-
-	if [ ! -f $config_path/i2c_bus_connect_devs ];
-	then
-		log_info "Can't find" "$config_path"/i2c_bus_connect_devs " database required for name assign for sensor" "$path"
-		echo "$voltmon_name"
-		return
-	fi
-
-	# load i2c devices list which should be connected on demand
-	declare -a asic_i2c_bus_connect_table="($(< $config_path/i2c_bus_connect_devs))"
-
-	i2caddr_regex="i2c-[0-9]+/([0-9]+)-00([a-zA-Z0-9]+)/"
-	[[ $i2c_busdev_path =~ $i2cbus_regex ]]
-	if [ "${#BASH_REMATCH[1]}" == 3 ]; then
-		echo "$voltmon_name"
-		return
-	else
-		i2cbus="${BASH_REMATCH[1]}"
-		i2caddr="${BASH_REMATCH[2]}"
-	fi
-
-	for ((i=0; i<${#asic_i2c_bus_connect_table[@]}; i+=4)); do
-		if [ $i2cbus == "${asic_i2c_bus_connect_table[i+2]}" ] && [ $i2addr == "${asic_i2c_bus_connect_table[i+1]}" ] ;
-		then
-			voltmon_name="${asic_i2c_bus_connect_table[i+3]}"
-			break
+		# Load i2c devices list which should be connected on demand.
+		declare -a dynamic_i2c_bus_connect_table="($(< $config_path/i2c_bus_connect_devices))"
+	
+		# extract i2c bud/dev addr from device sysfs path
+		i2caddr_regex="i2c-[0-9]+/([0-9]+)-00([a-zA-Z0-9]+)/"
+		[[ $i2c_busdev_path =~ $i2cbus_regex ]]
+		if [ "${#BASH_REMATCH[1]}" == 3 ]; then
+			echo "$voltmon_name"
+			return
+		else
+			i2cbus="${BASH_REMATCH[1]}"
+			i2caddr="${BASH_REMATCH[2]}"
 		fi
-	done
+	
+		for ((i=0; i<${#dynamic_i2c_bus_connect_table[@]}; i+=4)); do
+			# match device by i2c bus/addr
+			if [ $i2cbus == "${dynamic_i2c_bus_connect_table[i+2]}" ] && [ $i2addr == "${dynamic_i2c_bus_connect_table[i+1]}" ] ;
+			then
+				voltmon_name="${dynamic_i2c_bus_connect_table[i+3]}"
+				echo "$voltmon_name"
+				return
+			fi
+		done
+	fi
+
+	# we not matched i2c device with dev_list file or file not exist
+	# returning passed "voltmon{1..100}" name or "undefined" in case if passed 'voltmon_nameX"
+	if [ "$voltmon_name" == "voltmon_nameX" ];
+	then
+		voltmon_name="undefined"
+		return	
+	fi
 
 	echo "$voltmon_name"
 }
@@ -641,10 +647,14 @@ if [ "$1" == "add" ]; then
 			done
 			;;
 		*)
-			# get voltmon prefix.
-			# for voltmon[0..100] name will not change - just return it
-			# for voltmonX we try to get name based on dev id/bus and system connect table
+			# Get i2c voltmon prefix.
+			# For voltmon[0..100] name will not change - just return it.
+			# For voltmonX we will try to get name based on dev id/bus and system connect table.
 			prefix=$(get_i2c_voltmon_prefix "$2" "$4")
+			if [[ $prefix == "undefined" ]];
+			then
+				exit
+			fi
 
 			# TMP workaround until dictionary is implemented.
 			dev_addr=$(echo "$4" | xargs dirname | xargs dirname | xargs basename )
@@ -907,7 +917,7 @@ if [ "$1" == "add" ]; then
 		log_info "I2C infrastucture for line card $3 is created."
 	fi
 
-	# Create i2c bus
+	# Create i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 connected."
 		handle_i2cbus_dev_action $4 "add"
@@ -957,7 +967,7 @@ else
 	   [ "$2" == "voltmon3" ] || [ "$2" == "voltmon4" ] ||
 	   [ "$2" == "voltmon5" ] || [ "$2" == "voltmon6" ] ||
 	   [ "$2" == "voltmon7" ] || [ "$2" == "voltmon12" ] ||
-	   [ "$2" == "voltmon13" ] ||
+	   [ "$2" == "voltmon13" ] || [ "$2" == "voltmonX" ] ||
 	   [ "$2" == "comex_voltmon1" ] || [ "$2" == "comex_voltmon2" ] ||
 	   [ "$2" == "hotswap" ]; then
 		if [ "$2" == "comex_voltmon1" ]; then
@@ -1132,7 +1142,7 @@ else
 		destroy_linecard_i2c_links "$3"
 	fi
 
-	# Removed i2c bus
+	# Removed i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 connected."
 		handle_i2cbus_dev_action $4 "remove"

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -273,15 +273,16 @@ mqm97xx_power_base_connect_table=(    max11603 0x6d 5 \
 			24c512 0x51 8)
 
 e3597_base_connect_table=(    max11603 0x6d 5 \
-			mp2975 0x22 5 \
-			mp2975 0x23 5 \
-			mp2975 0x24 5 \
-			mp2975 0x25 5 \
-			mp2975 0x26 5 \
-			mp2975 0x27 5 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
+			
+e3597_dynamic_i2c_bus_connect_table=(  mp2975 0x22 5 voltmon1 \
+			mp2975 0x23 5  voltmon2 \
+			mp2975 0x24 5  voltmon3 \
+			mp2975 0x25 5  voltmon4 \
+			mp2975 0x26 5  voltmon5 \
+			mp2975 0x27 5  voltmon6)
 
 p4697_base_connect_table=(    max11603 0x6d 5 \
 			adt75 0x49 7 \
@@ -293,7 +294,7 @@ p4697_base_rev1_connect_table=(    max11603 0x6d 5 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
 
-p4697_asic_i2c_bus_connect_table=(  mp2975 0x23 26 voltmon1 \
+p4697_dynamic_i2c_bus_connect_table=(  mp2975 0x23 26 voltmon1 \
 			mp2975 0x24 26 voltmon2 \
 			mp2975 0x27 26 voltmon3 \
 			mp2975 0x23 31 voltmon4 \
@@ -629,19 +630,19 @@ add_cpu_board_to_connection_table()
 	connect_table+=(${cpu_connection_table[@]})
 }
 
-add_asic_i2c_bus_dev_connection_table()
+add_i2c_dynamic_bus_dev_connection_table()
 {
 	connection_table=("$@")
-	asic_i2cbus_connection_table=""
+	dynamic_i2cbus_connection_table=""
 
-	echo "${connection_table[@]}" > $config_path/i2c_bus_connect_devs
+	echo "${connection_table[@]}" > $config_path/i2c_bus_connect_devices
 	for ((i=0; i<${#connection_table[@]}; i+=4)); do
-		asic_i2cbus_connection_table[$i]="${connection_table[i]}"
-		asic_i2cbus_connection_table[$i+1]="${connection_table[i+1]}"
-		asic_i2cbus_connection_table[$i+2]="${connection_table[i+2]}"
+		dynamic_i2cbus_connection_table[$i]="${connection_table[i]}"
+		dynamic_i2cbus_connection_table[$i+1]="${connection_table[i+1]}"
+		dynamic_i2cbus_connection_table[$i+2]="${connection_table[i+2]}"
 	done
 
-	connect_table+=(${asic_i2cbus_connection_table[@]})
+	connect_table+=(${dynamic_i2cbus_connection_table[@]})
 }
 
 msn274x_specific()
@@ -1070,6 +1071,7 @@ mqm87xx_rev1_specific()
 e3597_specific()
 {
 	connect_table=(${e3597_base_connect_table[@]})
+	add_i2c_dynamic_bus_dev_connection_table "${e3597_dynamic_i2c_bus_connect_table[@]}"
 	add_cpu_board_to_connection_table
 
 	thermal_type=$thermal_type_def
@@ -1106,7 +1108,7 @@ p4697_specific()
 		connect_table=(${p4697_base_connect_table[@]})
 	fi
 
-	add_asic_i2c_bus_dev_connection_table "${p4697_asic_i2c_bus_connect_table[@]}"
+	add_i2c_dynamic_bus_dev_connection_table "${p4697_dynamic_i2c_bus_connect_table[@]}"
 	add_cpu_board_to_connection_table
 
 	thermal_type=$thermal_type_def
@@ -1120,7 +1122,7 @@ p4697_specific()
 	echo 23000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 4 > $config_path/cpld_num
-	lm_sensors_config="$lm_sensors_configs_path/e4597_sensors.conf"
+	lm_sensors_config="$lm_sensors_configs_path/p4697_sensors.conf"
 }
 
 msn_spc2_common()


### PR DESCRIPTION
In udev rules, we have filtering only by i2c address without bus number.
It can cause conflict when we have voltmons on the same addresses
but on different buses. Also, we have configuration when on 2 different systems
we have voltmons with different names but on the same i2c address.

With this commit we introducing voltmon-per-system definition.
For old system we don't need make any changed. For the new systems if we have
conflicts we need to define voltmon connection table in format:

system_dynamic_i2c_bus_connect_table=(
                        <dev_type> <i2c_addr> <i2c_bus> <voltmon_name> \
                        <dev_type> <i2c_addr> <i2c_bus> <voltmon_name> \
                        ...
                        addr> <i2c_bus> <voltmon_name>)

and connect it in platform init:
add_i2c_dynamic_bus_dev_connection_table "${system_dynamic_i2c_bus_connect_table[@]}"

If voltmon addr/bus not defined in table or table  does not exist at all then voltmon
will be connected with the name defined in udev rule

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
