### PR TITLE
hw-mgmt: scripts: define I2C CPU brd offset in P4262 system.

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -111,6 +111,7 @@ leakage_count=0
 
 ndr_cpu_bus_offset=18
 ng800_cpu_bus_offset=34
+
 connect_table=()
 named_busses=()
 
@@ -2216,6 +2217,9 @@ pre_devtr_init()
 		*)
 			;;
 		esac
+		;;
+	VMOD0017)
+		echo $ndr_cpu_bus_offset > $config_path/cpu_brd_bus_offset
 		;;
 	*)
 		;;


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
