### PR TITLE
hw-mgmt: topology: Add support for MQM9700 SYSID=5 with XDPE+STTS sensors

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1338,7 +1338,7 @@ mqm97xx_specific()
 					voltmon_connection_table=(${mqm97xx_xpde_voltmon_connect_table[@]})
 					lm_sensors_config="$lm_sensors_configs_path/mqm9700_rev1_sensors.conf"
 					;;
-				13)
+				5|13)
 					connect_table+=(${mqm97xx_rev2_base_connect_table[@]})
 					voltmon_connection_table=(${mqm97xx_xpde_voltmon_connect_table[@]})
 					lm_sensors_config="$lm_sensors_configs_path/mqm9700_rev1_sensors.conf"


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
