### PR TITLE
hw-mgmt: init: Remove redundant sleep from init flow

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -904,7 +904,6 @@ if [ "$1" == "add" ]; then
 			;;
 		esac
 		# Allow insertion of all the attributes, but skip redundant cpld entries.
-		sleep 1
 		if [ -d "$3""$4" ]; then
 			local cpld_num
 			for attrpath in "$3""$4"/*; do


### PR DESCRIPTION
Remove sleep to speed-up initialization

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>