### PR TITLE
hw-mgmt: topology: Remove A2D i2c sensors from MSN2700/MSN2410 systems Remove A2D i2c sensors from MSN2700/MSN2410 systems management + CPU board

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -114,8 +114,10 @@ connect_table=()
 #
 # Ivybridge and Rangeley CPU mostly used on SPC1 systems.
 #
-cpu_type0_connection_table=(	max11603 0x6d 15 \
+cpu_type0_A2D_connection_table=( max11603 0x6d 15 \
 			24c32 0x51 16)
+
+cpu_type0_connection_table=(24c32 0x51 16)
 
 #
 # Broadwell CPU, mostly used on SPC2/SPC3 systems.
@@ -147,8 +149,13 @@ cpu_type2_connection_table=(	max11603 0x6d 15 \
 
 cpu_type2_mps_voltmon_connection_table=(mp2975 0x6b 15 comex_voltmon1)
 
-
 msn2700_base_connect_table=(	pmbus 0x27 5 \
+			pmbus 0x41 5 \
+			lm75 0x4a 7 \
+			24c32 0x51 8 \
+			lm75 0x49 17)
+
+msn2700_A2D_base_connect_table=(	pmbus 0x27 5 \
 			pmbus 0x41 5 \
 			max11603 0x6d 5 \
 			lm75 0x4a 7 \
@@ -176,36 +183,27 @@ msn2010_base_connect_table=(	max11603 0x6d 5 \
 			lm75 0x4b 7 \
 			24c32 0x51 8)
 
-mqm8700_base_connect_table=(	max11603 0x64 5 \
-			tps53679 0x70 5 \
-			tps53679 0x71 5 \
+mqm8700_connect_table=( tmp102 0x49 7 \
+			tmp102 0x4a 7 \
+			24c32 0x51 8)
+
+mqm8700_A2D_connect_table=( 	max11603 0x64 5 \
 			tmp102 0x49 7 \
 			tmp102 0x4a 7 \
 			24c32 0x51 8)
 
-msn37xx_connect_table=( 	max11603 0x64 5 \
-			tps53679 0x70 5 \
-			tps53679 0x71 5 \
-			tmp102 0x49 7 \
-			tmp102 0x4a 7 \
-			24c32 0x51 8)
+mqm8700_voltmon_connect_table=( tps53679 0x70 5 voltmon1 \
+			tps53679 0x71 5 voltmon2)
 
-mqm8700_rev1_base_connect_table=(    max11603 0x64 5 \
-			mp2975 0x62 5 \
-			mp2975 0x66 5 \
-			tmp102 0x49 7 \
-			tmp102 0x4a 7 \
-			24c32 0x51 8)
+mqm8700_rev1_voltmon_connect_table=( mp2975 0x62 5 voltmon1 \
+			mp2975 0x66 5 voltmon2)
 
-msn37xx_secured_connect_table=(    max11603 0x64 5 \
-			tps53679 0x70 5 \
-			tps53679 0x71 5 \
-			tmp102 0x49 7 \
+msn37xx_secured_connect_table=(  max11603 0x64 5 \
+			tmp102 0x49 7 \ 
 			tmp102 0x4a 7 \
 			24c512 0x51 8)
 
-msn37xx_A1_connect_table=(	max11603 0x64 5 \
-			tmp102 0x49 7 \
+msn37xx_A1_connect_table=(tmp102 0x49 7 \
 			tmp102 0x49 7 \
 			adt75 0x4a 7 \
 			24c512 0x51 8)
@@ -243,8 +241,19 @@ msn27002_msn24102_msb78002_base_connect_table=( pmbus 0x27 5 \
 			max11603 0x6d 15 \
 			lm75 0x49 17)
 
-msn4700_msn4600_base_connect_table=(	max11603 0x6d 5 \
+msn4700_msn4600_base_connect_table=( max11603 0x6d 5 \
 			xdpe12284 0x62 5 \
+			xdpe12284 0x64 5 \
+			xdpe12284 0x66 5 \
+			xdpe12284 0x68 5 \
+			xdpe12284 0x6a 5 \
+			xdpe12284 0x6c 5 \
+			xdpe12284 0x6e 5 \
+			tmp102 0x49 7 \
+			tmp102 0x4a 7 \
+			24c32 0x51 8)
+
+msn4600C_base_connect_table=( xdpe12284 0x62 5 \
 			xdpe12284 0x64 5 \
 			xdpe12284 0x66 5 \
 			xdpe12284 0x68 5 \
@@ -257,6 +266,15 @@ msn4700_msn4600_base_connect_table=(	max11603 0x6d 5 \
 
 msn4700_msn4600_A1_base_connect_table=(	max11603 0x6d 5 \
 			mp2975 0x62 5 \
+			mp2975 0x64 5 \
+			mp2975 0x66 5 \
+			mp2975 0x6a 5 \
+			mp2975 0x6e 5 \
+			tmp102 0x49 7 \
+			tmp102 0x4a 7 \
+			24c32 0x51 8)
+
+msn4600C_A1_base_connect_table=(	mp2975 0x62 5 \
 			mp2975 0x64 5 \
 			mp2975 0x66 5 \
 			mp2975 0x6a 5 \
@@ -662,10 +680,19 @@ add_cpu_board_to_connection_table()
 
 	case $cpu_type in
 		$RNG_CPU|$IVB_CPU)
-			cpu_connection_table=( ${cpu_type0_connection_table[@]} )
-			;;
+			board=$(< /sys/devices/virtual/dmi/id/product_name)
+			case $board in
+				MSN241*|MSN27*)
+					# Spider Panther removed A2D from SFF
+					cpu_connection_table=( ${cpu_type0_connection_table[@]} )
+					;;
+				*)
+					cpu_connection_table=( ${cpu_type0_A2D_connection_table[@]} )
+					;;
+			esac
+		;;
 		$BDW_CPU)
-			# None respin BWD version not support to read HW_REV (255).
+			# None respin BWD version not supporting HW_REV (255).
 			case $HW_REV in
 				0|3)
 					cpu_connection_table=( ${cpu_type1_a1_connection_table[@]} )
@@ -684,7 +711,7 @@ add_cpu_board_to_connection_table()
 					sku=$(< /sys/devices/virtual/dmi/id/product_sku)
 					case $sku in
 						HI116|HI112|HI124|HI100)
-							#Anaconda 100/200 Tigon Jaguar
+							#Anaconda 100/200 Tigon Jaguar removed A2D from BWD
 							cpu_connection_table=( ${cpu_type1_connection_table[@]} )
 							;;
 						*)
@@ -775,16 +802,16 @@ msn21xx_specific()
 
 msn24xx_specific()
 {
-	connect_table+=(${msn2700_base_connect_table[@]})
-	add_cpu_board_to_connection_table
-
 	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
 	case $sku in
 		HI138)
+			# SGN2410_A1
+			connect_table+=(${msn2700_A2D_base_connect_table[@]})
 			hotplug_fans=0
 			max_tachos=0
 		;;
 		*)
+			connect_table+=(${msn2700_base_connect_table[@]})
 			thermal_type=$thermal_type_t1
 			max_tachos=8
 			hotplug_fans=4
@@ -796,6 +823,7 @@ msn24xx_specific()
 			echo 24c02 > $config_path/psu_eeprom_type
 			;;
 	esac
+	add_cpu_board_to_connection_table
 
 	echo 3 > $config_path/cpld_num
 	echo cpld3 > $config_path/cpld_port
@@ -805,7 +833,16 @@ msn24xx_specific()
 
 msn27xx_msb_msx_specific()
 {
-	connect_table+=(${msn2700_base_connect_table[@]})
+	product=$(< /sys/devices/virtual/dmi/id/product_name)
+	case $product in
+		MSN27*|MSN241*)
+			# Panther Spider
+			connect_table+=(${msn2700_base_connect_table[@]})
+			;;
+		*)
+			connect_table+=(${msn2700_A2D_base_connect_table[@]})
+			;;
+	esac
 	add_cpu_board_to_connection_table
 
 	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
@@ -878,12 +915,13 @@ connect_msn3700()
 					lm_sensors_config="$lm_sensors_configs_path/msn3700_A1_sensors.conf"
 			;;
 			*)
