### PR TITLE
hw-mgmt: kernel patches: downstream: mlxsw: i2c: Prevent transaction …

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0160-TMP-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
+++ b/recipes-kernel/linux/linux-4.19/0160-TMP-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
@@ -1,0 +1,126 @@
+From 3cd363878eb1a32987c1f156c6fb62c69099ab89 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 2 Jun 2022 16:49:55 +0300
+Subject: [PATCH v4.19 ISSU WA 1/1] TMP: mlxsw: i2c: Prevent transaction
+ execution for special chip states
+
+Do not run transaction in cases chip is in reset or in-service update
+states.
+In such case firmware is not accessible and will reject transaction
+with the relevant status "RUNNING_RESET" or "FW_ISSU_ONGOING".
+In case transaction is failed do to one of these reasons, stop sending
+transactions. In such case driver is about to be removed since it
+cannot continue running after reset or in-service update. And
+re-probed again after reset or in-service update is completed.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/cmd.h |  4 ++++
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 29 ++++++++++++++++++++---
+ 2 files changed, 30 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/cmd.h b/drivers/net/ethernet/mellanox/mlxsw/cmd.h
+index 0772e4339..6329ebb09 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/cmd.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/cmd.h
+@@ -149,6 +149,8 @@ enum mlxsw_cmd_status {
+ 	MLXSW_CMD_STATUS_BAD_NVMEM	= 0x0B,
+ 	/* Device is currently running reset */
+ 	MLXSW_CMD_STATUS_RUNNING_RESET	= 0x26,
++	/* FW ISSU ongoing. */
++	MLXSW_CMD_STATUS_FW_ISSU	= 0x27,
+ 	/* Bad management packet (silently discarded). */
+ 	MLXSW_CMD_STATUS_BAD_PKT	= 0x30,
+ };
+@@ -180,6 +182,8 @@ static inline const char *mlxsw_cmd_status_str(u8 status)
+ 		return "BAD_NVMEM";
+ 	case MLXSW_CMD_STATUS_RUNNING_RESET:
+ 		return "RUNNING_RESET";
++	case MLXSW_CMD_STATUS_FW_ISSU:
++		return "FW_ISSU_ONGOING";
+ 	case MLXSW_CMD_STATUS_BAD_PKT:
+ 		return "BAD_PKT";
+ 	default:
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index c50535184..3b6f73e4a 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -75,6 +75,7 @@
+  * @sys_event_handler: system events handler callback;
+  * @irq: IRQ line number;
+  * @irq_unhandled_count: number of unhandled interrupts;
++ * @status: status to indicate chip reset or in-service update;
+  */
+ struct mlxsw_i2c {
+ 	struct {
+@@ -94,6 +95,7 @@ struct mlxsw_i2c {
+ 	void (*sys_event_handler)(struct mlxsw_core *mlxsw_core);
+ 	int irq;
+ 	atomic_t irq_unhandled_count;
++	u8 status;
+ };
+ 
+ #define MLXSW_I2C_READ_MSG(_client, _addr_buf, _buf, _len) {	\
+@@ -240,6 +242,19 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
+ 	return 0;
+ }
+ 
++static bool
++mlxsw_i2c_cmd_status_verify(struct device *dev, struct mlxsw_i2c *mlxsw_i2c,
++			    u8 status)
++{
++	if (status == MLXSW_CMD_STATUS_FW_ISSU ||
++	    status == MLXSW_CMD_STATUS_RUNNING_RESET) {
++		mlxsw_i2c->status = status;
++		dev_info(dev, "FW status=%x(%s))\n", status, mlxsw_cmd_status_str(status));
++		return true;
++	}
++	return false;
++}
++
+ /* Routine posts initialization command to ASIC through mail box. */
+ static int
+ mlxsw_i2c_write_init_cmd(struct i2c_client *client,
+@@ -423,6 +438,10 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+ 
+ 	WARN_ON(in_mbox_size % sizeof(u32) || out_mbox_size % sizeof(u32));
+ 
++	/* Do not run transaction if chip is in reset or in-service update state. */
++	if (mlxsw_i2c->status)
++		return 0;
++
+ 	if (in_mbox) {
+ 		reg_size = mlxsw_i2c_get_reg_size(in_mbox);
+ 		num = reg_size / mlxsw_i2c->block_size;
+@@ -497,6 +516,8 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+ 
+ cmd_fail:
+ 	mutex_unlock(&mlxsw_i2c->cmd.lock);
++	if (mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, *status))
++		err = 0;
+ 	return err;
+ }
+ 
+@@ -710,14 +731,16 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
+ 	/* Wait until go bit is cleared. */
+ 	err = mlxsw_i2c_wait_go_bit(client, mlxsw_i2c, &status);
+ 	if (err) {
+-		dev_err(&client->dev, "HW semaphore is not released");
++		if (!mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, status))
++			dev_err(&client->dev, "HW semaphore is not released");
+ 		goto errout;
+ 	}
+ 
+ 	/* Validate transaction completion status. */
+ 	if (status) {
+-		dev_err(&client->dev, "Bad transaction completion status %x\n",
+-			status);
++		if (!mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, status))
++			dev_err(&client->dev, "Bad transaction completion status %x\n",
++				status);
+ 		err = -EIO;
+ 		goto errout;
+ 	}
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0169-TMP-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
+++ b/recipes-kernel/linux/linux-5.10/0169-TMP-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
@@ -1,0 +1,126 @@
+From 905e264cdc094639fc824f88a9df14812bc7b66a Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 2 Jun 2022 15:34:53 +0300
+Subject: [PATCH v5.10 ISSU WA 1/1] TMP: mlxsw: i2c: Prevent transaction
+ execution for special chip states
+
+Do not run transaction in cases chip is in reset or in-service update
+states.
+In such case firmware is not accessible and will reject transaction
+with the relevant status "RUNNING_RESET" or "FW_ISSU_ONGOING".
+In case transaction is failed do to one of these reasons, stop sending
+transactions. In such case driver is about to be removed since it
+cannot continue running after reset or in-service update. And
+re-probed again after reset or in-service update is completed.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/cmd.h |  4 ++++
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 29 ++++++++++++++++++++---
+ 2 files changed, 30 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/cmd.h b/drivers/net/ethernet/mellanox/mlxsw/cmd.h
+index 5ffdfb532..a7d47da97 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/cmd.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/cmd.h
+@@ -149,6 +149,8 @@ enum mlxsw_cmd_status {
+ 	MLXSW_CMD_STATUS_BAD_NVMEM	= 0x0B,
+ 	/* Device is currently running reset */
+ 	MLXSW_CMD_STATUS_RUNNING_RESET	= 0x26,
++	/* FW ISSU ongoing. */
++	MLXSW_CMD_STATUS_FW_ISSU	= 0x27,
+ 	/* Bad management packet (silently discarded). */
+ 	MLXSW_CMD_STATUS_BAD_PKT	= 0x30,
+ };
+@@ -180,6 +182,8 @@ static inline const char *mlxsw_cmd_status_str(u8 status)
+ 		return "BAD_NVMEM";
+ 	case MLXSW_CMD_STATUS_RUNNING_RESET:
+ 		return "RUNNING_RESET";
++	case MLXSW_CMD_STATUS_FW_ISSU:
++		return "FW_ISSU_ONGOING";
+ 	case MLXSW_CMD_STATUS_BAD_PKT:
+ 		return "BAD_PKT";
+ 	default:
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index 778bc9054..27f1c06dc 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -76,6 +76,7 @@
+  * @sys_event_handler: system events handler callback;
+  * @irq: IRQ line number;
+  * @irq_unhandled_count: number of unhandled interrupts;
++ * @status: status to indicate chip reset or in-service update;
+  */
+ struct mlxsw_i2c {
+ 	struct {
+@@ -95,6 +96,7 @@ struct mlxsw_i2c {
+ 	void (*sys_event_handler)(struct mlxsw_core *mlxsw_core);
+ 	int irq;
+ 	atomic_t irq_unhandled_count;
++	u8 status;
+ };
+ 
+ #define MLXSW_I2C_READ_MSG(_client, _addr_buf, _buf, _len) {	\
+@@ -241,6 +243,19 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
+ 	return 0;
+ }
+ 
++static bool
++mlxsw_i2c_cmd_status_verify(struct device *dev, struct mlxsw_i2c *mlxsw_i2c,
++			    u8 status)
++{
++	if (status == MLXSW_CMD_STATUS_FW_ISSU ||
++	    status == MLXSW_CMD_STATUS_RUNNING_RESET) {
++		mlxsw_i2c->status = status;
++		dev_info(dev, "FW status=%x(%s))\n", status, mlxsw_cmd_status_str(status));
++		return true;
++	}
++	return false;
++}
++
+ /* Routine posts initialization command to ASIC through mail box. */
+ static int
+ mlxsw_i2c_write_init_cmd(struct i2c_client *client,
+@@ -424,6 +439,10 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+ 
+ 	WARN_ON(in_mbox_size % sizeof(u32) || out_mbox_size % sizeof(u32));
+ 
++	/* Do not run transaction if chip is in reset or in-service update state. */
++	if (mlxsw_i2c->status)
++		return 0;
++
+ 	if (in_mbox) {
+ 		reg_size = mlxsw_i2c_get_reg_size(in_mbox);
+ 		num = reg_size / mlxsw_i2c->block_size;
+@@ -498,6 +517,8 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+ 
+ cmd_fail:
+ 	mutex_unlock(&mlxsw_i2c->cmd.lock);
++	if (mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, *status))
++		err = 0;
+ 	return err;
+ }
+ 
+@@ -710,14 +731,16 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
+ 	/* Wait until go bit is cleared. */
+ 	err = mlxsw_i2c_wait_go_bit(client, mlxsw_i2c, &status);
+ 	if (err) {
+-		dev_err(&client->dev, "HW semaphore is not released");
++		if (!mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, status))
++			dev_err(&client->dev, "HW semaphore is not released");
+ 		goto errout;
+ 	}
+ 
+ 	/* Validate transaction completion status. */
+ 	if (status) {
+-		dev_err(&client->dev, "Bad transaction completion status %x\n",
+-			status);
++		if (!mlxsw_i2c_cmd_status_verify(&client->dev, mlxsw_i2c, status))
++			dev_err(&client->dev, "Bad transaction completion status %x\n",
++				status);
+ 		err = -EIO;
+ 		goto errout;
+ 	}
+-- 
+2.20.1
+


### PR DESCRIPTION
…execution for special chip states

Do not run transaction in cases chip is in reset or in-service update
states.
In such case firmware is not accessible and will reject transaction
with the relevant status "RUNNING_RESET" or "FW_ISSU_ONGOING".
In case transaction is failed do to one of these reasons, stop sending
transactions. In such case driver is about to be removed since it
cannot continue running after reset or in-service update. And
re-probed again after reset or in-service update is completed.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>