### PR TITLE
hw-mgmt: kernel patches: Add patch for extending hotplug confuguration

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -351,6 +351,7 @@ Kernel-5.10
 |0183-platform-mellanox-Split-initialization-procedure.patch             |                                            | pending                                         |                                                              |
 |0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch          |                                            | pending                                         |                                                              |
 |0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch         |                                            | pending                                         |                                                              |
+|0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch         |                                            | pending                                         |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  

--- a/recipes-kernel/linux/linux-5.10/0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch
+++ b/recipes-kernel/linux/linux-5.10/0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch
@@ -1,7 +1,7 @@
-From 72642773d914740f57415471a696fe56ed5dbc44 Mon Sep 17 00:00:00 2001
+From 74ab8a216510df924ca88d2f3d5944eb107264d0 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 11 Dec 2022 09:26:48 +0200
-Subject: [PATCH backport 5.10 1/4] platform: mellanox: Introduce support of
+Subject: [PATCH backport 5.10 1/5] platform: mellanox: Introduce support of
  new Nvidia L1 switch
 
 Add support for new L1 switch nodes providing L1 connectivity for
@@ -27,11 +27,11 @@ operation.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 394 +++++++++++++++++++++++++++-
- 1 file changed, 392 insertions(+), 2 deletions(-)
+ drivers/platform/x86/mlx-platform.c | 395 +++++++++++++++++++++++++++-
+ 1 file changed, 393 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 4bbe1d8f0..3810620f6 100644
+index 4bbe1d8f0..a2addd1b3 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -15,6 +15,7 @@
@@ -132,7 +132,7 @@ index 4bbe1d8f0..3810620f6 100644
  static const int mlxplat_rack_switch_channels[] = {
  	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
  };
-@@ -2409,6 +2436,155 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_rack_switch_data = {
+@@ -2409,6 +2436,156 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_rack_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW,
  };
  
@@ -272,6 +272,7 @@ index 4bbe1d8f0..3810620f6 100644
 +		.count = ARRAY_SIZE(mlxplat_mlxcpld_l1_switch_health_events_items_data),
 +		.inversed = 0,
 +		.health = false,
++		.ind = 8,
 +	},
 +};
 +
