### PR TITLE
hw-mgmt: init: Make common helper for retry mechanism

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -233,3 +233,35 @@ disconnect_device()
 
 	return 0
 }
+
+# Common retry helper function.
+# Input:
+# - $1 - user function to execute.
+# - $2 - retry timeout delay window.
+# - $3 - retry counter.
+# - $4 - user log to be produced if user function failed (optional).
+# Output:
+# - return code (0 - success; 1 - failure).
+# Example:
+# retry_helper find_regio_sysfs_path_helper 0.5 10 "mlxreg_io is not loaded"
+function retry_helper()
+{
+	local user_func="$1"
+	local retry_to="$2"
+	local retry_cnt="$3"
+	local user_log="$4"
+
+	for ((i=0; i<${retry_cnt}; i+=1)); do
+		$user_func
+		if [ $? -eq 0 ]; then
+			return 0
+		fi
+		sleep "$retry_to"
+	done
+
+	if [ ! -z "$$user_log" ]; then
+		log_err "$user_log"
+	fi
+
+	return 1
+}

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -541,18 +541,11 @@ function find_regio_sysfs_path_helper()
 
 function find_regio_sysfs_path()
 {
-	local retry_to=0.5
-	local retry_cnt=10
 
-	for ((i=0; i<${retry_cnt}; i+=1)); do
-		find_regio_sysfs_path_helper
-		if [ $? -eq 0 ]; then
-			return 0
-		fi
-		sleep "$retry_to"
-	done
-
-	log_err "mlxreg_io is not loaded"
+	retry_helper find_regio_sysfs_path_helper 0.5 10 "mlxreg_io is not loaded"
+	if [ $? -eq 0 ]; then
+		return 0
+	fi
 	return 1
 }
 


### PR DESCRIPTION
Add generic function to be used for retries.
Function is defined as below

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>