### PR TITLE
hw-mgmt: topology: Fix setting for SGX H100 system Fix I2C bus device address.

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -284,22 +284,22 @@ e3597_dynamic_i2c_bus_connect_table=(  mp2975 0x22 5 voltmon1 \
 			mp2975 0x26 5  voltmon5 \
 			mp2975 0x27 5  voltmon6)
 
-p4697_base_connect_table=(    max11603 0x6d 5 \
+p4697_base_connect_table=(    max11603 0x6d 7 \
 			adt75 0x49 7 \
 			adt75 0x4a 7 \
 			24c512 0x51 8)
 
-p4697_rev1_base_connect_table=(    max11603 0x6d 5 \
+p4697_rev1_base_connect_table=(    max11603 0x6d 7 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
 
-p4697_dynamic_i2c_bus_connect_table=(  mp2975 0x23 26 voltmon1 \
-			mp2975 0x24 26 voltmon2 \
-			mp2975 0x27 26 voltmon3 \
-			mp2975 0x23 31 voltmon4 \
-			mp2975 0x24 31 voltmon5 \
-			mp2975 0x27 31 voltmon6)
+p4697_dynamic_i2c_bus_connect_table=(  mp2975 0x23 28 voltmon1 \
+			mp2975 0x24 28 voltmon2 \
+			mp2975 0x27 28 voltmon3 \
+			mp2975 0x23 33 voltmon4 \
+			mp2975 0x24 33 voltmon5 \
+			mp2975 0x27 33 voltmon6)
 
 msn4800_base_connect_table=( mp2975 0x62 5 \
 	mp2975 0x64 5 \
@@ -1089,8 +1089,7 @@ e3597_specific()
 
 p4697_specific()
 {
-	local cpu_bus_offset=18
-
+	local cpu_bus_offset=10
 	regio_path=$(find_regio_sysfs_path)
 	res=$?
 	if [ $res -eq 0 ]; then


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
