### PR TITLE
hw-mgmt: patches 5.10 & 4.19: Update NDR modular chassis patch

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,7 +1,7 @@
-From 1446d9a519c33c5b374dcc2ef15dd4119c0e2dfe Mon Sep 17 00:00:00 2001
+From d2a7a38621348bb81cb2bb466a24e93436b00f58 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 27 Jan 2022 15:07:28 +0200
-Subject: [PATCH 2/9] platform: mellanox: Introduce support for NDR InfiniBand
+Subject: [PATCH 1/8] platform: mellanox: Introduce support for NDR InfiniBand
  modular chassis
 X-NVConfidentiality: public
 
@@ -33,7 +33,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 460 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 7124226b9..7eb8e129c 100644
+index 7124226b9..c0def9b97 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,12 @@
@@ -262,7 +262,7 @@ index 7124226b9..7eb8e129c 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_leaf_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +	{
@@ -271,7 +271,7 @@ index 7124226b9..7eb8e129c 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_ROPE_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_rope_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +};
@@ -330,7 +330,7 @@ index 7124226b9..7eb8e129c 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_spine_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +	{
@@ -339,7 +339,7 @@ index 7124226b9..7eb8e129c 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_ROPE_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_rope_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +};
@@ -431,12 +431,12 @@ index 7124226b9..7eb8e129c 100644
 +	{
 +		.label = "leakage:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +	},
 +	{
 +		.label = "leakage:orange",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +	},
 +};
 +

--- a/recipes-kernel/linux/linux-4.19/0159-platform-mellanox-Add-COME-board-revision-register.patch
+++ b/recipes-kernel/linux/linux-4.19/0159-platform-mellanox-Add-COME-board-revision-register.patch
@@ -1,7 +1,7 @@
-From 8aae6ff832b2383edc5739b546b18ffc14fb0d26 Mon Sep 17 00:00:00 2001
+From 772606c8ed136fc4613c35c3979a03610570f260 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 6 Jul 2022 17:26:41 +0300
-Subject: [PATCH 3/9] platform: mellanox: Add COME board revision register
+Subject: [PATCH 2/8] platform: mellanox: Add COME board revision register
 X-NVConfidentiality: public
 
 Add to CPLD COME board configuration register for getting a board
@@ -15,7 +15,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 21 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 7eb8e129c..9d60aeff2 100644
+index c0def9b97..d1fd7cfdb 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -160,6 +160,7 @@

--- a/recipes-kernel/linux/linux-4.19/0160-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-4.19/0160-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,7 +1,7 @@
-From 1b32b9305337f6606fdcc1c1f0b5561234bc2264 Mon Sep 17 00:00:00 2001
+From a793dad1c289428a6b8dec32471cc16520975e5a Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
-Subject: [PATCH 4/9] platform: mellanox: Introduce support for NVLink4 managed
+Subject: [PATCH 3/8] platform: mellanox: Introduce support for NVLink4 managed
  switch
 X-NVConfidentiality: public
 
@@ -37,7 +37,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 203 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 9d60aeff2..135da4fa3 100644
+index d1fd7cfdb..e81c88877 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -93,6 +93,12 @@

--- a/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -1,8 +1,8 @@
-From 6ff4d4717eace1fc0835cab85cf6f0675e37a2a5 Mon Sep 17 00:00:00 2001
+From 3594ddeac91b39ea783a9eb0f0536f5930fbb4f8 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 27 Jan 2022 15:07:28 +0200
-Subject: [PATCH 1/8] platform: mellanox: Introduce support for NDR InfiniBand
- modular chassis
+Subject: [PATCH 01/10] platform: mellanox: Introduce support for NDR
+ InfiniBand modular chassis
 X-NVConfidentiality: public
 
 Add support for MQM9510-N leaf and MQM9520-N spine blades for two
