### PR TITLE
hw-mgmt: kernel patches: Add patches for dynamic I2C bus allocation

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -361,9 +361,7 @@ Kernel-5.10
 |0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch         |                                            | pending                                         |                                                              |
 |0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch         |                                            | pending                                         |                                                              |
 |0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch         |                                            | pending                                         |                                                              |
-|0196-platform-mellanox-Use-dynamic-I2C-channels-allocatio.patch         |                                            | pending                                         |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  
 © 2021 GitHub, Inc.
->>>>>>> 62ec361... hw-mgmt: kernel patches: Add patches for dynamic I2C bus allocation and extra I2C features

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -346,13 +346,24 @@ Kernel-5.10
 |0178-platform-mellanox-Introduce-support-for-next-generat.patch         |                                            |                                                 | SN5600                                                       |
 |0179-DS-iio-pressure-icp20100-add-driver-for-InvenSense-ICP-.patch      |                                            | downstream for OPT-OS use only                  | SN5600                                                       |
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch         | 525dd5aed67a2f4f7278116fb92a24e6a53e2622   | accepted                                        |                                                              |
-|0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch          |                                            | pending                                         |                                                              |
+|0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch          |                                            | downstream (disable upstream patch from 5.10.74)|                                                              |
 |0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch         |                                            | pending                                         |                                                              |
 |0183-platform-mellanox-Split-initialization-procedure.patch             |                                            | pending                                         |                                                              |
 |0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch          |                                            | pending                                         |                                                              |
 |0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch         |                                            | pending                                         |                                                              |
 |0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch         |                                            | pending                                         |                                                              |
+|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch         |                                            | pending                                         |                                                              |
+|0188-i2c-mux-Add-register-map-based-mux-driver.patch                    |                                            | pending                                         |                                                              |
+|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch         |                                            | pending                                         |                                                              |
+|0190-i2c-mlxcpld-Modify-base-address-type.patch                         |                                            | pending                                         |                                                              |
+|0191-i2c-mlxcpld-Allow-to-configure-base-address-of-regis.patch         |                                            | pending                                         |                                                              |
+|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch         |                                            | pending                                         |                                                              |
+|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch         |                                            | pending                                         |                                                              |
+|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch         |                                            | pending                                         |                                                              |
+|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch         |                                            | pending                                         |                                                              |
+|0196-platform-mellanox-Use-dynamic-I2C-channels-allocatio.patch         |                                            | pending                                         |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  
-© 2023 GitHub, Inc.
+© 2021 GitHub, Inc.
+>>>>>>> 62ec361... hw-mgmt: kernel patches: Add patches for dynamic I2C bus allocation and extra I2C features

