### PR TITLE
hw-mgmt: patches: 4.19/5.10 Fix 16-ch i2c bus mux support in NVLink4 managed switch

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0157-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-4.19/0157-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,7 +1,7 @@
-From 25a1b0a5c14499df8b0e53e64a2a39058591cabe Mon Sep 17 00:00:00 2001
+From b94ee21fc259212284eeb6acc1771134565f87e5 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 27 Jan 2022 15:07:28 +0200
-Subject: [PATCH] platform: mellanox: Introduce support for NDR InfiniBand
+Subject: [PATCH 1/3] platform: mellanox: Introduce support for NDR InfiniBand
  modular chassis
 
 Add support for MQM9510-N leaf and MQM9520-N spine blades for two
@@ -28,11 +28,11 @@ different I2C mux topology and extended LED and hotplug configuration.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 689 +++++++++++++++++++++++++++++++-----
- 1 file changed, 602 insertions(+), 87 deletions(-)
+ drivers/platform/x86/mlx-platform.c | 691 +++++++++++++++++++++++++++++++-----
+ 1 file changed, 604 insertions(+), 87 deletions(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 0ce52223a..9c517ebbe 100644
+index 170efd392..2add6b778 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -67,6 +67,9 @@
@@ -80,7 +80,7 @@ index 0ce52223a..9c517ebbe 100644
  
  /* Number of LPC attached MUX platform devices */
  #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
-@@ -457,6 +467,34 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+@@ -457,6 +467,36 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
  	},
  };
  
@@ -108,6 +108,8 @@ index 0ce52223a..9c517ebbe 100644
 +		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
 +		.reg_size = 1,
 +		.idle_in_use = 1,
++		.values = mlxplat_msn21xx_channels,
++		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
 +	},
 +
 +};
@@ -115,7 +117,7 @@ index 0ce52223a..9c517ebbe 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -592,7 +630,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_asic_items_data[] = {
+@@ -592,7 +632,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_asic_items_data[] = {
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
  		.mask = MLXPLAT_CPLD_ASIC_MASK,
  		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
@@ -124,7 +126,7 @@ index 0ce52223a..9c517ebbe 100644
  };
  
  static struct mlxreg_core_data mlxplat_mlxcpld_default_asic2_items_data[] = {
-@@ -1293,7 +1331,7 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+@@ -1293,7 +1333,7 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
  		.data = mlxplat_mlxcpld_default_asic_items_data,
  		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
@@ -133,7 +135,7 @@ index 0ce52223a..9c517ebbe 100644
  		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_asic_items_data),
  		.inversed = 0,
  		.health = true,
-@@ -1302,27 +1340,11 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
+@@ -1302,27 +1342,11 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
  		.data = mlxplat_mlxcpld_default_asic2_items_data,
  		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
@@ -163,7 +165,7 @@ index 0ce52223a..9c517ebbe 100644
  };
  
  static
