### PR TITLE
Fix voltmon sensors linking by their labels for mp2975.

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -74,8 +74,9 @@ fi
 # Voltmon sensors by label mapping:
 #                   dummy   sensor1       sensor2        sensor3
 VOLTMON_SENS_LABEL=("none" "vin\$|vin1"   "vout\$|vout1" "vout2")
-CURR_SENS_LABEL=(   "none" "iout\$|iout1" "iout2"        "none")
-POWER_SENS_LABEL=(  "none" "pout\$|pout"  "pout2"        "none")
+CURR_SENS_LABEL=(   "none" "iin\$|iin1"   "iout\$|iout1" "iout2")
+POWER_SENS_LABEL=(  "none" "pin\$|pin1"   "pout\$|pout1" "pout2")
+
 
 # Find sensor index which label matching to mask.
 # $1 - path to sensor in sysfs
@@ -734,26 +735,46 @@ if [ "$1" == "add" ]; then
 				find_sensor_by_label "$3""$4" "in" "${VOLTMON_SENS_LABEL[$i]}"
 				sensor_id=$?
 				if [ ! $sensor_id -eq 0 ]; then
-					if [ -f "$3""$4"/in"$sensor_id"_input ]; then
-						ln -sf "$3""$4"/in"$sensor_id"_input $environment_path/"$prefix"_in"$i"_input
-					fi
+					check_n_link "$3""$4"/in"$sensor_id"_input $environment_path/"$prefix"_in"$i"_input
+
 					if [ -f "$3""$4"/in"$sensor_id"_alarm ]; then
 						ln -sf "$3""$4"/in"$sensor_id"_alarm $alarm_path/"$prefix"_in"$i"_alarm
 					elif [ -f "$3""$4"/in"$sensor_id"_crit_alarm ]; then
 						ln -sf "$3""$4"/in"$sensor_id"_crit_alarm $alarm_path/"$prefix"_in"$i"_alarm
 					fi
 				fi
-				if [ -f "$3""$4"/curr"$i"_input ]; then
-					ln -sf "$3""$4"/curr"$i"_input $environment_path/"$prefix"_curr"$i"_input
-				fi
-				if [ -f "$3""$4"/power"$i"_input ]; then
-					ln -sf "$3""$4"/power"$i"_input $environment_path/"$prefix"_power"$i"_input
-				fi
-				if [ -f "$3""$4"/curr"$i"_alarm ]; then
-					ln -sf "$3""$4"/curr"$i"_alarm $alarm_path/"$prefix"_curr"$i"_alarm
-				fi
-				if [ -f "$3""$4"/power"$i"_alarm ]; then
-					ln -sf "$3""$4"/power"$i"_alarm $alarm_path/"$prefix"_power"$i"_alarm
+				sensor_type=$(< "$3""$4"/name)
+				if [ $sensor_type == "mp2975" ]; then
+					find_sensor_by_label "$3""$4" "curr" "${CURR_SENS_LABEL[$i]}"
+					sensor_id=$?
+					if [ ! $sensor_id -eq 0 ]; then
+						check_n_link "$3""$4"/curr"$sensor_id"_input $environment_path/"$prefix"_curr"$i"_input
+						if [ -f "$3""$4"/curr"$sensor_id"_alarm ]; then
+							ln -sf "$3""$4"/curr"$sensor_id"_alarm $alarm_path/"$prefix"_curr"$i"_alarm
+						elif [ -f "$3""$4"/curr"$sensor_id"_crit_alarm ]; then
+							ln -sf "$3""$4"/curr"$sensor_id"_crit_alarm $alarm_path/"$prefix"_curr"$i"_alarm
+						elif [ -f "$3""$4"/curr"$sensor_id"_max_alarm ]; then
+							ln -sf "$3""$4"/curr"$sensor_id"_max_alarm $alarm_path/"$prefix"_curr"$i"_alarm
+						fi
+					fi
+
+					find_sensor_by_label "$3""$4" "power" "${POWER_SENS_LABEL[$i]}"
+					sensor_id=$?
+					if [ ! $sensor_id -eq 0 ]; then
+						check_n_link "$3""$4"/power"$sensor_id"_input $environment_path/"$prefix"_power"$i"_input
+						check_n_link "$3""$4"/power"$sensor_id"_alarm $alarm_path//"$prefix"_power"$i"_alarm
+					fi
+				else
+					check_n_link "$3""$4"/curr"$i"_input $environment_path/"$prefix"_curr"$i"_input
+					check_n_link "$3""$4"/power"$i"_input $environment_path/"$prefix"_power"$i"_input
+					check_n_link "$3""$4"/power"$i"_alarm $alarm_path//"$prefix"_power"$i"_alarm
+					if [ -f "$3""$4"/curr"$i"_alarm ]; then
+						ln -sf "$3""$4"/curr"$i"_alarm $alarm_path/"$prefix"_curr"$i"_alarm
+					elif [ -f "$3""$4"/curr"$i"_crit_alarm ]; then
+						ln -sf "$3""$4"/curr"$i"_crit_alarm $alarm_path/"$prefix"_curr"$i"_alarm
+					elif [ -f "$3""$4"/curr"$i"_max_alarm ]; then
+						ln -sf "$3""$4"/curr"$i"_max_alarm $alarm_path/"$prefix"_curr"$i"_alarm
+					fi
 				fi
 			done
 			;;


### PR DESCRIPTION
vin/vin1 -> voltmon_in1_input
vout/vout1 -> voltmon_in2_input
vout2 -> voltmon_in3_input

iin/iin1 -> voltmon_curr1_input
iout/iout1 -> voltmon_curr2_input
iout2 -> voltmon_curr3_input

pin/pin1 -> voltmon_power1_input
pout/pout1 -> voltmon_power2_input
pout2 -> voltmon_power3_input

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
