### PR TITLE
hw-mgmt: topology: Fix NVL4 volrmon senor names

### DIFF
--- a/usr/etc/hw-management-sensors/p4697_sensors.conf
+++ b/usr/etc/hw-management-sensors/p4697_sensors.conf
@@ -30,15 +30,15 @@ bus "i2c-15" "i2c-1-mux (chan_id 6)"
 bus "i2c-26" "NVIDIA NVSwitch i2c adapter 0 at 1:00.0"
     chip "mp2975-i2c-26-62"
         label in1      "PMIC-1 PSU 12V Rail (in1)"
-        label in2      "PMIC-1 VDD 0.825 LS1 Rail (out1)"
+        label in2      "PMIC-1 VDD 0.925 LR_A Rail (out1)"
         ignore in3
-        label temp1    "PMIC-1 VDD 0.825V Temp 1"
+        label temp1    "PMIC-1 VDD 0.925V LR_A Temp 1"
         ignore temp2
-        label power1   "PMIC-1 12V VDD 0.825V LS1 Pwr (in)"
-        label power2   "PMIC-1 VDD 0.825V LS1 Pwr (out1)"
+        label power1   "PMIC-1 12V VDD 0.925V LR_A Pwr (in)"
+        label power2   "PMIC-1 VDD 0.925V LR_A Pwr (out1)"
         ignore power3
-        label curr1    "PMIC-1 12V VDD 0.825V LS1 Curr (in1)"
-        label curr2    "PMIC-1 VDD 0.825V LS1 Curr (out1)"
+        label curr1    "PMIC-1 12V VDD 0.925V LR_A Curr (in1)"
+        label curr2    "PMIC-1 VDD 0.925V LR_A Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
@@ -48,52 +48,54 @@ bus "i2c-26" "NVIDIA NVSwitch i2c adapter 0 at 1:00.0"
         
     chip "mp2975-i2c-26-65"
         label in1      "PMIC-3 PSU 12V Rail (in)"
-        label in2      "PMIC-3 DVDD 0.925V LS1 Rail (out1)"
-        label in3      "PMIC-3 HVDD 1.35V LS1 Rail (out2)"
-        label temp1    "PMIC-3 HVDD 1.2V LS1 Rail Temp"
-        label power1   "PMIC-3 12V HVDD_1.2V DVDD_0.9V LS1 Pwr(in)"
-        label power2   "PMIC-3 HVDD 0.925V LS1 Rail Pwr (out1)"
-        label power3   "PMIC-3 DVDD 1.35V LS1 Rail Pwr (out2)"
-        label curr1    "PMIC-3 12V HVDD 1.2V LS1 Rail Curr (in)"
-        label curr2    "PMIC-3 HVDD 0.925V LS1 Rail Curr (out1)"
+        label in2      "PMIC-3 DVDD 0.925V LR_A Rail (out1)"
+        label in3      "PMIC-3 HVDD 1.35V LR_A Rail (out2)"
+        label temp1    "PMIC-3 HVDD 0.925V LR_A Rail Temp"
+        label power1   "PMIC-3 12V HVDD_1.35V DVDD_0.925V LR_A Pwr(in)"
+        label power2   "PMIC-3 HVDD 0.925V LR_A Rail Pwr (out1)"
+        label power3   "PMIC-3 DVDD 1.35V LR_A Rail Pwr (out2)"
+        label curr1    "PMIC-3 PSU 12V Rail Curr (in)"
+        label curr2    "PMIC-3 HVDD 0.925V LR_A Rail Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
         ignore curr6
-        label curr7    "PMIC-3 DVDD 1.35V LS1 Rail Curr (out2)"
+        label curr7    "PMIC-3 DVDD 1.35V LR_B Rail Curr (out2)"
         ignore curr8
         ignore curr9
         ignore curr10
 
     chip "mp2975-i2c-26-67"
         label in1      "PMIC-5 PSU 12V Rail (in)"
