### PR TITLE
[Komodo] Changing the temperature sensor

### DIFF
--- a/usr/etc/hw-management-sensors/sn3750sx_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn3750sx_sensors.conf
@@ -12,7 +12,7 @@ bus "i2c-2" "i2c-1-mux (chan_id 1)"
 bus "i2c-7" "i2c-1-mux (chan_id 6)"
     chip "tmp102-i2c-*-49"
         label temp1 "Ambient Fan Side Temp (air intake)"
-    chip "adt75-i2c-*-4a"
+    chip "tmp102-i2c-*-4a"
         label temp1 "Ambient Port Side Temp (air exhaust)"
 
 bus "i2c-15" "i2c-1-mux (chan_id 6)"

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -214,7 +214,7 @@ msn37xx_A1_voltmon_connect_table=( mp2975 0x62 5 voltmon1 \
 sn3750sx_secured_connect_table=(	mp2975 0x62 5 \
 			mp2975 0x66 5 \
 			tmp102 0x49 7 \
-			adt75 0x4a 7 \
+			tmp102 0x4a 7 \
 			24c512 0x51 8 \
 			24c128 0x54 9)
 


### PR DESCRIPTION
There has been a BOM change in the Komodo. Temperature sensor at 7-004a has been changed to tmp102 from adt75.

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>