### PR TITLE
hw-mgmt: sensors: Add WA for unsupported PSU command in SN5600 config

### DIFF
--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -210,6 +210,7 @@ chip "dps460-i2c-*-5a"
     label power2 "PSU-1(L) 12V Rail Pwr (out)"
     label curr1 "PSU-1(L) 220V Rail Curr (in)"
     label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    set power2_cap 0
 chip "dps460-i2c-*-59"
     label in1 "PSU-2(R) 220V Rail (in)"
     ignore in2


### PR DESCRIPTION
Delta 3K PSU does not support 0x31 (POUT_MAX) PMBus command. In response to this command it returns 0xff 0xff as data and 0xff as PEC. For PSU on address 0x5a the calculated PEC is indeed 0xff, which causes linux PMBus PSU driver to recognize this command as supported and create power2_cap sysfs attribute with some invalid data.

Add WA to show the value of this attribute as 0 in the output of "sensors" command.