### PR TITLE
hw-mgmt: kernels & script: fix CPLD PN representation on SN2201.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.2001) unstable; urgency=low
+hw-management (1.mlnx.7.0020.2002) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 22 Feb 2022 12:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 23 Feb 2022 12:22:00 +0300
 

--- a/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -63,7 +63,7 @@ new file mode 100644
 index 000000000..1a2103778
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
-@@ -0,0 +1,1232 @@
+@@ -0,0 +1,1225 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia sn2201 driver
@@ -137,8 +137,6 @@ index 000000000..1a2103778
 +#define NVSW_SN2201_PHY_I2C_BUS_NUM		2
 +/* Number of main mux channels. */
 +#define NVSW_SN2201_MAIN_MUX_CHNL_NUM		8
-+/* Number of fan tray mux channels. */
-+#define NVSW_SN2201_FAN_TRAY_MUX_CHNL_NUM	4
 +
 +#define NVSW_SN2201_MAIN_NR			0
 +#define NVSW_SN2201_MAIN_MUX_NR			1
@@ -149,15 +147,9 @@ index 000000000..1a2103778
 +#define NVSW_SN2201_MAIN_MUX_CH1_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 1)
 +#define NVSW_SN2201_MAIN_MUX_CH2_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 2)
 +#define NVSW_SN2201_MAIN_MUX_CH3_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 3)
-+#define NVSW_SN2201_MAIN_MUX_CH4_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 4)
 +#define NVSW_SN2201_MAIN_MUX_CH5_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 5)
 +#define NVSW_SN2201_MAIN_MUX_CH6_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 6)
 +#define NVSW_SN2201_MAIN_MUX_CH7_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 7)
-+
-+#define NVSW_SN2201_FAN_MUX_CH0_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 1)
-+#define NVSW_SN2201_FAN_MUX_CH1_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 2)
-+#define NVSW_SN2201_FAN_MUX_CH2_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 3)
-+#define NVSW_SN2201_FAN_MUX_CH3_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 4)
 +
 +#define NVSW_SN2201_CPLD_NR		NVSW_SN2201_MAIN_MUX_CH0_NR
 +#define NVSW_SN2201_NR_NONE		-1
@@ -165,7 +157,7 @@ index 000000000..1a2103778
 +/* Masks for aggregation, PSU presence and power, ASIC events
 + * in CPLD related registers.
 + */
-+#define NVSW_SN2201_CPLD_AGGR_ASIC_MASK_DEF	0xE0
++#define NVSW_SN2201_CPLD_AGGR_ASIC_MASK_DEF	0xe0
 +#define NVSW_SN2201_CPLD_AGGR_PSU_MASK_DEF	0x04
 +#define NVSW_SN2201_CPLD_AGGR_PWR_MASK_DEF	0x02
 +#define NVSW_SN2201_CPLD_AGGR_FAN_MASK_DEF	0x10
@@ -737,6 +729,7 @@ index 000000000..1a2103778
 +		.reg = NVSW_SN2201_CPLD_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
++		.regnum = 2,
 +	},
 +	{
 +		.label = "psu1_on",

--- a/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -64,7 +64,7 @@ new file mode 100644
 index 000000000..06a257ee1
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
-@@ -0,0 +1,1232 @@
+@@ -0,0 +1,1225 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia sn2201 driver
@@ -138,8 +138,6 @@ index 000000000..06a257ee1
 +#define NVSW_SN2201_PHY_I2C_BUS_NUM		2
 +/* Number of main mux channels. */
 +#define NVSW_SN2201_MAIN_MUX_CHNL_NUM		8
-+/* Number of fan tray mux channels. */
-+#define NVSW_SN2201_FAN_TRAY_MUX_CHNL_NUM	4
 +
 +#define NVSW_SN2201_MAIN_NR			0
 +#define NVSW_SN2201_MAIN_MUX_NR			1
@@ -150,15 +148,9 @@ index 000000000..06a257ee1
 +#define NVSW_SN2201_MAIN_MUX_CH1_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 1)
 +#define NVSW_SN2201_MAIN_MUX_CH2_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 2)
 +#define NVSW_SN2201_MAIN_MUX_CH3_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 3)
-+#define NVSW_SN2201_MAIN_MUX_CH4_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 4)
 +#define NVSW_SN2201_MAIN_MUX_CH5_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 5)
 +#define NVSW_SN2201_MAIN_MUX_CH6_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 6)
 +#define NVSW_SN2201_MAIN_MUX_CH7_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 7)
-+
-+#define NVSW_SN2201_FAN_MUX_CH0_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 1)
-+#define NVSW_SN2201_FAN_MUX_CH1_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 2)
-+#define NVSW_SN2201_FAN_MUX_CH2_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 3)
-+#define NVSW_SN2201_FAN_MUX_CH3_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 4)
 +
 +#define NVSW_SN2201_CPLD_NR		NVSW_SN2201_MAIN_MUX_CH0_NR
 +#define NVSW_SN2201_NR_NONE		-1
@@ -166,7 +158,7 @@ index 000000000..06a257ee1
 +/* Masks for aggregation, PSU presence and power, ASIC events
 + * in CPLD related registers.
 + */
-+#define NVSW_SN2201_CPLD_AGGR_ASIC_MASK_DEF	0xE0
++#define NVSW_SN2201_CPLD_AGGR_ASIC_MASK_DEF	0xe0
 +#define NVSW_SN2201_CPLD_AGGR_PSU_MASK_DEF	0x04
 +#define NVSW_SN2201_CPLD_AGGR_PWR_MASK_DEF	0x02
 +#define NVSW_SN2201_CPLD_AGGR_FAN_MASK_DEF	0x10
@@ -738,6 +730,7 @@ index 000000000..06a257ee1
 +		.reg = NVSW_SN2201_CPLD_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
++		.regnum = 2,
 +	},
 +	{
 +		.label = "psu1_on",

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1235,13 +1235,10 @@ sn2201_specific()
 	cpld2_mver=$(i2cget -f -y 1 0x3d 0x02)
 	cpld2_mver=${cpld2_mver:2}
 	echo $(( 16#$cpld2_mver )) > $system_path/cpld2_version_min
-	cpld2_pn=$(i2cget -f -y 1 0x3d 0x21)
-	cpld2_pn=${cpld2_pn:2}
+	cpld2_pn=$(i2cget -f -y 1 0x3d 0x21 w)
+	cpld2_pn=${cpld2_pn:3}
 	cpld2_pn=$(( 16#$cpld2_pn ))
-	cpld2_pn1=$(i2cget -f -y 1 0x3d 0x22)
-	cpld2_pn1=${cpld2_pn1:2}
-	cpld2_pn1=$(( 16#$cpld2_pn1 ))
-	echo $cpld2_pn1$cpld2_pn > $system_path/cpld2_pn
+	echo $cpld2_pn > $system_path/cpld2_pn
 	lm_sensors_config="$lm_sensors_configs_path/sn2201_sensors.conf"
 }
 


### PR DESCRIPTION
Fix CPU and MB CPLD access and representation in hw-management.
Clean unused defines in nvsw_sn2201 platform driver.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
