### PR TITLE
hw-mgmt: patches: 5.10: Add CPLD5 support

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,7 +1,7 @@
-From 7eb2ba41aa630a7487a2053a41272b12ed91bf54 Mon Sep 17 00:00:00 2001
+From 6ff4d4717eace1fc0835cab85cf6f0675e37a2a5 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 27 Jan 2022 15:07:28 +0200
-Subject: [PATCH 1/6] platform: mellanox: Introduce support for NDR InfiniBand
+Subject: [PATCH 1/8] platform: mellanox: Introduce support for NDR InfiniBand
  modular chassis
 X-NVConfidentiality: public
 
@@ -29,24 +29,27 @@ different I2C mux topology and extended LED and hotplug configuration.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 430 ++++++++++++++++++++++++++++++++++++
- 1 file changed, 430 insertions(+)
+ drivers/platform/x86/mlx-platform.c | 461 ++++++++++++++++++++++++++++++++++++
+ 1 file changed, 461 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 1819e0e3b..01a7a1d3a 100644
+index 1819e0e3b..a31dd0d2a 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
-@@ -90,6 +90,9 @@
+@@ -90,6 +90,12 @@
  #define MLXPLAT_CPLD_LPC_REG_FAN_OFFSET		0x88
  #define MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET	0x89
  #define MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET	0x8a
++#define MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET	0x8e
++#define MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET	0x8f
++#define MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET	0x90
 +#define MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET	0x97
 +#define MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET	0x98
 +#define MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET	0x99
  #define MLXPLAT_CPLD_LPC_REG_LC_VR_OFFSET	0x9a
  #define MLXPLAT_CPLD_LPC_REG_LC_VR_EVENT_OFFSET	0x9b
  #define MLXPLAT_CPLD_LPC_REG_LC_VR_MASK_OFFSET	0x9c
-@@ -108,6 +111,9 @@
+@@ -108,7 +114,11 @@
  #define MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET	0xa9
  #define MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET	0xaa
  #define MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET	0xab
@@ -54,9 +57,11 @@ index 1819e0e3b..01a7a1d3a 100644
 +#define MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET	0xb0
 +#define MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET	0xb1
  #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
++#define MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET	0xc4
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
-@@ -201,6 +207,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET	0xc9
+@@ -201,6 +211,7 @@
  					 MLXPLAT_CPLD_AGGR_MASK_LC_SDWN)
  #define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
  #define MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2	BIT(2)
@@ -64,7 +69,7 @@ index 1819e0e3b..01a7a1d3a 100644
  #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
  #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
  #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
-@@ -214,6 +221,8 @@
+@@ -214,6 +225,8 @@
  #define MLXPLAT_CPLD_LED_HI_NIBBLE_MASK	GENMASK(3, 0)
  #define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
  #define MLXPLAT_CPLD_GWP_MASK		GENMASK(0, 0)
@@ -73,7 +78,7 @@ index 1819e0e3b..01a7a1d3a 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -243,6 +252,7 @@
+@@ -243,6 +256,7 @@
  #define MLXPLAT_CPLD_CH2_ETH_MODULAR		3
  #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
  #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
@@ -81,7 +86,7 @@ index 1819e0e3b..01a7a1d3a 100644
  
  /* Number of LPC attached MUX platform devices */
  #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
-@@ -460,6 +470,36 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
+@@ -460,6 +474,36 @@ static struct i2c_mux_reg_platform_data mlxplat_modular_mux_data[] = {
  	},
  };
  
@@ -118,7 +123,7 @@ index 1819e0e3b..01a7a1d3a 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -2164,6 +2204,246 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
+@@ -2164,6 +2208,246 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
@@ -365,7 +370,7 @@ index 1819e0e3b..01a7a1d3a 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -2693,6 +2973,78 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
+@@ -2693,6 +2977,78 @@ static struct mlxreg_core_platform_data mlxplat_modular_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_led_data),
  };
  
