### PR TITLE
hw-mgmt: patches: 4.19/5.10 Add patch for locking operations

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0159-platform-mellanox-mlxreg-io-Add-locking-for-io-opera.patch
+++ b/recipes-kernel/linux/linux-4.19/0159-platform-mellanox-mlxreg-io-Add-locking-for-io-opera.patch
@@ -1,0 +1,106 @@
+From 38965799eff9c9e05c3ae71767d95e1718042888 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 7 Feb 2022 21:36:09 +0200
+Subject: [PATCH platform-next 1/1] platform/mellanox: mlxreg-io: Add locking
+ for io operations
+
+Add lock to protect user read/write access to the registers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index a9c083905..656231fb9 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -32,6 +32,7 @@
+  * @groups: list of sysfs attribute group for hwmon registration;
+  * @regsize: size of a register value;
+  * @regmax: max register value;
++ * @io_lock: user access locking;
+  */
+ struct mlxreg_io_priv_data {
+ 	struct platform_device *pdev;
+@@ -43,6 +44,7 @@ struct mlxreg_io_priv_data {
+ 	const struct attribute_group *groups[2];
+ 	int regsize;
+ 	int regmax;
++	struct mutex io_lock; /* Protects user access. */
+ };
+ 
+ static int
+@@ -120,14 +122,19 @@ mlxreg_io_attr_show(struct device *dev, struct device_attribute *attr,
+ 	u32 regval = 0;
+ 	int ret;
+ 
++	mutex_lock(&priv->io_lock);
++
+ 	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, 0, true,
+ 				priv->regsize, priv->regmax, &regval);
+ 	if (ret)
+ 		goto access_error;
+ 
++	mutex_unlock(&priv->io_lock);
++
+ 	return sprintf(buf, "%u\n", regval);
+ 
+ access_error:
++	mutex_unlock(&priv->io_lock);
+ 	return ret;
+ }
+ 
+@@ -149,6 +156,8 @@ mlxreg_io_attr_store(struct device *dev, struct device_attribute *attr,
+ 	if (ret)
+ 		return ret;
+ 
++	mutex_lock(&priv->io_lock);
++
+ 	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, input_val, false,
+ 				priv->regsize, priv->regmax, &regval);
+ 	if (ret)
+@@ -158,9 +167,12 @@ mlxreg_io_attr_store(struct device *dev, struct device_attribute *attr,
+ 	if (ret)
+ 		goto access_error;
+ 
++	mutex_unlock(&priv->io_lock);
++
+ 	return len;
+ 
+ access_error:
++	mutex_unlock(&priv->io_lock);
+ 	dev_err(&priv->pdev->dev, "Bus access error\n");
+ 	return ret;
+ }
+@@ -254,16 +266,27 @@ static int mlxreg_io_probe(struct platform_device *pdev)
+ 		return PTR_ERR(priv->hwmon);
+ 	}
+ 
++	mutex_init(&priv->io_lock);
+ 	dev_set_drvdata(&pdev->dev, priv);
+ 
+ 	return 0;
+ }
+ 
++static int mlxreg_io_remove(struct platform_device *pdev)
++{
++	struct mlxreg_io_priv_data *priv = dev_get_drvdata(&pdev->dev);
++
++	mutex_destroy(&priv->io_lock);
++
++	return 0;
++}
++
+ static struct platform_driver mlxreg_io_driver = {
+ 	.driver = {
+ 	    .name = "mlxreg-io",
+ 	},
+ 	.probe = mlxreg_io_probe,
++	.remove = mlxreg_io_remove,
+ };
+ 
+ module_platform_driver(mlxreg_io_driver);
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-mlxreg-io-Add-locking-for-io-opera.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-mlxreg-io-Add-locking-for-io-opera.patch
@@ -1,0 +1,106 @@
+From 77e8886b6019a37335c66dceb39429c33eb87f28 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 7 Feb 2022 21:22:04 +0200
+Subject: [PATCH platform-next 02/10] platform/mellanox: mlxreg-io: Add locking
+ for io operations
+
+Add lock to protect user read/write access to the registers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index 2c2686d5c..ddc08abf3 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -31,6 +31,7 @@
+  * @group: sysfs attribute group;
+  * @groups: list of sysfs attribute group for hwmon registration;
+  * @regsize: size of a register value;
++ * @io_lock: user access locking;
+  */
+ struct mlxreg_io_priv_data {
+ 	struct platform_device *pdev;
+@@ -41,6 +42,7 @@ struct mlxreg_io_priv_data {
+ 	struct attribute_group group;
+ 	const struct attribute_group *groups[2];
+ 	int regsize;
++	struct mutex io_lock; /* Protects user access. */
+ };
+ 
+ static int
+@@ -116,14 +118,19 @@ mlxreg_io_attr_show(struct device *dev, struct device_attribute *attr,
+ 	u32 regval = 0;
+ 	int ret;
+ 
++	mutex_lock(&priv->io_lock);
++
+ 	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, 0, true,
+ 				priv->regsize, &regval);
+ 	if (ret)
+ 		goto access_error;
+ 
++	mutex_unlock(&priv->io_lock);
++
+ 	return sprintf(buf, "%u\n", regval);
+ 
+ access_error:
++	mutex_unlock(&priv->io_lock);
+ 	return ret;
+ }
+ 
+@@ -145,6 +152,8 @@ mlxreg_io_attr_store(struct device *dev, struct device_attribute *attr,
+ 	if (ret)
+ 		return ret;
+ 
++	mutex_lock(&priv->io_lock);
++
+ 	ret = mlxreg_io_get_reg(priv->pdata->regmap, data, input_val, false,
+ 				priv->regsize, &regval);
+ 	if (ret)
+@@ -154,9 +163,12 @@ mlxreg_io_attr_store(struct device *dev, struct device_attribute *attr,
+ 	if (ret)
+ 		goto access_error;
+ 
++	mutex_unlock(&priv->io_lock);
++
+ 	return len;
+ 
+ access_error:
++	mutex_unlock(&priv->io_lock);
+ 	dev_err(&priv->pdev->dev, "Bus access error\n");
+ 	return ret;
+ }
+@@ -246,16 +258,27 @@ static int mlxreg_io_probe(struct platform_device *pdev)
+ 		return PTR_ERR(priv->hwmon);
+ 	}
+ 
++	mutex_init(&priv->io_lock);
+ 	dev_set_drvdata(&pdev->dev, priv);
+ 
+ 	return 0;
+ }
+ 
++static int mlxreg_io_remove(struct platform_device *pdev)
++{
++	struct mlxreg_io_priv_data *priv = dev_get_drvdata(&pdev->dev);
++
++	mutex_destroy(&priv->io_lock);
++
++	return 0;
++}
++
+ static struct platform_driver mlxreg_io_driver = {
+ 	.driver = {
+ 	    .name = "mlxreg-io",
+ 	},
+ 	.probe = mlxreg_io_probe,
++	.remove = mlxreg_io_remove,
+ };
+ 
+ module_platform_driver(mlxreg_io_driver);
+-- 
+2.20.1
+


### PR DESCRIPTION
Add lock to protect user read/write access to the registers.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>