### PR TITLE
hw-mgmt: scripts: Fix inconsistent label name of pca9555 gpiochip on SN2201

### DIFF
--- a/usr/usr/bin/hw-management-i2c-gpio-expander.sh
+++ b/usr/usr/bin/hw-management-i2c-gpio-expander.sh
@@ -42,7 +42,7 @@ if [ "$board_type" == "VMOD0014" ]; then
 	for gpiochip in /sys/class/gpio/*; do
 		if [ -d "$gpiochip" ] && [ -e "$gpiochip"/label ]; then
 			gpiolabel=$(<"$gpiochip"/label)
-			if [ "$gpiolabel" == "7-0027" ]; then
+			if [ "$gpiolabel" == "7-0027" ] || [ "$gpiolabel" == "pca9555" ]; then
 				gpiobase=$(<"$gpiochip"/base)
 				break
 			fi


### PR DESCRIPTION
There is inconsistency in labej name reported by pca9555 gpiochip.
In kernel 5.10.43 it's reported according to bus-address (7-0027) and
in kernel 4.19 it's reported by driver name - pca9555.
Check both cases when looking to gpiobase.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
