### PR TITLE
hw-mgmt: patches: v5.10: Skip attempt to access line card INI

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0135-mlxsw-core_linecards-Add-line-card-objects-and-imple.patch
+++ b/recipes-kernel/linux/linux-5.10/0135-mlxsw-core_linecards-Add-line-card-objects-and-imple.patch
@@ -747,7 +747,7 @@ index 000000000000..f1a1e5cf6a5f
 +	const u8 *data;
 +	size_t size;
 +	int err;
-+
++	return 0; /* Skip for non-upstream flow. */
 +	types_info = kzalloc(sizeof(*types_info), GFP_KERNEL);
 +	if (!types_info)
 +		return -ENOMEM;


### PR DESCRIPTION
In upstream code mlxsw driver has ability to burn INI.
This is not relevant for case when mlxsw_minimal driver is co-existing with
Nvidia SDK software, where this file is not supposed to be present.

Disable any attempt to find INI file to avoid output of warning message.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>