### PR TITLE
hw-mgmt: sensors & scripts: changes for SN5600

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.4036) unstable; urgency=low
+hw-management (1.mlnx.7.0020.4038) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 08 Oct 2022 11:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Sun, 13 Oct 2022 11:55:00 +0300
 

--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -9,262 +9,266 @@ bus "i2c-39" "i2c-1-mux (chan_id 6)"
 
 # Temperature sensors
 chip "mlxsw-i2c-*-48"
-        label temp1 "Ambient ASIC Temp"
+    label temp1 "Ambient ASIC Temp"
 
 chip "tmp102-i2c-*-49"
-        label temp1 "Ambient Fan Side Temp (air intake)"
+    label temp1 "Ambient Fan Side Temp (air intake)"
 chip "adt75-i2c-*-49"
-        label temp1 "Ambient Fan Side Temp (air intake)"
+    label temp1 "Ambient Fan Side Temp (air intake)"
 chip "tmp102-i2c-*-4a"
-        label temp1 "Ambient Port Side Temp (air exhaust)"
+    label temp1 "Ambient Port Side Temp (air exhaust)"
 chip "adt75-i2c-*-4a"
-        label temp1 "Ambient Port Side Temp (air exhaust)"
+    label temp1 "Ambient Port Side Temp (air exhaust)"
 
 # Power controllers
 chip "mp2975-i2c-*-62"
-        label in1      "PMIC-1 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-1 VDD_M ADJ Rail (out1)"
-        ignore in3
-        label temp1    "PMIC-1 VDD_M ADJ Temp 1"
-        ignore temp2
-        label power1   "PMIC-1 13V5 VDD_M (in)"
-        label power2   "PMIC-1 VDD_M Rail Pwr (out1)"
-        ignore power3
-        label curr1    "PMIC-1 13V5 VDD_M Rail Curr (in1)"
-        label curr2    "PMIC-1 VDD_M Rail Curr (out1)"
-        ignore curr3
-        ignore curr4
-        ignore curr5
-        ignore curr6
-        ignore curr7
-        ignore curr8
-        ignore curr9
-        ignore curr10
+    label in1      "PMIC-1 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-1 VDD_M ADJ Rail (out1)"
+    ignore in3
+    label temp1    "PMIC-1 VDD_M ADJ Temp 1"
+    ignore temp2
+    label power1   "PMIC-1 13V5 VDD_M (in)"
+    label power2   "PMIC-1 VDD_M Rail Pwr (out1)"
+    ignore power3
+    label curr1    "PMIC-1 13V5 VDD_M Rail Curr (in1)"
+    label curr2    "PMIC-1 VDD_M Rail Curr (out1)"
+    ignore curr3
+    ignore curr4
+    ignore curr5
+    ignore curr6
+    ignore curr7
+    ignore curr8
+    ignore curr9
+    ignore curr10
 chip "mp2975-i2c-*-63"