-					connect_table+=(${msn37xx_connect_table[@]})
-					lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
+					connect_table+=(${mqm8700_connect_table[@]})
+					voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 			;;
 		esac
 	else
-		connect_table+=(${msn37xx_connect_table[@]})
+		connect_table+=(${mqm8700_connect_table[@]})
+		voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 	fi
 	add_i2c_dynamic_bus_dev_connection_table "${voltmon_connection_table[@]}"
 }
@@ -891,21 +929,30 @@ connect_msn3700()
 mqmxxx_msn37x_msn34x_specific()
 {
 	lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
+	local voltmon_connection_table=()
 
 	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
 	case $sku in
 		HI136)
 			# msn3700C-S
 			connect_table+=(${msn37xx_secured_connect_table[@]})
+			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 		;;
 		HI112|HI116)
 			# msn3700/msn3700C
 			connect_msn3700
 		;;
+		HI110)
+			# Jaguar
+			connect_table+=(${mqm8700_connect_table[@]})
+			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
+		;;
 		*)
-			connect_table+=(${mqm8700_base_connect_table[@]})
+			connect_table+=(${mqm8700_A2D_connect_table[@]})
+			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 		;;
 	esac
+	add_i2c_dynamic_bus_dev_connection_table "${voltmon_connection_table[@]}"
 	add_cpu_board_to_connection_table
 
 	tune_thermal_type=1
