### PR TITLE
hw-mgmt: patches: 4.19/5.10 Fix LED num for NVLink4 managed switch

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -285,7 +285,7 @@ index 9914e50..39a2a17 100644
 +	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
-+	mlxplat_led = &mlxplat_ndr_ib_modular_led_data;
++	mlxplat_led = &mlxplat_default_ng_led_data;
 +	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
 +	mlxplat_fan = &mlxplat_default_fan_data;
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -285,7 +285,7 @@ index 9914e50..39a2a17 100644
 +	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
-+	mlxplat_led = &mlxplat_ndr_ib_modular_led_data;
++	mlxplat_led = &mlxplat_default_ng_led_data;
 +	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
 +	mlxplat_fan = &mlxplat_default_fan_data;
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -552,6 +552,7 @@ function get_i2c_voltmon_prefix()
 }
 
 if [ "$1" == "add" ]; then
+
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then
 		exit 0

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -284,22 +284,22 @@ e3597_dynamic_i2c_bus_connect_table=(  mp2975 0x22 5 voltmon1 \
 			mp2975 0x26 5  voltmon5 \
 			mp2975 0x27 5  voltmon6)
 
-p4697_base_connect_table=(    max11603 0x6d 5 \
+p4697_base_connect_table=(    max11603 0x6d 7 \
 			adt75 0x49 7 \
 			adt75 0x4a 7 \
 			24c512 0x51 8)
 
-p4697_rev1_base_connect_table=(    max11603 0x6d 5 \
+p4697_rev1_base_connect_table=(    max11603 0x6d 7 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
 
-p4697_dynamic_i2c_bus_connect_table=(  mp2975 0x23 26 voltmon1 \
-			mp2975 0x24 26 voltmon2 \
-			mp2975 0x27 26 voltmon3 \
-			mp2975 0x23 31 voltmon4 \
-			mp2975 0x24 31 voltmon5 \
-			mp2975 0x27 31 voltmon6)
+p4697_dynamic_i2c_bus_connect_table=(  mp2975 0x23 28 voltmon1 \
+			mp2975 0x24 28 voltmon2 \
+			mp2975 0x27 28 voltmon3 \
+			mp2975 0x23 33 voltmon4 \
+			mp2975 0x24 33 voltmon5 \
+			mp2975 0x27 33 voltmon6)
 
 msn4800_base_connect_table=( mp2975 0x62 5 \
 	mp2975 0x64 5 \
@@ -1089,8 +1089,7 @@ e3597_specific()
 
 p4697_specific()
 {
-	local cpu_bus_offset=18
-
+	local cpu_bus_offset=10
 	regio_path=$(find_regio_sysfs_path)
 	res=$?
 	if [ $res -eq 0 ]; then
@@ -1120,6 +1119,7 @@ p4697_specific()
 	i2c_asic_addr=0xff
 	i2c_comex_mon_bus_default=23
 	i2c_bus_def_off_eeprom_cpu=24
+
 	echo 25000 > $config_path/fan_max_speed
 	echo 4500 > $config_path/fan_min_speed
 	echo 23000 > $config_path/psu_fan_max


### PR DESCRIPTION
Fix LED num for NVLink4 managed switch.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
