### PR TITLE
Add BWD COMEX A1 support to msn3700 system.

### DIFF
--- a/usr/etc/hw-management-sensors/msn3700_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn3700_sensors.conf
@@ -93,6 +93,32 @@ bus "i2c-15" "i2c-1-mux (chan_id 6)"
         label curr1 "PMIC-4 COMEX 1.2V Rail Curr (out)"
         ignore curr2
 
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-3 COMEX 1.8V Rail (out)"
+        label in3 "PMIC-3 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-3 Temp 1"
+        label power1 "PMIC-3 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-3 COMEX 1.8V Rail Pwr (out)"
+        label power3 "PMIC-3 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-3 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-3 COMEX 1.8V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-3 COMEX 1.05V Rail Curr (out)"
+        ignore curr6
+        
+    chip "mp2975-i2c-*-61"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 COMEX 1.2V Rail (out)"
+        label temp1 "PMIC-4 Temp 1"
+        label temp2 "PMIC-4 Temp 2"
+        label power1 "PMIC-4 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-4 COMEX 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-4 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-4 COMEX 1.2V Rail Curr (out)"
+        ignore curr3
+
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "dps460-i2c-*-58"


### PR DESCRIPTION
Add BWD COMEX A1 support to msn3700 system.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
