### PR TITLE
sensors.conf: Correcting SN3750SX sensors config

### DIFF
--- a/usr/etc/hw-management-sensors/sn3750sx_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn3750sx_sensors.conf
@@ -39,11 +39,19 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
         label in3 "PMIC-1 ASIC 1.2V Rail (out)"
         ignore in4
         label temp1 "PMIC-1 Temp 1"
-        label temp2 "PMIC-1 Temp 2"
-        label power1 "PMIC-1 ASIC 0.8V VCORE Rail Pwr (out)"
-        label power2 "PMIC-1 ASIC 1.2V Rail Pwr (out)"
-        label curr1 "PMIC-1 ASIC 0.8V VCORE Rail Curr (out)"
-        label curr2 "PMIC-1 ASIC 1.2V Rail Curr (out)"
+        label power1 "PMIC-1 PSU 12V Rail Pwr (in)"
+        label power2 "PMIC-1 ASIC 0.8V VCORE Rail Pwr (out)"
+        label power3 "PMIC-1 ASIC 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-1 PSU 12V Rail Curr (in)"
+        label curr2 "PMIC-1 ASIC 0.8V VCORE Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        ignore curr5
+        ignore curr6
+        ignore curr7
+        ignore curr8
+        label curr9 "PMIC-1 ASIC 1.2V Rail Curr (out)"
+        ignore curr10
     chip "mp2975-i2c-*-66"
         label in1 "PMIC-2 PSU 12V Rail (in)"
         label in2 "PMIC-2 ASIC 3.3V Rail (out)"
@@ -51,11 +59,17 @@ bus "i2c-5" "i2c-1-mux (chan_id 4)"
         label in3 "PMIC-2 ASIC 1.8V Rail (out)"
         ignore in4
         label temp1 "PMIC-2 Temp 1"
-        label temp2 "PMIC-2 Temp 2"
-        label power1 "PMIC-2 ASIC 3.3V Rail Pwr (out)"
-        label power2 "PMIC-2 ASIC 1.8V Rail Pwr (out)"
-        label curr1 "PMIC-2 ASIC 3.3V Rail Curr (out)"
-        label curr2 "PMIC-2 ASIC 1.8V Rail Curr (out)"
+        label power1 "PMIC-2 PSU 12V Rail Pwr (in)"
+        label power2 "PMIC-2 ASIC 3.3V Rail Pwr (out)"
+        compute power2 (2)*@, @/(2)
+        label power3 "PMIC-2 ASIC 1.8V Rail Pwr (out)"
+        label curr1 "PMIC-2  PSU 12V Rail Curr (in)"
+        label curr2 "PMIC-2 ASIC 3.3V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-2 ASIC 1.8V Rail Curr (out)"
+        ignore curr6
+        ignore curr7
 
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"


### PR DESCRIPTION
Adding the missed out power/current fields

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>