### PR TITLE
hw-mgmt: modules-load.d: remove not upstreamed icp201xx module from list.

### DIFF
--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -22,4 +22,3 @@ gpio-pca953x
 pmbus
 i2c-mux-mlxcpld
 lm25066
-icp201xx


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
