### PR TITLE
hw-mgmt: scripts: Add handling of LEDs udev change events on SN2201 system.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.2130) unstable; urgency=low
+hw-management (1.mlnx.7.0020.2131) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Mon, 18 Apr 2022 12:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Thu, 28 Apr 2022 12:22:00 +0300
 

--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -357,6 +357,9 @@ SUBSYSTEM=="leds", KERNEL=="mlxreg:*:amber", ACTION=="remove", RUN+="/usr/bin/hw
 SUBSYSTEM=="leds", KERNEL=="mlxreg:*:blue", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add led %S %p %k"
 SUBSYSTEM=="leds", KERNEL=="mlxreg:*:blue", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm led %S %p %k"
 
+# SN2201 fantray LED.
+SUBSYSTEM=="leds", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/leds-mlxreg/leds/mlxreg:fan*:*", ACTION=="change", RUN+="/usr/bin/hw-management-chassis-events.sh fantray-led-event %k %s{brightness}"
+
 # Voltage controllers ucd924, tps53679
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0027/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add voltmon1 %S %p"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0027/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm voltmon1 %S %p"

--- a/usr/usr/bin/hw-management-i2c-gpio-expander.sh
+++ b/usr/usr/bin/hw-management-i2c-gpio-expander.sh
@@ -65,6 +65,14 @@ if [ "$board_type" == "VMOD0014" ]; then
 	echo "out" > /sys/class/gpio/gpio355/direction
 	echo "out" > /sys/class/gpio/gpio356/direction
 	echo "out" > /sys/class/gpio/gpio357/direction
+
+	# Initialize fantray LED value.
+	for gpio_num in $(seq 350 357); do
+		if [ -e /sys/class/gpio/gpio"$gpio_num"/active_low ]; then
+			echo 1 > /sys/class/gpio/gpio"$gpio_num"/active_low
+		fi
+		echo 0 > /sys/class/gpio/gpio"$gpio_num"/value
+	done
 fi
 
 exit 0


### PR DESCRIPTION
1. Add handling of LEDs udev change events on SN2201 system.
2. Create LEDs trigger,delay_on, delay_off links just incase that correspondent
   files exist in sysfs.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