@@ -288,7 +289,7 @@ index 4bbe1d8f0..3810620f6 100644
  static struct spi_board_info rack_switch_switch_spi_board_info[] = {
  	{
  		.modalias       = "spidev",
-@@ -3066,6 +3242,114 @@ static struct mlxreg_core_platform_data mlxplat_qmb8700_led_data = {
+@@ -3066,6 +3243,114 @@ static struct mlxreg_core_platform_data mlxplat_qmb8700_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_qmb8700_led_data),
  };
  
@@ -403,7 +404,7 @@ index 4bbe1d8f0..3810620f6 100644
  /* Platform register access default */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_regs_io_data[] = {
  	{
-@@ -3594,12 +3878,48 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -3594,12 +3879,48 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mask = GENMASK(7, 0) & ~BIT(3),
  		.mode = 0200,
  	},
@@ -452,7 +453,7 @@ index 4bbe1d8f0..3810620f6 100644
  	{
  		.label = "asic_health",
  		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
-@@ -4913,11 +5233,18 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4913,11 +5234,18 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_SAFE_BIOS_OFFSET:
  	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
@@ -471,7 +472,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
-@@ -4932,6 +5259,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4932,6 +5260,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
@@ -480,7 +481,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_MASK_OFFSET:
-@@ -4960,6 +5289,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -4960,6 +5290,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
@@ -488,7 +489,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -5010,6 +5340,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5010,6 +5341,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
@@ -499,7 +500,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET:
-@@ -5019,6 +5353,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5019,6 +5354,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_GWP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
@@ -509,7 +510,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
-@@ -5040,6 +5377,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5040,6 +5378,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
@@ -519,7 +520,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -5076,6 +5416,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5076,6 +5417,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
@@ -527,7 +528,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
-@@ -5152,6 +5493,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5152,6 +5494,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
@@ -538,7 +539,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET:
-@@ -5161,6 +5506,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5161,6 +5507,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_GWP_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GWP_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GWP_MASK_OFFSET:
@@ -548,7 +549,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
-@@ -5182,6 +5530,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5182,6 +5531,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_EROTE_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_MASK_OFFSET:
@@ -558,7 +559,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_AGGRLC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_IN_OFFSET:
-@@ -5212,6 +5563,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5212,6 +5564,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_WD2_TLEFT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
@@ -566,7 +567,7 @@ index 4bbe1d8f0..3810620f6 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
-@@ -5407,7 +5759,6 @@ static struct resource mlxplat_mlxcpld_resources[] = {
+@@ -5407,7 +5760,6 @@ static struct resource mlxplat_mlxcpld_resources[] = {
  	[0] = DEFINE_RES_IRQ_NAMED(MLXPLAT_CPLD_LPC_SYSIRQ, "mlxreg-hotplug"),
  };
  
@@ -574,7 +575,7 @@ index 4bbe1d8f0..3810620f6 100644
  static struct mlxreg_core_hotplug_platform_data *mlxplat_i2c;
  static struct mlxreg_core_hotplug_platform_data *mlxplat_hotplug;
  static struct mlxreg_core_platform_data *mlxplat_led;
-@@ -5418,6 +5769,14 @@ static struct mlxreg_core_platform_data
+@@ -5418,6 +5770,14 @@ static struct mlxreg_core_platform_data
  static const struct regmap_config *mlxplat_regmap_config;
  static struct spi_board_info *mlxplat_spi;
  
@@ -589,7 +590,7 @@ index 4bbe1d8f0..3810620f6 100644
  static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -5740,6 +6099,29 @@ static int __init mlxplat_dmi_ng800_matched(const struct dmi_system_id *dmi)
+@@ -5740,6 +6100,29 @@ static int __init mlxplat_dmi_ng800_matched(const struct dmi_system_id *dmi)
  	return 1;
  }
  
@@ -619,7 +620,7 @@ index 4bbe1d8f0..3810620f6 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -5835,6 +6217,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -5835,6 +6218,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0015"),
  		},
  	},
@@ -632,7 +633,7 @@ index 4bbe1d8f0..3810620f6 100644
  	{
  		.callback = mlxplat_dmi_msn274x_matched,
  		.matches = {
-@@ -6167,6 +6555,8 @@ static void __exit mlxplat_exit(void)
+@@ -6167,6 +6556,8 @@ static void __exit mlxplat_exit(void)
  	struct mlxplat_priv *priv = platform_get_drvdata(mlxplat_dev);
  	int i;
  

--- a/recipes-kernel/linux/linux-5.10/0183-platform-mellanox-Split-initialization-procedure.patch
+++ b/recipes-kernel/linux/linux-5.10/0183-platform-mellanox-Split-initialization-procedure.patch
@@ -1,7 +1,7 @@
-From 2a112669cac9f5c1c2adc740d7d5bb126be73ab2 Mon Sep 17 00:00:00 2001
+From 5a2cfa144640a047ab17de5ef12dfefbe7e2f8c3 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 11 Dec 2022 10:44:43 +0200
-Subject: [PATCH backport 5.10 2/4] platform: mellanox: Split initialization
+Subject: [PATCH backport 5.10 2/5] platform: mellanox: Split initialization
  procedure
 
 Split mlxplat_init() into two by adding mlxplat_pre_init().
@@ -18,7 +18,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 60 insertions(+), 18 deletions(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 3810620f6..c06c1ad18 100644
+index a2addd1b3..199f22d72 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -330,6 +330,8 @@
@@ -39,7 +39,7 @@ index 3810620f6..c06c1ad18 100644
  };
  
  static struct platform_device *mlxplat_dev;
-@@ -6364,20 +6368,63 @@ static int mlxplat_mlxcpld_check_wd_capability(void *regmap)
+@@ -6365,20 +6369,63 @@ static int mlxplat_mlxcpld_check_wd_capability(void *regmap)
  	return 0;
  }
  
@@ -109,7 +109,7 @@ index 3810620f6..c06c1ad18 100644
  
  	priv = devm_kzalloc(&mlxplat_dev->dev, sizeof(struct mlxplat_priv),
  			    GFP_KERNEL);
-@@ -6387,12 +6434,8 @@ static int __init mlxplat_init(void)
+@@ -6388,12 +6435,8 @@ static int __init mlxplat_init(void)
  	}
  	platform_set_drvdata(mlxplat_dev, priv);
  
@@ -124,7 +124,7 @@ index 3810620f6..c06c1ad18 100644
  
  	if (!mlxplat_regmap_config)
  		mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config;
-@@ -6413,8 +6456,8 @@ static int __init mlxplat_init(void)
+@@ -6414,8 +6457,8 @@ static int __init mlxplat_init(void)
  	if (mlxplat_i2c)
  		mlxplat_i2c->regmap = priv->regmap;
  	priv->pdev_i2c = platform_device_register_resndata(&mlxplat_dev->dev, "i2c_mlxcpld",
@@ -135,7 +135,7 @@ index 3810620f6..c06c1ad18 100644
  							   mlxplat_i2c, sizeof(*mlxplat_i2c));
  	if (IS_ERR(priv->pdev_i2c)) {
  		err = PTR_ERR(priv->pdev_i2c);
-@@ -6438,8 +6481,8 @@ static int __init mlxplat_init(void)
+@@ -6439,8 +6482,8 @@ static int __init mlxplat_init(void)
  		priv->pdev_hotplug =
  		platform_device_register_resndata(&mlxplat_dev->dev,
  						  "mlxreg-hotplug", PLATFORM_DEVID_NONE,
@@ -146,7 +146,7 @@ index 3810620f6..c06c1ad18 100644
  						  mlxplat_hotplug, sizeof(*mlxplat_hotplug));
  		if (IS_ERR(priv->pdev_hotplug)) {
  			err = PTR_ERR(priv->pdev_hotplug);
-@@ -6544,7 +6587,6 @@ static int __init mlxplat_init(void)
+@@ -6545,7 +6588,6 @@ static int __init mlxplat_init(void)
  		platform_device_unregister(priv->pdev_mux[i]);
  	platform_device_unregister(priv->pdev_i2c);
  fail_alloc:
@@ -154,7 +154,7 @@ index 3810620f6..c06c1ad18 100644
  
  	return err;
  }
-@@ -6572,7 +6614,7 @@ static void __exit mlxplat_exit(void)
+@@ -6573,7 +6615,7 @@ static void __exit mlxplat_exit(void)
  		platform_device_unregister(priv->pdev_mux[i]);
  
  	platform_device_unregister(priv->pdev_i2c);

--- a/recipes-kernel/linux/linux-5.10/0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch
+++ b/recipes-kernel/linux/linux-5.10/0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch
@@ -1,7 +1,7 @@
-From 200ffcf0369b4b44923aab7c91c86c7db63d7ab1 Mon Sep 17 00:00:00 2001
+From 66efb7047c809f9842633869c565303b551fe4e3 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 11 Dec 2022 11:08:07 +0200
-Subject: [PATCH backport 5.10 3/4] platform: mellanox: Split logic in init and
+Subject: [PATCH backport 5.10 3/5] platform: mellanox: Split logic in init and
  exit flow
 
 Split logic in mlxplat_init()/mlxplat_exit() routines.
@@ -25,7 +25,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 205 insertions(+), 109 deletions(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index c06c1ad18..d7c5b8cb8 100644
+index 199f22d72..057da0e6a 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -321,6 +321,9 @@
@@ -66,7 +66,7 @@ index c06c1ad18..d7c5b8cb8 100644
  };
  
  /* Platform default channels */
-@@ -6412,68 +6419,9 @@ static void mlxplat_post_exit(void)
+@@ -6413,68 +6420,9 @@ static void mlxplat_post_exit(void)
  	mlxplat_lpc_cpld_device_exit();
  }
  
@@ -137,7 +137,7 @@ index c06c1ad18..d7c5b8cb8 100644
  
  	/* Add hotplug driver */
  	if (mlxplat_hotplug) {
-@@ -6486,19 +6434,10 @@ static int __init mlxplat_init(void)
+@@ -6487,19 +6435,10 @@ static int __init mlxplat_init(void)
  						  mlxplat_hotplug, sizeof(*mlxplat_hotplug));
  		if (IS_ERR(priv->pdev_hotplug)) {
  			err = PTR_ERR(priv->pdev_hotplug);
@@ -158,7 +158,7 @@ index c06c1ad18..d7c5b8cb8 100644
  	/* Add LED driver. */
  	if (mlxplat_led) {
  		mlxplat_led->regmap = priv->regmap;
-@@ -6508,7 +6447,7 @@ static int __init mlxplat_init(void)
+@@ -6509,7 +6448,7 @@ static int __init mlxplat_init(void)
  						  sizeof(*mlxplat_led));
  		if (IS_ERR(priv->pdev_led)) {
  			err = PTR_ERR(priv->pdev_led);
@@ -167,7 +167,7 @@ index c06c1ad18..d7c5b8cb8 100644
  		}
  	}
  
-@@ -6522,7 +6461,7 @@ static int __init mlxplat_init(void)
+@@ -6523,7 +6462,7 @@ static int __init mlxplat_init(void)
  								       sizeof(*mlxplat_regs_io));
  		if (IS_ERR(priv->pdev_io_regs)) {
  			err = PTR_ERR(priv->pdev_io_regs);
@@ -176,7 +176,7 @@ index c06c1ad18..d7c5b8cb8 100644
  		}
  	}
  
