### PR TITLE
Modifying some kernel patch names and contents

### DIFF
--- a/recipes-kernel/linux/linux-4.19/0071-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch
+++ b/recipes-kernel/linux/linux-4.19/0071-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch
@@ -13,9 +13,8 @@ Thus, for example, "status" LED on chassis is to be called, like it is
 called now on non-modular systems, on which platform device Id is not
 specified: "mlxreg:status:green". While for the line cards LEDs it will
 be called like: "pcicard48:status:green", "ibcard66:status:green",
-"nvlinkcard68:status:green", etcetera. Where line card prefix is
-specified according to the type of bus connecting line card to the
-chassis: PCI, InfiniBand, NVLink and so on.
+etc. Where line card prefix is specified according to the type of bus
+connecting line card to the chassis: PCI, InfiniBand, and so on.
 
 LED driver works on top of register space of the programmable devices
 (CPLD or FPGA), providing the logic for LED control. The programmable

--- a/recipes-kernel/linux/linux-4.19/0157-platform-mellanox-Introduce-support-for-COMe-managem.patch
+++ b/recipes-kernel/linux/linux-4.19/0157-platform-mellanox-Introduce-support-for-COMe-managem.patch
@@ -1,16 +1,12 @@
-From 307ab625dfd6e7d892a9bc9caff071e576a49f54 Mon Sep 17 00:00:00 2001
+From 5b47989b5ed3d80a5b67ca0a086af503fca428dc Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 26 Jan 2022 20:34:32 +0200
-Subject: [PATCH 1/9] platform: mellanox: Introduce support for COMe NVSwitch
- management module for Vulcan chassis
-X-NVConfidentiality: public
+Subject: platform: mellanox: Introduce support for COMe management module for
+ chassis
 
-The Vulcan is chassis containing Nvidia's Hopper dGPU (GH100), NVswitch
-(LS10) based HGX baseboard and COMe NVSwitch management module.
 The system is built for artificial intelligence and accelerated
-analytics applications. Vulcan is offered as an HGX product to cloud
-service providers and OEMs, who intend to build fully interconnected
-GPU systems for large scale deployments.
+analytics applications. Chassis is offered to cloud service
+providers and OEMs.
 
 Driver is extended to support new COMe NVSwitch management module.
 
@@ -21,7 +17,7 @@ Reviewed-by: Oleksandr Shamray <oleksandrs@nvidia.com>
  1 file changed, 269 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 0ce52223a..7124226b9 100644
+index 0ce52223a..1ac707994 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -67,6 +67,9 @@
@@ -46,7 +42,7 @@ index 0ce52223a..7124226b9 100644
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
-+/* Platform hotplug for NVLink blade systems family data  */
++/* Platform hotplug for chassis blade systems family data  */
 +static struct mlxreg_core_data mlxplat_mlxcpld_global_wp_items_data[] = {
 +	{
 +		.label = "global_wp_grant",
@@ -56,7 +52,7 @@ index 0ce52223a..7124226b9 100644
 +	},
 +};
 +
-+static struct mlxreg_core_item mlxplat_mlxcpld_nvlink_blade_items[] = {
++static struct mlxreg_core_item mlxplat_mlxcpld_chassis_blade_items[] = {
 +	{
 +		.data = mlxplat_mlxcpld_global_wp_items_data,
 +		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
@@ -69,9 +65,9 @@ index 0ce52223a..7124226b9 100644
 +};
 +
 +static
-+struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
-+	.items = mlxplat_mlxcpld_nvlink_blade_items,
-+	.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_blade_items),
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_chassis_blade_data = {
++	.items = mlxplat_mlxcpld_chassis_blade_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_chassis_blade_items),
 +	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
 +	.mask = MLXPLAT_CPLD_AGGR_MASK_COMEX,
 +	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
@@ -85,8 +81,8 @@ index 0ce52223a..7124226b9 100644
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_regs_io_data),
  };
  
-+/* Platform register access for NVLink blade systems family data  */
-+static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
++/* Platform register access for chassis blade systems family data  */
++static struct mlxreg_core_data mlxplat_mlxcpld_chassis_blade_regs_io_data[] = {
 +	{
 +		.label = "cpld1_version",
 +		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET,
@@ -277,9 +273,9 @@ index 0ce52223a..7124226b9 100644
 +	},
 +};
 +
-+static struct mlxreg_core_platform_data mlxplat_nvlink_blade_regs_io_data = {
-+		.data = mlxplat_mlxcpld_nvlink_blade_regs_io_data,
-+		.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_blade_regs_io_data),
++static struct mlxreg_core_platform_data mlxplat_chassis_blade_regs_io_data = {
++		.data = mlxplat_mlxcpld_chassis_blade_regs_io_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_chassis_blade_regs_io_data),
 +};
 +
  /* Platform FAN default */
@@ -318,14 +314,14 @@ index 0ce52223a..7124226b9 100644
  	return 1;
  }
  
