### PR TITLE
hw-mgmt: patches: 4.19/5.10 Add FAN LEDs registers to SN2201 system.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.2100) unstable; urgency=low
+hw-management (1.mlnx.7.0020.2130) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Thu, 14 Apr 2022 12:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Mon, 18 Apr 2022 12:22:00 +0300
 

--- a/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -63,7 +63,7 @@ new file mode 100644
 index 000000000..1a2103778
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
-@@ -0,0 +1,1211 @@
+@@ -0,0 +1,1259 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia sn2201 driver
@@ -130,6 +130,8 @@ index 000000000..1a2103778
 +#define NVSW_SN2201_WD_TMR_OFFSET_LSB               0x40
 +#define NVSW_SN2201_WD_TMR_OFFSET_MSB               0x41
 +#define NVSW_SN2201_WD_ACT_OFFSET                   0x42
++#define NVSW_SN2201_FAN_LED1_CTRL_OFFSET            0x50
++#define NVSW_SN2201_FAN_LED2_CTRL_OFFSET            0x51
 +#define NVSW_SN2201_REG_MAX                         0x43
 +
 +/* Number of physical I2C busses. */
@@ -243,6 +245,8 @@ index 000000000..1a2103778
 +	case NVSW_SN2201_WD_TMR_OFFSET_LSB:
 +	case NVSW_SN2201_WD_TMR_OFFSET_MSB:
 +	case NVSW_SN2201_WD_ACT_OFFSET:
++	case NVSW_SN2201_FAN_LED1_CTRL_OFFSET:
++	case NVSW_SN2201_FAN_LED2_CTRL_OFFSET:
 +		return true;
 +	}
 +	return false;
@@ -295,6 +299,8 @@ index 000000000..1a2103778
 +	case NVSW_SN2201_WD_TMR_OFFSET_LSB:
 +	case NVSW_SN2201_WD_TMR_OFFSET_MSB:
 +	case NVSW_SN2201_WD_ACT_OFFSET:
++	case NVSW_SN2201_FAN_LED1_CTRL_OFFSET:
++	case NVSW_SN2201_FAN_LED2_CTRL_OFFSET:
 +		return true;
 +	}
 +	return false;
@@ -346,6 +352,8 @@ index 000000000..1a2103778
 +	case NVSW_SN2201_FAN_PRSNT_MASK_OFFSET:
 +	case NVSW_SN2201_WD_TMR_OFFSET_LSB:
 +	case NVSW_SN2201_WD_TMR_OFFSET_MSB:
++	case NVSW_SN2201_FAN_LED1_CTRL_OFFSET:
++	case NVSW_SN2201_FAN_LED2_CTRL_OFFSET:
 +		return true;
 +	}
 +	return false;
@@ -688,6 +696,46 @@ index 000000000..1a2103778
 +		.label = "uid:blue",
 +		.reg = NVSW_SN2201_FRONT_UID_LED_CTRL_OFFSET,
 +		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan1:green",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan1:orange",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan2:green",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
++	},
++	{
++		.label = "fan2:orange",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
++	},
++	{
++		.label = "fan3:green",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan3:orange",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan4:green",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
++	},
++	{
++		.label = "fan4:orange",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
 +	},
 +};
 +
@@ -1094,7 +1142,7 @@ index 000000000..1a2103778
 +		dev_err(nvsw_sn2201->dev, "Failed to get adapter for bus %d\n",
 +			nvsw_sn2201->cpld_devs->nr);
 +		goto i2c_get_adapter_main_fail;
