### PR TITLE
hw-mgmt: psu: Add routine to set PSU fan speed

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -265,3 +265,25 @@ function retry_helper()
 
 	return 1
 }
+
+# Set PSU fan speed
+# Input:
+# - $1 - psu name
+# - $2 - psu speed
+# Output:
+# - none
+psu_set_fan_speed()
+{
+	local addr=$(< $config_path/"$1"_i2c_addr)
+	local bus=$(< $config_path/"$1"_i2c_bus)
+	local fan_config_command=$(< $config_path/fan_config_command)
+	local fan_speed_units=$(< $config_path/fan_speed_units)
+	local fan_command=$(< $config_path/fan_command)
+	local speed=$2
+
+	# Set fan speed units (percentage or RPM)
+	i2cset -f -y "$bus" "$addr" "$fan_config_command" "$fan_speed_units" bp
+
+	# Set fan speed
+	i2cset -f -y "$bus" "$addr" "$fan_command" "${speed}" wp
+}

--- a/usr/usr/bin/hw-management-thermal-control.sh
+++ b/usr/usr/bin/hw-management-thermal-control.sh
@@ -81,7 +81,6 @@ temp_fan_amb=$thermal_path/fan_amb
 temp_port_amb=$thermal_path/port_amb
 pwm=$thermal_path/pwm1
 asic=$thermal_path/asic
-fan_command=$config_path/fan_command
 tz_mode=$thermal_path/mlxsw/thermal_zone_mode
 tz_policy=$thermal_path/mlxsw/thermal_zone_policy
 tz_temp=$thermal_path/mlxsw/thermal_zone_temp
@@ -886,16 +885,9 @@ update_psu_fan_speed()
 		if [ -L $thermal_path/psu"$i"_pwr_status ]; then
 			pwr=$(< $thermal_path/psu"$i"_pwr_status)
 			if [ "$pwr" -eq 1 ]; then
-				bus=$(< $config_path/psu"$i"_i2c_bus)
-				addr=$(< $config_path/psu"$i"_i2c_addr)
-				command=$(< $fan_command)
 				entry=$(< $thermal_path/cooling_cur_state)
 				speed=${psu_fan_speed[$entry]}
-				# SN2201 sets psu fan speed in percentage mode.
-				if [ "$board_type" == "VMOD0014" ]; then
-					i2cset -f -y "$bus" "$addr" 0x3a 0x90 bp
-				fi
-				i2cset -f -y "$bus" "$addr" "$command" "$speed" wp
+				psu_set_fan_speed psu"$i" "$speed"
 			fi
 		fi
 	done

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -74,6 +74,8 @@ psu4_i2c_addr=0x5a
 psu_count=2
 fan_psu_default=0x3c
 fan_command=0x3b
+fan_config_command=0x3a
+fan_speed_units=0x90
 chipup_delay_default=0
 hotplug_psus=2
 hotplug_fans=6
@@ -1905,6 +1907,8 @@ set_config_data()
 	done
 	echo $fan_psu_default > $config_path/fan_psu_default
 	echo $fan_command > $config_path/fan_command
+	echo $fan_config_command > $config_path/fan_config_command
+	echo $fan_speed_units > $config_path/fan_speed_units
 	echo 35 > $config_path/thermal_delay
 	echo $chipup_delay_default > $config_path/chipup_delay
 	echo 0 > $config_path/chipdown_delay


### PR DESCRIPTION
For most PSUs we assume that fan speed is always given in duty cycle (percentage) units. This may not always be the case, for example the PSU FW default units may be RPM, or the units can be modified by kernel driver or userspace tools. Create a routine to set PSU fan speed that expicitly sets speed units and use it at all places where PSU fan speed is being set.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>