### PR TITLE
hw-mgmt: sensors.conf: changes of SN5600 sensors configuration.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.4030) unstable; urgency=low
+hw-management (1.mlnx.7.0020.4032) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 18 Oct 2022 11:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 22 Oct 2022 11:55:00 +0300
 

--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -59,7 +59,7 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
         label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
         label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
         label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
-	chip "mp2975-i2c-*-65"
+    chip "mp2975-i2c-*-65"
         label in1      "PMIC-4 PSU 13V5 Rail (in1)"
         label in2      "PMIC-4 VDD_T4 ADJ Rail (out1)"
         label in3      "PMIC-4 VDD_T5 ADJ Rail (out2)"
@@ -187,25 +187,25 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "pmbus-i2c-*-10"
         label in1      	"IBC-1 PWR CONV 54V Rail (in1)"
-        label in2      	"IBC-1 13V5 Rail (out1)"
+        ignore in2
         ignore in3
         label temp1    	"IBC-1 Temp 1"
         label curr1 	"IBC-1 13V5 Rail Curr (out)"
-	chip "pmbus-i2c-*-11"
+    chip "pmbus-i2c-*-11"
         label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
-        label in2      	"IBC-2 13V5 Rail (out1)"
+        ignore in2
         ignore in3
         label temp1    	"IBC-2 Temp 1"
         label curr1 	"IBC-2 13V5 Rail Curr (out)"
-	chip "pmbus-i2c-*-12"
+    chip "pmbus-i2c-*-12"
         label in1      	"IBC-3 PWR CONV 54V Rail (in1)"
-        label in2      	"IBC-3 13V5 Rail (out1)"
+        ignore in2
         ignore in3
         label temp1    	"IBC-3 Temp 1"
         label curr1 	"IBC-3 13V5 Rail Curr (out)"
-	chip "pmbus-i2c-*-13"
+    chip "pmbus-i2c-*-13"
         label in1      	"IBC-4 PWR CONV 54V Rail (in1)"
-        label in2      	"IBC-4 13V5 Rail (out1)"
+        ignore in2
         ignore in3
         label temp1    	"IBC-4 Temp 1"
         label curr1 	"IBC-4 13V5 Rail Curr (out)"
@@ -222,9 +222,9 @@ bus "i2c-39" "i2c-1-mux (chan_id 6)"
         label power3 "PMIC-6 COMEX VCCSA Pwr (pout2)"
         label curr1 "PMIC-6 COMEX Curr (iin)"
         label curr2 "PMIC-6 COMEX VCORE Rail Curr (out1)"
-                ignore curr3
-                ignore curr4
-                ignore curr5
+        ignore curr3
+        ignore curr4
+        ignore curr5
         label curr6 "PMIC-6 COMEX VCCSA Rail Curr (out2)"
         ignore curr7
 


### PR DESCRIPTION
1. Ignore exception VLs (in2) of Delta power-converter.
   This input isn't reported in standard linear form by vendor.
   It still can be read by raw pmbus command, not through pmbus driver, and converted
   by exception formula provided by Delta.
2. Beautify: fix indentations.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
