### PR TITLE
hw-mgmt: attributes: Avoid reading cpld3 version om MSB78xx systems

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -855,7 +855,7 @@ set_spc1_port_cpld()
 			fi
 			mt_dev=$(find /dev/mst -name *00_pciconf0)
 			cmd='mlxreg --reg_name MSCI  -d $mt_dev -g -i "index=2" | grep version | cut -d "|" -f2'
-			ver_hex=$(eval $cmd)
+			ver_hex=$(eval $cmd 2>/dev/null)
 			if [ ! -z "$ver_hex" ]; then
 				ver_dec=$(printf "%d" $ver_hex)
 			fi
@@ -975,10 +975,10 @@ msn27xx_msb_msx_specific()
 		;;
 		*)
 			echo 3 > $config_path/cpld_num
+			echo cpld3 > $config_path/cpld_port
 		;;
 	esac
 
-	echo cpld3 > $config_path/cpld_port
 	set_spc1_port_cpld
 
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"


### PR DESCRIPTION
There are only 2 CPLDs on MSB78xx systems, do not create cpld_port attribute to avoid reading cpld3 version on these systems. In case reading cpld3 version is attempted anyway, (e.g. due to error in system identification), do not display error message.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>