### PR TITLE
hw-mgmt: patches: 4.19/5.10 Fix LED num for NVLink4 managed switch

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -285,7 +285,7 @@ index 9914e50..39a2a17 100644
 +	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
-+	mlxplat_led = &mlxplat_ndr_ib_modular_led_data;
++	mlxplat_led = &mlxplat_default_ng_led_data;
 +	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
 +	mlxplat_fan = &mlxplat_default_fan_data;
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -285,7 +285,7 @@ index 9914e50..39a2a17 100644
 +	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
-+	mlxplat_led = &mlxplat_ndr_ib_modular_led_data;
++	mlxplat_led = &mlxplat_default_ng_led_data;
 +	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
 +	mlxplat_fan = &mlxplat_default_fan_data;
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)


### PR DESCRIPTION
Fix LED num for NVLink4 managed switch.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