-+static int __init mlxplat_dmi_nvlink_blade_matched(const struct dmi_system_id *dmi)
++static int __init mlxplat_dmi_chassis_blade_matched(const struct dmi_system_id *dmi)
 +{
 +	int i;
 +
 +	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
 +	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
 +	mlxplat_mux_data = mlxplat_default_mux_data;
-+	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_blade_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_chassis_blade_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
 +	for (i = 0; i < mlxplat_mux_num; i++) {
@@ -333,7 +329,7 @@ index 0ce52223a..7124226b9 100644
 +		mlxplat_mux_data[i].n_values =
 +				ARRAY_SIZE(mlxplat_msn21xx_channels);
 +	}
-+	mlxplat_regs_io = &mlxplat_nvlink_blade_regs_io_data;
++	mlxplat_regs_io = &mlxplat_chassis_blade_regs_io_data;
 +	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
 +	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
 +
@@ -348,7 +344,7 @@ index 0ce52223a..7124226b9 100644
  		},
  	},
 +	{
-+		.callback = mlxplat_dmi_nvlink_blade_matched,
++		.callback = mlxplat_dmi_chassis_blade_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
 +		},

--- a/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
+++ b/recipes-kernel/linux/linux-4.19/0158-platform-mellanox-Introduce-support-for-NDR-InfiniBa.patch
@@ -122,7 +122,7 @@ index 7124226b9..c0def9b97 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -2212,6 +2255,246 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
+@@ -2212,6 +2255,246 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_chassis_blade_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  

--- a/recipes-kernel/linux/linux-4.19/0159-platform-mellanox-Add-COME-board-revision-register.patch
+++ b/recipes-kernel/linux/linux-4.19/0159-platform-mellanox-Add-COME-board-revision-register.patch
@@ -52,7 +52,7 @@ index c0def9b97..d1fd7cfdb 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4475,6 +4488,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
+@@ -4475,6 +4488,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_chassis_blade_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},

--- a/recipes-kernel/linux/linux-4.19/0160-platform-mellanox-Introduce-support-for-rack-manager.patch
+++ b/recipes-kernel/linux/linux-4.19/0160-platform-mellanox-Introduce-support-for-rack-manager.patch
@@ -1,35 +1,18 @@
-From a793dad1c289428a6b8dec32471cc16520975e5a Mon Sep 17 00:00:00 2001
+From ca6320c0dd7c089c26f89811aedd247e656104fa Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
-Subject: [PATCH 3/8] platform: mellanox: Introduce support for NVLink4 managed
- switch
-X-NVConfidentiality: public
-
-Introduce support for Nvidia P4697 system, the NVLink4 rack switch
-implemented with two Nvidia LS10 NVSwitch ASICs, equipped on switch
-board and with Nvidia COME module.
+Subject: platform: mellanox: Introduce support for rack manager switch
 
 The rack switch is designed to provide high bandwidth, low latency
-NVLink connections between DGX products supporting external NVLink
-connectivity beginning with the Viking system. The system enables the
-deployment of a pod of "Viking" systems in a fully switched NVLink or
-fat-tree topology using optical fiber as the primary interconnect.
+connectivity using optical fiber as the primary interconnect.
 
-System supports 128 NVLink4 ports, 32 OSFP ports, non-blocking
-switching capacity of 25.6Tbps.
+System supports 32 OSFP ports, non-blocking switching capacity of
+25.6Tbps.
 System equipped with:
 - 2 replaceable power supplies (AC) with 1+1 redundancy model.
 - 7 replaceable fan drawers with 6+1 redundancy model.
-- 2 External Root of Trust or EROT (Glacier) devices for each of the
-  LS10 NVLink ASICs for the purpose of securing the LS10 firmware.
-  There are three interfaces available to access those devices:
-  - I2C interface from CPU side, which can be used to read basic
-    information from the EROT.
-  - The SPI out-of-band path from CPU (GSPI) provides a mechanism for
-    programming the EROT device in the case that both the primary and
-    fail-safe firmware images for the EROT device are corrupted.
-  - The SPI in-band interface from ASIC firmware (no CPU involved),
-    which is the main interface.
+- 2 External Root of Trust or EROT (Glacier) devices for securing
+  ASICs firmware.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
@@ -37,7 +20,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 203 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index d1fd7cfdb..e81c88877 100644
+index d08be0471..32d462be6 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -93,6 +93,12 @@
@@ -74,7 +57,7 @@ index d1fd7cfdb..e81c88877 100644
  		    MLXPLAT_CPLD_LOW_AGGR_MASK_LEAK,
  };
  
-+/* Platform hotplug for nvlink switch systems family data */
++/* Platform hotplug for rack switch systems family data */
 +static struct mlxreg_core_data mlxplat_mlxcpld_erot_ap_items_data[] = {
 +	{
 +		.label = "erot1_ap",
@@ -105,7 +88,7 @@ index d1fd7cfdb..e81c88877 100644
 +	},
 +};
 +