-        label in2      "PMIC-5 OSFP WEST_PORTS_P25_P32 Rail (out1)"
-        label in3      "PMIC-5 OSFP WEST_PORTS_P09_P16 Rail (out2)"
-        label temp1    "PMIC-5 OSFP WEST_PORTS_P01_P16 Rail Temp"
-        label power1   "PMIC-5 12V OSFP WEST_PORTS_P01_P16 (in)"
-        label power2   "PMIC-5 OSFP WEST_PORTS_P01_P08 Rail Pwr (out1)"
-        label power3   "PMIC-5 OSFP WEST_PORTS_P09_P16 Rail Pwr (out2)"
-        label curr1    "PMIC-5 12V OSFP WEST_PORTS_P01_P16 Rail Curr (in)"
-        label curr2    "PMIC-5 OSFP WEST_PORTS_P01_P08 Rail Curr (out1)"
+        label in2      "PMIC-5 OSFP WEST_L Rail (out1)"
+        compute in2 (3)*@, @/(3)
+        label in3      "PMIC-5 OSFP WEST_H Rail (out2)"
+        compute in3 (3)*@, @/(3)
+        label temp1    "PMIC-5 OSFP WEST_PORTS Rail Temp"
+        label power1   "PMIC-5 12V OSFP WEST_PORTS Rail Pwr (in)"
+        label power2   "PMIC-5 OSFP WEST_PORTS_L Rail Pwr (out1)"
+        label power3   "PMIC-5 OSFP WEST_PORTS_H Rail Pwr (out2)"
+        label curr1    "PMIC-5 12V OSFP WEST_PORTS Rail Curr (in)"
+        label curr2    "PMIC-5 OSFP WEST_PORTS_L Rail Curr (out1)"
         ignore curr3
         ignore curr4
-        label curr5    "PMIC-5 OSFP WEST_PORTS_P09_P16 Rail Curr (out2)"
+        label curr5    "PMIC-5 OSFP WEST_PORTS_H Rail Curr (out2)"
         ignore curr6
         ignore curr7
 
-# Power controllers
-bus "i2c-27" "NVIDIA NVSwitch i2c adapter 0 at 2:00.0"
-   chip "mp2975-i2c-27-62"
+
+bus "i2c-29" "NVIDIA NVSwitch i2c adapter 0 at 2:00.0"
+    chip "mp2975-i2c-29-62"
         label in1      "PMIC-1 PSU 12V Rail (in1)"
-        label in2      "PMIC-1 VDD 0.825 LS2 Rail (out1)"
+        label in2      "PMIC-1 VDD 0.925 LR_B Rail (out1)"
         ignore in3
-        label temp1    "PMIC-1 VDD 0.825V Temp 1"
+        label temp1    "PMIC-1 VDD 0.925V LR_B Temp 1"
         ignore temp2
-        label power1   "PMIC-1 12V VDD 0.825V LS2 Pwr (in)"
-        label power2   "PMIC-1 VDD 0.825V LS2 Pwr (out1)"
+        label power1   "PMIC-1 12V VDD 0.925V LR_B Pwr (in)"
+        label power2   "PMIC-1 VDD 0.925V LR_B Pwr (out1)"
         ignore power3
-        label curr1    "PMIC-1 12V VDD 0.825V LS2 Curr (in1)"
-        label curr2    "PMIC-1 VDD 0.825V LS2 Curr (out1)"
+        label curr1    "PMIC-1 12V VDD 0.925V LR_B Curr (in1)"
+        label curr2    "PMIC-1 VDD 0.925V LR_B Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
@@ -101,38 +103,40 @@ bus "i2c-27" "NVIDIA NVSwitch i2c adapter 0 at 2:00.0"
         ignore curr7
         ignore curr8
 
-    chip "mp2975-i2c-27-65"
+    chip "mp2975-i2c-29-65"
         label in1      "PMIC-3 PSU 12V Rail (in)"
