### PR TITLE
hw-mgmt: attributes: Fix SODIMM thermal sensor linkage

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -1,3 +1,4 @@
+
 ###########################################################################
 # Copyright (c) 2018-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
@@ -75,7 +76,8 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/coretemp.0/hwmon/hwmon*", ACTION
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/virtual/thermal/thermal_zone*/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add pch_temp %S %p"
 
 # SODIMM temp
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/i2c-*/0-001*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sodimm_temp %p %k %S %n"
 
 # NVME temp
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:*/0000:*:*.*/*:*:*.*/hwmon/hwmon*", DRIVERS=="nvme", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add nvme_temp %S %p"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -613,31 +613,35 @@ if [ "$1" == "add" ]; then
 		fi
 	fi
 	if [ "$2" == "sodimm_temp" ]; then
+		name=$(<"$3""$4"/name)
+		if [ "$name" != "jc42" ]; then
+			return
+		fi
 		check_cpu_type
 		shopt -s extglob
 		case $cpu_type in
 			$RNG_CPU)
-				sodimm1_addr='0-0018'
-				sodimm2_addr='0-001a'
+				sodimm1_addr='0018'
+				sodimm2_addr='001a'
 			;;
 			$IVB_CPU)
-				sodimm1_addr='0-001b'
-				sodimm2_addr='0-001a'
+				sodimm1_addr='001b'
+				sodimm2_addr='001a'
 			;;
 			$CFL_CPU)
-				sodimm1_addr='0-001c'
-				sodimm2_addr='@(0-001a|0-001e)'
+				sodimm1_addr='001c'
+				sodimm2_addr='@(001a|001e)'
 			;;
 			$DNV_CPU)
-				sodimm1_addr='0-0018'
-				sodimm2_addr='0-001a'
+				sodimm1_addr='0018'
+				sodimm2_addr='001a'
 			;;
 			*)
 				exit 0
 			;;
 		esac
 
-		sodimm_i2c_addr=$(echo "$3"|xargs dirname|xargs dirname|xargs basename)
+		sodimm_i2c_addr=$(echo "$3"|xargs dirname|xargs dirname|xargs basename | cut -f2 -d"-")
 		case $sodimm_i2c_addr in
 			$sodimm1_addr)
 				sodimm_name=sodimm1_temp


### PR DESCRIPTION
On some systems SODIMM thermal sensor can be found on i2c bus  other then
default i2c-0. This commit add possibility to connect SODIMM i2c thermal
sensor on all i2c buses

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
