### PR TITLE
hw-mgmt: scripts: make ii0 a2d link just in case that file exist.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,4 +2,3 @@ hw-management (1.mlnx.7.0020.5135) unstable; urgency=low
   [ MLNX ] 
 
  -- MellanoxBSP <system-sw-low-level@mellanox.com>  Sun, 1 Jan 2022 11:55:00 +0300
-

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -753,15 +753,15 @@ if [ "$1" == "add" ]; then
 		if [ "$board_type" == "VMOD0014" ]; then
 			for i in {0..7}; do
 				if [ -f "$3""$4"/in_voltage"$i"_scale ]; then
-					ln -sf "$3""$4"/in_voltage"$i"_scale $environment_path/"$2"_"$iio_name"_voltage_scale_"$i"
+					check_n_link "$3""$4"/in_voltage"$i"_scale $environment_path/"$2"_"$iio_name"_voltage_scale_"$i"
 				fi
 			done
 		else
-			ln -sf "$3""$4"/in_voltage-voltage_scale $environment_path/"$2"_"$iio_name"_voltage_scale
+			check_n_link "$3""$4"/in_voltage-voltage_scale $environment_path/"$2"_"$iio_name"_voltage_scale
 		fi
 		for i in {0..7}; do
 			if [ -f "$3""$4"/in_voltage"$i"_raw ]; then
-				ln -sf "$3""$4"/in_voltage"$i"_raw $environment_path/"$2"_"$iio_name"_raw_"$i"
+				check_n_link "$3""$4"/in_voltage"$i"_raw $environment_path/"$2"_"$iio_name"_raw_"$i"
 			fi
 		done
 	fi


### PR DESCRIPTION
This iio udev trigger is mixed-up on Moose system with iio pressure sensor.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
