### PR TITLE
hw-mgmt: scripts: report CPU core temp on SN2201 always for core 0, 1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.2144) unstable; urgency=low
+hw-management (1.mlnx.7.0020.2150) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Thu, 02 Jun 2022 16:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Thu, 16 Jun 2022 16:22:00 +0300
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1383,6 +1383,14 @@ sn2201_specific()
 	cpld2_pn=${cpld2_pn:3}
 	cpld2_pn=$(( 16#$cpld2_pn ))
 	echo $cpld2_pn > $system_path/cpld2_pn
+	id0=$(cat /proc/cpuinfo | grep -m1 "core id" | awk '{print $4}')
+	id0=$(($id0+2))
+	echo $id0> $config_path/core0_temp_id
+	id1=$(cat /proc/cpuinfo | grep -m2 "core id" | tail -n1 | awk '{print $4}')
+	id1=$(($id1+2))
+	echo $id1 > $config_path/core1_temp_id
+	sed -i "s/label temp8/label temp$id0/g" $lm_sensors_configs_path/sn2201_sensors.conf
+	sed -i "s/label temp14/label temp$id1/g" $lm_sensors_configs_path/sn2201_sensors.conf
 	lm_sensors_config="$lm_sensors_configs_path/sn2201_sensors.conf"
 }
 


### PR DESCRIPTION
Intel Denverton CPU has strange and not consistent numbering of Cores.
They can be numbered 6, 16 and in other batch of the same architecture they can be 4, 14 etc.
Create hw-management links and sensors rules report always for core 0, 1 as on all other
platforms with different CPU.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
