### PR TITLE
hw-mgmt: topology: Removed A2D sensor support

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -138,22 +138,19 @@ cpu_type1_xpde_voltmon_connection_table=(	xdpe12284 0x62 15 comex_voltmon1 \
 #
 # CoffeeLake CPU.
 #
-cpu_type2_connection_table=(	max11603 0x6d 15 \
-			24c32 0x50 16)
+cpu_type2_connection_table=(24c32 0x50 16)
 
 cpu_type2_mps_voltmon_connection_table=(mp2975 0x6b 15 comex_voltmon1)
 
 
 msn2700_base_connect_table=(	pmbus 0x27 5 \
 			pmbus 0x41 5 \
-			max11603 0x6d 5 \
 			lm75 0x4a 7 \
 			24c32 0x51 8 \
 			lm75 0x49 17)
 
 msn2100_base_connect_table=(	pmbus 0x27 5 \
 			pmbus 0x41 5 \
-			max11603 0x6d 5 \
 			lm75 0x4a 7 \
 			lm75 0x4b 7 \
 			24c32 0x51 8)
@@ -165,30 +162,23 @@ msn2740_base_connect_table=(	pmbus 0x27 5 \
 			tmp102 0x48 7 \
 			24c32 0x51 8)
 
-msn2010_base_connect_table=(	max11603 0x6d 5 \
-			tps53679 0x70 5 \
+msn2010_base_connect_table=(	tps53679 0x70 5 \
 			tps53679 0x71 5 \
 			lm75 0x4a 7 \
 			lm75 0x4b 7 \
 			24c32 0x51 8)
 
-mqm8700_base_connect_table=(	max11603 0x64 5 \
-			tps53679 0x70 5 \
-			tps53679 0x71 5 \
-			tmp102 0x49 7 \
+mqm8700_connect_table=( tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c32 0x51 8)
 
-mqm8700_rev1_base_connect_table=(    max11603 0x64 5 \
-			mp2975 0x62 5 \
-			mp2975 0x66 5 \
-			tmp102 0x49 7 \
-			tmp102 0x4a 7 \
-			24c32 0x51 8)
+mqm8700_voltmon_connect_table=( tps53679 0x70 5 voltmon1 \
+			tps53679 0x71 5 voltmon2)
 
-msn37xx_secured_connect_table=(    max11603 0x64 5 \
-			tps53679 0x70 5 \
-			tps53679 0x71 5 \
+mqm8700_rev1_voltmon_connect_table=( mp2975 0x62 5 voltmon1 \
+			mp2975 0x66 5 voltmon2)
+
+msn37xx_secured_connect_table=(  max11603 0x64 5 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
@@ -225,14 +215,12 @@ msn3800_base_connect_table=( max11603 0x6d 5 \
 
 msn27002_msn24102_msb78002_base_connect_table=( pmbus 0x27 5 \
 			pmbus 0x41 5 \
-			max11603 0x6d 5 \
 			lm75 0x4a 7 \
 			24c32 0x51 8 \
 			max11603 0x6d 15 \
 			lm75 0x49 17)
 
-msn4700_msn4600_base_connect_table=(	max11603 0x6d 5 \
-			xdpe12284 0x62 5 \
+msn4700_msn4600_base_connect_table=( xdpe12284 0x62 5 \
 			xdpe12284 0x64 5 \
 			xdpe12284 0x66 5 \
 			xdpe12284 0x68 5 \
@@ -243,8 +231,7 @@ msn4700_msn4600_base_connect_table=(	max11603 0x6d 5 \
 			tmp102 0x4a 7 \
 			24c32 0x51 8)
 
-msn4700_msn4600_A1_base_connect_table=(	max11603 0x6d 5 \
-			mp2975 0x62 5 \
+msn4700_msn4600_A1_base_connect_table=(	mp2975 0x62 5 \
 			mp2975 0x64 5 \
 			mp2975 0x66 5 \
 			mp2975 0x6a 5 \
@@ -287,8 +274,7 @@ mqm97xx_rev1_base_connect_table=(	mp2975 0x62 5 \
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
 
-mqm97xx_power_base_connect_table=(    max11603 0x6d 5 \
-			mp2975 0x62 5 \
+mqm97xx_power_base_connect_table=(  mp2975 0x62 5 \
 			mp2888 0x66 5 \
 			mp2975 0x68 5 \
 			mp2975 0x6a 5 \
@@ -623,9 +609,9 @@ get_fixed_fans_direction()
 # $1 - cpu bus offset.
 add_cpu_board_to_connection_table()
 {
-	local cpu_connection_table=( )
-	local cpu_voltmon_connection_table=( )
-	local HW_REV=0
+	local cpu_connection_table=()
+	local cpu_voltmon_connection_table=()
+	local HW_REV=255
 
 	regio_path=$(find_regio_sysfs_path)
 	if [ $? -eq 0 ]; then
@@ -686,9 +672,9 @@ add_cpu_board_to_connection_table()
 add_i2c_dynamic_bus_dev_connection_table()
 {
 	connection_table=("$@")
-	dynamic_i2cbus_connection_table=""
+	dynamic_i2cbus_connection_table=()
 
-	echo "${connection_table[@]}" >> $config_path/i2c_bus_connect_devices
+	echo -n "${connection_table[@]} " >> $config_path/i2c_bus_connect_devices
 	for ((i=0; i<${#connection_table[@]}; i+=4)); do
 		dynamic_i2cbus_connection_table[$i]="${connection_table[i]}"
 		dynamic_i2cbus_connection_table[$i+1]="${connection_table[i+1]}"
@@ -828,7 +814,7 @@ msn201x_specific()
 
 connect_msn3700()
 {
-	local voltmon_connection_table=( )
+	local voltmon_connection_table=()
 	regio_path=$(find_regio_sysfs_path)
 	res=$?
 	if [ $res -eq 0 ]; then
@@ -836,17 +822,18 @@ connect_msn3700()
 		case $sys_ver in
 			6|2)
 					# msn3700/msn3700C respin A1
-					connect_table+=(${msn37xx_A1_connect_tablev[@]})
+					connect_table+=(${msn37xx_A1_connect_table[@]})
 					voltmon_connection_table=(${msn37xx_A1_voltmon_connect_table[@]})
 					lm_sensors_config="$lm_sensors_configs_path/msn3700_A1_sensors.conf"
 			;;
 			*)
-					connect_table+=(${mqm8700_base_connect_table[@]})
-					lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
+					connect_table+=(${mqm8700_connect_table[@]})
+					voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 			;;
 		esac
 	else
-		connect_table+=(${mqm8700_base_connect_table[@]})
+		connect_table+=(${mqm8700_connect_table[@]})
+		voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 	fi
 	add_i2c_dynamic_bus_dev_connection_table "${voltmon_connection_table[@]}"
 }
@@ -854,21 +841,25 @@ connect_msn3700()
 mqmxxx_msn37x_msn34x_specific()
 {
 	lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
+	local voltmon_connection_table=()
 
 	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
 	case $sku in
 		HI136)
 			# msn3700C-S
 			connect_table+=(${msn37xx_secured_connect_table[@]})
+			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 		;;
 		HI112|HI116)
 			# msn3700/msn3700C
 			connect_msn3700
 		;;
 		*)
-			connect_table+=(${mqm8700_base_connect_table[@]})
+			connect_table+=(${mqm8700_connect_table[@]})
+			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 		;;
 	esac
+	add_i2c_dynamic_bus_dev_connection_table "${voltmon_connection_table[@]}"
 	add_cpu_board_to_connection_table
 
 	tune_thermal_type=1
@@ -919,7 +910,9 @@ msn3420_specific()
 
 msn_xh3000_specific()
 {
-	connect_table+=(${mqm8700_base_connect_table[@]})
+	connect_table+=(${mqm8700_connect_table[@]})
+	add_i2c_dynamic_bus_dev_connection_table "${mqm8700_voltmon_connect_table[@]}"
+
 	add_cpu_board_to_connection_table
 	hotplug_fans=0
 	hotplug_psus=0
@@ -1157,7 +1150,8 @@ mqm9520_specific()
 
 mqm87xx_rev1_specific()
 {
-	connect_table+=(${mqm8700_rev1_base_connect_table[@]})
+	connect_table+=(${mqm8700_connect_table[@]})
+	add_i2c_dynamic_bus_dev_connection_table "${mqm8700_rev1_voltmon_connect_table[@]}"
 	add_cpu_board_to_connection_table
 
 	thermal_type=$thermal_type_t5


### PR DESCRIPTION
Removed A2D sensor support from:
1. COMEX CFL board
2. msn3700
3. msn3700C
4. mqm8700
5. msn4600
6. msn4600C
7. msn2700
8. msn2100
9. msn2010
10. mqm9700
11. mqm9510
12. mqm9520

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