-        label in1      "PMIC-2 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-2 VDD_T0 ADJ Rail (out1)"
-        label in3      "PMIC-2 VDD_T1 ADJ Rail (out2)"
-        label temp1    "PMIC-2 VDD_T0 ADJ Temp 1"
-        label temp2    "PMIC-2 VDD_T1 ADJ Temp 2"
-        label power1   "PMIC-2 13V5 VDD_T0 VDD_T1 (in)"
-        label power2   "PMIC-2 VDD_T0 Rail Pwr (out1)"
-        label power3   "PMIC-2 VDD_T1 Rail Pwr (out2)"
-        label curr1    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in1)"
-        label curr2    "PMIC-2 VDD_T0 Rail Curr (out1)"
-        label curr3    "PMIC-2 VDD_T1 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-2 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-2 VDD_T0 ADJ Rail (out1)"
+    label in3      "PMIC-2 VDD_T1 ADJ Rail (out2)"
+    label temp1    "PMIC-2 VDD_T0 ADJ Temp 1"
+    label temp2    "PMIC-2 VDD_T1 ADJ Temp 2"
+    label power1   "PMIC-2 13V5 VDD_T0 VDD_T1 (in)"
+    label power2   "PMIC-2 VDD_T0 Rail Pwr (out1)"
+    label power3   "PMIC-2 VDD_T1 Rail Pwr (out2)"
+    label curr1    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in1)"
+    label curr2    "PMIC-2 VDD_T0 Rail Curr (out1)"
+    label curr3    "PMIC-2 VDD_T1 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-64"
-        label in1      "PMIC-3 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-3 VDD_T2 ADJ Rail (out1)"
-        label in3      "PMIC-3 VDD_T3 ADJ Rail (out2)"
-        label temp1    "PMIC-3 VDD_T2 ADJ Temp 1"
-        label temp2    "PMIC-3 VDD_T3 ADJ Temp 2"
-        label power1   "PMIC-3 13V5 VDD_T2 VDD_T3 (in)"
-        label power2   "PMIC-3 VDD_T2 Rail Pwr (out1)"
-        label power3   "PMIC-3 VDD_T3 Rail Pwr (out2)"
-        label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
-        label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
-        label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-3 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-3 VDD_T2 ADJ Rail (out1)"
+    label in3      "PMIC-3 VDD_T3 ADJ Rail (out2)"
+    label temp1    "PMIC-3 VDD_T2 ADJ Temp 1"
+    label temp2    "PMIC-3 VDD_T3 ADJ Temp 2"
+    label power1   "PMIC-3 13V5 VDD_T2 VDD_T3 (in)"
+    label power2   "PMIC-3 VDD_T2 Rail Pwr (out1)"
+    label power3   "PMIC-3 VDD_T3 Rail Pwr (out2)"
+    label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
+    label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
+    label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-65"
-        label in1      "PMIC-4 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-4 VDD_T4 ADJ Rail (out1)"
-        label in3      "PMIC-4 VDD_T5 ADJ Rail (out2)"
-        label temp1    "PMIC-4 VDD_T4 ADJ Temp 1"
-        label temp2    "PMIC-4 VDD_T5 ADJ Temp 2"
-        label power1   "PMIC-4 13V5 VDD_T4 VDD_T5 (in)"
-        label power2   "PMIC-4 VDD_T4 Rail Pwr (out1)"
-        label power3   "PMIC-4 VDD_T5 Rail Pwr (out2)"
-        label curr1    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in1)"
-        label curr2    "PMIC-4 VDD_T4 Rail Curr (out1)"
-        label curr3    "PMIC-4 VDD_T5 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-4 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-4 VDD_T4 ADJ Rail (out1)"
+    label in3      "PMIC-4 VDD_T5 ADJ Rail (out2)"
+    label temp1    "PMIC-4 VDD_T4 ADJ Temp 1"
+    label temp2    "PMIC-4 VDD_T5 ADJ Temp 2"
+    label power1   "PMIC-4 13V5 VDD_T4 VDD_T5 (in)"
+    label power2   "PMIC-4 VDD_T4 Rail Pwr (out1)"
+    label power3   "PMIC-4 VDD_T5 Rail Pwr (out2)"
+    label curr1    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in1)"
+    label curr2    "PMIC-4 VDD_T4 Rail Curr (out1)"
+    label curr3    "PMIC-4 VDD_T5 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-66"
-        label in1      "PMIC-5 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-5 VDD_T6 ADJ Rail (out1)"
-        label in3      "PMIC-5 VDD_T7 ADJ Rail (out2)"
-        label temp1    "PMIC-5 VDD_T6 ADJ Temp 1"
-        label temp2    "PMIC-5 VDD_T7 ADJ Temp 2"
-        label power1   "PMIC-5 13V5 VDD_T6 VDD_T7 (in)"
-        label power2   "PMIC-5 VDD_T6 Rail Pwr (out1)"
-        label power3   "PMIC-5 VDD_T7 Rail Pwr (out2)"
-        label curr1    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in1)"
-        label curr2    "PMIC-5 VDD_T6 Rail Curr (out1)"
-        label curr3    "PMIC-5 VDD_T7 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-5 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-5 VDD_T6 ADJ Rail (out1)"
+    label in3      "PMIC-5 VDD_T7 ADJ Rail (out2)"
+    label temp1    "PMIC-5 VDD_T6 ADJ Temp 1"
+    label temp2    "PMIC-5 VDD_T7 ADJ Temp 2"
+    label power1   "PMIC-5 13V5 VDD_T6 VDD_T7 (in)"
+    label power2   "PMIC-5 VDD_T6 Rail Pwr (out1)"
+    label power3   "PMIC-5 VDD_T7 Rail Pwr (out2)"
+    label curr1    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in1)"
+    label curr2    "PMIC-5 VDD_T6 Rail Curr (out1)"
+    label curr3    "PMIC-5 VDD_T7 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-67"
-        label in1      "PMIC-6 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-6 DVDD_T0 ADJ Rail (out1)"
-        label in3      "PMIC-6 DVDD_T1 ADJ Rail (out2)"
-        label temp1    "PMIC-6 DVDD_T0 ADJ Temp 1"
-        label temp2    "PMIC-6 DVDD_T1 ADJ Temp 2"
-        label power1   "PMIC-6 13V5 DVDD_T0 DVDD_T1 (in)"
-        label power2   "PMIC-6 DVDD_T0 Rail Pwr (out1)"
-        label power3   "PMIC-6 DVDD_T1 Rail Pwr (out2)"
-        label curr1    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)"
-        label curr2    "PMIC-6 DVDD_T0 Rail Curr (out1)"
-        label curr3    "PMIC-6 DVDD_T1 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-6 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-6 DVDD_T0 ADJ Rail (out1)"
+    label in3      "PMIC-6 DVDD_T1 ADJ Rail (out2)"
+    label temp1    "PMIC-6 DVDD_T0 ADJ Temp 1"
+    label temp2    "PMIC-6 DVDD_T1 ADJ Temp 2"
+    label power1   "PMIC-6 13V5 DVDD_T0 DVDD_T1 (in)"
+    label power2   "PMIC-6 DVDD_T0 Rail Pwr (out1)"
+    label power3   "PMIC-6 DVDD_T1 Rail Pwr (out2)"
+    label curr1    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)"
+    label curr2    "PMIC-6 DVDD_T0 Rail Curr (out1)"
+    label curr3    "PMIC-6 DVDD_T1 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-68"
-        label in1      "PMIC-7 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-7 DVDD_T2 ADJ Rail (out1)"
-        label in3      "PMIC-7 DVDD_T3 ADJ Rail (out2)"
-        label temp1    "PMIC-7 DVDD_T2 ADJ Temp 1"
-        label temp2    "PMIC-7 DVDD_T3 ADJ Temp 2"
-        label power1   "PMIC-7 13V5 DVDD_T2 DVDD_T3 (in)"
-        label power2   "PMIC-7 DVDD_T2 Rail Pwr (out1)"
-        label power3   "PMIC-7 DVDD_T3 Rail Pwr (out2)"
-        label curr1    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in1)"
-        label curr2    "PMIC-7 DVDD_T2 Rail Curr (out1)"
-        label curr3    "PMIC-7 DVDD_T3 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-7 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-7 DVDD_T2 ADJ Rail (out1)"
+    label in3      "PMIC-7 DVDD_T3 ADJ Rail (out2)"
+    label temp1    "PMIC-7 DVDD_T2 ADJ Temp 1"
+    label temp2    "PMIC-7 DVDD_T3 ADJ Temp 2"
+    label power1   "PMIC-7 13V5 DVDD_T2 DVDD_T3 (in)"
+    label power2   "PMIC-7 DVDD_T2 Rail Pwr (out1)"
+    label power3   "PMIC-7 DVDD_T3 Rail Pwr (out2)"
+    label curr1    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in1)"
+    label curr2    "PMIC-7 DVDD_T2 Rail Curr (out1)"
+    label curr3    "PMIC-7 DVDD_T3 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-69"
-        label in1      "PMIC-8 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-8 DVDD_T4 ADJ Rail (out1)"
-        label in3      "PMIC-8 DVDD_T5 ADJ Rail (out2)"
-        label temp1    "PMIC-8 DVDD_T4 ADJ Temp 1"
-        label temp2    "PMIC-8 DVDD_T5 ADJ Temp 2"
-        label power1   "PMIC-8 13V5 DVDD_T4 DVDD_T5 (in)"
-        label power2   "PMIC-8 DVDD_T4 Rail Pwr (out1)"
-        label power3   "PMIC-8 DVDD_T5 Rail Pwr (out2)"
-        label curr1    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in1)"
-        label curr2    "PMIC-8 DVDD_T4 Rail Curr (out1)"
-        label curr3    "PMIC-8 DVDD_T5 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-8 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-8 DVDD_T4 ADJ Rail (out1)"
+    label in3      "PMIC-8 DVDD_T5 ADJ Rail (out2)"
+    label temp1    "PMIC-8 DVDD_T4 ADJ Temp 1"
+    label temp2    "PMIC-8 DVDD_T5 ADJ Temp 2"
+    label power1   "PMIC-8 13V5 DVDD_T4 DVDD_T5 (in)"
+    label power2   "PMIC-8 DVDD_T4 Rail Pwr (out1)"
+    label power3   "PMIC-8 DVDD_T5 Rail Pwr (out2)"
+    label curr1    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in1)"
+    label curr2    "PMIC-8 DVDD_T4 Rail Curr (out1)"
+    label curr3    "PMIC-8 DVDD_T5 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-6a"
-        label in1      "PMIC-9 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-9 DVDD_T6 ADJ Rail (out1)"
-        label in3      "PMIC-9 DVDD_T7 ADJ Rail (out2)"
-        label temp1    "PMIC-9 DVDD_T6 ADJ Temp 1"
-        label temp2    "PMIC-9 DVDD_T7 ADJ Temp 2"
-        label power1   "PMIC-9 13V5 DVDD_T6 DVDD_T7 (in)"
-        label power2   "PMIC-9 DVDD_T6 Rail Pwr (out1)"
-        label power3   "PMIC-9 DVDD_T7 Rail Pwr (out2)"
-        label curr1    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in1)"
-        label curr2    "PMIC-9 DVDD_T6 Rail Curr (out1)"
-        label curr3    "PMIC-9 DVDD_T7 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-9 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-9 DVDD_T6 ADJ Rail (out1)"
+    label in3      "PMIC-9 DVDD_T7 ADJ Rail (out2)"
+    label temp1    "PMIC-9 DVDD_T6 ADJ Temp 1"
+    label temp2    "PMIC-9 DVDD_T7 ADJ Temp 2"
+    label power1   "PMIC-9 13V5 DVDD_T6 DVDD_T7 (in)"
+    label power2   "PMIC-9 DVDD_T6 Rail Pwr (out1)"
+    label power3   "PMIC-9 DVDD_T7 Rail Pwr (out2)"
+    label curr1    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in1)"
+    label curr2    "PMIC-9 DVDD_T6 Rail Curr (out1)"
+    label curr3    "PMIC-9 DVDD_T7 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 chip "mp2975-i2c-*-6b"
-        label in1      "PMIC-10 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-10 HVDD_T03 1V2 Rail (out1)"
-        label in3      "PMIC-10 HVDD_T47 1V2 Rail (out2)"
-        label temp1    "PMIC-10 HVDD_T03 1V2 Temp 1"
-        label temp2    "PMIC-10 HVDD_T47 1V2 Temp 2"
-        label power1   "PMIC-10 13V5 HVDD_T03 HVDD_T47 (in)"
-        label power2   "PMIC-10 HVDD_T03 Rail Pwr (out1)"
-        label power3   "PMIC-10 HVDD_T47 Rail Pwr (out2)"
-        label curr1    "PMIC-10 13V5 HVDD_T03 HVDD_T47 Rail Curr (in1)"
-        label curr2    "PMIC-10 HVDD_T03 Rail Curr (out1)"
-        label curr3    "PMIC-10 HVDD_T47 Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
-        ignore curr7
-        ignore curr8
-        ignore curr9
-        ignore curr10
-        ignore curr11
+    label in1      "PMIC-10 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-10 HVDD_T03 1V2 Rail (out1)"
+    label in3      "PMIC-10 HVDD_T47 1V2 Rail (out2)"
+    label temp1    "PMIC-10 HVDD_T03 1V2 Temp 1"
+    label temp2    "PMIC-10 HVDD_T47 1V2 Temp 2"
+    label power1   "PMIC-10 13V5 HVDD_T03 HVDD_T47 (in)"
+    label power2   "PMIC-10 HVDD_T03 Rail Pwr (out1)"
+    label power3   "PMIC-10 HVDD_T47 Rail Pwr (out2)"
+    label curr1    "PMIC-10 13V5 HVDD_T03 HVDD_T47 Rail Curr (in1)"
+    label curr2    "PMIC-10 HVDD_T03 Rail Curr (out1)"
+    label curr3    "PMIC-10 HVDD_T47 Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
+    ignore curr7
+    ignore curr8
+    ignore curr9
+    ignore curr10
+    ignore curr11
 chip "mp2975-i2c-*-6e"
