### PR TITLE
hw-mgmt: scripts: fix mix-up of jtag tdi - tdo pins on SN2201

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.2002) unstable; urgency=low
+hw-management (1.mlnx.7.0020.2035) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 23 Feb 2022 12:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Sun, 03 Apr 2022 12:22:00 +0300
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -498,10 +498,10 @@ set_jtag_gpio()
 			jtag_tck=131
 			;;
 		$DNV_CPU)
+			jtag_tdi=86
 			jtag_tck=87
 			jtag_tms=88
-			jtag_tdo=86
-			jtag_tdi=89
+			jtag_tdo=89
 			;;
 		*)
 			return 0


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
