### PR TITLE
TMP: mlxsw: minimal: Ignore error reading SPAD

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0168-TMP-mlxsw-minimal-Ignore-error-reading-SPAD-register.patch
+++ b/recipes-kernel/linux/linux-5.10/0168-TMP-mlxsw-minimal-Ignore-error-reading-SPAD-register.patch
@@ -1,0 +1,30 @@
+From f6c9aa4deaf58f0bb3b0c9bbc9804479defb8c73 Mon Sep 17 00:00:00 2001
+From: root <root@fit-build-116.mtl.labs.mlnx>
+Date: Tue, 5 Apr 2022 21:35:55 +0300
+Subject: [PATCH mlxsw/TMP 1/1] TMP: mlxsw: minimal: Ignore error reading SPAD
+ register
+
+WA until FW will add support for SPAD register for
+Infiniband systems.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+index 3d07c2dcf..f5f814a7d 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+@@ -49,7 +49,7 @@ static int mlxsw_m_base_mac_get(struct mlxsw_m *mlxsw_m)
+ 
+ 	err = mlxsw_reg_query(mlxsw_m->core, MLXSW_REG(spad), spad_pl);
+ 	if (err)
+-		return err;
++		return 0; /* TMP until FW will support SPAD for IB systems */
+ 	mlxsw_reg_spad_base_mac_memcpy_from(spad_pl, mlxsw_m->base_mac);
+ 	return 0;
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
Workaround until the firmware will add support for SPAD register
for Infiniband systems.

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>