### PR TITLE
hw-mgmt: Optimize time of creation CPLD attributes

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -630,6 +630,31 @@ function check_cpld_attrs()
     return $take
 }
 
+handle_cpld_versions()
+{
+	CPLD3_VER_DEF="0"
+	cpld_num_loc="${1}"
+
+	for ((i=1; i<=cpld_num_loc; i+=1)); do
+		if [ -f $system_path/cpld"$i"_pn ]; then
+			cpld_pn=$(cat $system_path/cpld"$i"_pn)
+		fi
+		if [ -f $system_path/cpld"$i"_version ]; then
+			cpld_ver=$(cat $system_path/cpld"$i"_version)
+		fi
+		if [ -f $system_path/cpld"$i"_version_min ]; then
+			cpld_ver_min=$(cat $system_path/cpld"$i"_version_min)
+		fi
+		if [ -z "$str" ]; then
+			str=$(printf "CPLD%06d_REV%02d%02d" "$cpld_pn" "$cpld_ver" "$cpld_ver_min")
+		else
+			str=$str$(printf "_CPLD%06d_REV%02d%02d" "$cpld_pn" "$cpld_ver" "$cpld_ver_min")
+		fi
+	done
+	echo "$str" > $system_path/cpld_base
+	echo "$str" > $system_path/cpld
+}
+
 if [ "$1" == "add" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then
@@ -826,6 +851,7 @@ if [ "$1" == "add" ]; then
 					ln -sf "$3""$4"/"$attrname" $system_path/"$attrname"
 				fi
 			done
+			handle_cpld_versions "$cpld_num"
 		fi
 		for ((i=1; i<=$(<$config_path/max_tachos); i+=1)); do
 			if [ -L $thermal_path/fan"$i"_status ]; then

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -35,44 +35,8 @@
 source hw-management-helpers.sh
 
 # Local constants and paths.
-max_fan_drwr=8
 CPLD3_VER_DEF="0"
  
-handle_cpld_versions()
-{
-	cpld_num_loc="${1}"
-
-	for ((i=1; i<=cpld_num_loc; i+=1)); do
-		if [ -f $system_path/cpld"$i"_pn ]; then
-			cpld_pn=$(cat $system_path/cpld"$i"_pn)
-		fi
-		if [ -f $system_path/cpld"$i"_version ]; then
-			cpld_ver=$(cat $system_path/cpld"$i"_version)
-		fi
-		if [ -f $system_path/cpld"$i"_version_min ]; then
-			cpld_ver_min=$(cat $system_path/cpld"$i"_version_min)
-		fi
-		if [ -z "$str" ]; then
-			str=$(printf "CPLD%06d_REV%02d%02d" "$cpld_pn" "$cpld_ver" "$cpld_ver_min")
-		else
-			str=$str$(printf "_CPLD%06d_REV%02d%02d" "$cpld_pn" "$cpld_ver" "$cpld_ver_min")
-		fi
-	done
-	echo "$str" > $system_path/cpld_base
-	echo "$str" > $system_path/cpld
-}
-
-set_fan_drwr_num()
-{
-	drwr_num=0
-	for ((i=1; i<=max_fan_drwr; i+=1)); do
-		if [ -L $thermal_path/fan"$i"_status ]; then
-			drwr_num=$((drwr_num+1))
-		fi
-	done
-	echo $drwr_num > $config_path/fan_drwr_num
-}
-
 board=$(cat /sys/devices/virtual/dmi/id/board_name)
 cpld_num=$(cat $config_path/cpld_num)
 case $board in
@@ -90,38 +54,3 @@ case $board in
 		;;
 esac
 
-timeout 60 bash -c 'until [ -L /var/run/hw-management/system/cpld1_version ]; do sleep 1; done'
-sleep 1
-
-# Read cpld3 version with the mlxreg from mft package
-if [ -f $config_path/cpld_port ];
-then
-    cpld=$(< $config_path/cpld_port)
-    if [ $cpld == "cpld3" ] && [ ! -f $system_path/cpld3_version ];
-    then
-        ver_dec=$CPLD3_VER_DEF
-        # check if mlxreg exists
-        if [ -x "$(command -v mlxreg)" ];
-        then
-            lsmod | grep mst_pci >/dev/null 2>&1
-            if [  $? -ne 0 ];
-            then
-                mst start  >/dev/null 2>&1
-                sleep 2
-            fi
-            mt_dev=$(find /dev/mst -name *00_pciconf0)
-            cmd='mlxreg --reg_name MSCI  -d $mt_dev -g -i "index=2" | grep version | cut -d "|" -f2'
-            ver_hex=$(eval $cmd)
-            if [ ! -z "$ver_hex" ]; then
-               ver_dec=$(printf "%d" $ver_hex)
-            fi
-        fi
-        echo "$ver_dec" > $system_path/cpld3_version
-    fi
-fi
-
-handle_cpld_versions $cpld_num
-# Do not set for fixed fans systems. For fixed fans systems fan_drwr_num set in system specific init function.
-if [ ! -f $config_path/fixed_fans_system ]; then
-	set_fan_drwr_num
-fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -85,11 +85,6 @@ lm_sensors_configs_path="/etc/hw-management-sensors"
 tune_thermal_type=0
 i2c_freq_400=0xf
 i2c_freq_reg=0x2004
-pn_sanity_offset=62
-fan_dir_pn_offset=11
-# 46 - F, 52 - R
-fan_direction_exhaust=46
-fan_direction_intake=52
 # ASIC PCIe Ids.
 spc3_pci_id=cf70
 spc4_pci_id=cf80
@@ -628,23 +623,6 @@ set_jtag_gpio()
 	fi
 }
 
