### PR TITLE
mlxsw: thermal: Fix out-of-bounds memory accesses

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -346,6 +346,7 @@ Kernel-5.10
 |0178-platform-mellanox-Introduce-support-for-next-generat.patch         |                                            |                                                 | SN5600                                                       |
 |0179-DS-iio-pressure-icp20100-add-driver-for-InvenSense-ICP-.patch      |                                            | downstream for OPT-OS use only                  | SN5600                                                       |
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch         | 525dd5aed67a2f4f7278116fb92a24e6a53e2622   |  accepted                                       |                                                              |
+|0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch          |                                            | pending                                         |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  

--- a/recipes-kernel/linux/linux-5.10/0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch
+++ b/recipes-kernel/linux/linux-5.10/0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch
@@ -1,0 +1,103 @@
+From 74c72228e14995ddf5a20f701a14a13760f8c04a Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Mon, 19 Dec 2022 20:17:14 +0200
+Subject: Revert Fix out of bounds memory accesses in thermal
+
+From: Alexander Allen <arallen@nvidia.com>
+Date: Thu, 31 Mar 2022 17:17:59 +0000
+Subject: 0999 Revert "mlxsw: thermal: Fix out-of-bounds memory
+ accesses"
+
+This reverts commit e59d839743b50cb1d3f42a786bea48cc5621d254.
+
+Commit is reverted until thermal infrastructure is ready for other fan devices used by Nvidia systems.
+Usage of `cooling_cur_state` for setting fan speed has been deprecated in kernel 5.17 by thermal maintainers.
+New interface for fan speed enforcing should be done from `hwmon`.
+After all fan drivers are aligned, commit will be retuned back.
+
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 51 ++++++++++++++++++++--
+ 1 file changed, 47 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 529108a..ff63013 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -23,9 +23,19 @@
+ #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
+ #define MLXSW_THERMAL_TEMP_SCORE_MAX	GENMASK(31, 0)
+ #define MLXSW_THERMAL_MAX_STATE	10
+-#define MLXSW_THERMAL_MIN_STATE	2
+ #define MLXSW_THERMAL_MAX_DUTY	255
+ 
++/* Minimum and maximum fan allowed speed in percent: from 20% to 100%. Values
++ * MLXSW_THERMAL_MAX_STATE + x, where x is between 2 and 10 are used for
++ * setting fan speed dynamic minimum. For example, if value is set to 14 (40%)
++ * cooling levels vector will be set to 4, 4, 4, 4, 4, 5, 6, 7, 8, 9, 10 to
++ * introduce PWM speed in percent: 40, 40, 40, 40, 40, 50, 60. 70, 80, 90, 100.
++ */
++#define MLXSW_THERMAL_SPEED_MIN		(MLXSW_THERMAL_MAX_STATE + 2)
++#define MLXSW_THERMAL_SPEED_MAX		(MLXSW_THERMAL_MAX_STATE * 2)
++#define MLXSW_THERMAL_SPEED_MIN_LEVEL	2		/* 20% */
++
++
+ /* External cooling devices, allowed for binding to mlxsw thermal zones. */
+ static char * const mlxsw_thermal_external_allowed_cdev[] = {
+ 	"mlxreg_fan",
+@@ -656,16 +666,49 @@ static int mlxsw_thermal_set_cur_state(struct thermal_cooling_device *cdev,
+ 	struct mlxsw_thermal *thermal = cdev->devdata;
+ 	struct device *dev = thermal->bus_info->dev;
+ 	char mfsc_pl[MLXSW_REG_MFSC_LEN];
++	unsigned long cur_state, i;
+ 	int idx;
++	u8 duty;
+ 	int err;
+ 
+-	if (state > MLXSW_THERMAL_MAX_STATE)
+-		return -EINVAL;
+-
+ 	idx = mlxsw_get_cooling_device_idx(thermal, cdev);
+ 	if (idx < 0)
+ 		return idx;
+ 
++	/* Verify if this request is for changing allowed fan dynamical
++	 * minimum. If it is - update cooling levels accordingly and update
++	 * state, if current state is below the newly requested minimum state.
++	 * For example, if current state is 5, and minimal state is to be
++	 * changed from 4 to 6, thermal->cooling_levels[0 to 5] will be changed
++	 * all from 4 to 6. And state 5 (thermal->cooling_levels[4]) should be
++	 * overwritten.
++	 */
++	if (state >= MLXSW_THERMAL_SPEED_MIN &&
++	    state <= MLXSW_THERMAL_SPEED_MAX) {
++		state -= MLXSW_THERMAL_MAX_STATE;
++		for (i = 0; i <= MLXSW_THERMAL_MAX_STATE; i++)
++			thermal->cooling_levels[i] = max(state, i);
++
++		mlxsw_reg_mfsc_pack(mfsc_pl, idx, 0);
++		err = mlxsw_reg_query(thermal->core, MLXSW_REG(mfsc), mfsc_pl);
++		if (err)
++			return err;
++
++		duty = mlxsw_reg_mfsc_pwm_duty_cycle_get(mfsc_pl);
++		cur_state = mlxsw_duty_to_state(duty);
++
++		/* If current fan state is lower than requested dynamical
++		 * minimum, increase fan speed up to dynamical minimum.
++		 */
++		if (state < cur_state)
++			return 0;
++
++		state = cur_state;
++	}
++
++	if (state > MLXSW_THERMAL_MAX_STATE)
++		return -EINVAL;
++
+ 	/* Normalize the state to the valid speed range. */
+ 	state = thermal->cooling_levels[state];
+ 	mlxsw_reg_mfsc_pack(mfsc_pl, idx, mlxsw_state_to_duty(state));
+-- 
+2.14.1
+


### PR DESCRIPTION
This reverts commit e59d839743b50cb1d3f42a786bea48cc5621d254.

Commit is reverted until thermal infrastructure is ready for other fan devices used by Nvidia systems. Usage of `cooling_cur_state` for setting fan speed has been deprecated
 in kernel 5.17 by thermal maintainers. New interface for fan
 speed enforcing should be done from `hwmon`.

After all fan drivers are aligned, commit will be retuned back.

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>