### PR TITLE
hw-mgmt: kernel patches v4.19 & v5.10: Align emc2305 driver with mlxreg-fan driver.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.2150) unstable; urgency=low
+hw-management (1.mlnx.7.0020.2151) unstable; urgency=low
   [ MLNX ]
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Thu, 16 Jun 2022 16:22:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 22 Jun 2022 16:22:00 +0300
 

--- a/recipes-kernel/linux/linux-4.19/0145-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+++ b/recipes-kernel/linux/linux-4.19/0145-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
@@ -245,7 +245,7 @@ index 000000000..0625c7c3b
 +	 * from 4 to 6. And state 5 (fan->cooling_levels[4]) should be
 +	 * overwritten.
 +	 */
-+	if (state >= (data->max_state + data->min_cfg_state) &&
++	if (state > (data->max_state + data->min_cfg_state) &&
 +	    state <= (data->max_state * 2)) {
 +		config = true;
 +
@@ -257,7 +257,7 @@ index 000000000..0625c7c3b
 +
 +		cur_state = data->cur_state;
 +		if (state < cur_state)
-+			return 1;
++			return 0;
 +
 +		state = cur_state;
 +	}

--- a/recipes-kernel/linux/linux-5.10/0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+++ b/recipes-kernel/linux/linux-5.10/0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
@@ -174,7 +174,7 @@ index 000000000..3f98bdcd2
 +	 * from 4 to 6. And state 5 (fan->cooling_levels[4]) should be
 +	 * overwritten.
 +	 */
-+	if (state >= (data->max_state + data->min_cfg_state) &&
++	if (state > (data->max_state + data->min_cfg_state) &&
 +	    state <= (data->max_state * 2)) {
 +		config = true;
 +
@@ -186,7 +186,7 @@ index 000000000..3f98bdcd2
 +
 +		cur_state = data->cur_state;
 +		if (state < cur_state)
-+			return 1;
++			return 0;
 +
 +		state = cur_state;
 +	}


### PR DESCRIPTION
Set the same manner of setting cooling_cur_state in SN2201 as on other systems,
where it's done through mlxreg_fan driver.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