@@ -444,7 +449,47 @@ index 1819e0e3b..01a7a1d3a 100644
  /* Platform led data for QMB8700 system */
  static struct mlxreg_core_data mlxplat_mlxcpld_qmb8700_led_data[] = {
  	{
-@@ -3297,6 +3649,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3101,6 +3457,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "cpld5_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "cpld1_pn",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
+@@ -3129,6 +3491,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 		.regnum = 2,
+ 	},
++	{
++		.label = "cpld5_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
+ 	{
+ 		.label = "cpld1_version_min",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
+@@ -3153,6 +3522,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "cpld5_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "asic_reset",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
+@@ -3297,6 +3672,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mask = GENMASK(7, 0) & ~BIT(4),
  		.mode = 0644,
  	},
@@ -457,7 +502,7 @@ index 1819e0e3b..01a7a1d3a 100644
  	{
  		.label = "asic_health",
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
-@@ -4558,6 +4916,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4558,6 +4939,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -466,7 +511,7 @@ index 1819e0e3b..01a7a1d3a 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
-@@ -4574,6 +4934,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4574,6 +4957,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -475,7 +520,24 @@ index 1819e0e3b..01a7a1d3a 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4659,6 +5021,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4602,6 +4987,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
+@@ -4610,6 +4996,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+@@ -4659,6 +5047,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -485,7 +547,7 @@ index 1819e0e3b..01a7a1d3a 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -4682,6 +5047,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4682,6 +5073,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -495,7 +557,32 @@ index 1819e0e3b..01a7a1d3a 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
-@@ -4792,6 +5160,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4697,6 +5091,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
+@@ -4737,6 +5132,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
+@@ -4745,6 +5141,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
+@@ -4792,6 +5190,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -505,7 +592,7 @@ index 1819e0e3b..01a7a1d3a 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -4815,6 +5186,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4815,6 +5216,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -515,7 +602,15 @@ index 1819e0e3b..01a7a1d3a 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
-@@ -5282,6 +5656,48 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
+@@ -4824,6 +5228,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
+@@ -5282,6 +5687,48 @@ static int __init mlxplat_dmi_qmb8700_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -564,7 +659,7 @@ index 1819e0e3b..01a7a1d3a 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5346,6 +5762,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5346,6 +5793,20 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0009"),
  		},
  	},

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Add-COME-board-revision-register.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Add-COME-board-revision-register.patch
@@ -1,8 +1,8 @@
-From 9efa1e465f570a270a7561588a2e0dedee4ee13e Mon Sep 17 00:00:00 2001
+From 242741f0b82c9e03bd8f024c85174b53b6ff33ef Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 6 Jul 2022 17:26:41 +0300
-Subject: [PATCH platform backport v5.10 1/6] platform: mellanox: Add COME
- board revision register
+Subject: [PATCH 2/8] platform: mellanox: Add COME board revision register
+X-NVConfidentiality: public
 
 Add to CPLD COME board configuration register for getting a board
 revision. The value of this register is pushed by hardware through
@@ -15,10 +15,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 21 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 01a7a1d3a..f6ff82c8e 100644
+index a31dd0d2a..7cabc488e 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
-@@ -156,6 +156,7 @@
+@@ -160,6 +160,7 @@
  #define MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET	0xfa
  #define MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET	0xfb
  #define MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET	0xfc
@@ -26,7 +26,7 @@ index 01a7a1d3a..f6ff82c8e 100644
  #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
  #define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
  #define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
-@@ -3730,6 +3731,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3753,6 +3754,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -39,7 +39,7 @@ index 01a7a1d3a..f6ff82c8e 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4208,6 +4215,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+@@ -4231,6 +4238,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -52,7 +52,7 @@ index 01a7a1d3a..f6ff82c8e 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4405,6 +4418,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
+@@ -4428,6 +4441,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -65,7 +65,7 @@ index 01a7a1d3a..f6ff82c8e 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -5092,6 +5111,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5119,6 +5138,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -73,7 +73,7 @@ index 01a7a1d3a..f6ff82c8e 100644
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
  		return true;
  	}
-@@ -5225,6 +5245,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5256,6 +5276,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -82,5 +82,5 @@ index 01a7a1d3a..f6ff82c8e 100644
  		return true;
  	}
 -- 
-2.20.1
+2.14.1
 

--- a/recipes-kernel/linux/linux-5.10/0164-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-5.10/0164-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,8 +1,9 @@
-From 13a60e6bdac5883e678d8df8ae1fb17ba001d3d0 Mon Sep 17 00:00:00 2001
+From e8a3b233531f79bef59c692dbf6a4d230827a114 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
-Subject: [PATCH platform backport v5.10 2/6] platform: mellanox: Introduce
- support for NVLink4 managed switch
+Subject: [PATCH 3/8] platform: mellanox: Introduce support for NVLink4 managed
+ switch
+X-NVConfidentiality: public
 
 Introduce support for Nvidia P4697 system, the NVLink4 rack switch
 implemented with two Nvidia LS10 NVSwitch ASICs, equipped on switch
