### PR TITLE
Enable i2c 3.4MHz support for Komodo

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1951,26 +1951,38 @@ do_chip_up_down()
 	fi
 	board=$(cat /sys/devices/virtual/dmi/id/board_name)
 	case $board in
-	VMOD0011)
-		# Chip up / down operations are to be performed for ASIC virtual address 0x37.
-		i2c_asic_addr_name=0037
-		i2c_asic_addr=0x37
-		i2c_asic_bus_default=3
-		;;
-	VMOD0010)
-		sku=$(< /sys/devices/virtual/dmi/id/product_sku)
-		case $sku in
-		HI140|HI141)
+		VMOD0005)
+			sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+			case $sku in
+				HI146)
+					# Chip up / down operations are to be performed for ASIC virtual address 0x37.
+					i2c_asic_addr_name=0037
+					i2c_asic_addr=0x37
+					;;
+				*)
+					;;
+			esac
+			;;
+		VMOD0010)
+			sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+			case $sku in
+				HI140|HI141)
+					# Chip up / down operations are to be performed for ASIC virtual address 0x37.
+					i2c_asic_addr_name=0037
+					i2c_asic_addr=0x37
+					;;
+				*)
+					;;
+			esac
+			;;
+		VMOD0011)
 			# Chip up / down operations are to be performed for ASIC virtual address 0x37.
 			i2c_asic_addr_name=0037
 			i2c_asic_addr=0x37
+			i2c_asic_bus_default=3
 			;;
 		*)
 			;;
-		esac
-		;;
-	*)
-		;;
 	esac
 
 	map_asic_pci_to_i2c_bus $pci_bus


### PR DESCRIPTION
This patch enables the i2c 3.4MHz support for Aerial/Komodo

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>