### PR TITLE
Support for building arm64 deb package

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Build deb & rpm packages
         run: |
           debuild -us -uc -d
+          debuild -us -uc -b -aarm64
           cd rpm
           chmod a+x ./gen_rpm.sh
           ./gen_rpm.sh


### PR DESCRIPTION
Updating the GitHub workflow script to support building arm64 debian package.

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>