-+	} 
++	}
 +
 +	nvsw_sn2201->main_mux_devs_num = ARRAY_SIZE(nvsw_sn2201_main_mux_brdinfo);
 +	err = nvsw_sn2201_create_static_devices(nvsw_sn2201, nvsw_sn2201->main_mux_devs,
@@ -1102,7 +1150,7 @@ index 000000000..1a2103778
 +	if (err) {
 +		dev_err(nvsw_sn2201->dev, "Failed to create main mux devices\n");
 +		goto nvsw_sn2201_create_static_devices_fail;
-+	} 
++	}
 +
 +	nvsw_sn2201->cpld_devs->adapter = i2c_get_adapter(nvsw_sn2201->cpld_devs->nr);
 +	if (!nvsw_sn2201->cpld_devs->adapter) {
@@ -1114,7 +1162,7 @@ index 000000000..1a2103778
 +
 +	/* Create CPLD device. */
 +	nvsw_sn2201->cpld_devs->client = i2c_new_dummy(nvsw_sn2201->cpld_devs->adapter,
-+						       NVSW_SN2201_CPLD_I2CADDR);
++							      NVSW_SN2201_CPLD_I2CADDR);
 +	if (IS_ERR(nvsw_sn2201->cpld_devs->client)) {
 +		err = PTR_ERR(nvsw_sn2201->cpld_devs->client);
 +		dev_err(nvsw_sn2201->dev, "Failed to create %s cpld device at bus %d at addr 0x%02x\n",

--- a/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -64,7 +64,7 @@ new file mode 100644
 index 000000000..06a257ee1
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
-@@ -0,0 +1,1211 @@
+@@ -0,0 +1,1259 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia sn2201 driver
@@ -131,6 +131,8 @@ index 000000000..06a257ee1
 +#define NVSW_SN2201_WD_TMR_OFFSET_LSB               0x40
 +#define NVSW_SN2201_WD_TMR_OFFSET_MSB               0x41
 +#define NVSW_SN2201_WD_ACT_OFFSET                   0x42
++#define NVSW_SN2201_FAN_LED1_CTRL_OFFSET            0x50
++#define NVSW_SN2201_FAN_LED2_CTRL_OFFSET            0x51
 +#define NVSW_SN2201_REG_MAX                         0x43
 +
 +/* Number of physical I2C busses. */
@@ -244,6 +246,8 @@ index 000000000..06a257ee1
 +	case NVSW_SN2201_WD_TMR_OFFSET_LSB:
 +	case NVSW_SN2201_WD_TMR_OFFSET_MSB:
 +	case NVSW_SN2201_WD_ACT_OFFSET:
++	case NVSW_SN2201_FAN_LED1_CTRL_OFFSET:
++	case NVSW_SN2201_FAN_LED2_CTRL_OFFSET:
 +		return true;
 +	}
 +	return false;
@@ -296,6 +300,8 @@ index 000000000..06a257ee1
 +	case NVSW_SN2201_WD_TMR_OFFSET_LSB:
 +	case NVSW_SN2201_WD_TMR_OFFSET_MSB:
 +	case NVSW_SN2201_WD_ACT_OFFSET:
++	case NVSW_SN2201_FAN_LED1_CTRL_OFFSET:
++	case NVSW_SN2201_FAN_LED2_CTRL_OFFSET:
 +		return true;
 +	}
 +	return false;
@@ -347,6 +353,8 @@ index 000000000..06a257ee1
 +	case NVSW_SN2201_FAN_PRSNT_MASK_OFFSET:
 +	case NVSW_SN2201_WD_TMR_OFFSET_LSB:
 +	case NVSW_SN2201_WD_TMR_OFFSET_MSB:
++	case NVSW_SN2201_FAN_LED1_CTRL_OFFSET:
++	case NVSW_SN2201_FAN_LED2_CTRL_OFFSET:
 +		return true;
 +	}
 +	return false;
@@ -689,6 +697,46 @@ index 000000000..06a257ee1
 +		.label = "uid:blue",
 +		.reg = NVSW_SN2201_FRONT_UID_LED_CTRL_OFFSET,
 +		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan1:green",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan1:orange",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan2:green",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
++	},
++	{
++		.label = "fan2:orange",
++		.reg = NVSW_SN2201_FAN_LED1_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
++	},
++	{
++		.label = "fan3:green",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan3:orange",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(7, 4),
++	},
++	{
++		.label = "fan4:green",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
++	},
++	{
++		.label = "fan4:orange",
++		.reg = NVSW_SN2201_FAN_LED2_CTRL_OFFSET,
++		.mask = GENMASK(3, 0),
 +	},
 +};
 +


### PR DESCRIPTION
Add "dummy" CPLD FAN LEDs registers to the SN2201 system.
CPLD doesn't handle FAN LEDs on SN2201 but this register will allow triggering of actual LED change
through GPIO by hw-mgmt Udev handler script.
CPLD will change the state of the front panel FAN LED according to these registers.
Also, these registers add alignment of hw-mgmt attributes on SN2201 with other systems.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
