### PR TITLE
hw-mgmt: kernel v5.10: Add new patches

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -434,6 +434,9 @@ Kernel-5.10
 |0266-UBUNTU-SAUCE-mlxbf-pmc-Bug-fix-for-BlueField-3-count.patch         |                                            |                                                 |                                                              |
 |0267-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch         |                                            |                                                 |                                                              |
 |0268-DS-mlxsw-core_linecards-Disable-firmware-bundling-ma.patch         |                                            | downstream                                      |                                                              |
+|0269-platform-mellanox-Cosmetic-changes.patch                           |                                            |                                                 |                                                              |
+|0270-platform-mellanox-Fix-order-in-exit-flow.patch                     |                                            |                                                 |                                                              |
+|0271-platform-mellanox-Add-new-attributes.patch                         |                                            |                                                 |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  

--- a/recipes-kernel/linux/linux-5.10/0269-platform-mellanox-Cosmetic-changes.patch
+++ b/recipes-kernel/linux/linux-5.10/0269-platform-mellanox-Cosmetic-changes.patch
@@ -1,0 +1,74 @@
+From da7c9365e155de2a038cbc1cded3a56ea9a363aa Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 27 Feb 2023 15:24:43 +0000
+Subject: [PATCH backport 5.10 1/3] platform: mellanox: Cosmetic changes
+
+Fix routines and labels names by s/topology/topology.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 849fdf5de..656056089 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -6876,7 +6876,7 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ 	return 0;
+ }
+ 
+-static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
++static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ {
+ 	int i, err;
+ 
+@@ -6921,7 +6921,7 @@ static int mlxplat_i2c_mux_topolgy_init(struct mlxplat_priv *priv)
+ 	return err;
+ }
+ 
+-static void mlxplat_i2c_mux_topolgy_exit(struct mlxplat_priv *priv)
++static void mlxplat_i2c_mux_topology_exit(struct mlxplat_priv *priv)
+ {
+ 	int i;
+ 
+@@ -6937,7 +6937,7 @@ static int mlxplat_i2c_main_complition_notify(void *handle, int id)
+ {
+ 	struct mlxplat_priv *priv = handle;
+ 
+-	return mlxplat_i2c_mux_topolgy_init(priv);
++	return mlxplat_i2c_mux_topology_init(priv);
+ }
+ 
+ static int mlxplat_i2c_main_init(struct mlxplat_priv *priv)
+@@ -6964,14 +6964,14 @@ static int mlxplat_i2c_main_init(struct mlxplat_priv *priv)
+ 	}
+ 
+ 	if (priv->i2c_main_init_status == MLXPLAT_I2C_MAIN_BUS_NOTIFIED) {
+-		err = mlxplat_i2c_mux_topolgy_init(priv);
++		err = mlxplat_i2c_mux_topology_init(priv);
+ 		if (err)
+-			goto fail_mlxplat_i2c_mux_topolgy_init;
++			goto fail_mlxplat_i2c_mux_topology_init;
+ 	}
+ 
+ 	return 0;
+ 
+-fail_mlxplat_i2c_mux_topolgy_init:
++fail_mlxplat_i2c_mux_topology_init:
+ fail_platform_i2c_register:
+ fail_mlxplat_mlxcpld_verify_bus_topology:
+ 	return err;
+@@ -6979,7 +6979,7 @@ static int mlxplat_i2c_main_init(struct mlxplat_priv *priv)
+ 
+ static void mlxplat_i2c_main_exit(struct mlxplat_priv *priv)
+ {
+-	mlxplat_i2c_mux_topolgy_exit(priv);
++	mlxplat_i2c_mux_topology_exit(priv);
+ 	if (priv->pdev_i2c)
+ 		platform_device_unregister(priv->pdev_i2c);
+ }
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0270-platform-mellanox-Fix-order-in-exit-flow.patch
+++ b/recipes-kernel/linux/linux-5.10/0270-platform-mellanox-Fix-order-in-exit-flow.patch
@@ -1,0 +1,39 @@
+From 89d0e497e62b90e8faa2b67c298cedeab47b8f8b Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 27 Feb 2023 16:09:17 +0000
+Subject: [PATCH backport 5.10 2/3] platform: mellanox: Fix order in exit flow
+
+Fix exit flow order: call mlxplat_post_exit() after
+mlxplat_i2c_main_exit() in order to unregister main i2c driver before
+to "mlxplat" driver.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 656056089..42fd7e4e0 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -6929,8 +6929,6 @@ static void mlxplat_i2c_mux_topology_exit(struct mlxplat_priv *priv)
+ 		if (priv->pdev_mux[i])
+ 			platform_device_unregister(priv->pdev_mux[i]);
+ 	}
+-
+-	mlxplat_post_exit();
+ }
+ 
+ static int mlxplat_i2c_main_complition_notify(void *handle, int id)
+@@ -7068,6 +7066,7 @@ static void __exit mlxplat_exit(void)
+ 		unregister_reboot_notifier(mlxplat_reboot_nb);
+ 	mlxplat_pre_exit(priv);
+ 	mlxplat_i2c_main_exit(priv);
++	mlxplat_post_exit();
+ }
+ module_exit(mlxplat_exit);
+ 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0271-platform-mellanox-Add-new-attributes.patch
+++ b/recipes-kernel/linux/linux-5.10/0271-platform-mellanox-Add-new-attributes.patch
@@ -1,0 +1,49 @@
+From 6cb8f4e432f8209a3775877d690a979a2e786afc Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 27 Feb 2023 18:56:09 +0000
+Subject: [PATCH backport 5.10 3/3] platform: mellanox: Add new attributes
+
+Add two new attributes:
+"lid_open" - to indicate system intrusion detection.
+"reset_long_pwr_pb" - to indicate that system has been reset due to
+long press of power button.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 42fd7e4e0..4eb327720 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -4067,6 +4067,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(1),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "lid_open",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "clk_brd1_boot_fail",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
+@@ -4706,6 +4712,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_chassis_blade_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(6),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "reset_long_pwr_pb",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "pwr_cycle",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
+-- 
+2.20.1
+


### PR DESCRIPTION
Add patches:
0269-platform-mellanox-Cosmetic-changes.patch
0270-platform-mellanox-Fix-order-in-exit-flow.patch 0271-platform-mellanox-Add-new-attributes.patch

Update patch table.