### PR TITLE
hw-mgmt: patches: 4.19: Rebse patches from 5.10

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0157-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-4.19/0157-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,0 +1,1044 @@
+From 25a1b0a5c14499df8b0e53e64a2a39058591cabe Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 27 Jan 2022 15:07:28 +0200
+Subject: [PATCH] platform: mellanox: Introduce support for NDR InfiniBand
+ modular chassis
+
+Add support for MQM9510-N leaf and MQM9520-N spine blades for two
+flavors of NDR InfiniBand chassis:
+- MCS9500: 1,600Tb/s, 2048-port NDR InfiniBand chassis, which includes
+  32 leaves and 16 spines.
+- MCS9510: 800Tb/s, 1024-port NDR InfiniBand chassis, which includes
+  16 leaves and 8 spines.
+
+MQM9510-N leaf is Nvidia Mellanox Quantum(TM) 2 NDR InfiniBand switch
+equipped with 64 NDR ports, 32 OSFP dual ports, Coffee Lake COMe
+module, 2 Quantum-2 NDR InfiniBand ASICs, 2 Power Supplies (AC) and
+with hybrid cooled (liquid and air), supporting non-blocking switching
+capacity of 2x25.6Tbps.
+MQM9520-N spine is Nvidia Mellanox Quantum(TM) 2 NDR InfiniBand switch,
+equipped with 64 NDR ports, Coffee Lake COMe module, 2 Quantum-2 NDR
+InfiniBand ASICs, 2 Power Supplies (AC) and with hybrid cooled (liquid
+and air).
+
+Both leaf and spine switches are two rack unit height.
+
+New switches reuse configuration of board class "VMOD0010" with slight
+different I2C mux topology and extended LED and hotplug configuration.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 689 +++++++++++++++++++++++++++++++-----
+ 1 file changed, 602 insertions(+), 87 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 0ce52223a..9c517ebbe 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -67,6 +67,9 @@
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET	0x43
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET	0x44
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET 0x45
++#define MLXPLAT_CPLD_LPC_REG_GWP_OFFSET		0x4a
++#define MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET	0x4b
++#define MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET	0x4c
+ #define MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET 0x50
+ #define MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET	0x51
+ #define MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET	0x52
+@@ -105,6 +108,9 @@
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET	0xa9
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET	0xaa
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET	0xab
++#define MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET	0xaf
++#define MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET	0xb0
++#define MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET	0xb1
+ #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
+ #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
+ #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
+@@ -198,6 +204,7 @@
+ 					 MLXPLAT_CPLD_AGGR_MASK_LC_SDWN)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2	BIT(2)
++#define MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK	BIT(4)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
+ #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
+@@ -211,6 +218,8 @@
+ #define MLXPLAT_CPLD_LED_LO_NIBBLE_MASK	GENMASK(7, 4)
+ #define MLXPLAT_CPLD_LED_HI_NIBBLE_MASK	GENMASK(3, 0)
+ #define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
++#define MLXPLAT_CPLD_GWP_MASK		GENMASK(0, 0)
++#define MLXPLAT_CPLD_LEAK_MASK		GENMASK(0, 0)
+ #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
+ #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
+ 
+@@ -240,6 +249,7 @@
+ #define MLXPLAT_CPLD_CH2_ETH_MODULAR		3
+ #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
+ #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
++#define MLXPLAT_CPLD_CH2_IB_MODULAR		18
+ 
+ /* Number of LPC attached MUX platform devices */
+ #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
+@@ -457,6 +467,34 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+ 	},
+ };
+ 
++/* Platform channels for ib modular system family */
++static const int mlxplat_ib_modular_channels[] = {
++	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
++};
++
++/* Platform IB modular mux data */
++static struct i2c_mux_reg_platform_data mlxplat_ib_modular_mux_data[] = {
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_ib_modular_channels,
++		.n_values = ARRAY_SIZE(mlxplat_ib_modular_channels),
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH2_IB_MODULAR,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.reg_size = 1,
++		.idle_in_use = 1,
++	},
++
++};
++
+ /* Platform hotplug devices */
+ static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
+ 	{
+@@ -592,7 +630,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_asic_items_data[] = {
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+ 		.mask = MLXPLAT_CPLD_ASIC_MASK,
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
+-	}
++	},
+ };
+ 
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_asic2_items_data[] = {
+@@ -1293,7 +1331,7 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+ 		.data = mlxplat_mlxcpld_default_asic_items_data,
+ 		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+-		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
+ 		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
+ 		.inversed = 0,
+ 		.health = true,
+@@ -1302,27 +1340,11 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+ 		.data = mlxplat_mlxcpld_default_asic2_items_data,
+ 		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
+-		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
+ 		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic2_items_data),
+ 		.inversed = 0,
+ 		.health = true,
+-	},
+-	/*{
+-		.data = mlxplat_mlxcpld_asic_thermal_items_data,
+-		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
+-		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+-		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
+-		.count = ARRAY_SIZE(mlxplat_mlxcpld_asic_thermal_items_data),
+-		.inversed = 0,
+-	},
+-	{
+-		.data = mlxplat_mlxcpld_asic2_thermal_items_data,
+-		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
+-		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
+-		.mask = MLXPLAT_CPLD_ASIC_MASK | MLXPLAT_CPLD_ASIC_THERMAL_MASK,
+-		.count = ARRAY_SIZE(mlxplat_mlxcpld_asic2_thermal_items_data),
+-		.inversed = 0,
+-	},*/
++	}
+ };
+ 
+ static
+@@ -2176,6 +2198,118 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_modular_data = {
+ 	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
+ };
+ 
++/* Platform hotplug for NVLink blade systems family data  */
++static struct mlxreg_core_data mlxplat_mlxcpld_global_wp_items_data[] = {
++	{
++		.label = "global_wp_grant",
++		.reg = MLXPLAT_CPLD_LPC_REG_GWP_OFFSET,
++		.mask = MLXPLAT_CPLD_GWP_MASK,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++static struct mlxreg_core_item mlxplat_mlxcpld_nvlink_blade_items[] = {
++	{
++		.data = mlxplat_mlxcpld_global_wp_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_GWP_OFFSET,
++		.mask = MLXPLAT_CPLD_GWP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_global_wp_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++};
++
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
++	.items = mlxplat_mlxcpld_nvlink_blade_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_blade_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
++};
++
++/* Platform hotplug for modular IB systems family data */
++static struct mlxreg_core_data mlxplat_mlxcpld_leakage_items_data[] = {
++	{
++		.label = "leakage",
++		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
++		.mask = MLXPLAT_CPLD_LEAK_MASK,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++static struct mlxreg_core_item mlxplat_mlxcpld_ndr_ib_modular_items[] = {
++	{
++		.data = mlxplat_mlxcpld_ext_psu_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_ext_psu_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_ext_pwr_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_ext_pwr_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_ng_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_NG_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_asic_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_asic2_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic2_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_leakage_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
++		.mask = MLXPLAT_CPLD_LEAK_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++};
++
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
++	.items = mlxplat_mlxcpld_ndr_ib_modular_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_ndr_ib_modular_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2 |
++		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
++};
++
+ /* Platform led default data */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
+ 	{
+@@ -2269,7 +2403,6 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_led_wc_data[] = {
+ 	},
+ };
+ 
+-
+ static struct mlxreg_core_platform_data mlxplat_default_led_wc_data = {
+ 		.data = mlxplat_mlxcpld_default_led_wc_data,
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_led_wc_data),
+@@ -2457,14 +2590,14 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_led_data[] = {
+ 	{
+ 		.label = "fan7:green",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
+-		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
+ 		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
+ 		.bit = BIT(6),
+ 	},
+ 	{
+ 		.label = "fan7:orange",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
+-		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
+ 		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
+ 		.bit = BIT(6),
+ 	},
+@@ -2706,6 +2839,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_led_data),
+ };
+ 
++/* Platform led for modular IB systems with liquid cooling */
++static struct mlxreg_core_data mlxplat_mlxcpld_ndr_ib_modular_led_data[] = {
++	{
++		.label = "status:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "status:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK
++	},
++	{
++		.label = "psu:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "psu:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++	},
++	{
++		.label = "fan1:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(0),
++	},
++	{
++		.label = "fan1:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(0),
++	},
++	{
++		.label = "fan2:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(1),
++	},
++	{
++		.label = "fan2:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(1),
++	},
++	{
++		.label = "fan3:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(2),
++	},
++	{
++		.label = "fan3:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(2),
++	},
++	{
++		.label = "fan4:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(3),
++	},
++	{
++		.label = "fan4:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(3),
++	},
++	{
++		.label = "uid:blue",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "leakage:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "leakage:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_ndr_ib_modular_led_data = {
++		.data = mlxplat_mlxcpld_ndr_ib_modular_led_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_ndr_ib_modular_led_data),
++};
++
+ /* Platform led data for QMB8700 system */
+ static struct mlxreg_core_data mlxplat_mlxcpld_qmb8700_led_data[] = {
+ 	{
+@@ -3167,16 +3400,16 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
+-		.label = "asic1_reset",
++		.label = "asic_reset",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(3),
+-		.mode = 0200,
++		.mode = 0644,
+ 	},
+ 	{
+ 		.label = "asic2_reset",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
+ 		.bit = GENMASK(7, 0) & ~BIT(2),
+-		.mode = 0200,
++		.mode = 0444,
+ 	},
+ 	{
+ 		.label = "reset_long_pb",
+@@ -3317,6 +3550,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = 1,
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "asic2_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "fan_dir",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION,
+@@ -3672,49 +3912,49 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+ 		.label = "lc1_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc2_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(1),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc3_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(2),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc4_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(3),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc5_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(4),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc6_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(5),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc7_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(6),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "lc8_rst_mask",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(7),
+-		.mode = 0644,
++		.mode = 0200,
+ 	},
+ 	{
+ 		.label = "psu1_on",
+@@ -3764,12 +4004,6 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(7),
+ 		.mode = 0644,
+ 	},
+-	{
+-		.label = "os_ready",
+-		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
+-		.mask = GENMASK(7, 0) & ~BIT(6),
+-		.mode = 0444,
+-	},
+ 	{
+ 		.label = "jtag_enable",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_FIELD_UPGRADE,
+@@ -3875,6 +4109,203 @@ static struct mlxreg_core_platform_data mlxplat_modular_regs_io_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_regs_io_data),
+ };
+ 
++/* Platform register access for NVLink blade systems family data  */
++static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
++	{
++		.label = "cpld1_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld1_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld1_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_aux_pwr_or_ref",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_from_comex",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_platform",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_soc",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_wd",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_voltmon_upgrade_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_system",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_sw_pwr_off",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_thermal",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_reload_bios",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_ac_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "pwr_cycle",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0200,
++	},
++	{
++		.label = "pwr_down",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0200,
++	},
++	{
++		.label = "global_wp_request",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0644,
++	},
++	{
++		.label = "jtag_enable",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "comm_chnl_ready",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0200,
++	},
++	{
++		.label = "bios_safe_mode",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_active_image",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_auth_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "bios_upgrade_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
++	{
++		.label = "voltreg_update_status",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET,
++		.mask = MLXPLAT_CPLD_VOLTREG_UPD_MASK,
++		.bit = 5,
++		.mode = 0444,
++	},
++	{
++		.label = "vpd_wp",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0644,
++	},
++	{
++		.label = "pcie_asic_reset_dis",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "global_wp_response",
++		.reg = MLXPLAT_CPLD_LPC_REG_GWP_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0444,
++	},
++	{
++		.label = "config1",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "config2",
++		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "ufm_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_nvlink_blade_regs_io_data = {
++		.data = mlxplat_mlxcpld_nvlink_blade_regs_io_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_blade_regs_io_data),
++};
++
+ /* Platform FAN default */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+ 	{
+@@ -4015,6 +4446,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+ static struct mlxreg_core_platform_data mlxplat_default_fan_data = {
+ 		.data = mlxplat_mlxcpld_default_fan_data,
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_fan_data),
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
+ };
+ 
+ /* Platform FAN default */
+@@ -4363,6 +4795,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
+@@ -4389,6 +4823,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
+ 	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
+@@ -4457,6 +4893,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+@@ -4495,6 +4934,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
+ 	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
+@@ -4588,6 +5030,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+@@ -4626,6 +5071,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
+@@ -5045,6 +5493,28 @@ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_nvlink_blade_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
++	mlxplat_mux_data = mlxplat_default_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_blade_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	for (i = 0; i < mlxplat_mux_num; i++) {
++		mlxplat_mux_data[i].values = mlxplat_msn21xx_channels;
++		mlxplat_mux_data[i].n_values =
++				ARRAY_SIZE(mlxplat_msn21xx_channels);
++	}
++	mlxplat_regs_io = &mlxplat_nvlink_blade_regs_io_data;
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return 1;
++}
++
+ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+@@ -5071,6 +5541,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_ib_modular_mux_data);
++	mlxplat_mux_data = mlxplat_ib_modular_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_ndr_ib_modular_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_ndr_ib_modular_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return 1;
++}
++
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+ 		.callback = mlxplat_dmi_default_wc_matched,
+@@ -5135,6 +5626,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0009"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_ndr_ib_modular_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI140"),
++		},
++	},
++	{
++		.callback = mlxplat_dmi_ndr_ib_modular_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_ng400_matched,
+ 		.matches = {
+@@ -5147,6 +5652,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0011"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_nvlink_blade_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_msn274x_matched,
+ 		.matches = {
+@@ -5336,22 +5847,20 @@ static int __init mlxplat_init(void)
+ 	nr = (nr == mlxplat_max_adap_num) ? -1 : nr;
+ 	if (mlxplat_i2c)
+ 		mlxplat_i2c->regmap = priv->regmap;
+-	priv->pdev_i2c = platform_device_register_resndata(
+-					&mlxplat_dev->dev, "i2c_mlxcpld",
+-					nr, mlxplat_mlxcpld_resources,
+-					ARRAY_SIZE(mlxplat_mlxcpld_resources),
+-					mlxplat_i2c, sizeof(*mlxplat_i2c));
++	priv->pdev_i2c = platform_device_register_resndata(&mlxplat_dev->dev, "i2c_mlxcpld",
++							   nr, mlxplat_mlxcpld_resources,
++							   ARRAY_SIZE(mlxplat_mlxcpld_resources),
++							   mlxplat_i2c, sizeof(*mlxplat_i2c));
+ 	if (IS_ERR(priv->pdev_i2c)) {
+ 		err = PTR_ERR(priv->pdev_i2c);
+ 		goto fail_alloc;
+ 	}
+ 
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+-		priv->pdev_mux[i] = platform_device_register_resndata(
+-						&priv->pdev_i2c->dev,
+-						"i2c-mux-reg", i, NULL,
+-						0, &mlxplat_mux_data[i],
+-						sizeof(mlxplat_mux_data[i]));
++		priv->pdev_mux[i] = platform_device_register_resndata(&priv->pdev_i2c->dev,
++								      "i2c-mux-reg", i, NULL, 0,
++								      &mlxplat_mux_data[i],
++								      sizeof(mlxplat_mux_data[i]));
+ 		if (IS_ERR(priv->pdev_mux[i])) {
+ 			err = PTR_ERR(priv->pdev_mux[i]);
+ 			goto fail_platform_mux_register;
+@@ -5359,16 +5868,18 @@ static int __init mlxplat_init(void)
+ 	}
+ 
+ 	/* Add hotplug driver */
+-	mlxplat_hotplug->regmap = priv->regmap;
+-	priv->pdev_hotplug = platform_device_register_resndata(
+-				&mlxplat_dev->dev, "mlxreg-hotplug",
+-				PLATFORM_DEVID_NONE,
+-				mlxplat_mlxcpld_resources,
+-				ARRAY_SIZE(mlxplat_mlxcpld_resources),
+-				mlxplat_hotplug, sizeof(*mlxplat_hotplug));
+-	if (IS_ERR(priv->pdev_hotplug)) {
+-		err = PTR_ERR(priv->pdev_hotplug);
+-		goto fail_platform_mux_register;
++	if (mlxplat_hotplug) {
++		mlxplat_hotplug->regmap = priv->regmap;
++		priv->pdev_hotplug =
++		platform_device_register_resndata(&mlxplat_dev->dev,
++						  "mlxreg-hotplug", PLATFORM_DEVID_NONE,
++						  mlxplat_mlxcpld_resources,
++						  ARRAY_SIZE(mlxplat_mlxcpld_resources),
++						  mlxplat_hotplug, sizeof(*mlxplat_hotplug));
++		if (IS_ERR(priv->pdev_hotplug)) {
++			err = PTR_ERR(priv->pdev_hotplug);
++			goto fail_platform_mux_register;
++		}
+ 	}
+ 
+ 	/* Set default registers. */
+@@ -5381,24 +5892,26 @@ static int __init mlxplat_init(void)
+ 	}
+ 
+ 	/* Add LED driver. */
+-	mlxplat_led->regmap = priv->regmap;
+-	priv->pdev_led = platform_device_register_resndata(
+-				&mlxplat_dev->dev, "leds-mlxreg",
+-				PLATFORM_DEVID_NONE, NULL, 0,
+-				mlxplat_led, sizeof(*mlxplat_led));
+-	if (IS_ERR(priv->pdev_led)) {
+-		err = PTR_ERR(priv->pdev_led);
+-		goto fail_platform_hotplug_register;
++	if (mlxplat_led) {
++		mlxplat_led->regmap = priv->regmap;
++		priv->pdev_led =
++		platform_device_register_resndata(&mlxplat_dev->dev, "leds-mlxreg",
++						  PLATFORM_DEVID_NONE, NULL, 0, mlxplat_led,
++						  sizeof(*mlxplat_led));
++		if (IS_ERR(priv->pdev_led)) {
++			err = PTR_ERR(priv->pdev_led);
++			goto fail_platform_hotplug_register;
++		}
+ 	}
+ 
+ 	/* Add registers io access driver. */
+ 	if (mlxplat_regs_io) {
+ 		mlxplat_regs_io->regmap = priv->regmap;
+-		priv->pdev_io_regs = platform_device_register_resndata(
+-					&mlxplat_dev->dev, "mlxreg-io",
+-					PLATFORM_DEVID_NONE, NULL, 0,
+-					mlxplat_regs_io,
+-					sizeof(*mlxplat_regs_io));
++		priv->pdev_io_regs = platform_device_register_resndata(&mlxplat_dev->dev,
++								       "mlxreg-io",
++								       PLATFORM_DEVID_NONE, NULL,
++								       0, mlxplat_regs_io,
++								       sizeof(*mlxplat_regs_io));
+ 		if (IS_ERR(priv->pdev_io_regs)) {
+ 			err = PTR_ERR(priv->pdev_io_regs);
+ 			goto fail_platform_led_register;
+@@ -5408,11 +5921,10 @@ static int __init mlxplat_init(void)
+ 	/* Add FAN driver. */
+ 	if (mlxplat_fan) {
+ 		mlxplat_fan->regmap = priv->regmap;
+-		priv->pdev_fan = platform_device_register_resndata(
+-					&mlxplat_dev->dev, "mlxreg-fan",
+-					PLATFORM_DEVID_NONE, NULL, 0,
+-					mlxplat_fan,
+-					sizeof(*mlxplat_fan));
++		priv->pdev_fan = platform_device_register_resndata(&mlxplat_dev->dev, "mlxreg-fan",
++								   PLATFORM_DEVID_NONE, NULL, 0,
++								   mlxplat_fan,
++								   sizeof(*mlxplat_fan));
+ 		if (IS_ERR(priv->pdev_fan)) {
+ 			err = PTR_ERR(priv->pdev_fan);
+ 			goto fail_platform_io_regs_register;
+@@ -5426,11 +5938,10 @@ static int __init mlxplat_init(void)
+ 	for (j = 0; j < MLXPLAT_CPLD_WD_MAX_DEVS; j++) {
+ 		if (mlxplat_wd_data[j]) {
+ 			mlxplat_wd_data[j]->regmap = priv->regmap;
+-			priv->pdev_wd[j] = platform_device_register_resndata(
+-						&mlxplat_dev->dev, "mlx-wdt",
+-						j, NULL, 0,
+-						mlxplat_wd_data[j],
+-						sizeof(*mlxplat_wd_data[j]));
++			priv->pdev_wd[j] =
++				platform_device_register_resndata(&mlxplat_dev->dev, "mlx-wdt", j,
++								  NULL, 0, mlxplat_wd_data[j],
++								  sizeof(*mlxplat_wd_data[j]));
+ 			if (IS_ERR(priv->pdev_wd[j])) {
+ 				err = PTR_ERR(priv->pdev_wd[j]);
+ 				goto fail_platform_wd_register;
+@@ -5455,9 +5966,11 @@ fail_platform_io_regs_register:
+ 	if (mlxplat_regs_io)
+ 		platform_device_unregister(priv->pdev_io_regs);
+ fail_platform_led_register:
+-	platform_device_unregister(priv->pdev_led);
++	if (mlxplat_led)
++		platform_device_unregister(priv->pdev_led);
+ fail_platform_hotplug_register:
+-	platform_device_unregister(priv->pdev_hotplug);
++	if (mlxplat_hotplug)
++		platform_device_unregister(priv->pdev_hotplug);
+ fail_platform_mux_register:
+ 	while (--i >= 0)
+ 		platform_device_unregister(priv->pdev_mux[i]);
+@@ -5480,8 +5993,10 @@ static void __exit mlxplat_exit(void)
+ 		platform_device_unregister(priv->pdev_fan);
+ 	if (priv->pdev_io_regs)
+ 		platform_device_unregister(priv->pdev_io_regs);
+-	platform_device_unregister(priv->pdev_led);
+-	platform_device_unregister(priv->pdev_hotplug);
++	if (priv->pdev_led)
++		platform_device_unregister(priv->pdev_led);
++	if (priv->pdev_hotplug)
++		platform_device_unregister(priv->pdev_hotplug);
+ 
+ 	for (i = mlxplat_mux_num - 1; i >= 0 ; i--)
+ 		platform_device_unregister(priv->pdev_mux[i]);
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,0 +1,273 @@
+From 1b7bd2816f95d86726da5fb7c9de44c21bb15d74 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 14 Feb 2022 13:24:44 +0200
+Subject: [PATCH] platform: mellanox: Introduce support for NVLink4 managed
+ switch
+
+Introduce support for Nvidia P4697 system, the NVLink4 rack switch
+implemented with two Nvidia LS10 NVSwitch ASICs, equipped on switch
+board and with Nvidia COME module.
+
+The rack switch is designed to provide high bandwidth, low latency
+NVLink connections between DGX products supporting external NVLink
+connectivity beginning with the Viking system. The system enables the
+deployment of a pod of "Viking" systems in a fully switched NVLink or
+fat-tree topology using optical fiber as the primary interconnect.
+
+System supports 128 NVLink4 ports, 32 OSFP ports, non-blocking
+switching capacity of 25.6Tbps.
+System equipped with:
+- 2 replaceable power supplies (AC) with 1+1 redundancy model.
+- 7 replaceable fan drawers with 6+1 redundancy model.
+- 2 External Root of Trust or EROT (Glacier) devices for each of the
+  LS10 NVLink ASICs for the purpose of securing the LS10 firmware.
+  There are three interfaces available to access those devices:
+  - I2C interface from CPU side, which can be used to read basic
+    information from the EROT.
+  - The SPI out-of-band path from CPU (GSPI) provides a mechanism for
+    programming the EROT device in the case that both the primary and
+    fail-safe firmware images for the EROT device are corrupted.
+  - The SPI in-band interface from ASIC firmware (no CPU involved),
+    which is the main interface.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 166 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 166 insertions(+)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 9c517ebbe..960fae383 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -90,6 +90,12 @@
+ #define MLXPLAT_CPLD_LPC_REG_FAN_OFFSET		0x88
+ #define MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET	0x89
+ #define MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET	0x8a
++#define MLXPLAT_CPLD_LPC_REG_EROT_OFFSET	0x91
++#define MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET	0x92
++#define MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET	0x93
++#define MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET	0x94
++#define MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET	0x95
++#define MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET	0x96
+ #define MLXPLAT_CPLD_LPC_REG_LC_VR_OFFSET	0x9a
+ #define MLXPLAT_CPLD_LPC_REG_LC_VR_EVENT_OFFSET	0x9b
+ #define MLXPLAT_CPLD_LPC_REG_LC_VR_MASK_OFFSET	0x9c
+@@ -220,6 +226,7 @@
+ #define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
+ #define MLXPLAT_CPLD_GWP_MASK		GENMASK(0, 0)
+ #define MLXPLAT_CPLD_LEAK_MASK		GENMASK(0, 0)
++#define MLXPLAT_CPLD_EROT_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
+ #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
+ 
+@@ -2310,6 +2317,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
+ 		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
+ };
+ 
++/* Platform hotplug for nvlink switch systems family data */
++static struct mlxreg_core_data mlxplat_mlxcpld_erot_ap_items_data[] = {
++	{
++		.label = "erot1_ap",
++		.reg = MLXPLAT_CPLD_LPC_REG_EROT_OFFSET,
++		.mask = BIT(0),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "erot2_ap",
++		.reg = MLXPLAT_CPLD_LPC_REG_EROT_OFFSET,
++		.mask = BIT(1),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++static struct mlxreg_core_data mlxplat_mlxcpld_erot_error_items_data[] = {
++	{
++		.label = "erot1_error",
++		.reg = MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET,
++		.mask = BIT(0),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++	{
++		.label = "erot2_error",
++		.reg = MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET,
++		.mask = BIT(1),
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++	},
++};
++
++static struct mlxreg_core_item mlxplat_mlxcpld_nvlink_switch_items[] = {
++	{
++		.data = mlxplat_mlxcpld_ext_psu_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_ext_psu_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_ext_pwr_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_EXT_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_PSU_I2C_CAP_OFFSET,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_ext_pwr_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_default_ng_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_NG_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_erot_ap_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_EROT_OFFSET,
++		.mask = MLXPLAT_CPLD_EROT_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_erot_ap_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_erot_error_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET,
++		.mask = MLXPLAT_CPLD_EROT_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_erot_error_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++};
++
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_switch_data = {
++	.items = mlxplat_mlxcpld_nvlink_switch_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_switch_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
++};
++
+ /* Platform led default data */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
+ 	{
+@@ -3411,6 +3509,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0) & ~BIT(2),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "erot1_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
++		.bit = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0644,
++	},
++	{
++		.label = "erot2_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
++		.bit = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0644,
++	},
++	{
++		.label = "erot1_recovery",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
++		.bit = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0644,
++	},
++	{
++		.label = "erot2_recovery",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
++		.bit = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0644,
++	},
+ 	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+@@ -4807,6 +4929,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
+@@ -4911,6 +5037,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
+@@ -5048,6 +5180,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
+@@ -5562,6 +5700,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_nvlink_switch_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_ib_modular_mux_data);
++	mlxplat_mux_data = mlxplat_ib_modular_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_ndr_ib_modular_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++
++	return 1;
++}
++
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+ 		.callback = mlxplat_dmi_default_wc_matched,
+@@ -5640,6 +5799,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_nvlink_switch_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI142"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_ng400_matched,
+ 		.matches = {
+-- 
+2.14.1
+


### PR DESCRIPTION
platform: mellanox: Introduce support for NDR InfiniBand modular chassis

    Add support for MQM9510-N leaf and MQM9520-N spine blades for two
    flavors of NDR InfiniBand chassis:
    - MCS9500: 1,600Tb/s, 2048-port NDR InfiniBand chassis, which includes
      32 leaves and 16 spines.
    - MCS9510: 800Tb/s, 1024-port NDR InfiniBand chassis, which includes
      16 leaves and 8 spines.

platform: mellanox: Introduce support for NVLink4 managed switch

    Introduce support for Nvidia P4697 system, the NVLink4 rack switch
    implemented with two Nvidia LS10 NVSwitch ASICs, equipped on switch
    board and with Nvidia COME module.

Signed-off-by: Oleksandr Shamray oleksandrs@nvidia.com
