### PR TITLE
hw-mgmt: psu: Fix reporting of Delta 550 FW version

### DIFF
--- a/usr/usr/bin/hw_management_psu_fw_update_common.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_common.py
@@ -167,7 +167,6 @@ def pmbus_read_mfr_id(i2c_bus, i2c_addr):
     ret = pmbus_read_block(i2c_bus, i2c_addr, 0x99)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())[1:]
-        print(ascii_str)
         return ascii_str
     return ''
 
@@ -178,7 +177,6 @@ def pmbus_read_mfr_model(i2c_bus, i2c_addr):
     ret = pmbus_read_block(i2c_bus, i2c_addr, 0x9a)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())[1:]
-        print(ascii_str)
         return ascii_str
     return ''
 
@@ -189,7 +187,6 @@ def pmbus_read_mfr_revision(i2c_bus, i2c_addr):
     ret = pmbus_read_block(i2c_bus, i2c_addr, 0x9b)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())[1:]
-        print(ascii_str)
         return ascii_str
     return ''
 

--- a/usr/usr/bin/hw_management_psu_fw_update_delta.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_delta.py
@@ -60,11 +60,17 @@ MFR_FWUPLOAD_REVISION = 0xd5
 MFR_MODEL_3000AB_10G = "DPS-3000AB-10 G"
 MFR_FWUPLOAD_STATUS_3000AB_10G = 0xd8
 
+MFR_MODEL_500AB = "DPS-550AB"
+
 def read_mfr_fw_revision(i2c_bus, i2c_addr):
     """
     @summary: Read MFR_FW_REVISION.
     """
-    ret = psu_upd_cmn.pmbus_read(i2c_bus, i2c_addr, MFR_FWUPLOAD_REVISION, 6)
+    mfr_model = psu_upd_cmn.pmbus_read_mfr_model(i2c_bus, i2c_addr)
+    if mfr_model.startswith(MFR_MODEL_500AB):
+        ret = psu_upd_cmn.pmbus_read(i2c_bus, i2c_addr, MFR_FWUPLOAD_REVISION, 8)
+    else:
+        ret = psu_upd_cmn.pmbus_read(i2c_bus, i2c_addr, MFR_FWUPLOAD_REVISION, 6)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())
         return ascii_str


### PR DESCRIPTION
Delta 550 FW version reporting format (XX.YY.ZZ) differs from other Delta PSUs (2000/3000), which report FW version as XX.YY. Add check to detect 550 model and report its FW version correctly.

Signed-off-by: Felix Radensky <fradensky@nvidia.com>