### PR TITLE
Fixing a build break

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch
+++ b/recipes-kernel/linux/linux-5.10/0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch
@@ -1,30 +1,28 @@
-From 74c72228e14995ddf5a20f701a14a13760f8c04a Mon Sep 17 00:00:00 2001
+From 06ca1dd91c883bb2eca68ecc6cf8f82a86349a5e Mon Sep 17 00:00:00 2001
 From: Ciju Rajan K <crajank@nvidia.com>
-Date: Mon, 19 Dec 2022 20:17:14 +0200
-Subject: Revert Fix out of bounds memory accesses in thermal
-
-From: Alexander Allen <arallen@nvidia.com>
-Date: Thu, 31 Mar 2022 17:17:59 +0000
-Subject: 0999 Revert "mlxsw: thermal: Fix out-of-bounds memory
- accesses"
+Date: Tue, 20 Dec 2022 04:53:24 +0200
+Subject: mlxsw: thermal: Fix out-of-bounds memory accesses
 
 This reverts commit e59d839743b50cb1d3f42a786bea48cc5621d254.
 
-Commit is reverted until thermal infrastructure is ready for other fan devices used by Nvidia systems.
-Usage of `cooling_cur_state` for setting fan speed has been deprecated in kernel 5.17 by thermal maintainers.
-New interface for fan speed enforcing should be done from `hwmon`.
+Commit is reverted until thermal infrastructure is ready for
+other fan devices used by Nvidia systems. Usage of
+`cooling_cur_state` for setting fan speed has been deprecated
+ in kernel 5.17 by thermal maintainers. New interface for fan
+ speed enforcing should be done from `hwmon`.
+
 After all fan drivers are aligned, commit will be retuned back.
 
 Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
 ---
- drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 51 ++++++++++++++++++++--
- 1 file changed, 47 insertions(+), 4 deletions(-)
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 52 +++++++++++++++++++---
+ 1 file changed, 47 insertions(+), 5 deletions(-)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
-index 529108a..ff63013 100644
+index 529108aea..0cdd0b7ba 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
-@@ -23,9 +23,19 @@
+@@ -23,9 +23,18 @@
  #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
  #define MLXSW_THERMAL_TEMP_SCORE_MAX	GENMASK(31, 0)
  #define MLXSW_THERMAL_MAX_STATE	10
@@ -41,11 +39,10 @@ index 529108a..ff63013 100644
 +#define MLXSW_THERMAL_SPEED_MAX		(MLXSW_THERMAL_MAX_STATE * 2)
 +#define MLXSW_THERMAL_SPEED_MIN_LEVEL	2		/* 20% */
 +
-+
  /* External cooling devices, allowed for binding to mlxsw thermal zones. */
  static char * const mlxsw_thermal_external_allowed_cdev[] = {
  	"mlxreg_fan",
-@@ -656,16 +666,49 @@ static int mlxsw_thermal_set_cur_state(struct thermal_cooling_device *cdev,
+@@ -656,16 +665,49 @@ static int mlxsw_thermal_set_cur_state(struct thermal_cooling_device *cdev,
  	struct mlxsw_thermal *thermal = cdev->devdata;
  	struct device *dev = thermal->bus_info->dev;
  	char mfsc_pl[MLXSW_REG_MFSC_LEN];
@@ -98,6 +95,15 @@ index 529108a..ff63013 100644
  	/* Normalize the state to the valid speed range. */
  	state = thermal->cooling_levels[state];
  	mlxsw_reg_mfsc_pack(mfsc_pl, idx, mlxsw_state_to_duty(state));
+@@ -1143,7 +1185,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 
+ 	/* Initialize cooling levels per PWM state. */
+ 	for (i = 0; i < MLXSW_THERMAL_MAX_STATE; i++)
+-		thermal->cooling_levels[i] = max(MLXSW_THERMAL_MIN_STATE, i);
++		thermal->cooling_levels[i] = max(MLXSW_THERMAL_SPEED_MIN_LEVEL, i);
+ 
+ 	thermal->polling_delay = bus_info->low_frequency ?
+ 				 MLXSW_THERMAL_SLOW_POLL_INT :
 -- 
 2.14.1
 


### PR DESCRIPTION
This patch fixes the build break introduced by
0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>