### PR TITLE
hw-mgmt: patches: 4.19 & 5.10: report 0 RPM speed in EMC2305 driver for SN2201 system.

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0145-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+++ b/recipes-kernel/linux/linux-4.19/0145-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
@@ -137,7 +137,7 @@ new file mode 100644
 index 000000000..0625c7c3b
 --- /dev/null
 +++ b/drivers/hwmon/emc2305.c
-@@ -0,0 +1,521 @@
+@@ -0,0 +1,526 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Hardware monitoring driver for EMC2305 fan controller
@@ -169,6 +169,7 @@ index 000000000..0625c7c3b
 +#define EMC2305_REG_PRODUCT_ID		0xfd
 +#define EMC2305_TACH_REGS_UNUSE_BITS	3
 +#define EMC2305_TACH_CNT_MULTIPLIER	0x02
++#define EMC2305_TACH_RANGE_MIN		480
 +
 +/*
 + * Factor by equations [2] and [3] from data sheet; valid for fans where the number of edges
@@ -299,11 +300,15 @@ index 000000000..0625c7c3b
 +	int ret;
 +
 +	ret = i2c_smbus_read_word_swapped(client, EMC2305_REG_FAN_TACH(channel));
-+	if (ret < 0)
++	if (ret <= 0)
 +		return ret;
 +
 +	ret = ret >> EMC2305_TACH_REGS_UNUSE_BITS;
-+	return EMC2305_RPM_FACTOR * EMC2305_TACH_CNT_MULTIPLIER / (ret > 0 ? ret : 1);
++	ret = EMC2305_RPM_FACTOR / ret;
++	if (ret <= EMC2305_TACH_RANGE_MIN)
++		return 0;
++
++	return ret * EMC2305_TACH_CNT_MULTIPLIER; 
 +}
 +
 +static int emc2305_show_pwm(struct device *dev, int channel)
@@ -659,6 +664,3 @@ index 000000000..0625c7c3b
 +MODULE_DESCRIPTION("SMSC EMC2305 fan controller driver");
 +MODULE_LICENSE("GPL");
 +
--- 
-2.20.1
-

--- a/recipes-kernel/linux/linux-5.10/0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+++ b/recipes-kernel/linux/linux-5.10/0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
@@ -66,7 +66,8 @@ new file mode 100644
 index 000000000..3f98bdcd2
 --- /dev/null
 +++ b/drivers/hwmon/emc2305.c
-@@ -0,0 +1,518 @@
+
+@@ -0,0 +1,523 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Hardware monitoring driver for EMC2305 fan controller
@@ -98,6 +99,7 @@ index 000000000..3f98bdcd2
 +#define EMC2305_REG_PRODUCT_ID		0xfd
 +#define EMC2305_TACH_REGS_UNUSE_BITS	3
 +#define EMC2305_TACH_CNT_MULTIPLIER	0x02
++#define EMC2305_TACH_RANGE_MIN		480
 +
 +/*
 + * Factor by equations [2] and [3] from data sheet; valid for fans where the number of edges
@@ -228,11 +230,15 @@ index 000000000..3f98bdcd2
 +	int ret;
 +
 +	ret = i2c_smbus_read_word_swapped(client, EMC2305_REG_FAN_TACH(channel));
-+	if (ret < 0)
++	if (ret <= 0)
 +		return ret;
 +
 +	ret = ret >> EMC2305_TACH_REGS_UNUSE_BITS;
-+	return EMC2305_RPM_FACTOR * EMC2305_TACH_CNT_MULTIPLIER / (ret > 0 ? ret : 1);
++	ret = EMC2305_RPM_FACTOR / ret;
++	if (ret <= EMC2305_TACH_RANGE_MIN)
++		return 0;
++
++	return ret * EMC2305_TACH_CNT_MULTIPLIER;
 +}
 +
 +static int emc2305_show_pwm(struct device *dev, int channel)
@@ -585,6 +591,6 @@ index 000000000..3f98bdcd2
 +MODULE_DESCRIPTION("SMSC EMC2305 fan controller driver");
 +MODULE_LICENSE("GPL");
 +
--- 
+--
 2.20.1
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1391,7 +1391,7 @@ sn2201_specific()
 	hotplug_psus=2
 	echo 1 > $config_path/fan_dir_eeprom
 	echo 22000 > $config_path/fan_max_speed
-	echo 960 > $config_path/fan_min_speed
+	echo 2200 > $config_path/fan_min_speed
 	echo 16000 > $config_path/psu_fan_max
 	echo 2500 > $config_path/psu_fan_min
 	cpld2_ver=$(i2cget -f -y 1 0x3d 0x01)


### PR DESCRIPTION
1. Support 0 RPM report in case that tacho read is below minimal range.
2. Change Fan minimal to 2200 RPM. This is a real RPM speed when FAN still rotates.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