@@ -33,7 +33,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 461 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 1819e0e3b..a31dd0d2a 100644
+index 1819e0e3b..b3a5f0230 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,12 @@
@@ -263,7 +263,7 @@ index 1819e0e3b..a31dd0d2a 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_leaf_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +	{
@@ -272,7 +272,7 @@ index 1819e0e3b..a31dd0d2a 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_ROPE_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_rope_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +};
@@ -331,7 +331,7 @@ index 1819e0e3b..a31dd0d2a 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_spine_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +	{
@@ -340,7 +340,7 @@ index 1819e0e3b..a31dd0d2a 100644
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK2_OFFSET,
 +		.mask = MLXPLAT_CPLD_LEAK_ROPE_MASK,
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_leakage_rope_items_data),
-+		.inversed = 0,
++		.inversed = 1,
 +		.health = false,
 +	},
 +};
@@ -432,12 +432,12 @@ index 1819e0e3b..a31dd0d2a 100644
 +	{
 +		.label = "leakage:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +	},
 +	{
 +		.label = "leakage:orange",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK
 +	},
 +};
 +

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Add-COME-board-revision-register.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Add-COME-board-revision-register.patch
@@ -1,7 +1,7 @@
-From 242741f0b82c9e03bd8f024c85174b53b6ff33ef Mon Sep 17 00:00:00 2001
+From 4f9b675f12b900f544d82eff62401d51390d23df Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 6 Jul 2022 17:26:41 +0300
-Subject: [PATCH 2/8] platform: mellanox: Add COME board revision register
+Subject: [PATCH 02/10] platform: mellanox: Add COME board revision register
 X-NVConfidentiality: public
 
 Add to CPLD COME board configuration register for getting a board
@@ -15,7 +15,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 21 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index a31dd0d2a..7cabc488e 100644
+index b3a5f0230..799917b5b 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -160,6 +160,7 @@

--- a/recipes-kernel/linux/linux-5.10/0164-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
+++ b/recipes-kernel/linux/linux-5.10/0164-platform-mellanox-Introduce-support-for-NVLink4-mana.patch
@@ -1,8 +1,8 @@
-From e8a3b233531f79bef59c692dbf6a4d230827a114 Mon Sep 17 00:00:00 2001
+From 0a4db5f312f0bec933e7fe2df6b4518f209fce9c Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
-Subject: [PATCH 3/8] platform: mellanox: Introduce support for NVLink4 managed
- switch
+Subject: [PATCH 03/10] platform: mellanox: Introduce support for NVLink4
+ managed switch
 X-NVConfidentiality: public
 
 Introduce support for Nvidia P4697 system, the NVLink4 rack switch
@@ -37,7 +37,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 228 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 7cabc488e..47fe870e8 100644
+index 799917b5b..7249f68c9 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -93,6 +93,12 @@

--- a/recipes-kernel/linux/linux-5.10/0173-TMP-platform-mlx-platform-Add-SPI-path-for-NVLink-sw.patch
+++ b/recipes-kernel/linux/linux-5.10/0173-TMP-platform-mlx-platform-Add-SPI-path-for-NVLink-sw.patch
@@ -1,7 +1,7 @@
-From 64228d47e3c18c0cafc7eaf2bbb920a69a401692 Mon Sep 17 00:00:00 2001
+From fed215875bdea5c4e5808ae71eded9bae8d92d6a Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 15 May 2022 14:31:10 +0300
-Subject: [PATCH 6/8] TMP: platform: mlx-platform: Add SPI path for NVLink
+Subject: [PATCH 06/10] TMP: platform: mlx-platform: Add SPI path for NVLink
  switch for EROT access
 X-NVConfidentiality: public
 
@@ -14,7 +14,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  2 files changed, 17 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 47fe870e8..c61ac69b4 100644
+index 7249f68c9..50a080931 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -16,6 +16,7 @@


### PR DESCRIPTION
1. Add inversion to leakage status attributes
2. Fix leakage LED CPLD mask

Signed-off-by: Felix Radensky <fradensky@nvidia.com>