--- a/recipes-kernel/linux/linux-5.10/0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch
+++ b/recipes-kernel/linux/linux-5.10/0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch
@@ -1,0 +1,37 @@
+From e1d1afba7f7285bebb2d30fce961901ee944d201 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 9 Nov 2022 09:43:28 +0200
+Subject: [PATCH backport 5.10 01/10] platform_data/mlxreg: Add field with
+ mapped resource address
+
+Add field with PCIe remapped based address for passing it across
+relevant platform drivers sharing common system resources.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ include/linux/platform_data/mlxreg.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index a6bd74e29..0b9f81a6f 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -216,6 +216,7 @@ struct mlxreg_core_platform_data {
+  * @mask_low: low aggregation interrupt common mask;
+  * @deferred_nr: I2C adapter number must be exist prior probing execution;
+  * @shift_nr: I2C adapter numbers must be incremented by this value;
++ * @addr: mapped resource address;
+  * @handle: handle to be passed by callback;
+  * @completion_notify: callback to notify when platform driver probing is done;
+  */
+@@ -230,6 +231,7 @@ struct mlxreg_core_hotplug_platform_data {
+ 	u32 mask_low;
+ 	int deferred_nr;
+ 	int shift_nr;
++	void __iomem *addr;
+ 	void *handle;
+ 	int (*completion_notify)(void *handle, int id);
+ };
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0188-i2c-mux-Add-register-map-based-mux-driver.patch
+++ b/recipes-kernel/linux/linux-5.10/0188-i2c-mux-Add-register-map-based-mux-driver.patch
@@ -1,0 +1,246 @@
+From 190667f3539f731332d4b5be9c4a3fc084b44282 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 9 Nov 2022 12:22:12 +0200
+Subject: [PATCH backport 5.10 02/10] i2c: mux: Add register map based mux
+ driver
+
+Add 'regmap' mux driver to allow virtual bus switching by setting a
+single selector register.
+The 'regmap' is supposed to be passed to driver within a platform data
+by parent platform driver.
+
+The register can be on type of bus or mapped memory, supported by
+'regmap' infrastructure.
+
+Motivation is to support indirect access to register space.
+For example, Lattice FPGA LFD2NX-40 device, being connected through
+PCIe bus provides SPI or LPC bus logic through PCIe-to-SPI or
+PCIe-to-LPC bridging. Thus, FPGA operates as host controller and some
+slave devices can be connected to it. For example:
+CPU (PCIe) -> FPGA (PCIe-to-SPI bridge) -> CPLD or another FPGA
+CPU (PCIe) -> FPGA (PCIe-to-LPC bridge) -> CPLD or another FPGA
+where 1-st FPGA connected to PCIe is located on carrier board, while
+2-nd programming logic device is located on some switch board and
+cannot be connected to CPU PCIe root complex.
+
+In case mux selector register is located within the 2-nd device, SPI or
+LPC transaction is prepared sent by indirect access, through some
+pre-defined protocol.
+To support such protocol reg_read()/reg_write() callbacks are provided
+to 'regmap' object and these callback implements required indirect
+access.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/muxes/Kconfig                    |  12 ++
+ drivers/i2c/muxes/Makefile                   |   1 +
+ drivers/i2c/muxes/i2c-mux-regmap.c           | 121 +++++++++++++++++++
+ include/linux/platform_data/i2c-mux-regmap.h |  34 ++++++
+ 4 files changed, 168 insertions(+)
+ create mode 100644 drivers/i2c/muxes/i2c-mux-regmap.c
+ create mode 100644 include/linux/platform_data/i2c-mux-regmap.h
+
+diff --git a/drivers/i2c/muxes/Kconfig b/drivers/i2c/muxes/Kconfig
+index 1708b1a82..48becd945 100644
+--- a/drivers/i2c/muxes/Kconfig
++++ b/drivers/i2c/muxes/Kconfig
+@@ -99,6 +99,18 @@ config I2C_MUX_REG
+ 	  This driver can also be built as a module.  If so, the module
+ 	  will be called i2c-mux-reg.
+ 
++config I2C_MUX_REGMAP
++	tristate "Register map based I2C multiplexer"
++	depends on REGMAP
++	help
++	  If you say yes to this option, support will be included for a
++	  register map based I2C multiplexer. This driver provides access to
++	  I2C busses connected through a MUX, which is controlled
++	  by a single register through the regmap.
++
++	  This driver can also be built as a module. If so, the module
++	  will be called i2c-mux-regmap.
++
+ config I2C_DEMUX_PINCTRL
+ 	tristate "pinctrl-based I2C demultiplexer"
+ 	depends on PINCTRL && OF
+diff --git a/drivers/i2c/muxes/Makefile b/drivers/i2c/muxes/Makefile
+index 6d9d865e8..092dca428 100644
+--- a/drivers/i2c/muxes/Makefile
++++ b/drivers/i2c/muxes/Makefile
+@@ -14,5 +14,6 @@ obj-$(CONFIG_I2C_MUX_PCA9541)	+= i2c-mux-pca9541.o
+ obj-$(CONFIG_I2C_MUX_PCA954x)	+= i2c-mux-pca954x.o
+ obj-$(CONFIG_I2C_MUX_PINCTRL)	+= i2c-mux-pinctrl.o
+ obj-$(CONFIG_I2C_MUX_REG)	+= i2c-mux-reg.o
++obj-$(CONFIG_I2C_MUX_REGMAP)	+= i2c-mux-regmap.o
+ 
+ ccflags-$(CONFIG_I2C_DEBUG_BUS) := -DDEBUG
+diff --git a/drivers/i2c/muxes/i2c-mux-regmap.c b/drivers/i2c/muxes/i2c-mux-regmap.c
+new file mode 100644
+index 000000000..1ab5f94af
+--- /dev/null
++++ b/drivers/i2c/muxes/i2c-mux-regmap.c
+@@ -0,0 +1,121 @@
++// SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0
++/*
++ * Regmap i2c mux driver
++ *
++ * Copyright (C) 2023 Nvidia Technologies Ltd.
++ */
++
++#include <linux/device.h>
++#include <linux/i2c.h>
++#include <linux/i2c-mux.h>
++#include <linux/io.h>
++#include <linux/init.h>
++#include <linux/module.h>
++#include <linux/platform_data/i2c-mux-regmap.h>
++#include <linux/platform_device.h>
++#include <linux/regmap.h>
++#include <linux/slab.h>
++
++/* i2c_mux_regmap - mux control structure:
++ * @last_val - last selected register value or -1 if mux deselected;
++ * @pdata: platform data;
++ */
++struct i2c_mux_regmap {
++	int last_val;
++	struct i2c_mux_regmap_platform_data pdata;
++};
++
++static int i2c_mux_regmap_select_chan(struct i2c_mux_core *muxc, u32 chan)
++{
++	struct i2c_mux_regmap *mux = i2c_mux_priv(muxc);
++	int err = 0;
++
++	/* Only select the channel if its different from the last channel */
++	if (mux->last_val != chan) {
++		err = regmap_write(mux->pdata.regmap, mux->pdata.sel_reg_addr, chan);
++		mux->last_val = err < 0 ? -1 : chan;
++	}
++
++	return err;
++}
++
++static int i2c_mux_regmap_deselect(struct i2c_mux_core *muxc, u32 chan)
++{
++	struct i2c_mux_regmap *mux = i2c_mux_priv(muxc);
++
++	/* Deselect active channel */
++	mux->last_val = -1;
++
++	return regmap_write(mux->pdata.regmap, mux->pdata.sel_reg_addr, 0);
++}
++
++/* Probe/reomove functions */
++static int i2c_mux_regmap_probe(struct platform_device *pdev)
++{
++	struct i2c_mux_regmap_platform_data *pdata = dev_get_platdata(&pdev->dev);
++	struct i2c_mux_regmap *mux;
++	struct i2c_adapter *parent;
++	struct i2c_mux_core *muxc;
++	int num, err;
++
++	if (!pdata)
++		return -EINVAL;
++
++	mux = devm_kzalloc(&pdev->dev, sizeof(*mux), GFP_KERNEL);
++	if (!mux)
++		return -ENOMEM;
++
++	memcpy(&mux->pdata, pdata, sizeof(*pdata));
++	parent = i2c_get_adapter(mux->pdata.parent);
++	if (!parent)
++		return -EPROBE_DEFER;
++
++	muxc = i2c_mux_alloc(parent, &pdev->dev, pdata->num_adaps, sizeof(*mux), 0,
++			     i2c_mux_regmap_select_chan, i2c_mux_regmap_deselect);
++	if (!muxc)
++		return -ENOMEM;
++
++	platform_set_drvdata(pdev, muxc);
++	muxc->priv = mux;
++	mux->last_val = -1; /* force the first selection */
++
++	/* Create an adapter for each channel. */
++	for (num = 0; num < pdata->num_adaps; num++) {
++		err = i2c_mux_add_adapter(muxc, 0, pdata->chan_ids[num], 0);
++		if (err)
++			goto err_i2c_mux_add_adapter;
++	}
++
++	/* Notify caller when all channels' adapters are created. */
++	if (pdata->completion_notify)
++		pdata->completion_notify(pdata->handle, muxc->parent, muxc->adapter);
++
++	return 0;
++
++err_i2c_mux_add_adapter:
++	i2c_mux_del_adapters(muxc);
++	return err;
++}
++
++static int i2c_mux_regmap_remove(struct platform_device *pdev)
++{
++	struct i2c_mux_core *muxc = platform_get_drvdata(pdev);
++
++	i2c_mux_del_adapters(muxc);
++	return 0;
++}
++
++static struct platform_driver i2c_mux_regmap_driver = {
++	.driver = {
++		.name = "i2c-mux-regmap",
++	},
++	.probe = i2c_mux_regmap_probe,
++	.remove = i2c_mux_regmap_remove,
++};
++
++module_platform_driver(i2c_mux_regmap_driver);
++
++MODULE_AUTHOR("Vadim Pasternak (vadimp@nvidia.com)");
++MODULE_DESCRIPTION("Regmap I2C multiplexer driver");
++MODULE_LICENSE("Dual BSD/GPL");
++MODULE_ALIAS("platform:i2c-mux-regmap");
+diff --git a/include/linux/platform_data/i2c-mux-regmap.h b/include/linux/platform_data/i2c-mux-regmap.h
+new file mode 100644
+index 000000000..a06614e5e
+--- /dev/null
++++ b/include/linux/platform_data/i2c-mux-regmap.h
+@@ -0,0 +1,34 @@
++/* SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0 */
++/*
++ * Regmap i2c mux driver
++ *
++ * Copyright (C) 2023 Nvidia Technologies Ltd.
++ */
++
++#ifndef __LINUX_PLATFORM_DATA_I2C_MUX_REGMAP_H
++#define __LINUX_PLATFORM_DATA_I2C_MUX_REGMAP_H
++
++/**
++ * struct i2c_mux_regmap_platform_data - Platform-dependent data for i2c-mux-regmap
++ * @regmap: register map of parent device;
++ * @parent: Parent I2C bus adapter number
++ * @chan_ids - channels array
++ * @num_adaps - number of adapters
++ * @sel_reg_addr - mux select register offset in CPLD space
++ * @reg_size: register size in bytes
++ * @handle: handle to be passed by callback
++ * @completion_notify: callback to notify when all the adapters are created
++ */
++struct i2c_mux_regmap_platform_data {
++	void *regmap;
++	int parent;
++	const unsigned int *chan_ids;
++	int num_adaps;
++	int sel_reg_addr;
++	u8 reg_size;
++	void *handle;
++	int (*completion_notify)(void *handle, struct i2c_adapter *parent,
++				 struct i2c_adapter *adapters[]);
++};
++
++#endif	/* __LINUX_PLATFORM_DATA_I2C_MUX_REGMAP_H */
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch
+++ b/recipes-kernel/linux/linux-5.10/0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch
@@ -1,0 +1,29 @@
+From c4d1a7d7f51a8315f727c9210961ed93b922d440 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 7 Nov 2022 12:00:37 +0200
+Subject: [PATCH backport 5.10 03/10] i2c: mlxcpld: Allow driver to run on
+ ARM64 architecture
+
+Extend driver dependency by ARM64 architecture.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/Kconfig | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/i2c/busses/Kconfig b/drivers/i2c/busses/Kconfig
+index 7e693dcbd..c984305ee 100644
+--- a/drivers/i2c/busses/Kconfig
++++ b/drivers/i2c/busses/Kconfig
+@@ -1328,7 +1328,7 @@ config I2C_ICY
+ 
+ config I2C_MLXCPLD
+ 	tristate "Mellanox I2C driver"
+-	depends on X86_64 || COMPILE_TEST
++	depends on X86_64 || ARM64 || COMPILE_TEST
+ 	help
+ 	  This exposes the Mellanox platform I2C busses to the linux I2C layer
+ 	  for X86 based systems.
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0190-i2c-mlxcpld-Modify-base-address-type.patch
+++ b/recipes-kernel/linux/linux-5.10/0190-i2c-mlxcpld-Modify-base-address-type.patch
@@ -1,0 +1,49 @@
+From d2130ff4d3aed72611f07213e9eceeb084f0fc65 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 9 Nov 2022 10:29:22 +0200
+Subject: [PATCH backport 5.10 04/10] i2c: mlxcpld: Modify base address type
+
+Change type of base address from 'u32' to 'u64'.
+
+Motivation is to support memory mapped virtual base address on ARM64
+architecture.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 72fcfb17d..57aea396c 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -68,7 +68,7 @@ struct  mlxcpld_i2c_curr_xfer {
+ 
+ struct mlxcpld_i2c_priv {
+ 	struct i2c_adapter adap;
+-	u32 base_addr;
++	u64 base_addr;
+ 	struct mutex lock;
+ 	struct  mlxcpld_i2c_curr_xfer xfer;
+ 	struct device *dev;
+@@ -99,7 +99,7 @@ static void mlxcpld_i2c_lpc_read_buf(u8 *data, u8 len, u32 addr)
+ static void mlxcpld_i2c_read_comm(struct mlxcpld_i2c_priv *priv, u8 offs,
+ 				  u8 *data, u8 datalen)
+ {
+-	u32 addr = priv->base_addr + offs;
++	u64 addr = priv->base_addr + offs;
+ 
+ 	switch (datalen) {
+ 	case 1:
+@@ -124,7 +124,7 @@ static void mlxcpld_i2c_read_comm(struct mlxcpld_i2c_priv *priv, u8 offs,
+ static void mlxcpld_i2c_write_comm(struct mlxcpld_i2c_priv *priv, u8 offs,
+ 				   u8 *data, u8 datalen)
+ {
+-	u32 addr = priv->base_addr + offs;
++	u64 addr = priv->base_addr + offs;
+ 
+ 	switch (datalen) {
+ 	case 1:
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0191-i2c-mlxcpld-Allow-to-configure-base-address-of-regis.patch
+++ b/recipes-kernel/linux/linux-5.10/0191-i2c-mlxcpld-Allow-to-configure-base-address-of-regis.patch
@@ -1,0 +1,34 @@
+From 0fcfc9b2eb7f071f3aa64845d262f1e8e4f741e7 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 9 Nov 2022 10:35:58 +0200
+Subject: [PATCH backport 5.10 05/10] i2c: mlxcpld: Allow to configure base
+ address of register space
+
+Allow to use configured base address.
+
+Currently driver uses constant base address of register space.
+On new systems this base address could be different, thus it could be
+passed to the driver through platform data.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 57aea396c..cd5401ce4 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -538,6 +538,9 @@ static int mlxcpld_i2c_probe(struct platform_device *pdev)
+ 		err = mlxcpld_i2c_set_frequency(priv, pdata);
+ 		if (err)
+ 			goto mlxcpld_i2_probe_failed;
++
++		if (pdata->addr)
++			priv->base_addr = (*(u64 __force *)pdata->addr);
+ 	}
+ 
+ 	/* Register with i2c layer */
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch
+++ b/recipes-kernel/linux/linux-5.10/0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch
@@ -1,0 +1,57 @@
+From 22447625fff0e742b3dc9c2f78bbaac29b1f1031 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Sun, 27 Nov 2022 10:43:23 +0200
+Subject: [PATCH backport 5.10 06/10] i2c: mlxcpld: Add support for extended
+ transaction length for i2c-mlxcpld
+
+Add support for extended length of read and write transactions.
+New FPGA logic allows to increase size of the read and write
+transactions length. This feature is verified through capability
+register 'CPBLTY_REG'. Two bits 5 and 6 of the register are used for
+length capability detection. Value '10' indicates support of extended
+transaction length - 128 bytes for read transactions and 132 for write
+transactions.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index cd5401ce4..0e1807be7 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -22,6 +22,7 @@
+ #define MLXCPLD_I2C_BUS_NUM		1
+ #define MLXCPLD_I2C_DATA_REG_SZ		36
+ #define MLXCPLD_I2C_DATA_SZ_BIT		BIT(5)
++#define MLXCPLD_I2C_DATA_EXT2_SZ_BIT	BIT(6)
+ #define MLXCPLD_I2C_DATA_SZ_MASK	GENMASK(6, 5)
+ #define MLXCPLD_I2C_SMBUS_BLK_BIT	BIT(7)
+ #define MLXCPLD_I2C_MAX_ADDR_LEN	4
+@@ -466,6 +467,13 @@ static const struct i2c_adapter_quirks mlxcpld_i2c_quirks_ext = {
+ 	.max_comb_1st_msg_len = 4,
+ };
+ 
++static const struct i2c_adapter_quirks mlxcpld_i2c_quirks_ext2 = {
++	.flags = I2C_AQ_COMB_WRITE_THEN_READ,
++	.max_read_len = (MLXCPLD_I2C_DATA_REG_SZ - 4) * 4,
++	.max_write_len = (MLXCPLD_I2C_DATA_REG_SZ - 4) * 4 + MLXCPLD_I2C_MAX_ADDR_LEN,
++	.max_comb_1st_msg_len = 4,
++};
++
+ static struct i2c_adapter mlxcpld_i2c_adapter = {
+ 	.owner          = THIS_MODULE,
+ 	.name           = "i2c-mlxcpld",
+@@ -550,6 +558,8 @@ static int mlxcpld_i2c_probe(struct platform_device *pdev)
+ 	/* Check support for extended transaction length */
+ 	if ((val & MLXCPLD_I2C_DATA_SZ_MASK) == MLXCPLD_I2C_DATA_SZ_BIT)
+ 		mlxcpld_i2c_adapter.quirks = &mlxcpld_i2c_quirks_ext;
++	else if ((val & MLXCPLD_I2C_DATA_SZ_MASK) == MLXCPLD_I2C_DATA_EXT2_SZ_BIT)
++		mlxcpld_i2c_adapter.quirks = &mlxcpld_i2c_quirks_ext2;
+ 	/* Check support for smbus block transaction */
+ 	if (val & MLXCPLD_I2C_SMBUS_BLK_BIT)
+ 		priv->smbus_block = true;
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch
+++ b/recipes-kernel/linux/linux-5.10/0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch
@@ -1,0 +1,99 @@
+From e1d377039ba9a364f4e7f9816f5f0b7a3b165b43 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 18 Jan 2023 15:08:46 +0200
+Subject: [PATCH backport 5.10 07/10] platform: mellanox: mlx-platform: Add mux
+ selection register to regmap
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Extend writeable, readable, volatile registers of the 'regmap' object
+with for I2C mux selector registers.
+
+The motivation is to pass this object extended with selector registers
+to I2C mux driver working over ‘regmap’.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 28 ++++++++++++++++++++--------
+ 1 file changed, 20 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index e8c656d6e..03c744f37 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -140,6 +140,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET	0xd2
+ #define MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET	0xd3
+ #define MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET	0xd9
++#define MLXPLAT_CPLD_LPC_REG_I2C_CH1_OFFSET	0xdb
++#define MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET	0xda
++#define MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET	0xdc
++#define MLXPLAT_CPLD_LPC_REG_I2C_CH4_OFFSET	0xdd
+ #define MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET	0xde
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET	0xdf
+ #define MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET	0xe0
+@@ -173,23 +177,19 @@
+ #define MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET	0xfc
+ #define MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET	0xfd
+ #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
+-#define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
+-#define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
+-#define MLXPLAT_CPLD_LPC_I2C_CH3_OFF		0xdc
+-#define MLXPLAT_CPLD_LPC_I2C_CH4_OFF		0xdd
+ 
+ #define MLXPLAT_CPLD_LPC_PIO_OFFSET		0x10000UL
+ #define MLXPLAT_CPLD_LPC_REG1	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
+-				  MLXPLAT_CPLD_LPC_I2C_CH1_OFF) | \
++				  MLXPLAT_CPLD_LPC_REG_I2C_CH1_OFFSET) | \
+ 				  MLXPLAT_CPLD_LPC_PIO_OFFSET)
+ #define MLXPLAT_CPLD_LPC_REG2	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
+-				  MLXPLAT_CPLD_LPC_I2C_CH2_OFF) | \
++				  MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET) | \
+ 				  MLXPLAT_CPLD_LPC_PIO_OFFSET)
+ #define MLXPLAT_CPLD_LPC_REG3	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
+-				  MLXPLAT_CPLD_LPC_I2C_CH3_OFF) | \
++				  MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET) | \
+ 				  MLXPLAT_CPLD_LPC_PIO_OFFSET)
+ #define MLXPLAT_CPLD_LPC_REG4	((MLXPLAT_CPLD_LPC_REG_BASE_ADRR + \
+-				  MLXPLAT_CPLD_LPC_I2C_CH4_OFF) | \
++				  MLXPLAT_CPLD_LPC_REG_I2C_CH4_OFFSET) | \
+ 				  MLXPLAT_CPLD_LPC_PIO_OFFSET)
+ 
+ /* Masks for aggregation, psu, pwr and fan event in CPLD related registers. */
+@@ -5307,6 +5307,10 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
+@@ -5434,6 +5438,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+@@ -5581,6 +5589,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TMR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_WD3_TLEFT_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG_CTRL_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_I2C_CH4_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_MVER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch
+++ b/recipes-kernel/linux/linux-5.10/0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch
@@ -1,0 +1,35 @@
+From 0047b78e44e2a2b411762bc1eb9717962d96550e Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 18 Jan 2023 15:25:37 +0200
+Subject: [PATCH backport 5.10 08/10] platform: mellanox: mlx-platform: Move
+ bus shift assignment out of the loop
+
+Move assignment of bus shift setting out of the loop to avoid redundant
+operation.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 03c744f37..5d96d5ffa 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -6371,10 +6371,11 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+ 		shift = *nr - mlxplat_mux_data[i].parent;
+ 		mlxplat_mux_data[i].parent = *nr;
+ 		mlxplat_mux_data[i].base_nr += shift;
+-		if (shift > 0)
+-			mlxplat_hotplug->shift_nr = shift;
+ 	}
+ 
++	if (shift > 0)
++		mlxplat_hotplug->shift_nr = shift;
++
+ 	return 0;
+ }
+ 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch
+++ b/recipes-kernel/linux/linux-5.10/0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch
@@ -1,8 +1,8 @@
-From b5c31fc1e613f103e6634ee901468b5e4b6fb265 Mon Sep 17 00:00:00 2001
+From c864dc50c33e981d324ead905523c6f233805519 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 18 Jan 2023 19:12:12 +0200
-Subject: [PATCH backport 5.10 09/10] platform/mellanox: Add support for
- dynamic I2C channels infrastructure
+Subject: [PATCH backport 5.10 1/2] platform/mellanox: Add support for dynamic
+ I2C channels infrastructure
 
 Allow to support platform configuration for dynamically allocated I2C
 channels.