-@@ -2176,6 +2198,118 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_modular_data = {
+@@ -2176,6 +2200,118 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_modular_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
@@ -282,7 +284,7 @@ index 0ce52223a..9c517ebbe 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -2269,7 +2403,6 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_led_wc_data[] = {
+@@ -2269,7 +2405,6 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_led_wc_data[] = {
  	},
  };
  
@@ -290,7 +292,7 @@ index 0ce52223a..9c517ebbe 100644
  static struct mlxreg_core_platform_data mlxplat_default_led_wc_data = {
  		.data = mlxplat_mlxcpld_default_led_wc_data,
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_led_wc_data),
-@@ -2457,14 +2590,14 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_led_data[] = {
+@@ -2457,14 +2592,14 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_led_data[] = {
  	{
  		.label = "fan7:green",
  		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
@@ -307,7 +309,7 @@ index 0ce52223a..9c517ebbe 100644
  		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
  		.bit = BIT(6),
  	},
-@@ -2706,6 +2839,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
+@@ -2706,6 +2841,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_led_data),
  };
  
@@ -414,7 +416,7 @@ index 0ce52223a..9c517ebbe 100644
  /* Platform led data for QMB8700 system */
  static struct mlxreg_core_data mlxplat_mlxcpld_qmb8700_led_data[] = {
  	{
-@@ -3167,16 +3400,16 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3167,16 +3402,16 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -434,21 +436,21 @@ index 0ce52223a..9c517ebbe 100644
  	},
  	{
  		.label = "reset_long_pb",
-@@ -3317,6 +3550,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
- 		.bit = 1,
+@@ -3318,6 +3553,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  	},
-+	{
+ 	{
 +		.label = "asic2_health",
 +		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
 +		.mask = MLXPLAT_CPLD_ASIC_MASK,
 +		.bit = 1,
 +		.mode = 0444,
 +	},
- 	{
++	{
  		.label = "fan_dir",
  		.reg = MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION,
-@@ -3672,49 +3912,49 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+@@ -3672,49 +3914,49 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
  		.label = "lc1_rst_mask",
  		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
  		.mask = GENMASK(7, 0) & ~BIT(0),
@@ -506,20 +508,20 @@ index 0ce52223a..9c517ebbe 100644
  	},
  	{
  		.label = "psu1_on",
-@@ -3764,12 +4004,6 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
- 		.mask = GENMASK(7, 0) & ~BIT(7),
+@@ -3765,12 +4007,6 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
  		.mode = 0644,
  	},
--	{
+ 	{
 -		.label = "os_ready",
 -		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
 -		.mask = GENMASK(7, 0) & ~BIT(6),
 -		.mode = 0444,
 -	},
- 	{
+-	{
  		.label = "jtag_enable",
  		.reg = MLXPLAT_CPLD_LPC_REG_FIELD_UPGRADE,
-@@ -3875,6 +4109,203 @@ static struct mlxreg_core_platform_data mlxplat_modular_regs_io_data = {
+ 		.mask = GENMASK(3, 0),
+@@ -3875,6 +4111,203 @@ static struct mlxreg_core_platform_data mlxplat_modular_regs_io_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_regs_io_data),
  };
  
@@ -723,7 +725,7 @@ index 0ce52223a..9c517ebbe 100644
  /* Platform FAN default */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
  	{
-@@ -4015,6 +4446,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+@@ -4015,6 +4448,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
  static struct mlxreg_core_platform_data mlxplat_default_fan_data = {
  		.data = mlxplat_mlxcpld_default_fan_data,
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_fan_data),
@@ -731,7 +733,7 @@ index 0ce52223a..9c517ebbe 100644
  };
  
  /* Platform FAN default */
-@@ -4363,6 +4795,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4363,6 +4797,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
@@ -740,7 +742,7 @@ index 0ce52223a..9c517ebbe 100644
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
-@@ -4389,6 +4823,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4389,6 +4825,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -749,7 +751,7 @@ index 0ce52223a..9c517ebbe 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4457,6 +4893,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4457,6 +4895,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
@@ -759,7 +761,7 @@ index 0ce52223a..9c517ebbe 100644
  	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
-@@ -4495,6 +4934,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4495,6 +4936,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -769,7 +771,7 @@ index 0ce52223a..9c517ebbe 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4588,6 +5030,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4588,6 +5032,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
@@ -779,7 +781,7 @@ index 0ce52223a..9c517ebbe 100644
  	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
-@@ -4626,6 +5071,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4626,6 +5073,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -789,7 +791,7 @@ index 0ce52223a..9c517ebbe 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
-@@ -5045,6 +5493,28 @@ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
+@@ -5045,6 +5495,28 @@ static int __init mlxplat_dmi_modular_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -818,7 +820,7 @@ index 0ce52223a..9c517ebbe 100644
  static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -5071,6 +5541,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+@@ -5071,6 +5543,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -846,11 +848,10 @@ index 0ce52223a..9c517ebbe 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5135,6 +5626,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
- 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0009"),
+@@ -5136,6 +5629,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  		},
  	},
-+	{
+ 	{
 +		.callback = mlxplat_dmi_ndr_ib_modular_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
@@ -864,23 +865,24 @@ index 0ce52223a..9c517ebbe 100644
 +			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
 +		},
 +	},
- 	{
++	{
  		.callback = mlxplat_dmi_ng400_matched,
  		.matches = {
-@@ -5147,6 +5652,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
- 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0011"),
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
+@@ -5148,6 +5655,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  		},
  	},
-+	{
+ 	{
 +		.callback = mlxplat_dmi_nvlink_blade_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
 +		},
 +	},
- 	{
++	{
  		.callback = mlxplat_dmi_msn274x_matched,
  		.matches = {
-@@ -5336,22 +5847,20 @@ static int __init mlxplat_init(void)
+ 			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+@@ -5336,22 +5849,20 @@ static int __init mlxplat_init(void)
  	nr = (nr == mlxplat_max_adap_num) ? -1 : nr;
  	if (mlxplat_i2c)
  		mlxplat_i2c->regmap = priv->regmap;
@@ -911,7 +913,7 @@ index 0ce52223a..9c517ebbe 100644
  		if (IS_ERR(priv->pdev_mux[i])) {
  			err = PTR_ERR(priv->pdev_mux[i]);
  			goto fail_platform_mux_register;
-@@ -5359,16 +5868,18 @@ static int __init mlxplat_init(void)
+@@ -5359,16 +5870,18 @@ static int __init mlxplat_init(void)
  	}
  
  	/* Add hotplug driver */
@@ -940,7 +942,7 @@ index 0ce52223a..9c517ebbe 100644
  	}
  
  	/* Set default registers. */
-@@ -5381,24 +5892,26 @@ static int __init mlxplat_init(void)
+@@ -5381,24 +5894,26 @@ static int __init mlxplat_init(void)
  	}
  
  	/* Add LED driver. */
@@ -980,7 +982,7 @@ index 0ce52223a..9c517ebbe 100644
  		if (IS_ERR(priv->pdev_io_regs)) {
  			err = PTR_ERR(priv->pdev_io_regs);
  			goto fail_platform_led_register;
-@@ -5408,11 +5921,10 @@ static int __init mlxplat_init(void)
+@@ -5408,11 +5923,10 @@ static int __init mlxplat_init(void)
  	/* Add FAN driver. */
  	if (mlxplat_fan) {
  		mlxplat_fan->regmap = priv->regmap;
@@ -996,7 +998,7 @@ index 0ce52223a..9c517ebbe 100644
  		if (IS_ERR(priv->pdev_fan)) {
  			err = PTR_ERR(priv->pdev_fan);
  			goto fail_platform_io_regs_register;
-@@ -5426,11 +5938,10 @@ static int __init mlxplat_init(void)
+@@ -5426,11 +5940,10 @@ static int __init mlxplat_init(void)
  	for (j = 0; j < MLXPLAT_CPLD_WD_MAX_DEVS; j++) {
  		if (mlxplat_wd_data[j]) {
  			mlxplat_wd_data[j]->regmap = priv->regmap;
@@ -1012,7 +1014,7 @@ index 0ce52223a..9c517ebbe 100644
  			if (IS_ERR(priv->pdev_wd[j])) {
  				err = PTR_ERR(priv->pdev_wd[j]);
  				goto fail_platform_wd_register;
-@@ -5455,9 +5966,11 @@ fail_platform_io_regs_register:
+@@ -5455,9 +5968,11 @@ fail_platform_io_regs_register:
  	if (mlxplat_regs_io)
  		platform_device_unregister(priv->pdev_io_regs);
  fail_platform_led_register:
@@ -1026,7 +1028,7 @@ index 0ce52223a..9c517ebbe 100644
  fail_platform_mux_register:
  	while (--i >= 0)
  		platform_device_unregister(priv->pdev_mux[i]);
-@@ -5480,8 +5993,10 @@ static void __exit mlxplat_exit(void)
+@@ -5480,8 +5995,10 @@ static void __exit mlxplat_exit(void)
  		platform_device_unregister(priv->pdev_fan);
  	if (priv->pdev_io_regs)
  		platform_device_unregister(priv->pdev_io_regs);
@@ -1040,5 +1042,5 @@ index 0ce52223a..9c517ebbe 100644
  	for (i = mlxplat_mux_num - 1; i >= 0 ; i--)
  		platform_device_unregister(priv->pdev_mux[i]);
 -- 
-2.14.1
+2.8.4
 

--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,4 +1,4 @@
-From 4fc50a614dd571cf7f42a78ca915e2d9d1494994 Mon Sep 17 00:00:00 2001
+From 423b6c11616f3267793bfc315aefa54f5f7fc7a0 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
 Subject: [PATCH] platform: mellanox: Introduce support for NVLink4 managed
@@ -36,7 +36,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 176 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 9c517ebbe..1cd8b77f5 100644
+index 9914e50..39a2a17 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,12 @@
@@ -68,7 +68,7 @@ index 9c517ebbe..1cd8b77f5 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -2310,6 +2318,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
+@@ -2312,6 +2320,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
  		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
  };
  
@@ -166,11 +166,10 @@ index 9c517ebbe..1cd8b77f5 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -3411,6 +3510,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
- 		.bit = GENMASK(7, 0) & ~BIT(2),
+@@ -3414,6 +3513,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  	},
-+	{
+ 	{
 +		.label = "erot1_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
 +		.bit = GENMASK(7, 0) & ~BIT(6),
@@ -194,23 +193,24 @@ index 9c517ebbe..1cd8b77f5 100644
 +		.bit = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0644,
 +	},
- 	{
++	{
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
-@@ -3606,6 +3729,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
- 		.mask = GENMASK(7, 0) & ~BIT(4),
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+@@ -3609,6 +3732,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0644,
  	},
-+	{
+ 	{
 +		.label = "spi_chnl_select",
 +		.reg = MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT,
 +		.bit = GENMASK(7, 0),
 +		.mode = 0644,
 +	},
- 	{
++	{
  		.label = "config1",
  		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
-@@ -4807,6 +4936,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 		.bit = GENMASK(7, 0),
+@@ -4809,6 +4938,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -221,7 +221,7 @@ index 9c517ebbe..1cd8b77f5 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
-@@ -4826,6 +4959,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4828,6 +4961,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -229,7 +229,7 @@ index 9c517ebbe..1cd8b77f5 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -4911,6 +5045,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4913,6 +5047,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -242,7 +242,7 @@ index 9c517ebbe..1cd8b77f5 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -4938,6 +5078,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4940,6 +5080,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -250,7 +250,7 @@ index 9c517ebbe..1cd8b77f5 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -5048,6 +5189,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5050,6 +5191,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -263,7 +263,7 @@ index 9c517ebbe..1cd8b77f5 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -5075,6 +5222,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5077,6 +5224,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -271,7 +271,7 @@ index 9c517ebbe..1cd8b77f5 100644
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
-@@ -5562,6 +5710,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
+@@ -5564,6 +5712,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
  	return 1;
  }
  
@@ -299,20 +299,20 @@ index 9c517ebbe..1cd8b77f5 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5640,6 +5809,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
- 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
+@@ -5643,6 +5812,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  		},
  	},
-+	{
+ 	{
 +		.callback = mlxplat_dmi_nvlink_switch_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
 +			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI142"),
 +		},
 +	},
- 	{
++	{
  		.callback = mlxplat_dmi_ng400_matched,
  		.matches = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
 -- 
-2.14.1
+2.8.4
 

--- a/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -28,11 +28,11 @@ different I2C mux topology and extended LED and hotplug configuration.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 257 ++++++++++++++++++++++++++++
- 1 file changed, 257 insertions(+)
+ drivers/platform/x86/mlx-platform.c | 259 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 259 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 170efd392..9914e5035 100644
+index 170efd392..2add6b778 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -108,6 +108,9 @@
@@ -69,7 +69,7 @@ index 170efd392..9914e5035 100644
  
  /* Number of LPC attached MUX platform devices */
  #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
-@@ -460,6 +466,34 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+@@ -460,6 +466,36 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
  	},
  };
  
@@ -97,6 +97,8 @@ index 170efd392..9914e5035 100644
 +		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
 +		.reg_size = 1,
 +		.idle_in_use = 1,
++		.values = mlxplat_msn21xx_channels,
++		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
 +	},
 +
 +};
@@ -104,7 +106,7 @@ index 170efd392..9914e5035 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -2164,6 +2198,86 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
+@@ -2164,6 +2200,86 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
@@ -191,7 +193,7 @@ index 170efd392..9914e5035 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -2693,6 +2807,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
+@@ -2693,6 +2809,106 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_led_data),
  };
  
@@ -298,7 +300,7 @@ index 170efd392..9914e5035 100644
  /* Platform led data for QMB8700 system */
  static struct mlxreg_core_data mlxplat_mlxcpld_qmb8700_led_data[] = {
  	{
-@@ -4574,6 +4788,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4574,6 +4790,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -307,7 +309,7 @@ index 170efd392..9914e5035 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4682,6 +4898,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4682,6 +4900,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -317,7 +319,7 @@ index 170efd392..9914e5035 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4815,6 +5034,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4815,6 +5036,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -327,7 +329,7 @@ index 170efd392..9914e5035 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
-@@ -5282,6 +5504,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+@@ -5282,6 +5506,27 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -355,7 +357,7 @@ index 170efd392..9914e5035 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5346,6 +5589,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5346,6 +5591,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0009"),
  		},
  	},

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -68,7 +68,7 @@ index 9914e50..39a2a17 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -2278,6 +2286,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
+@@ -2280,6 +2288,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
  		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
  };
  
@@ -166,7 +166,7 @@ index 9914e50..39a2a17 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -3380,6 +3479,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3382,6 +3481,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -197,7 +197,7 @@ index 9914e50..39a2a17 100644
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
  		.mask = GENMASK(7, 0) & ~BIT(0),
-@@ -3575,6 +3698,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3577,6 +3700,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0644,
  	},
  	{
@@ -210,7 +210,7 @@ index 9914e50..39a2a17 100644
  		.label = "config1",
  		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
  		.bit = GENMASK(7, 0),
-@@ -4772,6 +4901,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4774,6 +4903,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -221,7 +221,7 @@ index 9914e50..39a2a17 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
-@@ -4791,6 +4924,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4793,6 +4926,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -229,7 +229,7 @@ index 9914e50..39a2a17 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -4875,6 +5009,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4877,6 +5011,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -242,7 +242,7 @@ index 9914e50..39a2a17 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -4902,6 +5042,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4904,6 +5044,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -250,7 +250,7 @@ index 9914e50..39a2a17 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -5011,6 +5152,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5013,6 +5154,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -263,7 +263,7 @@ index 9914e50..39a2a17 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -5038,6 +5185,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5040,6 +5187,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -271,7 +271,7 @@ index 9914e50..39a2a17 100644
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
-@@ -5525,6 +5673,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
+@@ -5527,6 +5675,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
  	return 1;
  }
  
@@ -299,7 +299,7 @@ index 9914e50..39a2a17 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5604,6 +5773,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5606,6 +5775,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  		},
  	},
  	{

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -289,7 +289,7 @@ p4697_base_connect_table=(    max11603 0x6d 5 \
 			adt75 0x4a 7 \
 			24c512 0x51 8)
 
-p4697_base_rev1_connect_table=(    max11603 0x6d 5 \
+p4697_rev1_base_connect_table=(    max11603 0x6d 5 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
@@ -1089,6 +1089,8 @@ e3597_specific()
 
 p4697_specific()
 {
+	local cpu_bus_offset=18
+
 	regio_path=$(find_regio_sysfs_path)
 	res=$?
 	if [ $res -eq 0 ]; then
@@ -1108,15 +1110,16 @@ p4697_specific()
 		connect_table=(${p4697_base_connect_table[@]})
 	fi
 
+	add_cpu_board_to_connection_table $cpu_bus_offset
 	add_i2c_dynamic_bus_dev_connection_table "${p4697_dynamic_i2c_bus_connect_table[@]}"
-	add_cpu_board_to_connection_table
 
 	thermal_type=$thermal_type_def
 	max_tachos=14
 	hotplug_fans=7
 	erot_count=2
 	i2c_asic_addr=0xff
-
+	i2c_comex_mon_bus_default=23
+	i2c_bus_def_off_eeprom_cpu=24
 	echo 25000 > $config_path/fan_max_speed
 	echo 4500 > $config_path/fan_min_speed
 	echo 23000 > $config_path/psu_fan_max


### PR DESCRIPTION
Fix 16-ch i2c bus mux support in NVLink4 managed switch

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