-        label in1      "PMIC-11 PSU 13V5 Rail (in1)"
-        label in2      "PMIC-11 VDDSCC 0V75 Rail (out1)"
-        label in3      "PMIC-11 DVDD_M ADJ Rail (out2)"
-        label temp1    "PMIC-11 VDDSCC 1V2 Temp 1"
-        label temp2    "PMIC-11 DVDD_M 1V2 Temp 2"
-        label power1   "PMIC-11 13V5 VDDSCC DVDD_M (in)"
-        label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
-        label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
-        label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-        label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-        label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
-        ignore curr4
-        ignore curr5
-        ignore curr6
+    label in1      "PMIC-11 PSU 13V5 Rail (in1)"
+    label in2      "PMIC-11 VDDSCC 0V75 Rail (out1)"
+    label in3      "PMIC-11 DVDD_M ADJ Rail (out2)"
+    label temp1    "PMIC-11 VDDSCC 1V2 Temp 1"
+    label temp2    "PMIC-11 DVDD_M 1V2 Temp 2"
+    label power1   "PMIC-11 13V5 VDDSCC DVDD_M (in)"
+    label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
+    label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
+    label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
+    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
+    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    ignore curr4
+    ignore curr5
+    ignore curr6
 
 # Power supplies
 
 chip "dps460-i2c-*-5a"
