### PR TITLE
hw-mgmt: service: Add restart delay to hw-mgmt systemd service

### DIFF
--- a/debian/hw-management.hw-management.service
+++ b/debian/hw-management.hw-management.service
@@ -8,6 +8,7 @@ RemainAfterExit=true
 ExecStartPre=-/bin/sh -c "/usr/bin/hw-management-ready.sh"
 ExecStart=/bin/sh -c "/usr/bin/hw-management.sh start"
 ExecStop=/bin/sh -c "/usr/bin/hw-management.sh stop"
+ExecStopPost=/bin/sleep 3
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add 3 sec delay between service stop and start to mimic the
behavior of "hw-management.sh restart".