### PR TITLE
hw-mgmt: patches 4.19: fix reset_pwr_converter_fail attribute.

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0169-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
+++ b/recipes-kernel/linux/linux-4.19/0169-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
@@ -1,0 +1,30 @@
+From 76d3b6c7399346c6b232c5edf358600239864b5b Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Mon, 19 Sep 2022 12:45:44 +0300
+Subject: [PATCH 1/1] platform: mellanox: fix reset_pwr_converter_fail
+ attribute.
+
+Change incorrect reset_voltmon_upgrade_fail atitribute name to
+reset_pwr_converter_fail.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index e81c88877..0f42bad09 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -3792,7 +3792,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 	},
+ 	{
+-		.label = "reset_voltmon_upgrade_fail",
++		.label = "reset_pwr_converter_fail",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(0),
+ 		.mode = 0444,
+-- 
+2.14.1
+


### PR DESCRIPTION
Change incorrect reset_voltmon_upgrade_fail atitribute name to
reset_pwr_converter_fail.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