-        label in1 "PSU-1(L) 220V Rail (in)"
-        ignore in2
-        label in3 "PSU-1(L) 12V Rail (out)"
-        label fan1 "PSU-1(L) Fan 1"
-        label temp1 "PSU-1(L) Temp 1"
-        label temp2 "PSU-1(L) Temp 2"
-        label temp3 "PSU-1(L) Temp 3"
-        label power1 "PSU-1(L) 220V Rail Pwr (in)"
-        label power2 "PSU-1(L) 12V Rail Pwr (out)"
-        label curr1 "PSU-1(L) 220V Rail Curr (in)"
-        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    label in1 "PSU-1(L) 220V Rail (in)"
+    ignore in2
+    label in3 "PSU-1(L) 12V Rail (out)"
+    label fan1 "PSU-1(L) Fan 1"
+    label temp1 "PSU-1(L) Temp 1"
+    label temp2 "PSU-1(L) Temp 2"
+    label temp3 "PSU-1(L) Temp 3"
+    label power1 "PSU-1(L) 220V Rail Pwr (in)"
+    label power2 "PSU-1(L) 12V Rail Pwr (out)"
+    label curr1 "PSU-1(L) 220V Rail Curr (in)"
+    label curr2 "PSU-1(L) 12V Rail Curr (out)"
 chip "dps460-i2c-*-59"
