### PR TITLE
hw-mgmt: infra: Remove bring-up WA for basic I2C frequency

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0161-i2c-mlxcpld-Fix-register-setting-for-400KHz-frequenc.patch
+++ b/recipes-kernel/linux/linux-4.19/0161-i2c-mlxcpld-Fix-register-setting-for-400KHz-frequenc.patch
@@ -1,0 +1,30 @@
+From 47b87d459766854b32b0a102a64f6848e47facd0 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 13 Jun 2022 21:03:05 +0300
+Subject: [PATCH i2c backport v4.19 1/1] i2c: mlxcpld: Fix register setting for
+ 400KHz frequency
+
+Fix setting of 'Half Cycle' register for 400KHz frequency.
+
+Fixes: fa1049135c15 ("i2c: mlxcpld: Modify register setting for 400KHz frequency")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index fb451d42a..85b78985f 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -49,7 +49,7 @@
+ #define MLXCPLD_LPCI2C_NACK_IND		2
+ 
+ #define MLXCPLD_I2C_FREQ_1000KHZ_SET	0x04
+-#define MLXCPLD_I2C_FREQ_400KHZ_SET	0x0c
++#define MLXCPLD_I2C_FREQ_400KHZ_SET	0x0e
+ #define MLXCPLD_I2C_FREQ_100KHZ_SET	0x42
+ 
+ enum mlxcpld_i2c_frequency {
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0170-i2c-mlxcpld-Fix-register-setting-for-400KHz-frequenc.patch
+++ b/recipes-kernel/linux/linux-5.10/0170-i2c-mlxcpld-Fix-register-setting-for-400KHz-frequenc.patch
@@ -1,0 +1,30 @@
+From 553016c0c35314b0cd9fc3ed3c37d04ec0c6c14e Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 13 Jun 2022 20:51:35 +0300
+Subject: [PATCH i2c backport v5.10 1/1] i2c: mlxcpld: Fix register setting for
+ 400KHz frequency
+
+Fix setting of 'Half Cycle' register for 400KHz frequency.
+
+Fixes: fa1049135c15 ("i2c: mlxcpld: Modify register setting for 400KHz frequency")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index fb451d42a..85b78985f 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -49,7 +49,7 @@
+ #define MLXCPLD_LPCI2C_NACK_IND		2
+ 
+ #define MLXCPLD_I2C_FREQ_1000KHZ_SET	0x04
+-#define MLXCPLD_I2C_FREQ_400KHZ_SET	0x0c
++#define MLXCPLD_I2C_FREQ_400KHZ_SET	0x0e
+ #define MLXCPLD_I2C_FREQ_100KHZ_SET	0x42
+ 
+ enum mlxcpld_i2c_frequency {
+-- 
+2.20.1
+

--- a/usr/etc/hw-management-sensors/msn4800_sensors_lc.conf
+++ b/usr/etc/hw-management-sensors/msn4800_sensors_lc.conf
@@ -243,17 +243,17 @@ bus "i2c-59" "i2c-*-mux (chan_id 4)"
         ignore curr4
     chip "mp2975-i2c-*-64"
         label in1 "Linecard PMIC-2 PSU 12V Rail (in)"
-        label in2 "Linecard PMIC-2 PORTS 1.8V Rail(out1)"
-        label in3 "Linecard PMIC-2 AGB 3.3V Rail(out2)"
+        label in2 "Linecard PMIC-2 AGB 1.8V Rail(out1)"
+        label in3 "Linecard PMIC-2 PORTS 3.3V Rail(out2)"
         compute in3 (2)*@, @/(2)
         ignore in4
-        label temp1 "Linecard PMIC-2 PORTS_3.3V_AGB_1.8V Ambient Temp 1"
+        label temp1 "Linecard PMIC-2 AGB_1.8V_PORTS_3.3V Ambient Temp 1"
         ignore temp2
-        label power1 "Linecard PMIC-2 12V PORTS_3.3V_AGB_1.8V Rail Pwr (in)"
-        label power2 "Linecard PMIC-2 PORTS 3.3V Rail Pwr (out)"
-        label power3 "Linecard PMIC-2 AGB 1.8V Rail Pwr (out)"
+        label power1 "Linecard PMIC-2 12V AGB_1.8V_PORTS_3.3V Rail Pwr (in)"
+        label power2 "Linecard PMIC-2 AGB 1.8V Rail Pwr (out)"
+        label power3 "Linecard PMIC-2 PORTS 3.3V Rail Pwr (out)"
         ignore power4
-        label curr1 "Linecard PMIC-2 12V PORTS_3.3V_AGB_1.8V Rail Curr (in)"
-        label curr2 "Linecard PMIC-2 PORTS 3.3V Rail Curr (out)"
-        label curr3 "Linecard PMIC-2 AGB 1.8V Rail Curr (out)"
+        label curr1 "Linecard PMIC-2 12V AGB_1.8V_PORTS_3.3V Rail Curr (in)"
+        label curr2 "Linecard PMIC-2 AGB 1.8V Rail Curr (out)"
+        label curr3 "Linecard PMIC-2 PORTS 3.3V Rail Curr (out)"
         ignore curr4

--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -114,8 +114,6 @@ cooling_level_updated=0
 
 # PSU fan speed vector
 psu_fan_speed=(0x3c 0x3c 0x3c 0x3c 0x3c 0x3c 0x3c 0x46 0x50 0x5a 0x64)
-# TMP for Buffalo BU
-psu_fan_speed_full=(0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64 0x64)
 
 # Thermal tables for the minimum FAN setting per system time. It contains
 # entries with ambient temperature threshold values and relevant minimum
@@ -741,15 +739,6 @@ thermal_periodic_report()
 			set_cur_state=$cooling
 		fi
 	fi
-	# TMP for Buffalo BU
-	case $board_type in
-	VMOD0011)
-		ps_fan_speed=${psu_fan_speed_full[$f5]}
-		;;
-	*)
-		ps_fan_speed=${psu_fan_speed[$f5]}
-		;;
-	esac
 	ps_fan_speed=${psu_fan_speed[$f5]}
 	f5=$((f5*10))
 	f6=$((set_cur_state*10))
