### PR TITLE
hw-mgmt init & docs: remove icp201xx pressure sensor from common hw-mgmt handling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.4034) unstable; urgency=low
+hw-management (1.mlnx.7.0020.4036) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Mon, 07 Oct 2022 11:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 08 Oct 2022 11:55:00 +0300
 

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -344,7 +344,7 @@ Kernel-5.10
 |0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch         |                                            |                                                 | SN5600                                                       |
 |0177-Documentation-ABI-fix-description-of-fix-reset_pwr_c.patch         |                                            |                                                 | SN5600                                                       |
 |0178-platform-mellanox-Introduce-support-for-next-generat.patch         |                                            |                                                 | SN5600                                                       |
-|0179-DS-iio-pressure-icp20100-add-driver-for-InvenSense-ICP-.patch      |                                            |                                                 | SN5600                                                       |
+|0179-DS-iio-pressure-icp20100-add-driver-for-InvenSense-ICP-.patch      |                                            | downstream for OPT-OS use only                  | SN5600                                                       |
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch         | 525dd5aed67a2f4f7278116fb92a24e6a53e2622   |  accepted                                       |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -22,4 +22,3 @@ gpio-pca953x
 pmbus
 i2c-mux-mlxcpld
 lm25066
-icp201xx

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -425,8 +425,6 @@ sn5600_base_connect_table=( \
 	pmbus  0x11 4 \
 	pmbus  0x13 4 \
 	pmbus  0x15 4 \
-	icp201xx 0x63 4 \
-	icp201xx 0x64 4 \
 	mp2975 0x62 5 \
 	mp2975 0x63 5 \
 	mp2975 0x64 5 \


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