-        label in1 "PSU-2(R) 220V Rail (in)"
-        ignore in2
-        label in3 "PSU-2(R) 12V Rail (out)"
-        label fan1 "PSU-2(R) Fan 1"
-        label temp1 "PSU-2(R) Temp 1"
-        label temp2 "PSU-2(R) Temp 2"
-        label temp3 "PSU-2(R) Temp 3"
-        label power1 "PSU-2(R) 220V Rail Pwr (in)"
-        label power2 "PSU-2(R) 12V Rail Pwr (out)"
-        label curr1 "PSU-2(R) 220V Rail Curr (in)"
-        label curr2 "PSU-2(R) 12V Rail Curr (out)"
+    label in1 "PSU-2(R) 220V Rail (in)"
+    ignore in2
+    label in3 "PSU-2(R) 12V Rail (out)"
+    label fan1 "PSU-2(R) Fan 1"
+    label temp1 "PSU-2(R) Temp 1"
+    label temp2 "PSU-2(R) Temp 2"
+    label temp3 "PSU-2(R) Temp 3"
+    label power1 "PSU-2(R) 220V Rail Pwr (in)"
+    label power2 "PSU-2(R) 12V Rail Pwr (out)"
+    label curr1 "PSU-2(R) 220V Rail Curr (in)"
+    label curr2 "PSU-2(R) 12V Rail Curr (out)"
 
 # Power converters
 chip "pmbus-i2c-*-10"
-        label in1      	"IBC-1 PWR CONV 54V Rail (in1)"
-        ignore in2
-        ignore in3
-        label temp1    	"IBC-1 Temp 1"
-        label curr1 	"IBC-1 13V5 Rail Curr (out)"
+    label in1      	"IBC-1 PWR CONV 54V Rail (in1)"
+    ignore in2
+    ignore in3
+    label temp1    	"IBC-1 Temp 1"
+    label curr1 	"IBC-1 13V5 Rail Curr (out)"
+    ignore curr2
 chip "pmbus-i2c-*-11"
-        label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
-        ignore in2
-        ignore in3
-        label temp1    	"IBC-2 Temp 1"
-        label curr1 	"IBC-2 13V5 Rail Curr (out)"
+    label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
+    ignore in2
+    ignore in3
+    label temp1    	"IBC-2 Temp 1"
+    label curr1 	"IBC-2 13V5 Rail Curr (out)"
+    ignore curr2
 chip "pmbus-i2c-*-13"