-@@ -6535,7 +6474,7 @@ static int __init mlxplat_init(void)
+@@ -6536,7 +6475,7 @@ static int __init mlxplat_init(void)
  								   sizeof(*mlxplat_fan));
  		if (IS_ERR(priv->pdev_fan)) {
  			err = PTR_ERR(priv->pdev_fan);
@@ -185,7 +185,7 @@ index c06c1ad18..d7c5b8cb8 100644
  		}
  	}
  
-@@ -6546,59 +6485,42 @@ static int __init mlxplat_init(void)
+@@ -6547,59 +6486,42 @@ static int __init mlxplat_init(void)
  	err = mlxplat_mlxcpld_check_wd_capability(priv->regmap);
  	if (err)
  		goto fail_platform_wd_register;
@@ -261,7 +261,7 @@ index c06c1ad18..d7c5b8cb8 100644
  	for (i = MLXPLAT_CPLD_WD_MAX_DEVS - 1; i >= 0 ; i--)
  		platform_device_unregister(priv->pdev_wd[i]);
  	if (priv->pdev_fan)
-@@ -6609,12 +6531,186 @@ static void __exit mlxplat_exit(void)
+@@ -6610,12 +6532,186 @@ static void __exit mlxplat_exit(void)
  		platform_device_unregister(priv->pdev_led);
  	if (priv->pdev_hotplug)
  		platform_device_unregister(priv->pdev_hotplug);

