### PR TITLE
hw-mgmt: init: Complete init flow only after the last attribute is cr…

### DIFF
--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -54,3 +54,7 @@ case $board in
 		;;
 esac
 
+if [ ! -f /var/run/hw-management/system/cpld_base ]; then
+	timeout 5 bash -c 'until [ -f /var/run/hw-management/system/cpld_base ]; do sleep 0.2; done'
+fi
+


### PR DESCRIPTION
…eated

Wait in initiailization flwo until  'cpld_base' is created internally after all other links are created. It combines few attributes together, so it is created at the end.

Fixes: [No RM] ("degradation in hw-mgmt V.7.0020.4001 on 2700: it takes more time to link the reboot cause files")
Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>