@@ -874,15 +863,6 @@ update_psu_fan_speed()
 				addr=$(< $config_path/psu"$i"_i2c_addr)
 				command=$(< $fan_command)
 				entry=$(< $thermal_path/cooling_cur_state)
-				# TMP for Buffalo BU
-				case $board_type in
-				VMOD0011)
-					speed=${psu_fan_speed_full[$entry]}
-				;;
-				*)
-					speed=${psu_fan_speed[$entry]}
-					;;
-				esac
 				speed=${psu_fan_speed[$entry]}
 				# SN2201 sets psu fan speed in percentage mode.
 				if [ "$board_type" == "VMOD0014" ]; then

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1358,8 +1358,6 @@ msn48xx_specific()
 	echo 14 > $config_path/pcie_default_i2c_bus
 	lm_sensors_config="$lm_sensors_configs_path/msn4800_sensors.conf"
 	lm_sensors_config_lc="$lm_sensors_configs_path/msn4800_sensors_lc.conf"
-	# TMP for Buffalo BU
-	iorw -b 0x2004 -w -l1 -v0x3f
 }
 
 sn2201_specific()
@@ -1603,16 +1601,7 @@ set_config_data()
 		psu_i2c_addr=psu"$idx"_i2c_addr
 		echo ${!psu_i2c_addr} > $config_path/psu"$idx"_i2c_addr
 	done
-
-	# TMP for Buffalo BU
-	case $board_type in
-	VMOD0011)
-		echo 0x64 > $config_path/fan_psu_default
-		;;
-	*)
-		echo $fan_psu_default > $config_path/fan_psu_default
-		;;
-	esac
+	echo $fan_psu_default > $config_path/fan_psu_default
 	echo $fan_command > $config_path/fan_command
 	echo 35 > $config_path/thermal_delay
 	echo $chipup_delay_default > $config_path/chipup_delay


### PR DESCRIPTION
Allow 400KHz as basic i2C frequency for SN4800 system.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>