### PR TITLE
hw-mgmt: patches 5.10: Add new patches for L1 switch support

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch
+++ b/recipes-kernel/linux/linux-5.10/0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch
@@ -1,0 +1,611 @@
+From d68961c4f9afc6d6242b39f32343a4c357c001bc Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Sun, 11 Dec 2022 09:26:48 +0200
+Subject: [PATCH backport 5.10 1/3] platform: mellanox: Introduce support of
+ new Nvidia L1 switch
+
+Add support for new L1 switch nodes providing L1 connectivity for
+multi-node networking chassis.
+
+The purpose is to provide compute server with full management and IO
+subsystems with connections to L1 switches.
+
+System contains the following components:
+- COMe module based on Intel Coffee Lake CPU
+- Switch baseboard with two ASICs, while
+  24 ports of each ASICs are connected to one backplane connector
+  32 ports of each ASIC are connected to 8 OSFPs
+- Integrated 60mm dual-rotor FANs inside L1 node (N+2 redundancy)
+- Support 48V or 54V DC input from the external power server.
+
+Add the structures related to the new systems to allow proper activation
+of the all required platform driver.
+
+Add poweroff callback to support deep power cycle flow, which should
+include special actions against CPLD device for performing graceful
+operation.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 366 +++++++++++++++++++++++++++-
+ 1 file changed, 365 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index eb07b271f..e5a4d2472 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -15,6 +15,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/platform_data/i2c-mux-reg.h>
+ #include <linux/platform_data/mlxreg.h>
++#include <linux/reboot.h>
+ #include <linux/regmap.h>
+ #include <linux/spi/spi.h>
+ 
+@@ -62,12 +63,19 @@
+ #define MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET	0x37
+ #define MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET	0x3a
+ #define MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET	0x3b
++#define MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET	0x3c
++#define MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET	0x3d
++#define MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET	0x3e
++#define MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET	0x3f
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET	0x40
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET	0x41
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET	0x42
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET	0x43
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCX_OFFSET	0x44
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET 0x45
++#define MLXPLAT_CPLD_LPC_REG_BRD_OFFSET		0x47
++#define MLXPLAT_CPLD_LPC_REG_BRD_EVENT_OFFSET	0x48
++#define MLXPLAT_CPLD_LPC_REG_BRD_MASK_OFFSET	0x49
+ #define MLXPLAT_CPLD_LPC_REG_GWP_OFFSET		0x4a
+ #define MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET	0x4b
+ #define MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET	0x4c
+@@ -97,6 +105,9 @@
+ #define MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET	0x94
+ #define MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET	0x95
+ #define MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET	0x96
++#define MLXPLAT_CPLD_LPC_REG_PWRB_OFFSET	0x97
++#define MLXPLAT_CPLD_LPC_REG_PWRB_EVENT_OFFSET	0x98
++#define MLXPLAT_CPLD_LPC_REG_PWRB_MASK_OFFSET	0x99
+ #define MLXPLAT_CPLD_LPC_REG_LC_VR_OFFSET	0x9a
+ #define MLXPLAT_CPLD_LPC_REG_LC_VR_EVENT_OFFSET	0x9b
+ #define MLXPLAT_CPLD_LPC_REG_LC_VR_MASK_OFFSET	0x9c
+@@ -128,6 +139,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET	0xd1
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET	0xd2
+ #define MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET	0xd3
++#define MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET	0xd9
+ #define MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET	0xde
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET	0xdf
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET	0xe0
+@@ -211,6 +223,7 @@
+ 					 MLXPLAT_CPLD_AGGR_MASK_LC_SDWN)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2	BIT(2)
++#define MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT	BIT(4)
+ #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
+ #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)
+@@ -225,6 +238,9 @@
+ #define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
+ #define MLXPLAT_CPLD_GWP_MASK		GENMASK(0, 0)
+ #define MLXPLAT_CPLD_EROT_MASK		GENMASK(1, 0)
++#define MLXPLAT_CPLD_PWR_BUTTON_MASK	BIT(0)
++#define MLXPLAT_CPLD_LATCH_RST_MASK	BIT(5)
++#define MLXPLAT_CPLD_INTRUSION_MASK	BIT(6)
+ #define MLXPLAT_CPLD_I2C_CAP_BIT	0x04
+ #define MLXPLAT_CPLD_I2C_CAP_MASK	GENMASK(5, MLXPLAT_CPLD_I2C_CAP_BIT)
+ 
+@@ -237,6 +253,8 @@
+ /* Masks for aggregation for modular systems */
+ #define MLXPLAT_CPLD_LPC_LC_MASK	GENMASK(7, 0)
+ 
++#define MLXPLAT_CPLD_HALT_MASK		BIT(3)
++
+ /* Default I2C parent bus number */
+ #define MLXPLAT_CPLD_PHYS_ADAPTER_DEF_NR	1
+ 
+@@ -317,6 +335,8 @@ struct mlxplat_priv {
+ 	void *regmap;
+ };
+ 
++static struct platform_device *mlxplat_dev;
++
+ /* Regions for LPC I2C controller and LPC base register space */
+ static const struct resource mlxplat_lpc_resources[] = {
+ 	[0] = DEFINE_RES_NAMED(MLXPLAT_CPLD_LPC_I2C_BASE_ADRR,
+@@ -2409,6 +2429,136 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_rack_switch_data = {
+ 	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
+ };
+ 
++/* Callback performs graceful shutdown after notification about power button event */
++static int mlxplat_mlxcpld_chassis_pwr_events_handler(void *handle, enum mlxreg_hotplug_kind kind,
++						      u8 action)
++{
++	dev_info(&mlxplat_dev->dev, "System shutdown due to short press of power button");
++	kernel_halt();
++	return 0;
++}
++
++static struct mlxreg_core_hotplug_notifier mlxplat_mlxcpld_chassis_pwr_events_notifier = {
++	.user_handler = mlxplat_mlxcpld_chassis_pwr_events_handler,
++};
++
++/* Platform hotplug for chassis systems family data  */
++static struct mlxreg_core_data mlxplat_mlxcpld_chassis_pwr_events_items_data[] = {
++	{
++		.label = "power_button",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWRB_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_BUTTON_MASK,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++		.hpdev.notifier = &mlxplat_mlxcpld_chassis_pwr_events_notifier,
++	},
++};
++
++/* Callback activates latch reset flow after notification about intrusion event */
++static int
++mlxplat_mlxcpld_chassis_intrusion_events_handler(void *handle, enum mlxreg_hotplug_kind kind,
++						 u8 action)
++{
++	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
++	u32 regval;
++	int err;
++
++	err = regmap_read(priv->regmap, MLXPLAT_CPLD_LPC_REG_GP1_OFFSET, &regval);
++	if (err)
++		goto fail_regmap_read;
++
++	if (action) {
++		dev_info(&mlxplat_dev->dev, "Detected intrusion - system latch is opened");
++		err = regmap_write(priv->regmap, MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++				   regval | MLXPLAT_CPLD_LATCH_RST_MASK);
++	} else {
++		dev_info(&mlxplat_dev->dev, "System latch is properly closed");
++		err = regmap_write(priv->regmap, MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++				   regval & ~MLXPLAT_CPLD_LATCH_RST_MASK);
++	}
++
++	if (err)
++		goto fail_regmap_write;
++
++	return 0;
++
++fail_regmap_read:
++fail_regmap_write:
++	dev_err(&mlxplat_dev->dev, "Register access failed");
++	return err;
++}
++
++static struct mlxreg_core_hotplug_notifier mlxplat_mlxcpld_chassis_intrusion_events_notifier = {
++	.user_handler = mlxplat_mlxcpld_chassis_intrusion_events_handler,
++};
++
++static struct mlxreg_core_data mlxplat_mlxcpld_chassis_intrusion_events_items_data[] = {
++	{
++		.label = "intrusion",
++		.reg = MLXPLAT_CPLD_LPC_REG_BRD_OFFSET,
++		.mask = MLXPLAT_CPLD_INTRUSION_MASK,
++		.hpdev.nr = MLXPLAT_CPLD_NR_NONE,
++		.hpdev.notifier = &mlxplat_mlxcpld_chassis_intrusion_events_notifier,
++	},
++};
++
++static struct mlxreg_core_item mlxplat_mlxcpld_chassis_events_items[] = {
++	{
++		.data = mlxplat_mlxcpld_default_ng_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_NG_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_erot_ap_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_EROT_OFFSET,
++		.mask = MLXPLAT_CPLD_EROT_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_erot_ap_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_erot_error_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET,
++		.mask = MLXPLAT_CPLD_EROT_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_erot_error_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_chassis_pwr_events_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWRB_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_BUTTON_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_chassis_pwr_events_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_chassis_intrusion_events_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_BRD_OFFSET,
++		.mask = MLXPLAT_CPLD_INTRUSION_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_chassis_intrusion_events_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++};
++
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_chassis_data = {
++	.items = mlxplat_mlxcpld_chassis_events_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_chassis_events_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT,
++};
++
+ static struct spi_board_info rack_switch_switch_spi_board_info[] = {
+ 	{
+ 		.modalias       = "spidev",
+@@ -3066,6 +3216,114 @@ static struct mlxreg_core_platform_data mlxplat_qmb8700_led_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_qmb8700_led_data),
+ };
+ 
++/* Platform led data for chassis system */
++static struct mlxreg_core_data mlxplat_mlxcpld_chassis_led_data[] = {
++	{
++		.label = "status:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++	{
++		.label = "status:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED1_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK
++	},
++	{
++		.label = "fan1:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(0),
++	},
++	{
++		.label = "fan1:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(0),
++	},
++	{
++		.label = "fan2:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(1),
++	},
++	{
++		.label = "fan2:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED2_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(1),
++	},
++	{
++		.label = "fan3:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(2),
++	},
++	{
++		.label = "fan3:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(2),
++	},
++	{
++		.label = "fan4:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(3),
++	},
++	{
++		.label = "fan4:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(3),
++	},
++	{
++		.label = "fan5:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(4),
++	},
++	{
++		.label = "fan5:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(4),
++	},
++	{
++		.label = "fan6:green",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(5),
++	},
++	{
++		.label = "fan6:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(5),
++	},
++	{
++		.label = "uid:blue",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED5_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_chassis_led_data = {
++		.data = mlxplat_mlxcpld_chassis_led_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_chassis_led_data),
++};
++
+ /* Platform register access default */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_regs_io_data[] = {
+ 	{
+@@ -3594,12 +3852,48 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(3),
+ 		.mode = 0200,
+ 	},
++	{
++		.label = "deep_pwr_cycle",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0200,
++	},
++	{
++		.label = "latch_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0200,
++	},
+ 	{
+ 		.label = "jtag_enable",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(4),
+ 		.mode = 0644,
+ 	},
++	{
++		.label = "dbg1",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg2",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg3",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
++	{
++		.label = "dbg4",
++		.reg = MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0644,
++	},
+ 	{
+ 		.label = "asic_health",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
+@@ -4913,11 +5207,18 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_SAFE_BIOS_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
+@@ -4932,6 +5233,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
+@@ -4960,6 +5263,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
+@@ -5010,6 +5314,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET:
+@@ -5019,6 +5327,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+@@ -5040,6 +5351,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
+@@ -5076,6 +5390,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+@@ -5152,6 +5467,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET:
+@@ -5161,6 +5480,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_BRD_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
+@@ -5182,6 +5504,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_EVENT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_PWRB_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
+@@ -5212,6 +5537,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+@@ -5407,7 +5733,6 @@ static struct resource mlxplat_mlxcpld_resources[] = {
+ 	[0] = DEFINE_RES_IRQ_NAMED(MLXPLAT_CPLD_LPC_SYSIRQ, "mlxreg-hotplug"),
+ };
+ 
+-static struct platform_device *mlxplat_dev;
+ static struct mlxreg_core_hotplug_platform_data *mlxplat_i2c;
+ static struct mlxreg_core_hotplug_platform_data *mlxplat_hotplug;
+ static struct mlxreg_core_platform_data *mlxplat_led;
+@@ -5418,6 +5743,14 @@ static struct mlxreg_core_platform_data
+ static const struct regmap_config *mlxplat_regmap_config;
+ static struct spi_board_info *mlxplat_spi;
+ 
++/* Platform default poweroff function */
++static void mlxplat_poweroff(void)
++{
++	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
++
++	regmap_write(priv->regmap, MLXPLAT_CPLD_LPC_REG_GP1_OFFSET, MLXPLAT_CPLD_HALT_MASK);
++}
++
+ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
+ {
+ 	int i;
+@@ -5740,6 +6073,29 @@ static int __init mlxplat_dmi_ng800_matched(const struct dmi_system_id *dmi)
+ 	return 1;
+ }
+ 
++static int __init mlxplat_dmi_chassis_matched(const struct dmi_system_id *dmi)
++{
++	int i;
++
++	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_num = ARRAY_SIZE(mlxplat_rack_switch_mux_data);
++	mlxplat_mux_data = mlxplat_rack_switch_mux_data;
++	mlxplat_hotplug = &mlxplat_mlxcpld_chassis_data;
++	mlxplat_hotplug->deferred_nr =
++		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++	mlxplat_led = &mlxplat_chassis_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++	mlxplat_fan = &mlxplat_default_fan_data;
++	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
++		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
++	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
++	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_rack_switch;
++	pm_power_off = mlxplat_poweroff;
++	mlxplat_spi = rack_switch_switch_spi_board_info;
++
++	return 1;
++}
++
+ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 	{
+ 		.callback = mlxplat_dmi_default_wc_matched,
+@@ -5835,6 +6191,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
+ 		},
+ 	},
++	{
++		.callback = mlxplat_dmi_chassis_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0017"),
++		},
++	},
+ 	{
+ 		.callback = mlxplat_dmi_msn274x_matched,
+ 		.matches = {
+@@ -6167,6 +6529,8 @@ static void __exit mlxplat_exit(void)
+ 	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
+ 	int i;
+ 
++	if (pm_power_off)
++		pm_power_off = NULL;
+ 	for (i = MLXPLAT_CPLD_WD_MAX_DEVS - 1; i >= 0 ; i--)
+ 		platform_device_unregister(priv->pdev_wd[i]);
+ 	if (priv->pdev_fan)
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0183-platform-mellanox-Split-initialization-procedure.patch
+++ b/recipes-kernel/linux/linux-5.10/0183-platform-mellanox-Split-initialization-procedure.patch
@@ -1,0 +1,168 @@
+From c924f335d7e107447df288f0c30f751b61da7b09 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Sun, 11 Dec 2022 10:44:43 +0200
+Subject: [PATCH backport 5.10 2/3] platform: mellanox: Split initialization
+ procedure
+
+Split mlxplat_init() into two by adding mlxplat_pre_init().
+
+Motivation is to prepare 'mlx-platform' driver to support systems
+equipped PCIe based programming logic device.
+
+Such systems are supposed to use different system resources, thus this
+commit separates resources allocation related code.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 78 ++++++++++++++++++++++-------
+ 1 file changed, 60 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index e5a4d2472..578ab331b 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -323,6 +323,8 @@
+  * @pdev_fan - FAN platform devices
+  * @pdev_wd - array of watchdog platform devices
+  * @regmap: device register map
++ * @hotplug_resources: system hotplug resources
++ * @hotplug_resources_size: size of system hotplug resources
+  */
+ struct mlxplat_priv {
+ 	struct platform_device *pdev_i2c;
+@@ -333,6 +335,8 @@ struct mlxplat_priv {
+ 	struct platform_device *pdev_fan;
+ 	struct platform_device *pdev_wd[MLXPLAT_CPLD_WD_MAX_DEVS];
+ 	void *regmap;
++	struct resource *hotplug_resources;
++	unsigned int hotplug_resources_size;
+ };
+ 
+ static struct platform_device *mlxplat_dev;
+@@ -6338,20 +6342,63 @@ static int mlxplat_mlxcpld_check_wd_capability(void *regmap)
+ 	return 0;
+ }
+ 
++static int mlxplat_lpc_cpld_device_init(struct resource **hotplug_resources,
++					unsigned int *hotplug_resources_size)
++{
++	int err;
++
++	mlxplat_dev = platform_device_register_simple(MLX_PLAT_DEVICE_NAME, PLATFORM_DEVID_NONE,
++						      mlxplat_lpc_resources,
++						      ARRAY_SIZE(mlxplat_lpc_resources));
++	if (IS_ERR(mlxplat_dev))
++		return PTR_ERR(mlxplat_dev);
++
++	mlxplat_mlxcpld_regmap_ctx.base = devm_ioport_map(&mlxplat_dev->dev,
++							  mlxplat_lpc_resources[1].start, 1);
++	if (!mlxplat_mlxcpld_regmap_ctx.base) {
++		err = -ENOMEM;
++		goto fail_devm_ioport_map;
++	}
++
++	*hotplug_resources = mlxplat_mlxcpld_resources;
++	*hotplug_resources_size = ARRAY_SIZE(mlxplat_mlxcpld_resources);
++
++	return 0;
++
++fail_devm_ioport_map:
++	platform_device_unregister(mlxplat_dev);
++	return err;
++}
++
++static void mlxplat_lpc_cpld_device_exit(void)
++{
++	platform_device_unregister(mlxplat_dev);
++}
++
++static int
++mlxplat_pre_init(struct resource **hotplug_resources, unsigned int *hotplug_resources_size)
++{
++	return mlxplat_lpc_cpld_device_init(hotplug_resources, hotplug_resources_size);
++}
++
++static void mlxplat_post_exit(void)
++{
++	mlxplat_lpc_cpld_device_exit();
++}
++
+ static int __init mlxplat_init(void)
+ {
++	unsigned int hotplug_resources_size;
++	struct resource *hotplug_resources;
+ 	struct mlxplat_priv *priv;
+ 	int i, j, nr, err;
+ 
+ 	if (!dmi_check_system(mlxplat_dmi_table))
+ 		return -ENODEV;
+ 
+-	mlxplat_dev = platform_device_register_simple(MLX_PLAT_DEVICE_NAME, -1,
+-					mlxplat_lpc_resources,
+-					ARRAY_SIZE(mlxplat_lpc_resources));
+-
+-	if (IS_ERR(mlxplat_dev))
+-		return PTR_ERR(mlxplat_dev);
++	err = mlxplat_pre_init(&hotplug_resources, &hotplug_resources_size);
++	if (err)
++		return err;
+ 
+ 	priv = devm_kzalloc(&mlxplat_dev->dev, sizeof(struct mlxplat_priv),
+ 			    GFP_KERNEL);
+@@ -6361,12 +6408,8 @@ static int __init mlxplat_init(void)
+ 	}
+ 	platform_set_drvdata(mlxplat_dev, priv);
+ 
+-	mlxplat_mlxcpld_regmap_ctx.base = devm_ioport_map(&mlxplat_dev->dev,
+-			       mlxplat_lpc_resources[1].start, 1);
+-	if (!mlxplat_mlxcpld_regmap_ctx.base) {
+-		err = -ENOMEM;
+-		goto fail_alloc;
+-	}
++	priv->hotplug_resources = hotplug_resources;
++	priv->hotplug_resources_size = hotplug_resources_size;
+ 
+ 	if (!mlxplat_regmap_config)
+ 		mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config;
+@@ -6387,8 +6430,8 @@ static int __init mlxplat_init(void)
+ 	if (mlxplat_i2c)
+ 		mlxplat_i2c->regmap = priv->regmap;
+ 	priv->pdev_i2c = platform_device_register_resndata(&mlxplat_dev->dev, "i2c_mlxcpld",
+-							   nr, mlxplat_mlxcpld_resources,
+-							   ARRAY_SIZE(mlxplat_mlxcpld_resources),
++							   nr, priv->hotplug_resources,
++							   priv->hotplug_resources_size,
+ 							   mlxplat_i2c, sizeof(*mlxplat_i2c));
+ 	if (IS_ERR(priv->pdev_i2c)) {
+ 		err = PTR_ERR(priv->pdev_i2c);
+@@ -6412,8 +6455,8 @@ static int __init mlxplat_init(void)
+ 		priv->pdev_hotplug =
+ 		platform_device_register_resndata(&mlxplat_dev->dev,
+ 						  "mlxreg-hotplug", PLATFORM_DEVID_NONE,
+-						  mlxplat_mlxcpld_resources,
+-						  ARRAY_SIZE(mlxplat_mlxcpld_resources),
++						  priv->hotplug_resources,
++						  priv->hotplug_resources_size,
+ 						  mlxplat_hotplug, sizeof(*mlxplat_hotplug));
+ 		if (IS_ERR(priv->pdev_hotplug)) {
+ 			err = PTR_ERR(priv->pdev_hotplug);
+@@ -6518,7 +6561,6 @@ static int __init mlxplat_init(void)
+ 		platform_device_unregister(priv->pdev_mux[i]);
+ 	platform_device_unregister(priv->pdev_i2c);
+ fail_alloc:
+-	platform_device_unregister(mlxplat_dev);
+ 
+ 	return err;
+ }
+@@ -6546,7 +6588,7 @@ static void __exit mlxplat_exit(void)
+ 		platform_device_unregister(priv->pdev_mux[i]);
+ 
+ 	platform_device_unregister(priv->pdev_i2c);
+-	platform_device_unregister(mlxplat_dev);
++	mlxplat_post_exit();
+ }
+ module_exit(mlxplat_exit);
+ 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch
+++ b/recipes-kernel/linux/linux-5.10/0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch
@@ -1,0 +1,406 @@
+From 5f0f53e1bb5954e6a04297568590adad3edc818f Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Sun, 11 Dec 2022 11:08:07 +0200
+Subject: [PATCH backport 5.10 3/3] platform: mellanox: Split logic in init and
+ exit flow
+
+Split logic in mlxplat_init()/mlxplat_exit() routines.
+Separate initialization of I2C infrastructure and others platform
+drivers.
+
+Motivation is to provide synchronization between I2C bus and mux
+drivers and other drivers using this infrastructure.
+I2C main bus and MUX busses are implemented in FPGA logic. On some new
+systems the numbers allocated for these busses could be variable
+depending on order of initialization of I2C native busses. Since bus
+numbers are passed to some other platform drivers during initialization
+flow, it is necessary to synchronize completion of I2C infrastructure
+drivers and activation of rest of drivers.
+
+For systems required such mechanism callbacks for I2C bus and MUX
+drivers are to be used, thus initialization flow will be performed in
+synchronized order.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 294 +++++++++++++++++-----------
+ 1 file changed, 185 insertions(+), 109 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 578ab331b..a1c50fa3e 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -6386,68 +6386,9 @@ static void mlxplat_post_exit(void)
+ 	mlxplat_lpc_cpld_device_exit();
+ }
+ 
+-static int __init mlxplat_init(void)
++static int mlxplat_post_init(struct mlxplat_priv *priv)
+ {
+-	unsigned int hotplug_resources_size;
+-	struct resource *hotplug_resources;
+-	struct mlxplat_priv *priv;
+-	int i, j, nr, err;
+-
+-	if (!dmi_check_system(mlxplat_dmi_table))
+-		return -ENODEV;
+-
+-	err = mlxplat_pre_init(&hotplug_resources, &hotplug_resources_size);
+-	if (err)
+-		return err;
+-
+-	priv = devm_kzalloc(&mlxplat_dev->dev, sizeof(struct mlxplat_priv),
+-			    GFP_KERNEL);
+-	if (!priv) {
+-		err = -ENOMEM;
+-		goto fail_alloc;
+-	}
+-	platform_set_drvdata(mlxplat_dev, priv);
+-
+-	priv->hotplug_resources = hotplug_resources;
+-	priv->hotplug_resources_size = hotplug_resources_size;
+-
+-	if (!mlxplat_regmap_config)
+-		mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config;
+-
+-	priv->regmap = devm_regmap_init(&mlxplat_dev->dev, NULL,
+-					&mlxplat_mlxcpld_regmap_ctx,
+-					mlxplat_regmap_config);
+-	if (IS_ERR(priv->regmap)) {
+-		err = PTR_ERR(priv->regmap);
+-		goto fail_alloc;
+-	}
+-
+-	err = mlxplat_mlxcpld_verify_bus_topology(&nr);
+-	if (nr < 0)
+-		goto fail_alloc;
+-
+-	nr = (nr == mlxplat_max_adap_num) ? -1 : nr;
+-	if (mlxplat_i2c)
+-		mlxplat_i2c->regmap = priv->regmap;
+-	priv->pdev_i2c = platform_device_register_resndata(&mlxplat_dev->dev, "i2c_mlxcpld",
+-							   nr, priv->hotplug_resources,
+-							   priv->hotplug_resources_size,
+-							   mlxplat_i2c, sizeof(*mlxplat_i2c));
+-	if (IS_ERR(priv->pdev_i2c)) {
+-		err = PTR_ERR(priv->pdev_i2c);
+-		goto fail_alloc;
+-	}
+-
+-	for (i = 0; i < mlxplat_mux_num; i++) {
+-		priv->pdev_mux[i] = platform_device_register_resndata(&priv->pdev_i2c->dev,
+-								      "i2c-mux-reg", i, NULL, 0,
+-								      &mlxplat_mux_data[i],
+-								      sizeof(mlxplat_mux_data[i]));
+-		if (IS_ERR(priv->pdev_mux[i])) {
+-			err = PTR_ERR(priv->pdev_mux[i]);
+-			goto fail_platform_mux_register;
+-		}
+-	}
++	int i, err;
+ 
+ 	/* Add hotplug driver */
+ 	if (mlxplat_hotplug) {
+@@ -6460,19 +6401,10 @@ static int __init mlxplat_init(void)
+ 						  mlxplat_hotplug, sizeof(*mlxplat_hotplug));
+ 		if (IS_ERR(priv->pdev_hotplug)) {
+ 			err = PTR_ERR(priv->pdev_hotplug);
+-			goto fail_platform_mux_register;
++			goto fail_platform_hotplug_register;
+ 		}
+ 	}
+ 
+-	/* Set default registers. */
+-	for (j = 0; j <  mlxplat_regmap_config->num_reg_defaults; j++) {
+-		err = regmap_write(priv->regmap,
+-				   mlxplat_regmap_config->reg_defaults[j].reg,
+-				   mlxplat_regmap_config->reg_defaults[j].def);
+-		if (err)
+-			goto fail_platform_mux_register;
+-	}
+-
+ 	/* Add LED driver. */
+ 	if (mlxplat_led) {
+ 		mlxplat_led->regmap = priv->regmap;
+@@ -6482,7 +6414,7 @@ static int __init mlxplat_init(void)
+ 						  sizeof(*mlxplat_led));
+ 		if (IS_ERR(priv->pdev_led)) {
+ 			err = PTR_ERR(priv->pdev_led);
+-			goto fail_platform_hotplug_register;
++			goto fail_platform_leds_register;
+ 		}
+ 	}
+ 
+@@ -6496,7 +6428,7 @@ static int __init mlxplat_init(void)
+ 								       sizeof(*mlxplat_regs_io));
+ 		if (IS_ERR(priv->pdev_io_regs)) {
+ 			err = PTR_ERR(priv->pdev_io_regs);
+-			goto fail_platform_led_register;
++			goto fail_platform_io_register;
+ 		}
+ 	}
+ 
+@@ -6509,7 +6441,7 @@ static int __init mlxplat_init(void)
+ 								   sizeof(*mlxplat_fan));
+ 		if (IS_ERR(priv->pdev_fan)) {
+ 			err = PTR_ERR(priv->pdev_fan);
+-			goto fail_platform_io_regs_register;
++			goto fail_platform_fan_register;
+ 		}
+ 	}
+ 
+@@ -6520,59 +6452,42 @@ static int __init mlxplat_init(void)
+ 	err = mlxplat_mlxcpld_check_wd_capability(priv->regmap);
+ 	if (err)
+ 		goto fail_platform_wd_register;
+-	for (j = 0; j < MLXPLAT_CPLD_WD_MAX_DEVS; j++) {
+-		if (mlxplat_wd_data[j]) {
+-			mlxplat_wd_data[j]->regmap = priv->regmap;
+-			priv->pdev_wd[j] =
+-				platform_device_register_resndata(&mlxplat_dev->dev, "mlx-wdt", j,
+-								  NULL, 0, mlxplat_wd_data[j],
+-								  sizeof(*mlxplat_wd_data[j]));
+-			if (IS_ERR(priv->pdev_wd[j])) {
+-				err = PTR_ERR(priv->pdev_wd[j]);
++	for (i = 0; i < MLXPLAT_CPLD_WD_MAX_DEVS; i++) {
++		if (mlxplat_wd_data[i]) {
++			mlxplat_wd_data[i]->regmap = priv->regmap;
++			priv->pdev_wd[i] =
++				platform_device_register_resndata(&mlxplat_dev->dev, "mlx-wdt", i,
++								  NULL, 0, mlxplat_wd_data[i],
++								  sizeof(*mlxplat_wd_data[i]));
++			if (IS_ERR(priv->pdev_wd[i])) {
++				err = PTR_ERR(priv->pdev_wd[i]);
+ 				goto fail_platform_wd_register;
+ 			}
+ 		}
+ 	}
+ 
+-	/* Sync registers with hardware. */
+-	regcache_mark_dirty(priv->regmap);
+-	err = regcache_sync(priv->regmap);
+-	if (err)
+-		goto fail_platform_wd_register;
+-
+ 	return 0;
+ 
+ fail_platform_wd_register:
+-	while (--j >= 0)
+-		platform_device_unregister(priv->pdev_wd[j]);
+-	if (mlxplat_fan)
+-		platform_device_unregister(priv->pdev_fan);
+-fail_platform_io_regs_register:
++	while (--i >= 0)
++		platform_device_unregister(priv->pdev_wd[i]);
++fail_platform_fan_register:
+ 	if (mlxplat_regs_io)
+ 		platform_device_unregister(priv->pdev_io_regs);
+-fail_platform_led_register:
++fail_platform_io_register:
+ 	if (mlxplat_led)
+ 		platform_device_unregister(priv->pdev_led);
+-fail_platform_hotplug_register:
++fail_platform_leds_register:
+ 	if (mlxplat_hotplug)
+ 		platform_device_unregister(priv->pdev_hotplug);
+-fail_platform_mux_register:
+-	while (--i >= 0)
+-		platform_device_unregister(priv->pdev_mux[i]);
+-	platform_device_unregister(priv->pdev_i2c);
+-fail_alloc:
+-
++fail_platform_hotplug_register:
+ 	return err;
+ }
+-module_init(mlxplat_init);
+ 
+-static void __exit mlxplat_exit(void)
++static void mlxplat_pre_exit(struct mlxplat_priv *priv)
+ {
+-	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
+ 	int i;
+ 
+-	if (pm_power_off)
+-		pm_power_off = NULL;
+ 	for (i = MLXPLAT_CPLD_WD_MAX_DEVS - 1; i >= 0 ; i--)
+ 		platform_device_unregister(priv->pdev_wd[i]);
+ 	if (priv->pdev_fan)
+@@ -6583,12 +6498,173 @@ static void __exit mlxplat_exit(void)
+ 		platform_device_unregister(priv->pdev_led);
+ 	if (priv->pdev_hotplug)
+ 		platform_device_unregister(priv->pdev_hotplug);
++}
++
++static int
++mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
++				  struct i2c_adapter *adapters[])
++{
++	struct mlxplat_priv *priv = handle;
+ 
+-	for (i = mlxplat_mux_num - 1; i >= 0 ; i--)
++	return mlxplat_post_init(priv);
++}
++
++static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
++{
++	int i, err;
++
++	for (i = 0; i < mlxplat_mux_num; i++) {
++		priv->pdev_mux[i] = platform_device_register_resndata(&priv->pdev_i2c->dev,
++								      "i2c-mux-reg", i, NULL, 0,
++								      &mlxplat_mux_data[i],
++								      sizeof(mlxplat_mux_data[i]));
++		if (IS_ERR(priv->pdev_mux[i])) {
++			err = PTR_ERR(priv->pdev_mux[i]);
++			goto fail_platform_mux_register;
++		}
++	}
++
++	return mlxplat_i2c_mux_complition_notify(priv, NULL, NULL);
++
++fail_platform_mux_register:
++	while (--i >= 0)
+ 		platform_device_unregister(priv->pdev_mux[i]);
++	return err;
++}
++
++static void mlxplat_i2c_mux_topolgy_exit(struct mlxplat_priv *priv)
++{
++	int i;
++
++	for (i = mlxplat_mux_num - 1; i >= 0 ; i--) {
++		if (priv->pdev_mux[i])
++			platform_device_unregister(priv->pdev_mux[i]);
++	}
++
++	mlxplat_post_exit();
++}
++
++static int mlxplat_i2c_main_complition_notify(void *handle, int id)
++{
++	struct mlxplat_priv *priv = handle;
++
++	return mlxplat_i2c_mux_topolgy_init(priv);
++}
++
++static int mlxplat_i2c_main_init(struct mlxplat_priv *priv)
++{
++	int nr, err;
++
++	if (!mlxplat_i2c)
++		return 0;
++
++	err = mlxplat_mlxcpld_verify_bus_topology(&nr);
++	if (nr < 0)
++		goto fail_mlxplat_mlxcpld_verify_bus_topology;
++
++	nr = (nr == mlxplat_max_adap_num) ? -1 : nr;
++	mlxplat_i2c->regmap = priv->regmap;
++	mlxplat_i2c->handle = priv;
++	mlxplat_i2c->completion_notify = mlxplat_i2c_main_complition_notify;
++
++	priv->pdev_i2c = platform_device_register_resndata(&mlxplat_dev->dev, "i2c_mlxcpld",
++							   nr, priv->hotplug_resources,
++							   priv->hotplug_resources_size,
++							   mlxplat_i2c, sizeof(*mlxplat_i2c));
++	if (IS_ERR(priv->pdev_i2c)) {
++		err = PTR_ERR(priv->pdev_i2c);
++		goto fail_platform_i2c_register;
++	}
++
++	return 0;
++
++fail_platform_i2c_register:
++fail_mlxplat_mlxcpld_verify_bus_topology:
++	return err;
++}
++
++static void mlxplat_i2c_main_exit(struct mlxplat_priv *priv)
++{
++	mlxplat_i2c_mux_topolgy_exit(priv);
++	if (priv->pdev_i2c)
++		platform_device_unregister(priv->pdev_i2c);
++}
++
++static int __init mlxplat_init(void)
++{
++	unsigned int hotplug_resources_size;
++	struct resource *hotplug_resources;
++	struct mlxplat_priv *priv;
++	int i, err;
++
++	if (!dmi_check_system(mlxplat_dmi_table))
++		return -ENODEV;
+ 
+-	platform_device_unregister(priv->pdev_i2c);
++	err = mlxplat_pre_init(&hotplug_resources, &hotplug_resources_size);
++	if (err)
++		return err;
++
++	priv = devm_kzalloc(&mlxplat_dev->dev, sizeof(struct mlxplat_priv),
++			    GFP_KERNEL);
++	if (!priv) {
++		err = -ENOMEM;
++		goto fail_alloc;
++	}
++	platform_set_drvdata(mlxplat_dev, priv);
++	priv->hotplug_resources = hotplug_resources;
++	priv->hotplug_resources_size = hotplug_resources_size;
++
++	if (!mlxplat_regmap_config)
++		mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config;
++
++	priv->regmap = devm_regmap_init(&mlxplat_dev->dev, NULL,
++					&mlxplat_mlxcpld_regmap_ctx,
++					mlxplat_regmap_config);
++	if (IS_ERR(priv->regmap)) {
++		err = PTR_ERR(priv->regmap);
++		goto fail_alloc;
++	}
++
++	/* Set default registers. */
++	for (i = 0; i <  mlxplat_regmap_config->num_reg_defaults; i++) {
++		err = regmap_write(priv->regmap,
++				   mlxplat_regmap_config->reg_defaults[i].reg,
++				   mlxplat_regmap_config->reg_defaults[i].def);
++		if (err)
++			goto fail_regmap_write;
++	}
++
++	err = mlxplat_i2c_main_init(priv);
++	if (err)
++		goto fail_mlxplat_i2c_main_init;
++
++	/* Sync registers with hardware. */
++	regcache_mark_dirty(priv->regmap);
++	err = regcache_sync(priv->regmap);
++	if (err)
++		goto fail_regcache_sync;
++
++	return 0;
++
++fail_regcache_sync:
++	mlxplat_pre_exit(priv);
++fail_mlxplat_i2c_main_init:
++fail_regmap_write:
++fail_alloc:
+ 	mlxplat_post_exit();
++
++	return err;
++}
++module_init(mlxplat_init);
++
++static void __exit mlxplat_exit(void)
++{
++	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
++
++	if (pm_power_off)
++		pm_power_off = NULL;
++	mlxplat_pre_exit(priv);
++	mlxplat_i2c_main_exit(priv);
+ }
+ module_exit(mlxplat_exit);
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
Add support for new system type.

Split init flow for serialization: initialize muxes only after main I2C bus is created to avoid drivers init re-ordering.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>