@@ -956,7 +1003,9 @@ msn3420_specific()
 
 msn_xh3000_specific()
 {
-	connect_table+=(${mqm8700_base_connect_table[@]})
+	connect_table+=(${mqm8700_A2D_connect_table[@]})
+	add_i2c_dynamic_bus_dev_connection_table "${mqm8700_voltmon_connect_table[@]}"
+
 	add_cpu_board_to_connection_table
 	hotplug_fans=0
 	hotplug_psus=0
@@ -1031,14 +1080,26 @@ msn27002_msb78002_specific()
 
 connect_msn4700_msn4600()
 {
-	connect_table+=(${msn4700_msn4600_base_connect_table[@]})
+	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+	if [ $sku == "HI124"]; then
+		# Tigon with removed A2D
+		connect_table+=(${msn4600C_base_connect_table[@]})
+	else
+		connect_table+=(${msn4700_msn4600_base_connect_table[@]})
+	fi
 	add_cpu_board_to_connection_table
 	lm_sensors_config="$lm_sensors_configs_path/msn4700_sensors.conf"
 }
 
 connect_msn4700_msn4600_A1()
 {
-	connect_table+=(${msn4700_msn4600_A1_base_connect_table[@]})
+	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+	if [ $sku == "HI124"]; then
+		# Tigon with removed A2D
+		connect_table+=(${msn4600C_A1_base_connect_table[@]})
+	else
+		connect_table+=(${msn4700_msn4600_A1_base_connect_table[@]})
+	fi
 	add_cpu_board_to_connection_table
 	lm_sensors_config="$lm_sensors_configs_path/msn4700_respin_sensors.conf"
 }
@@ -1176,7 +1237,6 @@ mqm9510_specific()
 	max_tachos=2
 	hotplug_fans=2
 	echo 4 > $config_path/cpld_num
-	lm_sensors_config="$lm_sensors_configs_path/mqm9510_sensors.conf"
 }
 
 mqm9520_specific()
@@ -1192,12 +1252,12 @@ mqm9520_specific()
 	max_tachos=2
 	hotplug_fans=2
 	echo 4 > $config_path/cpld_num
-	lm_sensors_config="$lm_sensors_configs_path/mqm9520_sensors.conf"
 }
 
 mqm87xx_rev1_specific()
 {
-	connect_table+=(${mqm8700_rev1_base_connect_table[@]})
+	connect_table+=(${mqm8700_connect_table[@]})
+	add_i2c_dynamic_bus_dev_connection_table "${mqm8700_rev1_voltmon_connect_table[@]}"
 	add_cpu_board_to_connection_table
 
 	thermal_type=$thermal_type_t5


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