-+static struct mlxreg_core_item mlxplat_mlxcpld_nvlink_switch_items[] = {
++static struct mlxreg_core_item mlxplat_mlxcpld_rack_switch_items[] = {
 +	{
 +		.data = mlxplat_mlxcpld_ext_psu_items_data,
 +		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
@@ -156,9 +139,9 @@ index d1fd7cfdb..e81c88877 100644
 +};
 +
 +static
-+struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_switch_data = {
-+	.items = mlxplat_mlxcpld_nvlink_switch_items,
-+	.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_switch_items),
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_rack_switch_data = {
++	.items = mlxplat_mlxcpld_rack_switch_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_rack_switch_items),
 +	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
 +	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
 +	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
@@ -303,14 +286,14 @@ index d1fd7cfdb..e81c88877 100644
  	return 1;
  }
  
-+static int __init mlxplat_dmi_nvlink_switch_matched(const struct dmi_system_id *dmi)
++static int __init mlxplat_dmi_rack_switch_matched(const struct dmi_system_id *dmi)
 +{
 +	int i;
 +
 +	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
 +	mlxplat_mux_num = ARRAY_SIZE(mlxplat_ib_modular_mux_data);
 +	mlxplat_mux_data = mlxplat_ib_modular_mux_data;
-+	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_rack_switch_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
 +	mlxplat_led = &mlxplat_default_ng_led_data;
@@ -332,7 +315,7 @@ index d1fd7cfdb..e81c88877 100644
  		},
  	},
 +	{
-+		.callback = mlxplat_dmi_nvlink_switch_matched,
++		.callback = mlxplat_dmi_rack_switch_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
 +			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI142"),

--- a/recipes-kernel/linux/linux-5.10/0051-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch
+++ b/recipes-kernel/linux/linux-5.10/0051-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch
@@ -1,8 +1,8 @@
-From 6fe5e1d9f90a7d704dedf156b8b1483f3cc245c1 Mon Sep 17 00:00:00 2001
+From 6782d682cb0510d0fee33f456ed3492834bad97d Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 7 Jul 2021 10:29:27 +0000
-Subject: [PATCH backport v5.10.43 51/67] leds: mlxreg: Allow
- multi-instantiation of same name LED for modular systems
+Subject: leds: mlxreg: Allow multi-instantiation of same name LED for modular
+ systems
 
 It could be more than one instance of LED with the same name in the
 modular systems. For example, "status" or "uid" LED can be located
@@ -13,9 +13,8 @@ Thus, for example, "status" LED on chassis is to be called, like it is
 called now on non-modular systems, on which platform device Id is not
 specified: "mlxreg:status:green". While for the line cards LEDs it will
 be called like: "pcicard48:status:green", "ibcard66:status:green",
-"nvlinkcard68:status:green", etcetera. Where line card prefix is
-specified according to the type of bus connecting line card to the
-chassis: PCI, InfiniBand, NVLink and so on.
+etc. Where line card prefix is specified according to the type of bus
+connecting line card to the chassis: PCI, InfiniBand and so on.
 
 LED driver works on top of register space of the programmable devices
 (CPLD or FPGA), providing the logic for LED control. The programmable
@@ -49,7 +48,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 13 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/leds/leds-mlxreg.c b/drivers/leds/leds-mlxreg.c
-index 0f2608a3496b..099ff4be291d 100644
+index 0f2608a34..099ff4be2 100644
 --- a/drivers/leds/leds-mlxreg.c
 +++ b/drivers/leds/leds-mlxreg.c
 @@ -245,8 +245,19 @@ static int mlxreg_led_config(struct mlxreg_led_priv_data *priv)
@@ -75,5 +74,5 @@ index 0f2608a3496b..099ff4be291d 100644
  		led_cdev->brightness = brightness;
  		led_cdev->max_brightness = LED_ON;
 -- 
-2.20.1
+2.14.1
 

--- a/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-COMe-managem.patch
+++ b/recipes-kernel/linux/linux-5.10/0160-platform-mellanox-Introduce-support-for-COMe-managem.patch
@@ -1,15 +1,12 @@
-From b9f03e961b69583c0310768075c3930795c76ff7 Mon Sep 17 00:00:00 2001
+From 333d4bcd32e3501d9bf3991dd5f2ff82061dab6b Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 26 Jan 2022 20:34:32 +0200
-Subject: [PATCH platform backport v5.10 04/10] platform: mellanox: Introduce
- support for COMe NVSwitch management module for Vulcan chassis
+Subject: [PATCH backport 5.10 01/17] platform: mellanox: Introduce support for
+ COMe management module for chassis
 
-The Vulcan is chassis containing Nvidia's Hopper dGPU (GH100), NVswitch
-(LS10) based HGX baseboard and COMe NVSwitch management module.
 The system is built for artificial intelligence and accelerated
-analytics applications. Vulcan is offered as an HGX product to cloud
-service providers and OEMs, who intend to build fully interconnected
-GPU systems for large scale deployments.
+analytics applications. Chassis is offered to cloud service
+providers and OEMs.
 
 Driver is extended to support new COMe NVSwitch management module.
 
@@ -20,7 +17,7 @@ Reviewed-by: Oleksandr Shamray <oleksandrs@nvidia.com>
  1 file changed, 269 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index cbe9eab34..ab26a62f8 100644
+index cbe9eab34..e06fd1725 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -67,6 +67,9 @@
@@ -45,7 +42,7 @@ index cbe9eab34..ab26a62f8 100644
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
-+/* Platform hotplug for NVLink blade systems family data  */
++/* Platform hotplug for chassis blade systems family data  */
 +static struct mlxreg_core_data mlxplat_mlxcpld_global_wp_items_data[] = {
 +	{
 +		.label = "global_wp_grant",
@@ -55,7 +52,7 @@ index cbe9eab34..ab26a62f8 100644
 +	},
 +};
 +
-+static struct mlxreg_core_item mlxplat_mlxcpld_nvlink_blade_items[] = {
++static struct mlxreg_core_item mlxplat_mlxcpld_chassis_blade_items[] = {
 +	{
 +		.data = mlxplat_mlxcpld_global_wp_items_data,
 +		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
@@ -68,9 +65,9 @@ index cbe9eab34..ab26a62f8 100644
 +};
 +
 +static
-+struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
-+	.items = mlxplat_mlxcpld_nvlink_blade_items,
-+	.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_blade_items),
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_chassis_blade_data = {
++	.items = mlxplat_mlxcpld_chassis_blade_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_chassis_blade_items),
 +	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
 +	.mask = MLXPLAT_CPLD_AGGR_MASK_COMEX,
 +	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
@@ -84,8 +81,8 @@ index cbe9eab34..ab26a62f8 100644
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_modular_regs_io_data),
  };
  
