### PR TITLE
hw-mgmt: Prepare infrastructure for symbolic links for I2C busses on …

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -486,6 +486,10 @@ SUBSYSTEM=="i2c", KERNEL=="*-0056", ACTION=="remove", RUN+="/usr/bin/hw-manageme
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add watchdog %S %p"
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm watchdog %S %p"
 
+# I2C links on main board
+SUBSYSTEM=="i2c-dev", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add i2c_link %S %p"
+SUBSYSTEM=="i2c-dev", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm i2c_link %S %p"
+
 # QSFP
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:01", KERNEL=="eth*", NAME="sfp1"
 SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_minimal", ATTR{address}=="*:02", KERNEL=="eth*", NAME="sfp2"

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -168,6 +168,44 @@ destroy_linecard_i2c_links()
 	rm -rf /dev/lc"$1"
 }
 
+create_main_i2c_links()
+{
+	local i2c_busdev_path="$1"
+
+	if [ ! -f $config_path/named_busses ]; then
+		return
+	fi
+
+	i2cbus_regex="i2c-([0-9]+)$"
+	[[ $i2c_busdev_path =~ $i2cbus_regex ]]
+	if [[ "${#BASH_REMATCH[@]}" != 2 ]]; then
+		return
+	else
+		i2cbus="${BASH_REMATCH[1]}"
+	fi
+
+	if [ ! -d /dev/main ]; then
+		mkdir /dev/main
+	fi
+
+	declare -a named_busses="($(< $config_path/named_busses))"
+	for ((i=0; i<${#named_busses[@]}; i+=2)); do
+		if [ "$i2cbus" == "${named_busses[i+1]}" ]; then
+			sym_name=${named_busses[i]}
+			if [ ! -L /dev/main/"$sym_name" ]; then
+				ln -s /dev/i2c-"$i2cbus" /dev/main/"$sym_name"
+			fi
+		fi
+	done
+}
+
+destroy_main_i2c_links()
+{
+	if [ -d /dev/main ]; then
+		rm -rf /dev/main
+	fi
+}
+
 find_linecard_match()
 {
 	local input_bus_num
@@ -1042,11 +1080,14 @@ if [ "$1" == "add" ]; then
 	if [ "$2" == "lc_topo" ]; then
 		log_info "I2C infrastucture for line card $3 is created."
 	fi
-
 	# Create i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 connected."
 		handle_i2cbus_dev_action $4 "add"
+	fi
+	# Create i2c links.
+	if [ "$2" == "i2c_link" ]; then
+		create_main_i2c_links "$4"
 	fi
 elif [ "$1" == "mv" ]; then
 	if [ "$2" == "sfp" ]; then
@@ -1277,14 +1318,17 @@ else
 			rm -rf "$hw_management_path"/lc"$linecard_num"
 		fi
 	fi
-	# Destroy line card i2c mux symbolic link infrastructure
+	# Destroy line card i2c mux symbolic link infrastructure.
 	if [ "$2" == "lc_topo" ]; then
 		destroy_linecard_i2c_links "$3"
 	fi
-
-	# Removed i2c bus.
+	# Remove i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 removed."
 		handle_i2cbus_dev_action $4 "remove"
+	fi
+	# Removed i2c links.
+	if [ "$2" == "i2c_link" ]; then
+		destroy_main_i2c_links
 	fi
 fi


### PR DESCRIPTION
…main board

Prepare basic infrastructure for creation symbolic links for I2C
busses.

Motivation is to provide meaningful names for I2C busses on main board
and to allow to application to access busses by meaningful name instead
of access by bus number.

Symbolic links will be created dynamically, like:
ls -l -t /dev/main/
	vpd -> /dev/i2c-8
	amb1 -> /dev/i2c-7
	vr1 -> /dev/i2c-5
	pwr -> /dev/i2c-4
	asic1 -> /dev/i2c-2
	come-fru -> /dev/i2c-16
	come-amb -> /dev/i2c-15
        come-vr -> /dev/i2c-15

Initial support is added as reference only for SN4700/MQM9700 systems.

Intention is to use it for new coming systems with complex I2C infrastructure.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>