@@ -32,17 +33,17 @@ System equipped with:
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 228 ++++++++++++++++++++++++++++
+ drivers/platform/x86/mlx-platform.c | 228 ++++++++++++++++++++++++++++++++++++
  1 file changed, 228 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index f6ff82c8e..20236a720 100644
+index 7cabc488e..47fe870e8 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
-@@ -90,6 +90,12 @@
- #define MLXPLAT_CPLD_LPC_REG_FAN_OFFSET		0x88
- #define MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET	0x89
- #define MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET	0x8a
+@@ -93,6 +93,12 @@
+ #define MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET	0x8e
+ #define MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET	0x8f
+ #define MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET	0x90
 +#define MLXPLAT_CPLD_LPC_REG_EROT_OFFSET	0x91
 +#define MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET	0x92
 +#define MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET	0x93
@@ -52,16 +53,16 @@ index f6ff82c8e..20236a720 100644
  #define MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET	0x97
  #define MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET	0x98
  #define MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET	0x99
-@@ -115,6 +121,8 @@
+@@ -118,6 +124,8 @@
  #define MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET	0xb0
  #define MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET	0xb1
  #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
 +#define MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET	0xc2
 +#define MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT	0xc3
+ #define MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET	0xc4
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
  #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET	0xc8
- #define MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET	0xc9
-@@ -224,6 +232,7 @@
+@@ -228,6 +236,7 @@
  #define MLXPLAT_CPLD_GWP_MASK		GENMASK(0, 0)
  #define MLXPLAT_CPLD_LEAK_MASK		GENMASK(7, 0)
  #define MLXPLAT_CPLD_LEAK_ROPE_MASK	GENMASK(0, 0)
@@ -69,7 +70,7 @@ index f6ff82c8e..20236a720 100644
  #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
  #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
  
-@@ -291,6 +300,9 @@
+@@ -295,6 +304,9 @@
  /* Minimum power required for turning on Ethernet modular system (WATT) */
  #define MLXPLAT_CPLD_ETH_MODULAR_PWR_MIN	50
  