-+/* Platform register access for NVLink blade systems family data  */
-+static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
++/* Platform register access for chassis blade systems family data  */
++static struct mlxreg_core_data mlxplat_mlxcpld_chassis_blade_regs_io_data[] = {
 +	{
 +		.label = "cpld1_version",
 +		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET,
@@ -276,9 +273,9 @@ index cbe9eab34..ab26a62f8 100644
 +	},
 +};
 +
-+static struct mlxreg_core_platform_data mlxplat_nvlink_blade_regs_io_data = {
-+		.data = mlxplat_mlxcpld_nvlink_blade_regs_io_data,
-+		.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_blade_regs_io_data),
++static struct mlxreg_core_platform_data mlxplat_chassis_blade_regs_io_data = {
++		.data = mlxplat_mlxcpld_chassis_blade_regs_io_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_chassis_blade_regs_io_data),
 +};
 +
  /* Platform FAN default */
@@ -317,14 +314,14 @@ index cbe9eab34..ab26a62f8 100644
  	return 1;
  }
  
-+static int __init mlxplat_dmi_nvlink_blade_matched(const struct dmi_system_id *dmi)
++static int __init mlxplat_dmi_chassis_blade_matched(const struct dmi_system_id *dmi)
 +{
 +	int i;
 +
 +	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
 +	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
 +	mlxplat_mux_data = mlxplat_default_mux_data;
-+	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_blade_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_chassis_blade_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
 +	for (i = 0; i < mlxplat_mux_num; i++) {
@@ -332,7 +329,7 @@ index cbe9eab34..ab26a62f8 100644
 +		mlxplat_mux_data[i].n_values =
 +				ARRAY_SIZE(mlxplat_msn21xx_channels);
 +	}
-+	mlxplat_regs_io = &mlxplat_nvlink_blade_regs_io_data;
++	mlxplat_regs_io = &mlxplat_chassis_blade_regs_io_data;
 +	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
 +	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
 +
@@ -347,7 +344,7 @@ index cbe9eab34..ab26a62f8 100644
  		},
  	},
 +	{
-+		.callback = mlxplat_dmi_nvlink_blade_matched,
++		.callback = mlxplat_dmi_chassis_blade_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
 +		},

--- a/recipes-kernel/linux/linux-5.10/0161-platform-x86-mlx-platform-Add-support-for-new-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0161-platform-x86-mlx-platform-Add-support-for-new-system.patch
@@ -1,8 +1,8 @@
-From 95abc792fcd4585e3c11ecee40724a141f2936aa Mon Sep 17 00:00:00 2001
+From 993337e78b0f9b88dba2a37eba37ae69828632e1 Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Sun, 24 Oct 2021 16:26:40 +0000
-Subject: [PATCH platform backport v5.10 05/10] platform/x86: mlx-platform: Add
- support for new system XH3000
+Subject: [PATCH backport 5.10 02/17] platform/x86: mlx-platform: Add support
+ for new system XH3000
 
 Add support for new system type XH3000, which is a water cooling
 Ethernet switch blade equipped with 32x200G Ethernet ports.
