### PR TITLE
hw-mgmt: Prepare infrastructure for symbolic links for I2C busses on …

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -486,6 +486,10 @@ SUBSYSTEM=="i2c", KERNEL=="*-0056", ACTION=="remove", RUN+="/usr/bin/hw-manageme
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add watchdog %S %p"
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm watchdog %S %p"
 
+# I2C links on main board
+SUBSYSTEM=="i2c-dev", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add i2c_link %S %p"
+SUBSYSTEM=="i2c-dev", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm i2c_link %S %p"
+
 # QSFP
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:01", KERNEL=="eth*", NAME="sfp1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:02", KERNEL=="eth*", NAME="sfp2"

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -168,6 +168,44 @@ destroy_linecard_i2c_links()
 	rm -rf /dev/lc"$1"
 }
 
+create_main_i2c_links()
+{
+	local i2c_busdev_path="$1"
+
+	if [ ! -f $config_path/named_busses ]; then
+		return
+	fi
+
+	i2cbus_regex="i2c-([0-9]+)$"
+	[[ $i2c_busdev_path =~ $i2cbus_regex ]]
+	if [[ "${#BASH_REMATCH[@]}" != 2 ]]; then
+		return
+	else
+		i2cbus="${BASH_REMATCH[1]}"
+	fi
+
+	if [ ! -d /dev/main ]; then
+		mkdir /dev/main
+	fi
+
+	declare -a named_busses="($(< $config_path/named_busses))"
+	for ((i=0; i<${#named_busses[@]}; i+=2)); do
+		if [ "$i2cbus" == "${named_busses[i+1]}" ]; then
+			sym_name=${named_busses[i]}
+			if [ ! -L /dev/main/"$sym_name" ]; then
+				ln -s /dev/i2c-"$i2cbus" /dev/main/"$sym_name"
+			fi
+		fi
+	done
+}
+
+destroy_main_i2c_links()
+{
+	if [ -d /dev/main ]; then
+		rm -rf /dev/main
+	fi
+}
+
 find_linecard_match()
 {
 	local input_bus_num
@@ -1042,11 +1080,14 @@ if [ "$1" == "add" ]; then
 	if [ "$2" == "lc_topo" ]; then
 		log_info "I2C infrastucture for line card $3 is created."
 	fi
-
 	# Create i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 connected."
 		handle_i2cbus_dev_action $4 "add"
+	fi
+	# Create i2c links.
+	if [ "$2" == "i2c_link" ]; then
+		create_main_i2c_links "$4"
 	fi
 elif [ "$1" == "mv" ]; then
 	if [ "$2" == "sfp" ]; then
@@ -1277,14 +1318,17 @@ else
 			rm -rf "$hw_management_path"/lc"$linecard_num"
 		fi
 	fi
-	# Destroy line card i2c mux symbolic link infrastructure
+	# Destroy line card i2c mux symbolic link infrastructure.
 	if [ "$2" == "lc_topo" ]; then
 		destroy_linecard_i2c_links "$3"
 	fi
-
-	# Removed i2c bus.
+	# Remove i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 removed."
 		handle_i2cbus_dev_action $4 "remove"
+	fi
+	# Removed i2c links.
+	if [ "$2" == "i2c_link" ]; then
+		destroy_main_i2c_links
 	fi
 fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -105,6 +105,7 @@ nv4_pci_id=22a3
 
 base_cpu_bus_offset=10
 connect_table=()
+named_busses=()
 
 #
 # Ivybridge and Rangeley CPU mostly used on SPC1 systems.
@@ -378,6 +379,10 @@ mqm9520_dynamic_i2c_bus_connect_table=( \
 	mp2975 0x6c 13 voltmon6 )
 
 p2317_connect_table=(	24c512 0x51 8)
+
+# I2C busses naming.
+cfl_come_named_busses=( come-vr 15 come-amb 15 come-fru 16 )
+msn47xx_mqm97xx_named_busses=( asic1 2 psu 4 vr 5 amb 7 vpd 8 )
 
 ACTION=$1
 
@@ -709,6 +714,30 @@ add_i2c_dynamic_bus_dev_connection_table()
 	done
 
 	connect_table+=(${dynamic_i2cbus_connection_table[@]})
+}
+
+add_come_named_busses()
+{
+	local come_named_busses=()
+
+	case $cpu_type in
+	$CFL_CPU)
+		come_named_busses+=( ${cfl_come_named_busses[@]} )
+		;;
+	*)
+		exit 0
+		;;
+	esac
+
+	# $1 may contain come board bus offset.
+	if [ ! -z "$1" ]; then
+		local come_board_bus_offset=$1
+		for ((i=0; i<${#come_named_busses[@]}; i+=2)); do
+			come_named_busses[$i+1]=$(( come_named_busses[i+1]-base_cpu_bus_offset+come_board_bus_offset ))
+		done
+	fi
+
+	named_busses+=(${come_named_busses[@]})
 }
 
 start_mst_for_spc1_port_cpld()
@@ -1057,6 +1086,9 @@ connect_msn4700_msn4600_A1()
 	connect_table+=(${msn4700_msn4600_A1_base_connect_table[@]})
 	add_cpu_board_to_connection_table
 	lm_sensors_config="$lm_sensors_configs_path/msn4700_respin_sensors.conf"
+	named_busses+=(${msn47xx_mqm97xx_named_busses[@]})
+	add_come_named_busses
+	echo -n "${named_busses[@]}" > $config_path/named_busses
 }
 
 msn47xx_specific()
@@ -1162,6 +1194,9 @@ mqm97xx_specific()
 				;;
 			*)
 				connect_table+=(${mqm97xx_base_connect_table[@]})
+				named_busses+=(${msn47xx_mqm97xx_named_busses[@]})
+				add_come_named_busses
+				echo -n "${named_busses[@]}" > $config_path/named_busses
 				;;
 		esac
 	else


### PR DESCRIPTION
…main board

Prepare basic infrastructure for creation symbolic links for I2C
busses.

Motivation is to provide meaningful names for I2C busses on main board
and to allow to application to access busses by meaningful name instead
of access by bus number.

Symbolic links will be created dynamically, like:
ls -l -t /dev/main/
	vpd -> /dev/i2c-8
	amb -> /dev/i2c-7
	vr -> /dev/i2c-5
	psu -> /dev/i2c-4
	asic1 -> /dev/i2c-2
	come-fru -> /dev/i2c-16
	come-amb -> /dev/i2c-15
        come-vr -> /dev/i2c-15

Initial support is added as reference only for SN4700/MQM9700 systems.

Intention is to use it for new coming systems with complex I2C infrastructure.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>