### PR TITLE
hw-mgmt: patches 5.10: hwmon: (pmbus) Fix sensors readouts for MPS Multi-phase mp2888 controller

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch
+++ b/recipes-kernel/linux/linux-5.10/0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch
@@ -1,0 +1,65 @@
+From ae1a79f21b9a91e1a8bf42586bd7a5c2afbb432a Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Mon, 19 Sep 2022 14:55:22 +0300
+Subject: [PATCH hwmon 1/1] hwmon: (pmbus) Fix sensors readouts for MPS
+ Multi-phase mp2888 controller
+
+Fix scale factors for reading MPS Multi-phase mp2888 controller.
+Fixed sensors:
+    - PIN/POUT: based on vendor documentation, set base scale factor 0.5W/LSB
+    - IOUT: based on vendor documentation, set base scale factor 0.25 A/LSB
+
+Fixes: e4db7719d037 ("hwmon: (pmbus) Add support for MPS Multi-phase mp2888 controller")
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/hwmon/pmbus/mp2888.c | 11 +++++------
+ 1 file changed, 5 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/hwmon/pmbus/mp2888.c b/drivers/hwmon/pmbus/mp2888.c
+index 8ecd4ad..529eb3c 100644
+--- a/drivers/hwmon/pmbus/mp2888.c
++++ b/drivers/hwmon/pmbus/mp2888.c
+@@ -109,7 +109,7 @@ mp2888_read_phase(struct i2c_client *client, struct mp2888_data *data, int page,
+ 	 * - Kcs is the DrMOS current sense gain of power stage, which is obtained from the
+ 	 *   register MP2888_MFR_VR_CONFIG1, bits 13-12 with the following selection of DrMOS
+ 	 *   (data->curr_sense_gain):
+-	 *   00b - 5µA/A, 01b - 8.5µA/A, 10b - 9.7µA/A, 11b - 10µA/A.
++	 *   00b - 8.5µA/A, 01b - 9.7µA/A, 1b - 10µA/A, 11b - 5µA/A.
+ 	 * - Rcs is the internal phase current sense resistor. This parameter depends on hardware
+ 	 *   assembly. By default it is set to 1kΩ. In case of different assembly, user should
+ 	 *   scale this parameter by dividing it by Rcs.
+@@ -118,10 +118,9 @@ mp2888_read_phase(struct i2c_client *client, struct mp2888_data *data, int page,
+ 	 * because sampling of current occurrence of bit weight has a big deviation, especially for
+ 	 * light load.
+ 	 */
+-	ret = DIV_ROUND_CLOSEST(ret * 100 - 9800, data->curr_sense_gain);
+-	ret = (data->phase_curr_resolution) ? ret * 2 : ret;
++	ret = DIV_ROUND_CLOSEST(ret * 200 - 19600, data->curr_sense_gain);
+ 	/* Scale according to total current resolution. */
+-	ret = (data->total_curr_resolution) ? ret * 8 : ret * 4;
++	ret = (data->total_curr_resolution) ? ret * 2 : ret;
+ 	return ret;
+ }
+ 
+@@ -212,7 +211,7 @@ static int mp2888_read_word_data(struct i2c_client *client, int page, int phase,
+ 		ret = pmbus_read_word_data(client, page, phase, reg);
+ 		if (ret < 0)
+ 			return ret;
+-		ret = data->total_curr_resolution ? ret * 2 : ret;
++		ret = data->total_curr_resolution ? ret  : DIV_ROUND_CLOSEST(ret, 2);
+ 		break;
+ 	case PMBUS_POUT_OP_WARN_LIMIT:
+ 		ret = pmbus_read_word_data(client, page, phase, reg);
+@@ -223,7 +222,7 @@ static int mp2888_read_word_data(struct i2c_client *client, int page, int phase,
+ 		 * set 1. Actual power is reported with 0.5W or 1W respectively resolution. Scaling
+ 		 * is needed to match both.
+ 		 */
+-		ret = data->total_curr_resolution ? ret * 4 : ret * 2;
++		ret = data->total_curr_resolution ? ret * 2 : ret;
+ 		break;
+ 	/*
+ 	 * The below registers are not implemented by device or implemented not according to the
+-- 
+2.8.4
+


### PR DESCRIPTION
Fix scale factors for reading MPS Multi-phase mp2888 controller.
Fixed sensors:
    - PIN/POUT: based on vendor documentation, set base scale factor 0.5W/LSB
    - IOUT: based on vendor documentation, set base scale factor 0.25 A/LSB
    - IOUT phases: fix calculation formula according to vendor documentation

Fixes: e4db7719d037 ("hwmon: (pmbus) Add support for MPS Multi-phase mp2888 controller")
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