@@ -17,7 +17,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 51 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index ab26a62f8..1819e0e3b 100644
+index e06fd1725..2b1441a87 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -2262,6 +2262,25 @@ static struct mlxreg_core_platform_data mlxplat_default_led_wc_data = {

--- a/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Add-COME-board-revision-register.patch
+++ b/recipes-kernel/linux/linux-5.10/0162-platform-mellanox-Add-COME-board-revision-register.patch
@@ -1,8 +1,8 @@
-From 4f9b675f12b900f544d82eff62401d51390d23df Mon Sep 17 00:00:00 2001
+From 01cec35c2103e425d9f66f35f9cb91db7e9d9267 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 6 Jul 2022 17:26:41 +0300
-Subject: [PATCH 02/10] platform: mellanox: Add COME board revision register
-X-NVConfidentiality: public
+Subject: [PATCH backport 5.10 03/17] platform: mellanox: Add COME board
+ revision register
 
 Add to CPLD COME board configuration register for getting a board
 revision. The value of this register is pushed by hardware through
@@ -15,10 +15,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 21 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index b3a5f0230..799917b5b 100644
+index 2b1441a87..1d0c13c65 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
-@@ -160,6 +160,7 @@
+@@ -150,6 +150,7 @@
  #define MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET	0xfa
  #define MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET	0xfb
  #define MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET	0xfc
@@ -26,7 +26,7 @@ index b3a5f0230..799917b5b 100644
  #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
  #define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
  #define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
-@@ -3753,6 +3754,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3372,6 +3373,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -39,7 +39,7 @@ index b3a5f0230..799917b5b 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4231,6 +4238,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
+@@ -3850,6 +3857,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -52,7 +52,7 @@ index b3a5f0230..799917b5b 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -4428,6 +4441,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_nvlink_blade_regs_io_data[] = {
+@@ -4047,6 +4060,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_chassis_blade_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -65,7 +65,7 @@ index b3a5f0230..799917b5b 100644
  	{
  		.label = "ufm_version",
  		.reg = MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET,
-@@ -5119,6 +5138,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -4724,6 +4743,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -73,7 +73,7 @@ index b3a5f0230..799917b5b 100644
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
  		return true;
  	}
-@@ -5256,6 +5276,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -4851,6 +4871,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_SLOT_QTY_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
@@ -82,5 +82,5 @@ index b3a5f0230..799917b5b 100644
  		return true;
  	}
 -- 
-2.14.1
+2.20.1
 

--- a/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-rack-manager.patch
+++ b/recipes-kernel/linux/linux-5.10/0163-platform-mellanox-Introduce-support-for-rack-manager.patch
@@ -1,43 +1,27 @@
-From c35379206d210285847d6341597e781f9f003047 Mon Sep 17 00:00:00 2001
+From 1be273d1553206882efd4c9ce9db1e603ca05c3f Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 14 Feb 2022 13:24:44 +0200
-Subject: [PATCH 01/14] platform: mellanox: Introduce support for NVLink4
- managed switch
-X-NVConfidentiality: public
-
-Introduce support for Nvidia P4697 system, the NVLink4 rack switch
-implemented with two Nvidia LS10 NVSwitch ASICs, equipped on switch
-board and with Nvidia COME module.
+Subject: [PATCH backport 5.10 04/17] platform: mellanox: Introduce support for
+ rack manager switch
 
 The rack switch is designed to provide high bandwidth, low latency
-NVLink connections between DGX products supporting external NVLink
-connectivity beginning with the Viking system. The system enables the
-deployment of a pod of "Viking" systems in a fully switched NVLink or
-fat-tree topology using optical fiber as the primary interconnect.
+connectivity using optical fiber as the primary interconnect.
 
-System supports 128 NVLink4 ports, 32 OSFP ports, non-blocking
-switching capacity of 25.6Tbps.
+System supports 32 OSFP ports, non-blocking switching capacity of
+25.6Tbps.
 System equipped with:
 - 2 replaceable power supplies (AC) with 1+1 redundancy model.
 - 7 replaceable fan drawers with 6+1 redundancy model.
-- 2 External Root of Trust or EROT (Glacier) devices for each of the
-  LS10 NVLink ASICs for the purpose of securing the LS10 firmware.
-  There are three interfaces available to access those devices:
-  - I2C interface from CPU side, which can be used to read basic
-    information from the EROT.
-  - The SPI out-of-band path from CPU (GSPI) provides a mechanism for
-    programming the EROT device in the case that both the primary and
-    fail-safe firmware images for the EROT device are corrupted.
-  - The SPI in-band interface from ASIC firmware (no CPU involved),
-    which is the main interface.
+- 2 External Root of Trust or EROT (Glacier) devices for securing
+  ASICs firmware.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 259 ++++++++++++++++++++++++++++++++++++
+ drivers/platform/x86/mlx-platform.c | 259 ++++++++++++++++++++++++++++
  1 file changed, 259 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index a9dc266d6..4c9106fd7 100644
+index 1d0c13c65..16754a7fd 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -90,6 +90,12 @@
@@ -74,7 +58,7 @@ index a9dc266d6..4c9106fd7 100644
  #define MLXPLAT_CPLD_CH2_ETH_MODULAR		3
  #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
  #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
-+#define MLXPLAT_CPLD_CH2_NVLINK				18
++#define MLXPLAT_CPLD_CH2_RACK_SWITCH		18
  
  /* Number of LPC attached MUX platform devices */
  #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
@@ -82,7 +66,7 @@ index a9dc266d6..4c9106fd7 100644
  /* Minimum power required for turning on Ethernet modular system (WATT) */
  #define MLXPLAT_CPLD_ETH_MODULAR_PWR_MIN	50
  
-+/* Default value for PWM control register for NVlink system */
++/* Default value for PWM control register for rack switch system */
 +#define MLXPLAT_REGMAP_NVSWITCH_PWM_DEFAULT 0xf4
 +
  /* mlxplat_priv - platform private data
@@ -92,13 +76,13 @@ index a9dc266d6..4c9106fd7 100644
  	},
  };
  
-+/* Platform channels for NVLink system family */
-+static const int mlxplat_nvlink_channels[] = {
++/* Platform channels for rack swicth system family */
++static const int mlxplat_rack_switch_channels[] = {
 +	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
 +};
 +
 +/* Platform IB modular mux data */
-+static struct i2c_mux_reg_platform_data mlxplat_nvlink_mux_data[] = {
++static struct i2c_mux_reg_platform_data mlxplat_rack_switch_mux_data[] = {
 +	{
 +		.parent = 1,
 +		.base_nr = MLXPLAT_CPLD_CH1,
@@ -106,12 +90,12 @@ index a9dc266d6..4c9106fd7 100644
 +		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
 +		.reg_size = 1,
 +		.idle_in_use = 1,
-+		.values = mlxplat_nvlink_channels,
-+		.n_values = ARRAY_SIZE(mlxplat_nvlink_channels),
++		.values = mlxplat_rack_switch_channels,
++		.n_values = ARRAY_SIZE(mlxplat_rack_switch_channels),
 +	},
 +	{
 +		.parent = 1,
-+		.base_nr = MLXPLAT_CPLD_CH2_NVLINK,
++		.base_nr = MLXPLAT_CPLD_CH2_RACK_SWITCH,
 +		.write_only = 1,
 +		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
 +		.reg_size = 1,
@@ -125,11 +109,11 @@ index a9dc266d6..4c9106fd7 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -2165,6 +2208,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_blade_data = {
+@@ -2165,6 +2208,97 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_chassis_blade_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
-+/* Platform hotplug for nvlink switch systems family data */
++/* Platform hotplug for  switch systems family data */
 +static struct mlxreg_core_data mlxplat_mlxcpld_erot_ap_items_data[] = {
 +	{
 +		.label = "erot1_ap",
@@ -160,7 +144,7 @@ index a9dc266d6..4c9106fd7 100644
 +	},
 +};
 +
-+static struct mlxreg_core_item mlxplat_mlxcpld_nvlink_switch_items[] = {
++static struct mlxreg_core_item mlxplat_mlxcpld_rack_switch_items[] = {
 +	{
 +		.data = mlxplat_mlxcpld_ext_psu_items_data,
 +		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
@@ -211,9 +195,9 @@ index a9dc266d6..4c9106fd7 100644
 +};
 +
 +static
-+struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_switch_data = {
-+	.items = mlxplat_mlxcpld_nvlink_switch_items,
-+	.counter = ARRAY_SIZE(mlxplat_mlxcpld_nvlink_switch_items),
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_rack_switch_data = {
++	.items = mlxplat_mlxcpld_rack_switch_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_rack_switch_items),
 +	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
 +	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
 +	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
@@ -359,7 +343,7 @@ index a9dc266d6..4c9106fd7 100644
  	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
  };
  
-+static const struct reg_default mlxplat_mlxcpld_regmap_nvlink[] = {
++static const struct reg_default mlxplat_mlxcpld_regmap_rack_switch[] = {
 +	{ MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET, MLXPLAT_REGMAP_NVSWITCH_PWM_DEFAULT },
 +	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
 +	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
@@ -373,7 +357,7 @@ index a9dc266d6..4c9106fd7 100644
  	.reg_write = mlxplat_mlxcpld_reg_write,
  };
  
-+static const struct regmap_config mlxplat_mlxcpld_regmap_config_nvlink = {
++static const struct regmap_config mlxplat_mlxcpld_regmap_config_rack_switch = {
 +	.reg_bits = 8,
 +	.val_bits = 8,
 +	.max_register = 255,
@@ -381,8 +365,8 @@ index a9dc266d6..4c9106fd7 100644
 +	.writeable_reg = mlxplat_mlxcpld_writeable_reg,
 +	.readable_reg = mlxplat_mlxcpld_readable_reg,
 +	.volatile_reg = mlxplat_mlxcpld_volatile_reg,
-+	.reg_defaults = mlxplat_mlxcpld_regmap_nvlink,
-+	.num_reg_defaults = ARRAY_SIZE(mlxplat_mlxcpld_regmap_nvlink),
++	.reg_defaults = mlxplat_mlxcpld_regmap_rack_switch,
++	.num_reg_defaults = ARRAY_SIZE(mlxplat_mlxcpld_regmap_rack_switch),
 +	.reg_read = mlxplat_mlxcpld_reg_read,
 +	.reg_write = mlxplat_mlxcpld_reg_write,
 +};
@@ -394,14 +378,14 @@ index a9dc266d6..4c9106fd7 100644
  	return 1;
  }
  
-+static int __init mlxplat_dmi_nvlink_switch_matched(const struct dmi_system_id *dmi)
++static int __init mlxplat_dmi_rack_switch_matched(const struct dmi_system_id *dmi)
 +{
 +	int i;
 +
 +	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
-+	mlxplat_mux_num = ARRAY_SIZE(mlxplat_nvlink_mux_data);
-+	mlxplat_mux_data = mlxplat_nvlink_mux_data;
-+	mlxplat_hotplug = &mlxplat_mlxcpld_nvlink_switch_data;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_rack_switch_mux_data);
++	mlxplat_mux_data = mlxplat_rack_switch_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_rack_switch_data;
 +	mlxplat_hotplug->deferred_nr =
 +		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
 +	mlxplat_led = &mlxplat_default_ng_led_data;
@@ -410,7 +394,7 @@ index a9dc266d6..4c9106fd7 100644
 +	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
 +		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
 +	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
-+	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_nvlink;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_rack_switch;
 +
 +	return 1;
 +}
@@ -423,7 +407,7 @@ index a9dc266d6..4c9106fd7 100644
  		},
  	},
 +	{
-+		.callback = mlxplat_dmi_nvlink_switch_matched,
++		.callback = mlxplat_dmi_rack_switch_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0010"),
 +			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI142"),
@@ -433,5 +417,5 @@ index a9dc266d6..4c9106fd7 100644
  		.callback = mlxplat_dmi_ng400_matched,
  		.matches = {
 -- 
-2.14.1
+2.20.1
 

--- a/recipes-kernel/linux/linux-5.10/0167-DS-lan743x-Add-support-for-fixed-phy.patch
+++ b/recipes-kernel/linux/linux-5.10/0167-DS-lan743x-Add-support-for-fixed-phy.patch
@@ -1,7 +1,7 @@
-From c6da2069c9edb6b91a8ca8acdd43d3a2eca46733 Mon Sep 17 00:00:00 2001
+From 0d712bde8af7487ec673427b290d6c626b702111 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Fri, 6 May 2022 16:52:53 +0300
-Subject: [PATCH net fixed phy 1/1] TMP: lan743x: Add support for fixed phy
+Subject: [PATCH backport 5.10 06/17] DS: lan743x: Add support for fixed phy
 
 Add support for fixed phy for non DTS architecture.
 

--- a/recipes-kernel/linux/linux-5.10/0172-DS-platform-mlx-platform-Add-SPI-path-for-rack-switc.patch
+++ b/recipes-kernel/linux/linux-5.10/0172-DS-platform-mlx-platform-Add-SPI-path-for-rack-switc.patch
@@ -1,9 +1,8 @@
-From fed215875bdea5c4e5808ae71eded9bae8d92d6a Mon Sep 17 00:00:00 2001
+From 3dafb2c8b1c961c6e786c84c1933efab55d0df7b Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 15 May 2022 14:31:10 +0300
-Subject: [PATCH 06/10] TMP: platform: mlx-platform: Add SPI path for NVLink
- switch for EROT access
-X-NVConfidentiality: public
+Subject: [PATCH backport 5.10 07/17] DS: platform: mlx-platform: Add SPI path
+ for rack switch for EROT access
 
 Create spidev for OOB access to External Root of Trusts devices.
 
@@ -14,7 +13,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  2 files changed, 17 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 7249f68c9..50a080931 100644
+index 16754a7fd..a580ab850 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -16,6 +16,7 @@
@@ -25,11 +24,11 @@ index 7249f68c9..50a080931 100644
  
  #define MLX_PLAT_DEVICE_NAME		"mlxplat"
  
-@@ -2552,6 +2553,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_nvlink_switch_data = {
+@@ -2299,6 +2300,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_rack_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
-+static struct spi_board_info nvlink_switch_spi_board_info[] = {
++static struct spi_board_info rack_switch_switch_spi_board_info[] = {
 +	{
 +		.modalias       = "spidev",
 +		.irq            = -1,
@@ -42,7 +41,7 @@ index 7249f68c9..50a080931 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -5628,6 +5639,7 @@ static struct mlxreg_core_platform_data *mlxplat_fan;
+@@ -5254,6 +5265,7 @@ static struct mlxreg_core_platform_data *mlxplat_fan;
  static struct mlxreg_core_platform_data
  	*mlxplat_wd_data[MLXPLAT_CPLD_WD_MAX_DEVS];
  static const struct regmap_config *mlxplat_regmap_config;
@@ -50,15 +49,15 @@ index 7249f68c9..50a080931 100644
  
  static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
  {
-@@ -5946,6 +5958,7 @@ static int __init mlxplat_dmi_spine_ndr_ib_modular_matched(const struct dmi_syst
+@@ -5462,6 +5474,7 @@ static int __init mlxplat_dmi_ng400_matched(const struct dmi_system_id *dmi)
  		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
  	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
  	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_ng400;
-+	mlxplat_spi = nvlink_switch_spi_board_info;
++	mlxplat_spi = rack_switch_switch_spi_board_info;
  
  	return 1;
  }
-@@ -6347,6 +6360,9 @@ static int __init mlxplat_init(void)
+@@ -5917,6 +5930,9 @@ static int __init mlxplat_init(void)
  		}
  	}
  
@@ -81,5 +80,5 @@ index a6f1e94af..227504340 100644
  /*-------------------------------------------------------------------------*/
  
 -- 
-2.14.1
+2.20.1
 

--- a/recipes-kernel/linux/linux-5.10/0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
+++ b/recipes-kernel/linux/linux-5.10/0176-platform-mellanox-fix-reset_pwr_converter_fail-attri.patch
@@ -1,8 +1,8 @@
-From c1b2d147f78087cd87e853effd7dcd27a3110f06 Mon Sep 17 00:00:00 2001
+From 2e1b50d35889e78b05f507d60984d19fed53d07b Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Sun, 4 Sep 2022 10:41:45 +0300
-Subject: [PATCH 1/4] platform: mellanox: fix reset_pwr_converter_fail
- attribute.
+Subject: [PATCH backport 5.10 12/17] platform: mellanox: fix
+ reset_pwr_converter_fail attribute.
 
 Change incorrect reset_voltmon_upgrade_fail atitribute name to
 reset_pwr_converter_fail.
@@ -14,10 +14,10 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 50a080931..df0ae4776 100644
+index a580ab850..b9ea12fad 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
-@@ -3758,7 +3758,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3414,7 +3414,7 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  	},
  	{
@@ -27,5 +27,5 @@ index 50a080931..df0ae4776 100644
  		.mask = GENMASK(7, 0) & ~BIT(0),
  		.mode = 0444,
 -- 
-2.14.1
+2.20.1
 

--- a/recipes-kernel/linux/linux-5.10/0178-platform-mellanox-Introduce-support-for-next-generat.patch
+++ b/recipes-kernel/linux/linux-5.10/0178-platform-mellanox-Introduce-support-for-next-generat.patch
@@ -1,9 +1,8 @@
-From f8972feef1114e7efa99f33066da2e7822d2e081 Mon Sep 17 00:00:00 2001
+From 6aabbd215bca0ed7d34d9f4ca6a7af1df80785bd Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Sun, 4 Sep 2022 14:03:58 +0300
-Subject: [PATCH 11/14] platform: mellanox: Introduce support for
+Subject: [PATCH backport 5.10 1/7] platform: mellanox: Introduce support for
  next-generation 800GB/s ethernet switch.
-X-NVConfidentiality: public
 
 Introduce support for Nvidia next-generation 800GB/s ethernet switch - SN5600.
 SN5600 is 51.2 Tbps Ethernet switch based on Nvidia Spectrum-4 ASIC.
@@ -22,22 +21,22 @@ Features:
 Signed-off-by: Michael Shych <michaelsh@nvidia.com>
 Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 101 ++++++++++++++++++++++++++++++++++++
- 1 file changed, 101 insertions(+)
+ drivers/platform/x86/mlx-platform.c | 178 ++++++++++++++++++++++++++++
+ 1 file changed, 178 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 32a4a062f..94c30554f 100644
+index b9ea12fad..af8da374e 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -255,6 +255,7 @@
  #define MLXPLAT_CPLD_CH3_ETH_MODULAR		43
  #define MLXPLAT_CPLD_CH4_ETH_MODULAR		51
- #define MLXPLAT_CPLD_CH2_NVLINK				18
+ #define MLXPLAT_CPLD_CH2_RACK_SWITCH		18
 +#define MLXPLAT_CPLD_CH2_NG800			34
  
  /* Number of LPC attached MUX platform devices */
  #define MLXPLAT_CPLD_LPC_MUX_DEVS		4
-@@ -505,6 +506,37 @@
+@@ -505,6 +506,37 @@ static struct i2c_mux_reg_platform_data mlxplat_rack_switch_mux_data[] = {
  
  };
  
@@ -75,7 +74,7 @@ index 32a4a062f..94c30554f 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -524,6 +556,15 @@
+@@ -524,6 +556,15 @@ static struct i2c_board_info mlxplat_mlxcpld_ext_pwr[] = {
  	},
  };
  
@@ -91,7 +90,7 @@ index 32a4a062f..94c30554f 100644
  static struct i2c_board_info mlxplat_mlxcpld_fan[] = {
  	{
  		I2C_BOARD_INFO("24c32", 0x50),
-@@ -603,6 +644,23 @@
+@@ -603,6 +644,23 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_pwr_wc_items_data[] = {
  	},
  };
  
@@ -115,7 +114,7 @@ index 32a4a062f..94c30554f 100644
  static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_items_data[] = {
  	{
  		.label = "fan1",
-@@ -1326,6 +1384,47 @@
+@@ -1326,6 +1384,47 @@ static struct mlxreg_core_item mlxplat_mlxcpld_ext_items[] = {
  	}
  };
  
@@ -163,7 +162,7 @@ index 32a4a062f..94c30554f 100644
  static
  struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
  	.items = mlxplat_mlxcpld_ext_items,
-@@ -1336,6 +1435,16 @@
+@@ -1336,6 +1435,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_ext_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2,
  };
  
@@ -180,49 +179,50 @@ index 32a4a062f..94c30554f 100644
  static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
  	{
  		.label = "pwr1",
-@@ -3324,6 +3433,12 @@
+@@ -3323,6 +3432,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(7),
  		.mode = 0644,
  	},
- 	{
++	{
 +		.label = "clk_brd_prog_en",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(1),
 +		.mode = 0644,
 +	},
-+	{
+ 	{
  		.label = "erot1_recovery",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
+@@ -3449,6 +3564,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mask = GENMASK(7, 0) & ~BIT(6),
-@@ -3450,6 +3565,12 @@
  		.mode = 0444,
  	},
- 	{
++	{
 +		.label = "reset_ac_ok_fail",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0444,
 +	},
-+	{
+ 	{
  		.label = "psu1_on",
  		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
- 		.mask = GENMASK(7, 0) & ~BIT(0),
-@@ -3531,6 +3652,12 @@
+@@ -3530,6 +3651,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.bit = 5,
  		.mode = 0444,
  	},
- 	{
++	{
 +		.label = "pwr_converter_prog_en",
 +		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(0),
 +		.mode = 0644,
 +	},
-+	{
+ 	{
  		.label = "vpd_wp",
  		.reg = MLXPLAT_CPLD_LPC_REG_GP0_OFFSET,
- 		.mask = GENMASK(7, 0) & ~BIT(3),
-@@ -3555,6 +3682,30 @@
+@@ -3554,6 +3681,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(1),
  		.mode = 0444,
  	},
- 	{
++	{
 +		.label = "clk_brd1_boot_fail",
 +		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(4),
@@ -246,11 +246,10 @@ index 32a4a062f..94c30554f 100644
 +		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0444,
 +	},
-+	{
+ 	{
  		.label = "spi_chnl_select",
  		.reg = MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT,
- 		.mask = GENMASK(7, 0),
-@@ -5568,6 +5719,27 @@
+@@ -5568,6 +5719,27 @@ static int __init mlxplat_dmi_rack_switch_matched(const struct dmi_system_id *dm
  	return 1;
  }
  
@@ -278,18 +277,19 @@ index 32a4a062f..94c30554f 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5652,6 +5824,12 @@
+@@ -5651,6 +5823,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0011"),
  		},
  	},
- 	{
++	{
 +		.callback = mlxplat_dmi_ng800_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0013"),
 +		},
 +	},
-+	{
- 		.callback = mlxplat_dmi_nvlink_blade_matched,
+ 	{
+ 		.callback = mlxplat_dmi_chassis_blade_matched,
  		.matches = {
- 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
---
-2.14.1
+-- 
+2.20.1
+


### PR DESCRIPTION
Removing the internal product name references from the kernel patches.

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>