-get_fixed_fans_direction()
-{
-	timeout 5 bash -c 'until [ -L /var/run/hw-management/eeprom/vpd_info ]; do sleep 0.2; done'
-	sanity_offset=$(grep MLNX $eeprom_path/vpd_info -b -a -o | cut -f1 -d:)
-	fan_dir_offset=$((sanity_offset+pn_sanity_offset+fan_dir_pn_offset))
-	fan_direction=$(xxd -u -p -l 1 -s $fan_dir_offset $eeprom_path/vpd_info)
-	case $fan_direction in
-	$fan_direction_exhaust)
-		echo 1 > $config_path/fixed_fans_dir
-		;;
-	$fan_direction_intake)
-		echo 0 > $config_path/fixed_fans_dir
-		;;
-	*)
-		;;
-	esac
-}
 
 # $1 - cpu bus offset.
 add_cpu_board_to_connection_table()
@@ -735,6 +713,41 @@ add_i2c_dynamic_bus_dev_connection_table()
 	connect_table+=(${dynamic_i2cbus_connection_table[@]})
 }
 
+start_mst_for_spc1_port_cpld()
+{
+	if [ ! -d /dev/mst ]; then
+		lsmod | grep mst_pci >/dev/null 2>&1
+		if [  $? -ne 0 ]; then
+			mst start  >/dev/null 2>&1
+		fi
+	fi
+}
+
+set_spc1_port_cpld()
+{
+	cpld=$(< $config_path/cpld_port)
+	if [ $cpld == "cpld3" ] && [ ! -f $system_path/cpld3_version ]; then
+		ver_dec=$CPLD3_VER_DEF
+		# check if mlxreg exists
+		if [ -x "$(command -v mlxreg)" ]; then
+			if [ ! -d /dev/mst ]; then
+				lsmod | grep mst_pci >/dev/null 2>&1
+				if [  $? -ne 0 ]; then
+					mst start  >/dev/null 2>&1
+					sleep 2
+				fi
+			fi
+			mt_dev=$(find /dev/mst -name *00_pciconf0)
+			cmd='mlxreg --reg_name MSCI  -d $mt_dev -g -i "index=2" | grep version | cut -d "|" -f2'
+			ver_hex=$(eval $cmd)
+			if [ ! -z "$ver_hex" ]; then
+				ver_dec=$(printf "%d" $ver_hex)
+			fi
+		fi
+		echo "$ver_dec" > $system_path/cpld3_version
+	fi
+}
+
 msn274x_specific()
 {
 	connect_table+=(${msn2740_base_connect_table[@]})
@@ -775,6 +788,7 @@ msn21xx_specific()
 
 msn24xx_specific()
 {
+	start_mst_for_spc1_port_cpld
 	connect_table+=(${msn2700_base_connect_table[@]})
 	add_cpu_board_to_connection_table
 
@@ -801,10 +815,13 @@ msn24xx_specific()
 	echo cpld3 > $config_path/cpld_port
 
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
+	set_spc1_port_cpld
+	cpld=$(< $config_path/cpld_port)
 }
 
 msn27xx_msb_msx_specific()
 {
+	start_mst_for_spc1_port_cpld
 	connect_table+=(${msn2700_base_connect_table[@]})
 	add_cpu_board_to_connection_table
 
@@ -838,6 +855,7 @@ msn27xx_msb_msx_specific()
 	esac
 
 	echo cpld3 > $config_path/cpld_port
+	set_spc1_port_cpld
 
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
 	get_i2c_bus_frequency_default
@@ -1848,15 +1866,7 @@ do_start()
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
 	fi
-	if [ -f $config_path/fixed_fans_system ] && [ "$(< $config_path/fixed_fans_system)" = 1 ]; then
-		get_fixed_fans_direction
-		if [ -f $config_path/fixed_fans_dir ]; then
-			for i in $(seq 1 "$(< $config_path/fan_drwr_num)"); do
-				cat $config_path/fixed_fans_dir > $thermal_path/fan"$i"_dir
-				echo 1 > $thermal_path/fan"$i"_status
-			done
-		fi
-	fi
+	log_info "Init completed."
 }
 
 do_stop()


### PR DESCRIPTION
Optimize time of creation CPLD port version attribute for SPC1 by
starting mst tools at early init to save 2 seconds delay in post init.

Remove CPLD attributes creation from post-init flow - do it on the fly.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>

### Testing done
1. Ran the regression on the platforms a) Panther b) Leopard c) Boxer d) Bulldog e) Lionfish
2. Fixed the issues in the fixed fan platforms (Boxer & Bulldog) and re-tested the failed scenarios

### **Observations**

**Without the patches**

root@localhost:~# systemd-analyze blame
         52.049s hw-management.service
Jun 28 11:13:55 localhost hw-management: Start Chassis HW management service.
Jun 28 11:14:45 localhost hw-management: Init completed.

**With the patches**

root@localhost:~# systemd-analyze blame
         10.203s hw-management.service
Jun 28 10:16:47 localhost hw-management: Start Chassis HW management service.               8s 
Jun 28 10:16:51 localhost hw-management: FAN speed is set to full speed
Jun 28 10:16:55 localhost hw-management: Init completed.

### Conclusion
There is about ~42 second reduction in the init time for hw-management.