### PR TITLE
hw-mgmt: topology: Fix voltmon i2c bus addresses for P4697 system Fix mp2975 voltmon's i2c bus addresses for P4697 system

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -374,9 +374,9 @@ p4697_rev1_base_connect_table=(    max11603 0x6d 7 \
 p4697_dynamic_i2c_bus_connect_table=(  mp2975 0x62 26 voltmon1 \
 			mp2975 0x65 26 voltmon2 \
 			mp2975 0x67 26 voltmon3 \
-			mp2975 0x62 27 voltmon4 \
-			mp2975 0x65 27 voltmon5 \
-			mp2975 0x67 27 voltmon6)
+			mp2975 0x62 29 voltmon4 \
+			mp2975 0x65 29 voltmon5 \
+			mp2975 0x67 29 voltmon6)
 
 msn4800_base_connect_table=( mp2975 0x62 5 \
 	mp2975 0x64 5 \


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
