### PR TITLE
hw-mgmt: patches: 5.10: Add OSFP support

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0174-core-Add-support-for-OSFP-transceiver-modules.patch
+++ b/recipes-kernel/linux/linux-5.10/0174-core-Add-support-for-OSFP-transceiver-modules.patch
@@ -1,0 +1,59 @@
+From 2d0cae902b722594b17335e7aceb6500d9bb4525 Mon Sep 17 00:00:00 2001
+From: Danielle Ratson <danieller@nvidia.com>
+Date: Tue, 22 Feb 2022 19:17:03 +0200
+Subject: [PATCH platform backport v5.10 1/1] mlxsw: core: Add support for OSFP
+ transceiver modules
+
+The driver can already dump the EEPROM contents of QSFP-DD transceiver
+modules via its ethtool_ops::get_module_info() and
+ethtool_ops::get_module_eeprom() callbacks.
+
+Add support for OSFP transceiver modules by adding their SFF-8024
+Identifier Value (0x19).
+
+This is required for future NVIDIA Spectrum-4 based systems that will be
+equipped with OSFP transceivers.
+
+Signed-off-by: Danielle Ratson <danieller@nvidia.com>
+Signed-off-by: Ido Schimmel <idosch@nvidia.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_env.c | 2 ++
+ drivers/net/ethernet/mellanox/mlxsw/reg.h      | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_env.c b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+index 98f7cf672d9e..f9c770eec8f8 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_env.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+@@ -61,6 +61,7 @@ mlxsw_env_validate_cable_ident(struct mlxsw_core *core, u8 slot_index, int id,
+ 		*qsfp = true;
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_OSFP:
+ 		*qsfp = true;
+ 		*cmis = true;
+ 		break;
+@@ -275,6 +276,7 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, u8 slot_index,
+ 			modinfo->eeprom_len = ETH_MODULE_SFF_8472_LEN / 2;
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD:
++	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_OSFP:
+ 		/* Use SFF_8636 as base type. ethtool should recognize specific
+ 		 * type through the identifier value.
+ 		 */
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index ce3842ed8460..bec9d94b718a 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -8950,6 +8950,7 @@ enum mlxsw_reg_mcia_eeprom_module_info_id {
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS	= 0x0D,
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28	= 0x11,
+ 	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_DD	= 0x18,
++	MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_OSFP	= 0x19,
+ };
+ 
+ enum mlxsw_reg_mcia_eeprom_module_info {
+-- 
+2.20.1
+


### PR DESCRIPTION
Add support for OSFP transceiver modules by adding their SFF-8024
Identifier Value (0x19).

This is required for future NVIDIA Spectrum-4 based systems that will be
equipped with OSFP transceivers.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>