-        label in1      	"IBC-3 PWR CONV 54V Rail (in1)"
-        ignore in2
-        ignore in3
-        label temp1    	"IBC-3 Temp 1"
-        label curr1 	"IBC-3 13V5 Rail Curr (out)"
+    label in1      	"IBC-3 PWR CONV 54V Rail (in1)"
+    ignore in2
+    ignore in3
+    label temp1    	"IBC-3 Temp 1"
+    label curr1 	"IBC-3 13V5 Rail Curr (out)"
+    ignore curr2
 chip "pmbus-i2c-*-15"
-        label in1      	"IBC-4 PWR CONV 54V Rail (in1)"
-        ignore in2
-        ignore in3
-        label temp1    	"IBC-4 Temp 1"
-        label curr1 	"IBC-4 13V5 Rail Curr (out)"
+    label in1      	"IBC-4 PWR CONV 54V Rail (in1)"
+    ignore in2
+    ignore in3
+    label temp1    	"IBC-4 Temp 1"
+    label curr1 	"IBC-4 13V5 Rail Curr (out)"
+    ignore curr2
 
 #COMEX CFL
 chip "mp2975-i2c-39-6b"
-        label in1 "PMIC-6 PSU 12V Rail (vin)"
-        label in2 "PMIC-6 COMEX VCORE (out1)"
-        label in3 "PMIC-6 COMEX VCCSA (out2)"
-        label temp1 "PMIC-6 Temp"
-        label power1 "PMIC-6 COMEX Pwr (pin)"
-        label power2 "PMIC-6 COMEX VCORE Pwr (pout1)"
-        label power3 "PMIC-6 COMEX VCCSA Pwr (pout2)"
-        label curr1 "PMIC-6 COMEX Curr (iin)"
-        label curr2 "PMIC-6 COMEX VCORE Rail Curr (out1)"
-        ignore curr3
-        ignore curr4
-        ignore curr5
-        label curr6 "PMIC-6 COMEX VCCSA Rail Curr (out2)"
-        ignore curr7
+    label in1 "PMIC-6 PSU 12V Rail (vin)"
+    label in2 "PMIC-6 COMEX VCORE (out1)"
+    label in3 "PMIC-6 COMEX VCCSA (out2)"
+    label temp1 "PMIC-6 Temp"
+    label power1 "PMIC-6 COMEX Pwr (pin)"
+    label power2 "PMIC-6 COMEX VCORE Pwr (pout1)"
+    label power3 "PMIC-6 COMEX VCCSA Pwr (pout2)"
+    label curr1 "PMIC-6 COMEX Curr (iin)"
+    label curr2 "PMIC-6 COMEX VCORE Rail Curr (out1)"
+    ignore curr3
+    ignore curr4
+    ignore curr5
+    label curr6 "PMIC-6 COMEX VCCSA Rail Curr (out2)"
+    ignore curr7
 
 # Chassis fans
 chip "mlxreg_fan-isa-*"
@@ -276,3 +280,18 @@ chip "mlxreg_fan-isa-*"
     label fan6 "Chassis Fan Drawer-3 Tach 2"
     label fan7 "Chassis Fan Drawer-4 Tach 1"
     label fan8 "Chassis Fan Drawer-4 Tach 2"
+
+# Memory sensors
+bus "i2c-0" "SMBus I801 adapter at efa0"
+chip "jc42-i2c-0-1c"
+    label temp1 "SODIMM Temp"
+
+chip "jc42-i2c-0-1a"
+    label temp1 "SODIMM Temp"
+
+# PCH
+chip "pch_cannonlake-virtual-*"
+    label temp1 "PCH Temp"
+
+chip "*-acpi-*"
+    label temp1 "ACPI temp"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -726,7 +726,7 @@ if [ "$1" == "add" ]; then
 
 		psu_addr=$(< $config_path/"$psu_name"_i2c_addr)
 		psu_eeprom_addr=$(printf '%02x\n' $((psu_addr - 8)))
-		eeprom_name=$2_info
+		eeprom_name=$psu_name_info
 		if [ "$board_type" == "VMOD0014" ]; then
 			eeprom_file=/sys/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld.1/i2c-1/i2c-$bus/$bus-00$psu_eeprom_addr/eeprom
 		else


### PR DESCRIPTION
1. Sensors: Rename SODIMM, PCH and ACPI sensors
2. Sensors: Ignore curr2 in power converter
3. Sensors: space alignment
4. Script: fix psu2_info renaming

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
