### PR TITLE
kernel patches: 5.10/4.19: Fix NVLink4 CPLD registers access

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,4 +1,4 @@
-From 68ab40f217ec2009dbf440653787c7e3a8ca3df0 Mon Sep 17 00:00:00 2001
+From f1229ed34fc4776c94f1795c026c51f43e9f6b26 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
 Subject: [PATCH 1/2] platform: mellanox: Introduce support for NVLink4 managed
@@ -32,11 +32,11 @@ System equipped with:
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 224 ++++++++++++++++++++++++++++++++++++
- 1 file changed, 224 insertions(+)
+ drivers/platform/x86/mlx-platform.c | 250 +++++++++++++++++++++++++++++++++++-
+ 1 file changed, 249 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 8ccf216..a7a47fa 100644
+index 8ccf216..9e157e0 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,12 @@
@@ -56,7 +56,7 @@ index 8ccf216..a7a47fa 100644
  #define MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET	0xb0
  #define MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET	0xb1
  #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
-+#define MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET	0xc2
++#define MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET	0xc2
 +#define MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT	0xc3
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
@@ -77,7 +77,17 @@ index 8ccf216..a7a47fa 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -2312,6 +2322,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
+@@ -287,6 +297,9 @@
+ /* Minimum power required for turning on Ethernet modular system (WATT) */
+ #define MLXPLAT_CPLD_ETH_MODULAR_PWR_MIN	50
+ 
++/* Default PWM_CONTROL register value for NVlink system */
++#define MLXPLAT_REGMAP_NVSWITCH_PWM_DEFAULT 0xf4
++
+ /* mlxplat_priv - platform private data
+  * @pdev_i2c - i2c controller platform device
+  * @pdev_mux - array of mux platform devices
+@@ -2312,6 +2325,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ndr_ib_modular_data = {
  		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
  };
  
@@ -175,62 +185,67 @@ index 8ccf216..a7a47fa 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -3386,6 +3487,42 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3382,10 +3486,46 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 	{
+ 		.label = "asic2_reset",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
+-		.bit = GENMASK(7, 0) & ~BIT(2),
++		.mask = GENMASK(7, 0) & ~BIT(2),
  		.mode = 0444,
  	},
  	{
 +		.label = "erot1_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(6),
++		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot2_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(7),
++		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot1_recovery",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(6),
++		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot2_recovery",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(7),
++		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot1_wp",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(4),
++		.mask = GENMASK(7, 0) & ~BIT(4),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot2_wp",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(5),
++		.mask = GENMASK(7, 0) & ~BIT(5),
 +		.mode = 0644,
 +	},
 +	{
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
  		.mask = GENMASK(7, 0) & ~BIT(0),
-@@ -3581,6 +3718,24 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3581,6 +3721,24 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0644,
  	},
  	{
 +		.label = "erot1_ap_reset",
-+		.reg = MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(0),
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
 +		.mode = 0444,
 +	},
 +	{
 +		.label = "erot2_ap_reset",
-+		.reg = MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(1),
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
 +		.mode = 0444,
 +	},
 +	{
@@ -243,7 +258,7 @@ index 8ccf216..a7a47fa 100644
  		.label = "config1",
  		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
  		.bit = GENMASK(7, 0),
-@@ -3593,6 +3748,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3593,6 +3751,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -256,7 +271,7 @@ index 8ccf216..a7a47fa 100644
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
  		.bit = GENMASK(7, 0),
-@@ -4071,6 +4232,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+@@ -4071,6 +4235,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -269,7 +284,7 @@ index 8ccf216..a7a47fa 100644
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
  		.bit = GENMASK(7, 0),
-@@ -4268,6 +4435,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
+@@ -4268,6 +4438,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -282,7 +297,7 @@ index 8ccf216..a7a47fa 100644
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
  		.bit = GENMASK(7, 0),
-@@ -4781,6 +4954,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4781,6 +4957,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -293,7 +308,7 @@ index 8ccf216..a7a47fa 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
-@@ -4800,6 +4977,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4800,6 +4980,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -301,7 +316,7 @@ index 8ccf216..a7a47fa 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -4885,6 +5063,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4885,6 +5066,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -314,16 +329,16 @@ index 8ccf216..a7a47fa 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -4912,6 +5096,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4912,6 +5099,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
-+	case MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
 +	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -4953,6 +5139,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4953,6 +5142,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -331,7 +346,7 @@ index 8ccf216..a7a47fa 100644
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
  		return true;
  	}
-@@ -5022,6 +5209,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5022,6 +5212,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -344,16 +359,16 @@ index 8ccf216..a7a47fa 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -5049,6 +5242,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5049,6 +5245,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
-+	case MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
 +	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
-@@ -5084,6 +5279,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5084,6 +5282,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -361,7 +376,42 @@ index 8ccf216..a7a47fa 100644
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
  		return true;
  	}
-@@ -5536,6 +5732,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
+@@ -5115,6 +5314,13 @@ static const struct reg_default mlxplat_mlxcpld_regmap_ng400[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
+ };
+ 
++static const struct reg_default mlxplat_mlxcpld_regmap_nvlink[] = {
++	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, MLXPLAT_REGMAP_NVSWITCH_PWM_DEFAULT },
++	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
++};
++
+ static const struct reg_default mlxplat_mlxcpld_regmap_eth_modular[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_GP2_OFFSET, 0x61 },
+ 	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
+@@ -5208,6 +5414,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_ng400 = {
+ 	.reg_write = mlxplat_mlxcpld_reg_write,
+ };
+ 
++static const struct regmap_config mlxplat_mlxcpld_regmap_config_nvlink = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.max_register = 255,
++	.cache_type = REGCACHE_FLAT,
++	.writeable_reg = mlxplat_mlxcpld_writeable_reg,
++	.readable_reg = mlxplat_mlxcpld_readable_reg,
++	.volatile_reg = mlxplat_mlxcpld_volatile_reg,
++	.reg_defaults = mlxplat_mlxcpld_regmap_nvlink,
++	.num_reg_defaults = ARRAY_SIZE(mlxplat_mlxcpld_regmap_nvlink),
++	.reg_read = mlxplat_mlxcpld_reg_read,
++	.reg_write = mlxplat_mlxcpld_reg_write,
++};
++
+ static const struct regmap_config mlxplat_mlxcpld_regmap_config_eth_modular = {
+ 	.reg_bits = 8,
+ 	.val_bits = 8,
+@@ -5536,6 +5756,27 @@ static int __init mlxplat_dmi_ndr_ib_modular_matched(const struct dmi_system_id
  	return 1;
  }
  
@@ -381,7 +431,7 @@ index 8ccf216..a7a47fa 100644
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
 +		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
 +	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
-+	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_nvlink;
 +
 +	return 1;
 +}
@@ -389,7 +439,7 @@ index 8ccf216..a7a47fa 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5615,6 +5832,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5615,6 +5856,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  		},
  	},
  	{

--- a/recipes-kernel/linux/linux-5.10/0159-mlx-platform-Add-support-for-systems-equipped-with-t.patch
+++ b/recipes-kernel/linux/linux-5.10/0159-mlx-platform-Add-support-for-systems-equipped-with-t.patch
@@ -1,8 +1,8 @@
-From aa04a34cfd8679f11622704dd50f854c7f96a4d8 Mon Sep 17 00:00:00 2001
+From a16c819d0896932ca52006fc0ba1c977bd2ad7f6 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 26 Jan 2022 17:16:26 +0200
-Subject: [PATCH platform-next 1/4] mlx-platform: Add support for systems
- equipped with two ASICs
+Subject: [PATCH platform backport v5.10 03/10] mlx-platform: Add support for
+ systems equipped with two ASICs
 
 Motivation is to support new systems equipped with two ASICs.
 
@@ -11,14 +11,14 @@ Extend driver with:
 - Per ASIC reset control, triggering reset of ASIC internal resources
   and restarting ASIC initialization flow.
 
-Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
-Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Oleksandr Shamray <oleksandrs@nvidia.com>
 ---
  drivers/platform/x86/mlx-platform.c | 52 ++++++++++++++++++++++++++++-
  1 file changed, 51 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index fac4b6dcf..68783c489 100644
+index a74fcd9d1..cbe9eab34 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -34,6 +34,7 @@
@@ -95,13 +95,13 @@ index fac4b6dcf..68783c489 100644
 +	{
 +		.label = "asic_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-+		.mask = GENMASK(3, 0) & ~BIT(0),
++		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "asic2_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-+		.bit = GENMASK(2, 0),
++		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,
 +	},
  	{

--- a/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-COMe-NVSwitc.patch
+++ b/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-COMe-NVSwitc.patch
@@ -1,8 +1,8 @@
-From b03f1abbe240336b11045ece1c9918543cc159e0 Mon Sep 17 00:00:00 2001
+From b9f03e961b69583c0310768075c3930795c76ff7 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 26 Jan 2022 20:34:32 +0200
-Subject: [PATCH platform-next 2/5] platform: mellanox: Introduce support for
- COMe NVSwitch management module for Vulcan chassis
+Subject: [PATCH platform backport v5.10 04/10] platform: mellanox: Introduce
+ support for COMe NVSwitch management module for Vulcan chassis
 
 The Vulcan is chassis containing Nvidia's Hopper dGPU (GH100), NVswitch
 (LS10) based HGX baseboard and COMe NVSwitch management module.
@@ -20,7 +20,7 @@ Reviewed-by: Oleksandr Shamray <oleksandrs@nvidia.com>
  1 file changed, 269 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 8ef80aa89..1c529fc03 100644
+index cbe9eab34..ab26a62f8 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -67,6 +67,9 @@

--- a/recipes-kernel/linux/linux-5.10/0161-platform-x86-mlx-platform-Add-support-for-new-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0161-platform-x86-mlx-platform-Add-support-for-new-system.patch
@@ -1,8 +1,8 @@
-From 94e16f81abc1f65d83a6a0fa099f75d9e3941086 Mon Sep 17 00:00:00 2001
+From 95abc792fcd4585e3c11ecee40724a141f2936aa Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Sun, 24 Oct 2021 16:26:40 +0000
-Subject: [PATCH platform-next 3/5] platform/x86: mlx-platform: Add support for
- new system XH3000
+Subject: [PATCH platform backport v5.10 05/10] platform/x86: mlx-platform: Add
+ support for new system XH3000
 
 Add support for new system type XH3000, which is a water cooling
 Ethernet switch blade equipped with 32x200G Ethernet ports.
@@ -17,7 +17,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 51 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 1c529fc03..170efd392 100644
+index ab26a62f8..1819e0e3b 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -2262,6 +2262,25 @@ static struct mlxreg_core_platform_data mlxplat_default_led_wc_data = {

--- a/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,9 +1,8 @@
-From 939c2cd85915a31ce1bb5f812f840dc594af3096 Mon Sep 17 00:00:00 2001
+From 984b5910647d74193c7517a623a3aa45d47a41bb Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 27 Jan 2022 15:07:28 +0200
-Subject: [PATCH 1/5] platform: mellanox: Introduce support for NDR InfiniBand
- modular chassis
-X-NVConfidentiality: public
+Subject: [PATCH platform backport v5.10 06/10] platform: mellanox: Introduce
+ support for NDR InfiniBand modular chassis
 
 Add support for MQM9510-N leaf and MQM9520-N spine blades for two
 flavors of NDR InfiniBand chassis:
@@ -29,11 +28,11 @@ different I2C mux topology and extended LED and hotplug configuration.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 424 ++++++++++++++++++++++++++++++++++++
+ drivers/platform/x86/mlx-platform.c | 424 ++++++++++++++++++++++++++++
  1 file changed, 424 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 170efd392..08d93b9a8 100644
+index 1819e0e3b..d915f2d8f 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,9 @@
@@ -573,5 +572,5 @@ index 170efd392..08d93b9a8 100644
  		.callback = mlxplat_dmi_ng400_matched,
  		.matches = {
 -- 
-2.14.1
+2.20.1
 

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,4 +1,4 @@
-From 66ae1631f2da44be85cbda7e0067c9da1bc56f11 Mon Sep 17 00:00:00 2001
+From a281efcf46f3e7ae755f5cd979717fe6215931af Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
 Subject: [PATCH 1/4] platform: mellanox: Introduce support for NVLink4 managed
@@ -32,11 +32,11 @@ System equipped with:
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 224 ++++++++++++++++++++++++++++++++++++
- 1 file changed, 224 insertions(+)
+ drivers/platform/x86/mlx-platform.c | 249 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 249 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 08d93b9a8..9562cc927 100644
+index d915f2d8f..e805cba71 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,12 @@
@@ -56,7 +56,7 @@ index 08d93b9a8..9562cc927 100644
  #define MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET	0xb0
  #define MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET	0xb1
  #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
-+#define MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET	0xc2
++#define MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET	0xc2
 +#define MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT	0xc3
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
@@ -77,7 +77,17 @@ index 08d93b9a8..9562cc927 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -2444,6 +2454,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_spine_ndr_ib_modular_da
+@@ -290,6 +300,9 @@
+ /* Minimum power required for turning on Ethernet modular system (WATT) */
+ #define MLXPLAT_CPLD_ETH_MODULAR_PWR_MIN	50
+ 
++/* Default value for PWM control register for NVlink system */
++#define MLXPLAT_REGMAP_NVSWITCH_PWM_DEFAULT 0xf4
++
+ /* mlxplat_priv - platform private data
+  * @pdev_i2c - i2c controller platform device
+  * @pdev_mux - array of mux platform devices
+@@ -2444,6 +2457,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_spine_ndr_ib_modular_da
  		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
  };
  
@@ -175,75 +185,76 @@ index 08d93b9a8..9562cc927 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -3517,6 +3618,42 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
- 		.bit = GENMASK(7, 0) & ~BIT(2),
+@@ -3517,6 +3621,42 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(2),
  		.mode = 0444,
  	},
 +	{
 +		.label = "erot1_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(6),
++		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot2_reset",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(7),
++		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot1_recovery",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(6),
++		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot2_recovery",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(7),
++		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot1_wp",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(4),
++		.mask = GENMASK(7, 0) & ~BIT(4),
 +		.mode = 0644,
 +	},
 +	{
 +		.label = "erot2_wp",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(5),
++		.mask = GENMASK(7, 0) & ~BIT(5),
 +		.mode = 0644,
 +	},
  	{
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
-@@ -3712,6 +3849,24 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3712,6 +3852,25 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mask = GENMASK(7, 0) & ~BIT(4),
  		.mode = 0644,
  	},
 +	{
 +		.label = "erot1_ap_reset",
-+		.reg = MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(0),
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
 +		.mode = 0444,
 +	},
 +	{
 +		.label = "erot2_ap_reset",
-+		.reg = MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET,
-+		.bit = GENMASK(7, 0) & ~BIT(1),
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
 +		.mode = 0444,
 +	},
 +	{
 +		.label = "spi_chnl_select",
 +		.reg = MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT,
-+		.bit = GENMASK(7, 0),
++		.mask = GENMASK(7, 0),
++		.bit = 1,
 +		.mode = 0644,
 +	},
  	{
  		.label = "config1",
  		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
-@@ -3724,6 +3879,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3724,6 +3883,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -256,7 +267,7 @@ index 08d93b9a8..9562cc927 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4202,6 +4363,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+@@ -4202,6 +4367,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -269,7 +280,7 @@ index 08d93b9a8..9562cc927 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4399,6 +4566,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
+@@ -4399,6 +4570,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -282,7 +293,7 @@ index 08d93b9a8..9562cc927 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4910,6 +5083,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4910,6 +5087,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -293,7 +304,7 @@ index 08d93b9a8..9562cc927 100644
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
-@@ -4931,6 +5108,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4931,6 +5112,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -301,7 +312,7 @@ index 08d93b9a8..9562cc927 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -5015,6 +5193,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5015,6 +5197,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -314,16 +325,16 @@ index 08d93b9a8..9562cc927 100644
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET:
-@@ -5045,6 +5229,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5045,6 +5233,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
-+	case MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
 +	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -5086,6 +5272,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5086,6 +5276,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -331,7 +342,7 @@ index 08d93b9a8..9562cc927 100644
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
  		return true;
  	}
-@@ -5154,6 +5341,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5154,6 +5345,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -344,16 +355,16 @@ index 08d93b9a8..9562cc927 100644
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET:
-@@ -5184,6 +5377,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5184,6 +5381,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
-+	case MLXPLAT_CPLD_LPC_REG_EROT_MON_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
 +	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
-@@ -5219,6 +5414,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5219,6 +5418,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -361,7 +372,42 @@ index 08d93b9a8..9562cc927 100644
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
  		return true;
  	}
-@@ -5692,6 +5888,27 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
+@@ -5250,6 +5450,13 @@ static const struct reg_default mlxplat_mlxcpld_regmap_ng400[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
+ };
+ 
++static const struct reg_default mlxplat_mlxcpld_regmap_nvlink[] = {
++	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, MLXPLAT_REGMAP_NVSWITCH_PWM_DEFAULT },
++	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
++	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
++};
++
+ static const struct reg_default mlxplat_mlxcpld_regmap_eth_modular[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_GP2_OFFSET, 0x61 },
+ 	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
+@@ -5343,6 +5550,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_ng400 = {
+ 	.reg_write = mlxplat_mlxcpld_reg_write,
+ };
+ 
++static const struct regmap_config mlxplat_mlxcpld_regmap_config_nvlink = {
++	.reg_bits = 8,
++	.val_bits = 8,
++	.max_register = 255,
++	.cache_type = REGCACHE_FLAT,
++	.writeable_reg = mlxplat_mlxcpld_writeable_reg,
++	.readable_reg = mlxplat_mlxcpld_readable_reg,
++	.volatile_reg = mlxplat_mlxcpld_volatile_reg,
++	.reg_defaults = mlxplat_mlxcpld_regmap_nvlink,
++	.num_reg_defaults = ARRAY_SIZE(mlxplat_mlxcpld_regmap_nvlink),
++	.reg_read = mlxplat_mlxcpld_reg_read,
++	.reg_write = mlxplat_mlxcpld_reg_write,
++};
++
+ static const struct regmap_config mlxplat_mlxcpld_regmap_config_eth_modular = {
+ 	.reg_bits = 8,
+ 	.val_bits = 8,
+@@ -5692,6 +5913,27 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
  	return 1;
  }
  
@@ -381,7 +427,7 @@ index 08d93b9a8..9562cc927 100644
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
 +		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
 +	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
-+	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_nvlink;
 +
 +	return 1;
 +}
@@ -389,7 +435,7 @@ index 08d93b9a8..9562cc927 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5770,6 +5987,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5770,6 +6012,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
  		},
  	},


### PR DESCRIPTION
Fix access to CPLD register bits: erot{X}_reset, erot{X}_recovery
Fix spi_chnl_select access
Fix default value for PWM_CONTROL CPLD register

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
