### PR TITLE
hw-mgmt: scripts & udev: add SSD temperature report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ CONFIG_SECURITY_LOCKDOWN_LSM_EARLY=y (if kernel version >= v5.4, optional up to 
 CONFIG_LOCK_DOWN_KERNEL_FORCE_CONFIDENTIALITY=y (if kernel version >= v5.4, optional up to user)
 CONFIG_THERMAL_NETLINK=y (if kernel version >= v5.10)
 CONFIG_SENSORS_XDPE152=m
+CONFIG_DRIVETEMP=m
 
 ```
 **Note:**

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-hw-management (1.mlnx.7.0020.4038) unstable; urgency=low
+hw-management (1.mlnx.7.0020.4040) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Sun, 13 Oct 2022 11:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Sun, 14 Oct 2022 11:55:00 +0300
 

--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -22,3 +22,4 @@ gpio-pca953x
 pmbus
 i2c-mux-mlxcpld
 lm25066
+drivetemp

--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -82,6 +82,9 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/i2c-*/*-001*/hwmon/hwmon*", 
 # NVME temp
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:*/0000:*:*.*/*:*:*.*/hwmon/hwmon*", DRIVERS=="nvme", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add nvme_temp %S %p"
 
+# SSD temp
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/0000:00:*/ata*/host*/*/*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add drivetemp %S %p"
+
 # Switch - FAN tachometers, ASIC and ports temperatures and faults (I2C).
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0048/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add switch %S %p"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-0048/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm switch %S %p"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -844,6 +844,15 @@ if [ "$1" == "add" ]; then
 			done
 		fi
 	fi
+	if [ "$2" == "drivetemp" ]; then
+		name=$(<"$3""$4"/name)
+		if [ "$name" == "drivetemp" ]; then
+			check_n_link "$3""$4"/temp1_input $thermal_path/drivetemp
+			check_n_link "$3""$4"/temp1_crit $thermal_path/drivetemp_crit
+			check_n_link "$3""$4"/temp1_max $thermal_path/drivetemp_max
+			check_n_link "$3""$4"/temp1_min $thermal_path/drivetemp_min
+		fi
+	fi
 elif [ "$1" == "change" ]; then
 	if [ "$2" == "hotplug_asic" ]; then
 		if [ -d /sys/module/mlxsw_pci ]; then


### PR DESCRIPTION
1. Drivetemp driver allows to report SSD temperature in sensors command.
2. Create drivetemp links in hw-management.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
