### PR TITLE
hw-mgmt: patches 5.10 & 4.19: clean "git am" warnings of EMC2305 patches for SN2201 system

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0145-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+++ b/recipes-kernel/linux/linux-4.19/0145-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
@@ -137,7 +137,7 @@ new file mode 100644
 index 000000000..0625c7c3b
 --- /dev/null
 +++ b/drivers/hwmon/emc2305.c
-@@ -0,0 +1,526 @@
+@@ -0,0 +1,525 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Hardware monitoring driver for EMC2305 fan controller
@@ -308,7 +308,7 @@ index 000000000..0625c7c3b
 +	if (ret <= EMC2305_TACH_RANGE_MIN)
 +		return 0;
 +
-+	return ret * EMC2305_TACH_CNT_MULTIPLIER; 
++	return ret * EMC2305_TACH_CNT_MULTIPLIER;
 +}
 +
 +static int emc2305_show_pwm(struct device *dev, int channel)
@@ -663,4 +663,5 @@ index 000000000..0625c7c3b
 +MODULE_AUTHOR("Claud Chang <claud.chang@deltaww.com>");
 +MODULE_DESCRIPTION("SMSC EMC2305 fan controller driver");
 +MODULE_LICENSE("GPL");
-+
+--
+2.20.1

--- a/recipes-kernel/linux/linux-5.10/0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
+++ b/recipes-kernel/linux/linux-5.10/0087-hwmon-Add-support-for-EMC2305-RPM-based-PWM-Fan-Spee.patch
@@ -66,8 +66,7 @@ new file mode 100644
 index 000000000..3f98bdcd2
 --- /dev/null
 +++ b/drivers/hwmon/emc2305.c
-
-@@ -0,0 +1,523 @@
+@@ -0,0 +1,522 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Hardware monitoring driver for EMC2305 fan controller
@@ -590,7 +589,5 @@ index 000000000..3f98bdcd2
 +MODULE_AUTHOR("Claud Chang <claud.chang@deltaww.com>");
 +MODULE_DESCRIPTION("SMSC EMC2305 fan controller driver");
 +MODULE_LICENSE("GPL");
-+
 --
 2.20.1
-


### PR DESCRIPTION
Remove blank lines and whitespaces in 5.10 and 4.19 patches.
They causes warning when patches are applied by "git am" command.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
