### PR TITLE
hw-mgmt: kernel patches 4.19 & 5.10: align reset_aux_pwr_or_ref attribute name on SN2201

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-4.19/0151-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -842,7 +842,7 @@ index 000000000000..0bcdc7c75007
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_aux_pwr_or_fu",
++		.label = "reset_aux_pwr_or_ref",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,

--- a/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -841,7 +841,7 @@ index 000000000000..0bcdc7c75007
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_aux_pwr_or_fu",
++		.label = "reset_aux_pwr_or_ref",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
