### PR TITLE
hw-mgmt: init: Add retry mechanism for regio detection

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -508,7 +508,7 @@ function restore_i2c_bus_frequency_default()
 	esac
 }
 
-function find_regio_sysfs_path()
+function find_regio_sysfs_path_helper()
 {
 	# Find hwmon{n} sysfs path for regio device
 	case $board_type in 
@@ -535,6 +535,22 @@ function find_regio_sysfs_path()
 		done
 		;;
 	esac
+
+	return 1
+}
+
+function find_regio_sysfs_path()
+{
+	local retry_to=0.5
+	local retry_cnt=10
+
+	for ((i=0; i<${retry_cnt}; i+=1)); do
+		find_regio_sysfs_path_helper
+		if [ $? -eq 0 ]; then
+			return 0
+		fi
+		sleep "$retry_to"
+	done
 
 	log_err "mlxreg_io is not loaded"
 	return 1


### PR DESCRIPTION
In some marginal cases during early initialization sysfs entry name for mlxreg-io driver can be created with some small delay. In such case the below error is output to syslog:
"ERR hw-management: mlxreg_io is not loaded".

Add retry mechanism to protect from such timing issue.

Fixes: [SONIC - Design - Bug SW #3177482] [Non-Functional ] [HW-mgmt] [error in log] | ERR hw-management: mlxreg_io is not loaded
Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>