### PR TITLE
hw-mgmt: patches: 4.19/5.10: Add sending udev event from leds-mlxreg driver.

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0159-leds-mlxreg-Send-udev-change-event.patch
+++ b/recipes-kernel/linux/linux-4.19/0159-leds-mlxreg-Send-udev-change-event.patch
@@ -1,0 +1,54 @@
+--- a/drivers/leds/leds-mlxreg.c	2022-04-25 14:42:07.698080756 +0300
++++ b/drivers/leds/leds-mlxreg.c	2022-04-25 16:05:29.091906358 +0300
+@@ -4,6 +4,7 @@
+ // Copyright (c) 2018 Vadim Pasternak <vadimp@mellanox.com>
+ 
+ #include <linux/bitops.h>
++#include <linux/ctype.h>
+ #include <linux/device.h>
+ #include <linux/io.h>
+ #include <linux/leds.h>
+@@ -144,15 +145,41 @@
+ 	return LED_OFF;
+ }
+ 
++static char *mlxreg_led_udev_envp[] = { NULL, NULL };
++
++static int
++mlxreg_led_udev_event_send(struct mlxreg_led_data *led_data, enum led_brightness value)
++{
++	struct mlxreg_core_data *data = led_data->data;
++	struct kobject *kobj = &led_data->led_cdev.dev->kobj;
++	int i;
++
++	char event_str[MLXREG_CORE_LABEL_MAX_SIZE + 2];
++	char label[MLXREG_CORE_LABEL_MAX_SIZE] = { 0 };
++
++	mlxreg_led_udev_envp[0] = event_str;
++        for (i = 0; data->label[i]; i++)                                                             
++		label[i] = toupper(data->label[i]);
++	snprintf(event_str, MLXREG_CORE_LABEL_MAX_SIZE, "%s=%d", label, value);
++
++	return kobject_uevent_env(kobj, KOBJ_CHANGE, mlxreg_led_udev_envp);
++}
++
+ static int
+ mlxreg_led_brightness_set(struct led_classdev *cled, enum led_brightness value)
+ {
+ 	struct mlxreg_led_data *led_data = cdev_to_priv(cled);
++	int err;
+ 
+ 	if (value)
+-		return mlxreg_led_store_hw(led_data, led_data->base_color);
++		err = mlxreg_led_store_hw(led_data, led_data->base_color);
++	else
++		err = mlxreg_led_store_hw(led_data, MLXREG_LED_IS_OFF);
++
++	if (!err)
++		return mlxreg_led_udev_event_send(led_data, value);
+ 	else
+-		return mlxreg_led_store_hw(led_data, MLXREG_LED_IS_OFF);
++		return err;
+ }
+ 
+ static enum led_brightness

--- a/recipes-kernel/linux/linux-5.10/0166-leds-mlxreg-Send-udev-change-event.patch
+++ b/recipes-kernel/linux/linux-5.10/0166-leds-mlxreg-Send-udev-change-event.patch
@@ -1,0 +1,52 @@
+--- a/drivers/leds/leds-mlxreg.c	2022-04-25 14:44:47.161635632 +0300
++++ b/drivers/leds/leds-mlxreg.c	2022-04-25 14:46:32.385351169 +0300
+@@ -11,6 +11,7 @@
+ #include <linux/of_device.h>
+ #include <linux/platform_data/mlxreg.h>
+ #include <linux/platform_device.h>
++#include <linux/string_helpers.h>
+ #include <linux/regmap.h>
+ 
+ /* Codes for LEDs. */
+@@ -144,15 +145,39 @@
+ 	return LED_OFF;
+ }
+ 
++static char *mlxreg_led_udev_envp[] = { NULL, NULL };
++
++static int
++mlxreg_led_udev_event_send(struct mlxreg_led_data *led_data, enum led_brightness value)
++{
++	struct mlxreg_core_data *data = led_data->data;
++	struct kobject *kobj = &led_data->led_cdev.dev->kobj;
++
++	char event_str[MLXREG_CORE_LABEL_MAX_SIZE + 2];
++	char label[MLXREG_CORE_LABEL_MAX_SIZE] = { 0 };
++
++	mlxreg_led_udev_envp[0] = event_str;
++	string_upper(label, data->label);
++	snprintf(event_str, MLXREG_CORE_LABEL_MAX_SIZE, "%s=%d", label, value);
++
++	return kobject_uevent_env(kobj, KOBJ_CHANGE, mlxreg_led_udev_envp);
++}
++
+ static int
+ mlxreg_led_brightness_set(struct led_classdev *cled, enum led_brightness value)
+ {
+ 	struct mlxreg_led_data *led_data = cdev_to_priv(cled);
++	int err;
+ 
+ 	if (value)
+-		return mlxreg_led_store_hw(led_data, led_data->base_color);
++		err = mlxreg_led_store_hw(led_data, led_data->base_color);
++	else
++		err = mlxreg_led_store_hw(led_data, MLXREG_LED_IS_OFF);
++
++	if (!err)
++		return mlxreg_led_udev_event_send(led_data, value);
+ 	else
+-		return mlxreg_led_store_hw(led_data, MLXREG_LED_IS_OFF);
++		return err;
+ }
+ 
+ static enum led_brightness


### PR DESCRIPTION
Add sending udev event from leds-mlxreg driver in case of color change.
Likely these patches will not be accepted upstream as they provide not
so regular flow.
Patches should be taken to NOS's as exceptions in upstream.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