@@ -18,11 +18,11 @@ adapters data.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/x86/mlx-platform.c | 67 +++++++++++++++++++++++++----
- 1 file changed, 58 insertions(+), 9 deletions(-)
+ drivers/platform/x86/mlx-platform.c | 69 ++++++++++++++++++++++++-----
+ 1 file changed, 59 insertions(+), 10 deletions(-)
 
 diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
-index 5d96d5ffa..f4942e554 100644
+index 5d96d5ffa..d0b03dbec 100644
 --- a/drivers/platform/x86/mlx-platform.c
 +++ b/drivers/platform/x86/mlx-platform.c
 @@ -14,6 +14,7 @@
@@ -104,17 +104,17 @@ index 5d96d5ffa..f4942e554 100644
 +			}
 +		}
 +	}
-+
+ 
+-	return mlxplat_post_init(priv);
 +	/* Start post initialization only after last nux segment is added */
 +	if (++priv->mux_added == mlxplat_mux_num)
 +		return mlxplat_post_init(priv);
- 
--	return mlxplat_post_init(priv);
++
 +	return 0;
  }
  
  static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
-@@ -6579,16 +6612,32 @@ static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
+@@ -6579,17 +6612,33 @@ static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
  	}
  
  	for (i = 0; i < mlxplat_mux_num; i++) {
@@ -145,12 +145,14 @@ index 5d96d5ffa..f4942e554 100644
  		}
  	}
  
