### PR TITLE
hw-mgmt: psu: Report Delta 2000 FW version

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -733,7 +733,7 @@ if [ "$1" == "add" ]; then
 		elif echo $mfr | grep -iq "Delta"; then
 			# Support FW update only for specific Delta PSU capacities
 			fw_ver="N/A"
-			if [ "$cap" == "550" ]; then
+			if [ "$cap" == "550" -o "$cap" == "2000" ]; then
 				fw_ver=$(hw_management_psu_fw_update_delta.py -v -b $bus -a $psu_addr)
 			fi
 			echo $fw_ver > $fw_path/"$2"_fw_ver


### PR DESCRIPTION
Delta 2000 PSU supports in-system FW update.
Add hw-management attribute reporting its FW version.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>