--- a/recipes-kernel/linux/linux-5.10/0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch
+++ b/recipes-kernel/linux/linux-5.10/0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch
@@ -1,7 +1,7 @@
-From 77bbbdc38944768c262ccb7e67b11a2dfd23036a Mon Sep 17 00:00:00 2001
+From 1b4dcf3170f53225a68a23658e971df8b061dab2 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 26 Dec 2022 22:28:33 +0200
-Subject: [PATCH backport 5.10 4/4] platform: mellanox: Extend all systems with
+Subject: [PATCH backport 5.10 4/5] platform: mellanox: Extend all systems with
  I2C notification callback
 
 Motivation is to provide synchronization between I2C main bus and other
@@ -13,7 +13,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 11 insertions(+)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index d7c5b8cb8..93854ea4b 100644
+index 057da0e6a..e8c656d6e 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -365,6 +365,11 @@ static const struct resource mlxplat_lpc_resources[] = {
@@ -28,7 +28,7 @@ index d7c5b8cb8..93854ea4b 100644
  /* Platform i2c next generation systems data */
  static struct mlxreg_core_data mlxplat_mlxcpld_i2c_ng_items_data[] = {
  	{
-@@ -5806,6 +5811,7 @@ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
+@@ -5807,6 +5812,7 @@ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
  	mlxplat_led = &mlxplat_default_led_data;
  	mlxplat_regs_io = &mlxplat_default_regs_io_data;
  	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
@@ -36,7 +36,7 @@ index d7c5b8cb8..93854ea4b 100644
  
  	return 1;
  }
-@@ -5828,6 +5834,7 @@ static int __init mlxplat_dmi_default_wc_matched(const struct dmi_system_id *dmi
+@@ -5829,6 +5835,7 @@ static int __init mlxplat_dmi_default_wc_matched(const struct dmi_system_id *dmi
  	mlxplat_led = &mlxplat_default_led_wc_data;
  	mlxplat_regs_io = &mlxplat_default_regs_io_data;
  	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
@@ -44,7 +44,7 @@ index d7c5b8cb8..93854ea4b 100644
  
  	return 1;
  }
-@@ -5875,6 +5882,7 @@ static int __init mlxplat_dmi_msn21xx_matched(const struct dmi_system_id *dmi)
+@@ -5876,6 +5883,7 @@ static int __init mlxplat_dmi_msn21xx_matched(const struct dmi_system_id *dmi)
  	mlxplat_led = &mlxplat_msn21xx_led_data;
  	mlxplat_regs_io = &mlxplat_msn21xx_regs_io_data;
  	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
@@ -52,7 +52,7 @@ index d7c5b8cb8..93854ea4b 100644
  
  	return 1;
  }
-@@ -5897,6 +5905,7 @@ static int __init mlxplat_dmi_msn274x_matched(const struct dmi_system_id *dmi)
+@@ -5898,6 +5906,7 @@ static int __init mlxplat_dmi_msn274x_matched(const struct dmi_system_id *dmi)
  	mlxplat_led = &mlxplat_default_led_data;
  	mlxplat_regs_io = &mlxplat_msn21xx_regs_io_data;
  	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
@@ -60,7 +60,7 @@ index d7c5b8cb8..93854ea4b 100644
  
  	return 1;
  }
-@@ -5919,6 +5928,7 @@ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
+@@ -5920,6 +5929,7 @@ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
  	mlxplat_led = &mlxplat_msn21xx_led_data;
  	mlxplat_regs_io = &mlxplat_msn21xx_regs_io_data;
  	mlxplat_wd_data[0] = &mlxplat_mlxcpld_wd_set_type1[0];
@@ -68,7 +68,7 @@ index d7c5b8cb8..93854ea4b 100644
  
  	return 1;
  }