+-	return mlxplat_i2c_mux_complition_notify(priv, NULL, NULL);
 +	if (mlxplat_mux_regmap_data && mlxplat_mux_regmap_data->completion_notify)
 +		return 0;
 +
- 	return mlxplat_i2c_mux_complition_notify(priv, NULL, NULL);
++	return mlxplat_post_init(priv);
  
  fail_platform_mux_register:
+ 	while (--i >= 0)
 -- 
 2.20.1
 

--- a/recipes-kernel/linux/linux-5.10/0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch
+++ b/recipes-kernel/linux/linux-5.10/0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch
@@ -1,0 +1,156 @@
+From b5c31fc1e613f103e6634ee901468b5e4b6fb265 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 18 Jan 2023 19:12:12 +0200
+Subject: [PATCH backport 5.10 09/10] platform/mellanox: Add support for
+ dynamic I2C channels infrastructure
+
+Allow to support platform configuration for dynamically allocated I2C
+channels.
+Motivation is to support I2C channels allocated in a non-continuous
+way.
+
+Currently hotplug platform driver data structure contains static mux
+channels for I2C hotplug devices. These channels numbers can be updated
+dynamically and returned by mux driver's callback through the adapters
+array.
+Thus, hotplug mux channels will be aligned according to the dynamic
+adapters data.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 67 +++++++++++++++++++++++++----
+ 1 file changed, 58 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 5d96d5ffa..f4942e554 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -14,6 +14,7 @@
+ #include <linux/module.h>
+ #include <linux/platform_device.h>
+ #include <linux/platform_data/i2c-mux-reg.h>
++#include <linux/platform_data/i2c-mux-regmap.h>
+ #include <linux/platform_data/mlxreg.h>
+ #include <linux/reboot.h>
+ #include <linux/regmap.h>
+@@ -336,6 +337,7 @@
+  * @hotplug_resources: system hotplug resources
+  * @hotplug_resources_size: size of system hotplug resources
+  * @hi2c_main_init_status: init status of I2C main bus
++ * @mux_added: number of added mux segments
+  */
+ struct mlxplat_priv {
+ 	struct platform_device *pdev_i2c;
+@@ -349,6 +351,7 @@ struct mlxplat_priv {
+ 	struct resource *hotplug_resources;
+ 	unsigned int hotplug_resources_size;
+ 	u8 i2c_main_init_status;
++	int mux_added;
+ };
+ 
+ static struct platform_device *mlxplat_dev;
+@@ -436,7 +439,9 @@ static struct i2c_mux_reg_platform_data mlxplat_default_mux_data[] = {
+ /* Platform mux configuration variables */
+ static int mlxplat_max_adap_num;
+ static int mlxplat_mux_num;
++static int mlxplat_mux_hotplug_num;
+ static struct i2c_mux_reg_platform_data *mlxplat_mux_data;
++static struct i2c_mux_regmap_platform_data *mlxplat_mux_regmap_data;
+ 
+ /* Platform extended mux data */
+ static struct i2c_mux_reg_platform_data mlxplat_extended_mux_data[] = {
+@@ -6368,12 +6373,17 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+ 	/* Shift adapter ids, since expected parent adapter is not free. */
+ 	*nr = i;
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+-		shift = *nr - mlxplat_mux_data[i].parent;
+-		mlxplat_mux_data[i].parent = *nr;
+-		mlxplat_mux_data[i].base_nr += shift;
++		if (mlxplat_mux_data) {
++			shift = *nr - mlxplat_mux_data[i].parent;
++			mlxplat_mux_data[i].parent = *nr;
++			mlxplat_mux_data[i].base_nr += shift;
++		} else if (mlxplat_mux_regmap_data) {
++			mlxplat_mux_regmap_data[i].parent = *nr;
++		}
+ 	}
+ 
+-	if (shift > 0)
++	/* Shift bus only if mux provided by 'mlxplat_mux_data'. */
++	if (shift > 0 && mlxplat_mux_data)
+ 		mlxplat_hotplug->shift_nr = shift;
+ 
+ 	return 0;
+@@ -6563,8 +6573,31 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ 				  struct i2c_adapter *adapters[])
+ {
+ 	struct mlxplat_priv *priv = handle;
++	struct mlxreg_core_item *item;
++	int i, j;
++
++	/*
++	 * Hotplug platform driver data structure contains static mux channels for I2C hotplug
++	 * devices. These channels numbers can be updated dynamically and returned by mux callback
++	 * through the adapters array. Update mux channels according to the dynamic adapters data.
++	 */
++	if (priv->mux_added == mlxplat_mux_hotplug_num) {
++		item = mlxplat_hotplug->items;
++		for (i = 0; i < mlxplat_hotplug->counter; i++, item++) {
++			struct mlxreg_core_data *data = item->data;
++
++			for (j = 0; j < item->count; j++, data++) {
++				if (data->hpdev.nr != MLXPLAT_CPLD_NR_NONE)
++					data->hpdev.nr = adapters[data->hpdev.nr - 2]->nr;
++			}
++		}
++	}
++
++	/* Start post initialization only after last nux segment is added */
++	if (++priv->mux_added == mlxplat_mux_num)
++		return mlxplat_post_init(priv);
+ 
+-	return mlxplat_post_init(priv);
++	return 0;
+ }
+ 
+ static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
+@@ -6579,16 +6612,32 @@ static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
+ 	}
+ 
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+-		priv->pdev_mux[i] = platform_device_register_resndata(&priv->pdev_i2c->dev,
+-								      "i2c-mux-reg", i, NULL, 0,
+-								      &mlxplat_mux_data[i],
+-								      sizeof(mlxplat_mux_data[i]));
++		if (mlxplat_mux_data) {
++			priv->pdev_mux[i] =
++				platform_device_register_resndata(&priv->pdev_i2c->dev,
++								  "i2c-mux-reg", i, NULL, 0,
++								  &mlxplat_mux_data[i],
++								  sizeof(mlxplat_mux_data[i]));
++		} else {
++			mlxplat_mux_regmap_data[i].handle = priv;
++			mlxplat_mux_regmap_data[i].regmap = priv->regmap;
++			mlxplat_mux_regmap_data[i].completion_notify =
++								mlxplat_i2c_mux_complition_notify;
++			priv->pdev_mux[i] =
++			platform_device_register_resndata(&priv->pdev_i2c->dev,
++							  "i2c-mux-regmap", i, NULL, 0,
++							   &mlxplat_mux_regmap_data[i],
++							   sizeof(mlxplat_mux_regmap_data[i]));
++		}
+ 		if (IS_ERR(priv->pdev_mux[i])) {
+ 			err = PTR_ERR(priv->pdev_mux[i]);
+ 			goto fail_platform_mux_register;
+ 		}
+ 	}
+ 
++	if (mlxplat_mux_regmap_data && mlxplat_mux_regmap_data->completion_notify)
++		return 0;
++
+ 	return mlxplat_i2c_mux_complition_notify(priv, NULL, NULL);
+ 
+ fail_platform_mux_register:
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0196-platform-mellanox-Use-dynamic-I2C-channels-allocatio.patch
+++ b/recipes-kernel/linux/linux-5.10/0196-platform-mellanox-Use-dynamic-I2C-channels-allocatio.patch
@@ -1,0 +1,76 @@
+From 1d75988b1656f80f2140f130ac2a80ddfeef7229 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 18 Jan 2023 19:44:41 +0200
+Subject: [PATCH backport 5.10 10/10] platform/mellanox: Use dynamic I2C
+ channels allocation for specific system
+
+Use 'i2c-mux-regmap' driver instead of 'i2c-mux-reg' driver for creation
+I2C mux infrastructure for system types on which I2C channels could be
+allocated in a non-continuous way.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/x86/mlx-platform.c | 25 +++++++++----------------
+ 1 file changed, 9 insertions(+), 16 deletions(-)
+
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index f4942e554..68e0269cf 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -530,28 +530,21 @@ static const int mlxplat_rack_switch_channels[] = {
+ };
+ 
+ /* Platform rack switch mux data */
+-static struct i2c_mux_reg_platform_data mlxplat_rack_switch_mux_data[] = {
++static struct i2c_mux_regmap_platform_data mlxplat_rack_switch_mux_data[] = {
+ 	{
+ 		.parent = 1,
+-		.base_nr = MLXPLAT_CPLD_CH1,
+-		.write_only = 1,
+-		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.chan_ids = mlxplat_rack_switch_channels,
++		.num_adaps = ARRAY_SIZE(mlxplat_rack_switch_channels),
++		.sel_reg_addr = MLXPLAT_CPLD_LPC_REG_I2C_CH1_OFFSET,
+ 		.reg_size = 1,
+-		.idle_in_use = 1,
+-		.values = mlxplat_rack_switch_channels,
+-		.n_values = ARRAY_SIZE(mlxplat_rack_switch_channels),
+ 	},
+ 	{
+ 		.parent = 1,
+-		.base_nr = MLXPLAT_CPLD_CH2_RACK_SWITCH,
+-		.write_only = 1,
+-		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.chan_ids = mlxplat_msn21xx_channels,
++		.num_adaps = ARRAY_SIZE(mlxplat_msn21xx_channels),
++		.sel_reg_addr = MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET,
+ 		.reg_size = 1,
+-		.idle_in_use = 1,
+-		.values = mlxplat_msn21xx_channels,
+-		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
+ 	},
+-
+ };
+ 
+ /* Platform channels for ng800 system family */
+@@ -6102,7 +6095,7 @@ static int __init mlxplat_dmi_rack_switch_matched(const struct dmi_system_id *dm
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
+ 	mlxplat_mux_num = ARRAY_SIZE(mlxplat_rack_switch_mux_data);
+-	mlxplat_mux_data = mlxplat_rack_switch_mux_data;
++	mlxplat_mux_regmap_data = mlxplat_rack_switch_mux_data;
+ 	mlxplat_hotplug = &mlxplat_mlxcpld_rack_switch_data;
+ 	mlxplat_hotplug->deferred_nr =
+ 		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+@@ -6145,7 +6138,7 @@ static int __init mlxplat_dmi_l1_switch_matched(const struct dmi_system_id *dmi)
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
+ 	mlxplat_mux_num = ARRAY_SIZE(mlxplat_rack_switch_mux_data);
+-	mlxplat_mux_data = mlxplat_rack_switch_mux_data;
++	mlxplat_mux_regmap_data = mlxplat_rack_switch_mux_data;
+ 	mlxplat_hotplug = &mlxplat_mlxcpld_l1_switch_data;
+ 	mlxplat_hotplug->deferred_nr =
+ 		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+-- 
+2.20.1
+


### PR DESCRIPTION
…nd extra I2C features

Add patches #0187 - #0196.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>