@@ -79,7 +80,7 @@ index f6ff82c8e..20236a720 100644
  /* mlxplat_priv - platform private data
   * @pdev_i2c - i2c controller platform device
   * @pdev_mux - array of mux platform devices
-@@ -2445,6 +2457,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_spine_ndr_ib_modular_da
+@@ -2449,6 +2461,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_spine_ndr_ib_modular_da
  		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
  };
  
@@ -177,7 +178,7 @@ index f6ff82c8e..20236a720 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -3518,6 +3621,42 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3541,6 +3644,42 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mask = GENMASK(7, 0) & ~BIT(2),
  		.mode = 0444,
  	},
@@ -220,7 +221,7 @@ index f6ff82c8e..20236a720 100644
  	{
  		.label = "reset_long_pb",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
-@@ -3719,6 +3858,25 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3742,6 +3881,25 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mask = GENMASK(7, 0) & ~BIT(4),
  		.mode = 0644,
  	},
@@ -246,7 +247,7 @@ index f6ff82c8e..20236a720 100644
  	{
  		.label = "config1",
  		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
-@@ -4935,6 +5093,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4958,6 +5116,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWR_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -257,7 +258,7 @@ index f6ff82c8e..20236a720 100644
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
-@@ -4956,6 +5118,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4979,6 +5141,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -265,7 +266,7 @@ index f6ff82c8e..20236a720 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -5040,6 +5203,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5066,6 +5229,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -278,7 +279,7 @@ index f6ff82c8e..20236a720 100644
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET:
-@@ -5070,6 +5239,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5096,6 +5265,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -287,7 +288,7 @@ index f6ff82c8e..20236a720 100644
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD1_TMR_OFFSET:
-@@ -5180,6 +5351,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5210,6 +5381,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -300,7 +301,7 @@ index f6ff82c8e..20236a720 100644
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK2_MASK_OFFSET:
-@@ -5210,6 +5387,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5240,6 +5417,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LEAK_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
@@ -309,7 +310,7 @@ index f6ff82c8e..20236a720 100644
  	case MLXPLAT_CPLD_LPC_REG_WD2_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
-@@ -5277,6 +5456,13 @@ static const struct reg_default mlxplat_mlxcpld_regmap_ng400[] = {
+@@ -5308,6 +5487,13 @@ static const struct reg_default mlxplat_mlxcpld_regmap_ng400[] = {
  	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
  };
  
@@ -323,7 +324,7 @@ index f6ff82c8e..20236a720 100644
  static const struct reg_default mlxplat_mlxcpld_regmap_eth_modular[] = {
  	{ MLXPLAT_CPLD_LPC_REG_GP2_OFFSET, 0x61 },
  	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, 0x00 },
-@@ -5370,6 +5556,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_ng400 = {
+@@ -5401,6 +5587,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_ng400 = {
  	.reg_write = mlxplat_mlxcpld_reg_write,
  };
  
@@ -344,7 +345,7 @@ index f6ff82c8e..20236a720 100644
  static const struct regmap_config mlxplat_mlxcpld_regmap_config_eth_modular = {
  	.reg_bits = 8,
  	.val_bits = 8,
-@@ -5719,6 +5919,27 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
+@@ -5750,6 +5950,27 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
  	return 1;
  }
  
@@ -372,7 +373,7 @@ index f6ff82c8e..20236a720 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5797,6 +6018,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5828,6 +6049,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI141"),
  		},
  	},
@@ -387,5 +388,5 @@ index f6ff82c8e..20236a720 100644
  		.callback = mlxplat_dmi_ng400_matched,
  		.matches = {
 -- 
-2.20.1
+2.14.1
 

--- a/recipes-kernel/linux/linux-5.10/0173-TMP-platform-mlx-platform-Add-SPI-path-for-NVLink-sw.patch
+++ b/recipes-kernel/linux/linux-5.10/0173-TMP-platform-mlx-platform-Add-SPI-path-for-NVLink-sw.patch
@@ -1,8 +1,9 @@
-From d2deb3bb1e8107938bb3a8927b37b695a166264a Mon Sep 17 00:00:00 2001
+From 64228d47e3c18c0cafc7eaf2bbb920a69a401692 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 15 May 2022 14:31:10 +0300
-Subject: [PATCH platform backport v5.10 5/6] TMP: platform: mlx-platform: Add
- SPI path for NVLink switch for EROT access
+Subject: [PATCH 6/8] TMP: platform: mlx-platform: Add SPI path for NVLink
+ switch for EROT access
+X-NVConfidentiality: public
 
 Create spidev for OOB access to External Root of Trusts devices.
 
@@ -13,7 +14,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  2 files changed, 17 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 20236a720..169459a8e 100644
+index 47fe870e8..c61ac69b4 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -16,6 +16,7 @@
@@ -24,7 +25,7 @@ index 20236a720..169459a8e 100644
  
  #define MLX_PLAT_DEVICE_NAME		"mlxplat"
  
-@@ -2548,6 +2549,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_switch_data = {
+@@ -2552,6 +2553,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
@@ -41,7 +42,7 @@ index 20236a720..169459a8e 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -5597,6 +5608,7 @@ static struct mlxreg_core_platform_data *mlxplat_fan;
+@@ -5628,6 +5639,7 @@ static struct mlxreg_core_platform_data *mlxplat_fan;
  static struct mlxreg_core_platform_data
  	*mlxplat_wd_data[MLXPLAT_CPLD_WD_MAX_DEVS];
  static const struct regmap_config *mlxplat_regmap_config;
@@ -49,7 +50,7 @@ index 20236a720..169459a8e 100644
  
  static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
  {
-@@ -5915,6 +5927,7 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
+@@ -5946,6 +5958,7 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
  		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
  	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
  	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
@@ -57,7 +58,7 @@ index 20236a720..169459a8e 100644
  
  	return 1;
  }
-@@ -6316,6 +6329,9 @@ static int __init mlxplat_init(void)
+@@ -6347,6 +6360,9 @@ static int __init mlxplat_init(void)
  		}
  	}
  
@@ -80,5 +81,5 @@ index a6f1e94af..227504340 100644
  /*-------------------------------------------------------------------------*/
  
 -- 
-2.20.1
+2.14.1
 


### PR DESCRIPTION
Add support for CPLD5 sysfs attributes.
CPLD5 is introduced in MQM9520 NDR modular spine.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>