-@@ -5968,6 +5978,7 @@ static int __init mlxplat_dmi_comex_matched(const struct dmi_system_id *dmi)
+@@ -5969,6 +5979,7 @@ static int __init mlxplat_dmi_comex_matched(const struct dmi_system_id *dmi)
  	mlxplat_fan = &mlxplat_default_fan_data;
  	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
  		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];

--- a/recipes-kernel/linux/linux-5.10/0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch
+++ b/recipes-kernel/linux/linux-5.10/0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch
@@ -1,0 +1,105 @@
+From 4244de9783c2348e15b40802c70816e4000e342d Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 9 Jan 2023 19:35:31 +0200
+Subject: [PATCH backport 5.10 5/5] platform/mellanox: mlxreg-hotplug: Allow
+ more flexible hotplug events configuration
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently hotplug configuration in logic device assumes that all items
+are provided with no holes.
+Thus, any group of hotplug events, associated with the specific
+status/event/mask registers is configured in those registers
+successively from bit zero to bit #n (#n < 8).
+
+This logic is changed int order to allow non-successive definition to
+support configuration with the skipped bits – for example bits 3, 5, 7
+in status/event/mask registers can be associated with hotplug events,
+while others can be skipped.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 28 ++++++++++++++++++----
+ 1 file changed, 23 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 117bc3f39..b7dcc64cd 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -239,6 +239,17 @@ static ssize_t mlxreg_hotplug_attr_show(struct device *dev,
+ #define PRIV_ATTR(i) priv->mlxreg_hotplug_attr[i]
+ #define PRIV_DEV_ATTR(i) priv->mlxreg_hotplug_dev_attr[i]
+ 
++static int mlxreg_hotplug_item_label_index_get(u32 mask, u32 bit)
++{
++	int i, j;
++
++	for (i = 0, j = -1; i <= bit; i++) {
++		if (mask & BIT(i))
++			j++;
++	}
++	return j;
++}
++
+ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ {
+ 	struct mlxreg_core_hotplug_platform_data *pdata;
+@@ -246,7 +257,7 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 	struct mlxreg_core_data *data;
+ 	unsigned long mask;
+ 	u32 regval;
+-	int num_attrs = 0, id = 0, i, j, k, ret;
++	int num_attrs = 0, id = 0, i, j, k, count, ret;
+ 
+ 	pdata = dev_get_platdata(&priv->pdev->dev);
+ 	item = pdata->items;
+@@ -272,7 +283,8 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 		/* Go over all unmasked units within item. */
+ 		mask = item->mask;
+ 		k = 0;
+-		for_each_set_bit(j, &mask, item->count) {
++		count = item->ind ? item->ind : item->count;
++		for_each_set_bit(j, &mask, count) {
+ 			if (data->capability) {
+ 				/*
+ 				 * Read capability register and skip non
+@@ -282,16 +294,17 @@ static int mlxreg_hotplug_attr_init(struct mlxreg_hotplug_priv_data *priv)
+ 						  data->capability, &regval);
+ 				if (ret)
+ 					return ret;
++
+ 				if (!(regval & data->bit)) {
+ 					data++;
+ 					continue;
+ 				}
+ 			}
++
+ 			PRIV_ATTR(id) = &PRIV_DEV_ATTR(id).dev_attr.attr;
+ 			PRIV_ATTR(id)->name = devm_kasprintf(&priv->pdev->dev,
+ 							     GFP_KERNEL,
+ 							     data->label);
+-
+ 			if (!PRIV_ATTR(id)->name) {
+ 				dev_err(priv->dev, "Memory allocation failed for attr %d.\n",
+ 					id);
+@@ -365,9 +378,14 @@ mlxreg_hotplug_work_helper(struct mlxreg_hotplug_priv_data *priv,
+ 	regval &= item->mask;
+ 	asserted = item->cache ^ regval;
+ 	item->cache = regval;
+-
+ 	for_each_set_bit(bit, &asserted, 8) {
+-		data = item->data + bit;
++		int pos;
++
++		pos = mlxreg_hotplug_item_label_index_get(item->mask, bit);
++		if (pos < 0)
++			goto out;
++
++		data = item->data + pos;
+ 		if (regval & BIT(bit)) {
+ 			if (item->inversed)
+ 				mlxreg_hotplug_device_destroy(priv, data, item->kind);
+-- 
+2.20.1
+


### PR DESCRIPTION
Currently hotplug configuration in logic device assumes that all items are provided with no holes.
Thus, any group of hotplug events, associated with the specific status/event/mask registers is configured in those registers successively from bit zero to bit #n (#n < 8).

This logic is changed int order to allow non-successive definition to support configuration with the skipped bits – for example bits 3, 5, 7 in status/event/mask registers can be associated with hotplug events, while others can be skipped.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>