### PR TITLE
hw-mgmt: init: Set config parameters before starting udev

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1892,10 +1892,10 @@ do_start()
 	fi
 	touch $udev_ready
 	depmod -a 2>/dev/null
+	set_config_data
 	udevadm trigger --action=add
 	set_sodimm_temp_limits
 	set_jtag_gpio "export"
-	set_config_data
 	create_event_files
 	hw-management-i2c-gpio-expander.sh
 	connect_platform


### PR DESCRIPTION
Make sure the configuration parameters are set before udev is
started, otherwise they may be undefined in scripts started by
udev rules.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>