### PR TITLE
hw-mgmt: topology: Fix dynamic i2c tables for MQM9510 and MQM9520

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -320,14 +320,14 @@ mqm9510_base_connect_table=( \
 	24c512 0x51 8)
 
 mqm9510_dynamic_i2c_bus_connect_table=( \
-	mp2888 0x62 5 \
-	mp2888 0x66 5 \
-	mp2888 0x68 5 \
-	mp2888 0x6c 5 \
-	mp2888 0x62 6 \
-	mp2888 0x66 6 \
-	mp2888 0x68 6 \
-	mp2888 0x6c 6)
+	mp2888 0x62 5 voltmon1 \
+	mp2888 0x66 5 voltmon2 \
+	mp2888 0x68 5 voltmon3 \
+	mp2888 0x6c 5 voltmon4 \
+	mp2888 0x62 6 voltmon5 \
+	mp2888 0x66 6 voltmon6 \
+	mp2888 0x68 6 voltmon7 \
+	mp2888 0x6c 6 voltmon8)
 
 mqm9520_base_connect_table=( \
 	tmp102 0x49 7 \
@@ -335,13 +335,13 @@ mqm9520_base_connect_table=( \
 	24c512 0x51 8)
 
 mqm9520_dynamic_i2c_bus_connect_table=( \
-	mp2888 0x66 5  \
-	mp2888 0x68 5  \
-	mp2888 0x6c 5  \
-	mp2888 0x62 13 \
-	mp2888 0x66 13 \
-	mp2888 0x68 13 \
-	mp2888 0x6c 13)
+	mp2888 0x66 5  voltmon1 \
+	mp2888 0x68 5  voltmon2 \
+	mp2888 0x6c 5  voltmon3 \
+	mp2888 0x62 13 voltmon4 \
+	mp2888 0x66 13 voltmon5 \
+	mp2888 0x68 13 voltmon6 \
+	mp2888 0x6c 13 voltmon7 )
 
 ACTION=$1
 


### PR DESCRIPTION
Signed-off-by: Felix Radensky <fradensky@nvidia.com>