### PR TITLE
Fixing the incorrect cpld entries

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -601,6 +601,35 @@ function get_i2c_voltmon_prefix()
 	echo "$voltmon_name"
 }
 
+function check_cpld_attrs_num()
+{
+   board=$(cat /sys/devices/virtual/dmi/id/board_name)
+   cpld_num=$(cat $config_path/cpld_num)
+   case "$board" in
+   VMOD0001|VMOD0003)
+       cpld_num=$((cpld_num-1))
+       ;;
+   *)
+       ;;
+   esac
+
+   return $cpld_num
+}
+
+function check_cpld_attrs()
+{
+    attrname="$1"
+    cpld_num="$2"
+    take=1
+
+    # Extracting the cpld number if the attribute starts with cpld<num>
+    num=`echo $attrname | grep -Po '^(cpld)\K\d+'`
+    # Seeing if the cpld index is valid for the platform
+    [[ ! -z "$num" ]] && [ $num -gt $cpld_num ] && take=0
+
+    return $take
+}
+
 if [ "$1" == "add" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then
@@ -780,14 +809,20 @@ if [ "$1" == "add" ]; then
 			linecard="$linecard_num"
 			;;
 		esac
-		# Allow to driver insertion off all the attributes.
+		# Allow insertion of all the attributes, but skip redundant cpld entries.
 		sleep 1
 		if [ -d "$3""$4" ]; then
+			local cpld_num
 			for attrpath in "$3""$4"/*; do
+				take=10
 				attrname=$(basename "${attrpath}")
+				check_cpld_attrs_num
+				cpld_num=$?
+				check_cpld_attrs "$attrname" "$cpld_num"
+				take=$?
 				if [ ! -d "$attrpath" ] && [ ! -L "$attrpath" ] &&
 				   [ "$attrname" != "uevent" ] &&
-				   [ "$attrname" != "name" ]; then
+				   [ "$attrname" != "name" ] && [ "$take" -ne 0 ] ; then
 					ln -sf "$3""$4"/"$attrname" $system_path/"$attrname"
 				fi
 			done

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -35,18 +35,12 @@
 source hw-management-helpers.sh
 
 # Local constants and paths.
-max_cpld=4
 max_fan_drwr=8
 CPLD3_VER_DEF="0"
  
 handle_cpld_versions()
 {
 	cpld_num_loc="${1}"
-	if [ "$cpld_num_loc" -lt "$max_cpld" ]; then
-		check_n_unlink $system_path/cpld"$max_cpld"_version
-		check_n_unlink $system_path/cpld"$max_cpld"_pn
-		check_n_unlink $system_path/cpld"$max_cpld"_version_min
-	fi
 
 	for ((i=1; i<=cpld_num_loc; i+=1)); do
 		if [ -f $system_path/cpld"$i"_pn ]; then
@@ -82,9 +76,6 @@ set_fan_drwr_num()
 board=$(cat /sys/devices/virtual/dmi/id/board_name)
 cpld_num=$(cat $config_path/cpld_num)
 case $board in
-	VMOD0001|VMOD0003)
-		cpld_num=$((cpld_num-1))
-		;;
 	VMOD0015)
 		# Special case to inform external node (BMC) that system ready
 		# for telemetry communication.


### PR DESCRIPTION
This patch fixes the incorrect number of cpld entries in
the '/var/run/hw-management/cpld*_*'. [cpld1..4]_* links are
created irrespective of the platform. For example, this
approach has lead to the existance of cpld4_* links, on a
platform with 3 cpld. This was happening due to a race
condition in which clean up of the unwanted symbolic links
executes before the actual entries are created.

Solution is to create the cpld links based on the platform
parameter 'cpld_num', which tells total number of cpld
per platform.

This addresses the bug 3107709

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>