-        label in2      "PMIC-3 DVDD 0.925V LS2 Rail (out1)"
-        label in3      "PMIC-3 HVDD 1.35V LS2 Rail (out2)"
-        label temp1    "PMIC-3 HVDD 1.2V LS2 Rail Temp"
-        label power1   "PMIC-3 12V HVDD_1.2V DVDD_0.9V LS2 Pwr(in)"
-        label power2   "PMIC-3 HVDD 0.925V LS2 Rail Pwr (out1)"
-        label power3   "PMIC-3 DVDD 1.35V LS2 Rail Pwr (out2)"
-        label curr1    "PMIC-3 12V HVDD 1.2V LS2 Rail Curr (in)"
-        label curr2    "PMIC-3 HVDD 0.925V LS2 Rail Curr (out1)"
+        label in2      "PMIC-3 DVDD 0.925V LR_B Rail (out1)"
+        label in3      "PMIC-3 HVDD 1.35V LR_B Rail (out2)"
+        label temp1    "PMIC-3 HVDD 0.925V LR_B Rail Temp"
+        label power1   "PMIC-3 12V HVDD_1.35V DVDD_0.925V LR_B Pwr(in)"
+        label power2   "PMIC-3 HVDD 0.925V LR_B Rail Pwr (out1)"
+        label power3   "PMIC-3 DVDD 1.35V LR_B Rail Pwr (out2)"
+        label curr1    "PMIC-3 PSU 12V Rail Curr (in)"
+        label curr2    "PMIC-3 HVDD 0.925V LR_B Rail Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
         ignore curr6
-        label curr7    "PMIC-3 DVDD 1.35V LS1 Rail Curr (out2)"
+        label curr7    "PMIC-3 DVDD 1.35V LR_B Rail Curr (out2)"
         ignore curr8
         ignore curr9
         ignore curr10
 
-    chip "mp2975-i2c-27-67"
-        label in1      "PMIC-6 PSU 12V Rail (in)"
-        label in2      "PMIC-6 OSFP EAST_PORTS_P17_P24 Rail (out1)"
-        label in3      "PMIC-6 OSFP EAST_PORTS_P09_P16 Rail (out2)"
-        label temp1    "PMIC-6 OSFP EAST_PORTS_171_P32 Rail Temp"
-        label power1   "PMIC-6 12V OSFP EAST_PORTS_P01_P16 (in)"
-        label power2   "PMIC-6 OSFP EAST_PORTS_P17_P24 Rail Pwr (out1)"
-        label power3   "PMIC-6 OSFP EAST_PORTS_P25_P32 Rail Pwr (out2)"
-        label curr1    "PMIC-6 12V OSFP EAST_PORTS_P01_P16 Rail Curr (in)"
-        label curr2    "PMIC-6 OSFP EAST_PORTS_P17_P24 Rail Curr (out1)"
+    chip "mp2975-i2c-29-67"
+        label in1      "PMIC-5 PSU 12V Rail (in)"
+        label in2      "PMIC-5 OSFP EAST_L Rail (out1)"
+        compute in2 (3)*@, @/(3)
+        label in3      "PMIC-5 OSFP EAST_H Rail (out2)"
+        compute in3 (3)*@, @/(3)
+        label temp1    "PMIC-5 OSFP EAST_PORTS Rail Temp"
+        label power1   "PMIC-5 12V OSFP EAST_PORTS Rail Pwr (in)"
+        label power2   "PMIC-5 OSFP EAST_PORTS_L Rail Pwr (out1)"
+        label power3   "PMIC-5 OSFP EAST_PORTS_H Rail Pwr (out2)"
+        label curr1    "PMIC-5 12V OSFP EAST_PORTS Rail Curr (in)"
+        label curr2    "PMIC-5 OSFP EAST_PORTS_L Rail Curr (out1)"
         ignore curr3
         ignore curr4
-        label curr5    "PMIC-6 OSFP EAST_PORTS_P25_P32 Rail Curr (out2)"
+        label curr5    "PMIC-5 OSFP WEST_PORTS_H Rail Curr (out2)"
         ignore curr6
         ignore curr7
 


### PR DESCRIPTION
Fix NVL4 volrmon senor names

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
