### PR TITLE
hw-mgmt: Prepare infrastructure for symbolic links for I2C busses on …

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -486,6 +486,10 @@ SUBSYSTEM=="i2c", KERNEL=="*-0056", ACTION=="remove", RUN+="/usr/bin/hw-manageme
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add watchdog %S %p"
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm watchdog %S %p"
 
+# I2C links on main board
+SUBSYSTEM=="i2c-dev", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add i2c_link %S %p"
+SUBSYSTEM=="i2c-deb", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm i2c_link %S %p"
+
 # QSFP
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:01", KERNEL=="eth*", NAME="sfp1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:02", KERNEL=="eth*", NAME="sfp2"


### PR DESCRIPTION
…main board

Prepare basic infrastructure for creation symbolic links for I2C
busses.

Motivation is to provide meaningful names for I2C busses on main board
and to allow to application to access busses by meaningful name instead
of access by bus number.

Symbolic links will be created dynamically, like:
ls -l -t /dev/main/
	vpd -> /dev/i2c-8
	ambient -> /dev/i2c-7
	vr -> /dev/i2c-5
	psu -> /dev/i2c-4
	asic -> /dev/i2c-2
	come-fru -> /dev/i2c-16
	come-vr-amb -> /dev/i2c-15

Initial support is added as reference only for SN4700 system.

Intention is to use it for new coming systems with complex I2C infrastructure.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>