### PR TITLE
hw-mgmt: rules: Add support for netdev renaming on multi-asic systems

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -487,7 +487,6 @@ SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="add", RUN+="/usr/bin/hw-man
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm watchdog %S %p"
 
 # QSFP
-SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{phys_port_name}!="", NAME="sf$attr{phys_port_name}"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:01", KERNEL=="eth*", NAME="sfp1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:02", KERNEL=="eth*", NAME="sfp2"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:03", KERNEL=="eth*", NAME="sfp3"
@@ -616,6 +615,7 @@ SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:7d"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:7e", KERNEL=="eth*", NAME="sfp126"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:7f", KERNEL=="eth*", NAME="sfp127"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:80", KERNEL=="eth*", NAME="sfp128"
+SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{phys_port_name}!="", PROGRAM="/usr/bin/hw-management-if-rename.sh sf$attr{phys_port_name} %S %p", NAME="%c"
 SUBSYSTEM=="net", ACTION=="move", DRIVERS=="mlxsw_minimal", RUN+="/usr/bin/hw-management-chassis-events.sh mv sfp %S %p"
 SUBSYSTEM=="i2c", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0048", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add cpld %S %p"
 SUBSYSTEM=="i2c", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0048", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm cpld %S %p"

--- a/usr/usr/bin/hw-management-if-rename.sh
+++ b/usr/usr/bin/hw-management-if-rename.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Copyright (c) 2018 - 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+source hw-management-helpers.sh
+
+port_name=$1
+board=$(< $board_type_file)
+
+case $board in
+VMOD0010)
+	sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+	case $sku in
+	HI140|HI141)
+		# Determine ASIC index according to ASIC I2C bus
+		busdir=$(echo ${2}${3} | xargs dirname | xargs dirname)
+		busfolder=$(basename $busdir)
+		bus="${busfolder:0:${#busfolder}-5}"
+		case $bus in
+		2)
+			# ASIC1 on leaf or spine
+			echo sw1${port_name}
+			;;
+		*)
+			# ASIC2 on leaf or spine
+			echo sw2${port_name}
+			;;
+		esac
+		;;
+	*)
+		echo ${port_name}
+		;;
+	esac
+	;;
+*)
+	echo ${port_name}
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
On mutli-asic systems like MQM9510 and MQM9520 the current netdev
renaming udev rule will create conflicts, as each port name appears
on multiple switches. Fix this by incorporating switch name into
port name. Also, move the rule to the end of list to ensure it is
executed last and not overriden by the old MAC-based netdev rules.