### PR TITLE
hw-mgmt: scripts & conf: configuration changes and fix for P4262 system

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0020.5039) unstable; urgency=low
+hw-management (1.mlnx.7.0020.5040) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Sun, 21 Feb 2023 21:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 28 Feb 2023 12:55:00 +0300

--- a/usr/etc/hw-management-sensors/p4262_sensors.conf
+++ b/usr/etc/hw-management-sensors/p4262_sensors.conf
@@ -8,27 +8,27 @@
 # Temperature sensors
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "tmp75-i2c-*-4d"
-        label temp1 "PDB Temp1"
+        label temp1 "Ambient PDB Temp Sensor1 (air exhaust)"
     chip "tmp75-i2c-*-4e"
-        label temp1 "PDB Temp2
+        label temp1 "Ambient PDB Temp Sensor2 (air exhaust)"
 
 bus "i2c-7" "i2c-1-mux (chan_id 6)"
-    chip "tmp75-i2c-*-48"
-        label temp1 "OSFP Side Temp1"
-    chip "tmp75-i2c-*-49"
-        label temp1 "OSFP Side Temp2"
-    chip "tmp75-i2c-*-4a"
-        label temp1 "OSFP Side Temp3"
-    chip "tmp75-i2c-*-4b"
-        label temp1 "OSFP Side Temp4"
-    chip "tmp75-i2c-*-4c"
-        label temp1 "Backplane Side Temp1"
-    chip "tmp75-i2c-*-4d"
-        label temp1 "Backplane Side Temp2"
-    chip "tmp75-i2c-*-4e"
-        label temp1 "Backplane Side Temp3"
-    chip "tmp75-i2c-*-4f"
-        label temp1 "Backplane Side Temp4"
+    chip "adt75-i2c-*-48"
+        label temp1 "Ambient Port Side Temp1 (air intake)"
+    chip "adt75-i2c-*-49"
+        label temp1 "Ambient Port Side Temp1 (air exhaust)"
+    chip "adt75-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp2 (air intake)"
+    chip "adt75-i2c-*-4b"
+        label temp1 "Ambient Port Side Temp2 (air exhaust)"
+    chip "adt75-i2c-*-4c"
+        label temp1 "Ambient Port Side Temp3 (air intake)"
+    chip "adt75-i2c-*-4d"
+        label temp1 "Ambient Port Side Temp3 (air exhaust)"
+    chip "adt75-i2c-*-4e"
+        label temp1 "Ambient Port Side Temp4 (air intake)"
+    chip "adt75-i2c-*-4f"
+        label temp1 "Ambient Port Side Temp4 (air exhaust)"
 
 bus "i2c-7" "i2c-1-mux (chan_id 6)"
     chip "adt75-i2c-*-49"
@@ -36,23 +36,19 @@ bus "i2c-7" "i2c-1-mux (chan_id 6)"
     chip "adt75-i2c-*-4a"
         label temp1 "Ambient Port Side Temp (air exhaust)"
 
-bus "i2c-15" "i2c-1-mux (chan_id 6)"
-    chip "tmp102-i2c-15-49"
-        label temp1 "Ambient COMEX Temp"
-
 # Power controllers
 bus "i2c-26" "NVIDIA LS10 i2c adapter 0 at 1:00.0"
-    chip "mp2975-i2c-26-62"
-        label in1      "PMIC-1 PSU 12V Rail (in1)"
-        label in2      "PMIC-1 VDD 0.825 LS1 Rail (out1)"
+    chip "mp2975-i2c-26-21"
+        label in1      "ASIC-1 VDD Vin Volt (in1)"
+        label in2      "ASIC_1 VDD Vout Volt (out1)"
         ignore in3
-        label temp1    "PMIC-1 VDD 0.825V Temp 1"
+        label temp1    "ASIC-1 VDD Temp"
         ignore temp2
-        label power1   "PMIC-1 12V VDD 0.825V LS1 Pwr (in)"
-        label power2   "PMIC-1 VDD 0.825V LS1 Pwr (out1)"
+        label power1   "ASIC-1 VDD Vout Pwr (in)"
+        label power2   "ASIC-1 VDD Vin Pwr (out1)"
         ignore power3
-        label curr1    "PMIC-1 12V VDD 0.825V LS1 Curr (in1)"
-        label curr2    "PMIC-1 VDD 0.825V LS1 Curr (out1)"
+        label curr1    "ASIC-1 VDD Vout Curr (in1)"
+        label curr2    "ASIC-1 VDD Vin Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
@@ -60,54 +56,56 @@ bus "i2c-26" "NVIDIA LS10 i2c adapter 0 at 1:00.0"
         ignore curr7
         ignore curr8
         
-    chip "mp2975-i2c-26-65"
-        label in1      "PMIC-2 PSU 12V Rail (in)"
-        label in2      "PMIC-2 DVDD 0.925V LS1 Rail (out1)"
-        label in3      "PMIC-2 HVDD 1.35V LS1 Rail (out2)"
-        label temp1    "PMIC-2 HVDD 1.2V LS1 Rail Temp"
-        label power1   "PMIC-2 12V HVDD_1.2V DVDD_0.9V LS1 Pwr(in)"
-        label power2   "PMIC-2 HVDD 0.925V LS1 Rail Pwr (out1)"
-        label power3   "PMIC-2 DVDD 1.35V LS1 Rail Pwr (out2)"
-        label curr1    "PMIC-2 12V HVDD 1.2V LS1 Rail Curr (in)"
-        label curr2    "PMIC-2 HVDD 0.925V LS1 Rail Curr (out1)"
+    chip "mp2975-i2c-26-23"
+        label in1      "ASIC-1 HVDD,DVDD Vin Volt (in)"
+        label in2      "ASIC-1 HVDD Vout Volt (out1)"
+        label in3      "ASIC-1 DVDD Vout Volt (out2)"
+        label temp1    "ASIC-1 HVDD,DVDD Temp"
+        label power1   "ASIC-1 HVDD,DVDD Vin Pwr (in)"
+        label power2   "ASIC-1 HVDD Vout Pwr (out1)"
+        label power3   "ASIC-1 DVDD Vout Pwr (out2)"
+        label curr1    "ASIC-1 VDD,DVDD Vin Curr (in)"
+        label curr2    "ASIC-1 HVDD Vout Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
         ignore curr6
-        label curr7    "PMIC-2 DVDD 1.35V LS1 Rail Curr (out2)"
+        label curr7    "ASIC-1 DVDD Vout Curr (out2)"
         ignore curr8
         ignore curr9
         ignore curr10
 
-    chip "mp2975-i2c-26-67"
-        label in1      "PMIC-3 PSU 12V Rail (in)"
-        label in2      "PMIC-3 OSFP --- (out1)"
-        label in3      "PMIC-3 OSFP --- (out2)"
-        label temp1    "PMIC-3 OSFP --- Temp"
-        label power1   "PMIC-3 12V OSFP --- (in)"
-        label power2   "PMIC-3 OSFP --- (out1)"
-        label power3   "PMIC-3 OSFP --- (out2)"
-        label curr1    "PMIC-3 12V OSFP --- (in)"
-        label curr2    "PMIC-3 OSFP --- (out1)"
+    chip "mp2975-i2c-26-2a"
+        label in1      "OSFP-Vreg Vin Volt (in)"
+        label in2      "OSFP-Vreg P01-P08 Vout Volt (out1)"
+        compute in2 (3)*@, @/(3)
+        label in3      "OSFP-Vreg P09-P16 Vout Volt (out2)"
+        compute in3 (3)*@, @/(3)
+        label temp1    "OSFP-Vreg P01-P08,P09-P16 Temp"
+        label power1   "OSFP-Vreg P01-P08,P09-P16 Vin Pwr (in)"
+        label power2   "OSFP-Vreg Ports P01-P08 Vout Pwr (out1)"
+        label power3   "OSFP-Vreg Ports P09-P16 Vout Pwr (out2)"
+        label curr1    "OSFP-Vreg Vin Curr (in)"
+        label curr2    "OSFP-Vreg Ports P01-P08 Vout Curr (out1)"
         ignore curr3
         ignore curr4
-        label curr5    "PMIC-3 OSFP --- (out2)"
+        label curr5    "OSFP-Vreg Ports P09-P016 Vout Curr (out2)"
         ignore curr6
         ignore curr7
 
 # Power controllers
 bus "i2c-29" "NVIDIA LS10 i2c adapter 0 at 2:00.0"
-   chip "mp2975-i2c-29-62"
-        label in1      "PMIC-4 PSU 12V Rail (in1)"
-        label in2      "PMIC-4 VDD 0.825 LS2 Rail (out1)"
+   chip "mp2975-i2c-29-21"
+        label in1      "ASIC-2 VDD Vin Volt (in1)"
+        label in2      "ASIC_2 VDD Vout Volt (out1)"
         ignore in3
-        label temp1    "PMIC-4 VDD 0.825V Temp 1"
+        label temp1    "ASIC-2 VDD Temp"
         ignore temp2
-        label power1   "PMIC-4 12V VDD 0.825V LS2 Pwr (in)"
-        label power2   "PMIC-4 VDD 0.825V LS2 Pwr (out1)"
+        label power1   "ASIC-2 VDD Vout Pwr (in)"
+        label power2   "ASIC-2 VDD Vin Pwr (out1)"
         ignore power3
-        label curr1    "PMIC-4 12V VDD 0.825V LS2 Curr (in1)"
-        label curr2    "PMIC-4 VDD 0.825V LS2 Curr (out1)"
+        label curr1    "ASIC-2 VDD Vout Curr (in1)"
+        label curr2    "ASIC-2 VDD Vin Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
@@ -115,79 +113,112 @@ bus "i2c-29" "NVIDIA LS10 i2c adapter 0 at 2:00.0"
         ignore curr7
         ignore curr8
 
-    chip "mp2975-i2c-29-65"
-        label in1      "PMIC-5 PSU 12V Rail (in)"
-        label in2      "PMIC-5 DVDD 0.925V LS2 Rail (out1)"
-        label in3      "PMIC-5 HVDD 1.35V LS2 Rail (out2)"
-        label temp1    "PMIC-5 HVDD 1.2V LS2 Rail Temp"
-        label power1   "PMIC-5 12V HVDD_1.2V DVDD_0.9V LS2 Pwr(in)"
-        label power2   "PMIC-5 HVDD 0.925V LS2 Rail Pwr (out1)"
-        label power3   "PMIC-5 DVDD 1.35V LS2 Rail Pwr (out2)"
-        label curr1    "PMIC-5 12V HVDD 1.2V LS2 Rail Curr (in)"
-        label curr2    "PMIC-5 HVDD 0.925V LS2 Rail Curr (out1)"
+    chip "mp2975-i2c-29-23"
+        label in1      "ASIC-2 HVDD,DVDD Vin Volt (in)"
+        label in2      "ASIC-2 HVDD Vout Volt (out1)"
+        label in3      "ASIC-2 DVDD Vout Volt (out2)"
+        label temp1    "ASIC-2 HVDD,DVDD Temp"
+        label power1   "ASIC-2 HVDD,DVDD Vin Pwr (in)"
+        label power2   "ASIC-2 HVDD Vout Pwr (out1)"
+        label power3   "ASIC-2 DVDD Vout Pwr (out2)"
+        label curr1    "ASIC-2 HVDD,DVDD Vin Curr (in)"
+        label curr2    "ASIC-2 HVDD Vout Curr (out1)"
         ignore curr3
         ignore curr4
         ignore curr5
         ignore curr6
-        label curr7    "PMIC-5 DVDD 1.35V LS1 Rail Curr (out2)"
+        label curr7    "ASIC-2 DVDD Vout Curr (out2)"
         ignore curr8
         ignore curr9
         ignore curr10
 
-# Power converters 
-# TBD MS. Should be filled with real name, ignore, possible scale and right number of voltages (in).
-chip "pmbus-i2c-*-10"
-    label in1      	"PDB IBC-1 ---"
-    label in2		"PDB IBC-1 ---"
-    label in3		"PDB IBC-1 ---"
-    label temp1    	"PDB IBC-1 Temp 1"
-    label curr1 	"PDB IBC-1 --- Curr (out)"
-    ignore curr2
+# Hot-swap
+chip "lm5066i-i2c-*-11"
+    label in1       "PDB-HSC VinDC Volt (in)"
+    label in2       "PDB-HSC Vout Volt (out)"
+    label in3
+    label temp1     "PDB-HSC Temp"
+    label power1    "PDB-HSC VinDC Pwr (in)"
+    label power2    "PDB-HSC Vout Pwr (out)"
+    label curr1     "PDB-HSC VinDC Curr (in)"
+    label curr2     "PDB-HSC Vout Curr (out)"
+
+# Power converters
+#54V_HSC to 12V_Main
+chip "pmbus-i2c-*-13"
+    label in1       "PDB-MAIN1 VinDC Volt (in)"
+    label in2       "PDB-MAIN1 Vout Volt (out)"
+    label in3
+    label temp1     "PDB-MAIN1 Temp"
+    label temp2
+    label temp3
+    label power1    "PDB-MAIN1 VinDC Pwr (in)"
+    label power2    "PDB-MAIN1 Vout Pwr (out)"
+    label curr1     "PDB-MAIN1 VinDC Curr (in)"
+    label curr2     "PDB-MAIN1 Vout Curr (out)"
+
+chip "pmbus-i2c-*-17"
+    label in1       "PDB-MAIN2 VinDC Volt (in)"
+    label in2       "PDB-MAIN2 Vout Volt (out)"
+    label in3
+    label temp1     "PDB-MAIN2 Temp"
+    label temp2
+    label temp3
+    label power1    "PDB-MAIN2 VinDC Pwr (in)"
+    label power2    "PDB-MAIN2 Vout Pwr (out)"
+    label curr1     "PDB-MAIN2 VinDC Curr (in)"
+    label curr2     "PDB-MAIN2 Vout Curr (out)"
+
+#JTB 54V_HSC to 12V_Standby
+chip "pmbus-i2c-*-16"
+    label in1       "PDB-STBY1 VinDC Volt (in)"
+    label in2       "PDB-STBY1 Vout Volt (out)"
+    label in3
+    label temp1     "PDB-STBY1 Temp"
+    label temp2
+    label temp3
+    label power1    "PDB-STBY1 VinDC Pwr (in)"
+    label power2    "PDB-STBY1 Vout Pwr (out)"
+    label curr1     "PDB-STBY1 VinDC Curr (in)"
+    label curr2     "PDB-STBY1 Vout Curr (out)"
 
 chip "pmbus-i2c-*-12"
-    label in1      	"PDB 12VSTBY-1 ---"
-    label in2		"PDB 12VSTBY-1 ---"
-    label in3		"PDB 12VSTBY-1 ---"
-    label temp1    	"PDB 12VSTBY-1 Temp 1"
-    label curr1 	"PDB 12VSTBY-1 --- Curr (out)"
-    ignore curr2
+    label in1       "PDB-STBY2 VinDC Volt (in)"
+    label in2       "PDB-STBY2 Vout Volt (out)"
+    label in3
+    label temp1     "PDB-STBY2 Temp"
+    label temp2
+    label temp3
+    label power1    "PDB-STBY2 VinDC Pwr (in)"
+    label power2    "PDB-STBY2 Vout Pwr (out)"
+    label curr1     "PDB-STBY2 VinDC Curr (in)"
+    label curr2     "PDB-STBY2 Vout Curr (out)"
 
-chip "pmbus-i2c-*-13"
-    label in1      	"PDB IBC-2 ---"
-    label in2		"PDB IBC-2 ---"
-    label in3		"PDB IBC-2 ---"
-    label temp1    	"PDB IBC-2 Temp 1"
-    label curr1 	"PDB IBC-2 --- Curr (out)"
-    ignore curr2
-
-chip "pmbus-i2c-*-16"
-    label in1      	"PDB 12VSTBY-2 ---"
-    label in2		"PDB 12VSTBY-2 ---"
-    label in3		"PDB 12VSTBY-2 ---"
-    label temp1    	"PDB 12VSTBY-2 Temp 1"
-    label curr1 	"PDB 12VSTBY-2 --- Curr (out)"
-    ignore curr2
-
+#54V_HSC to 12V_Fans
 chip "pmbus-i2c-*-1b"
-    label in1      	"PDB FAN48-12 ---"
-    label in2		"PDB FAN48-12 ---"
-    label in3		"PDB FAN48-12 ---"
-    label temp1    	"PDB FAN48-12 Temp 1"
-    label curr1 	"PDB FAN48-12 --- Curr (out)"
-    ignore curr2
+    label in1       "PDB-FAN VinDC Volt (in)"
+    label in2       "PDB-FAN Vout Volt (out)"
+    label in3
+    label temp1     "PDB-FAN Temp"
+    label temp2
+    label temp3
+    label power1    "PDB-FAN VinDC Pwr (in)"
+    label power2    "PDB-FAN Vout Pwr (out)"
+    label curr1     "PDB-FAN VinDC Curr (in)"
+    label curr2     "PDB-FAN Vout Curr (out)"
 
 #COMEX CFL
 bus "i2c-23" "i2c-1-mux (chan_id 6)"
     chip "mp2975-i2c-*-6b"
-        label in1 "PMIC-6 PSU 12V Rail (vin)"
-        label in2 "PMIC-6 COMEX VCORE (out1)"
-        label in3 "PMIC-6 COMEX VCCSA (out2)"
-        label temp1 "PMIC-6 Temp"
-        label power1 "PMIC-6 COMEX Pwr (pin)"
-        label power2 "PMIC-6 COMEX Pwr (pout)"
-        label curr1 "PMIC-6 COMEX Curr (iin)"
-        label curr2 "PMIC-6 COMEX VCORE Rail Curr (out1)"
-        label curr3 "PMIC-6 COMEX VCCSA Rail Curr (out2)"
+        label in1       "COMEX-VREG VCORE,VCCSA Vin Volt (vin)"
+        label in2       "COMEX-VREG VCORE Vout Volt (out1)"
+        label in3       "COMEX-VREG VCCSA Vout Volt (out2)"
+        label temp1     "COMEX-VREG VCORE,VCCSA Temp"
+        label power1    "COMEX-VREG VCORE,VCCSA Pwr (pin)"
+        label power2    "COMEX-VREG VCORE,VCCSA Vout Pwr (pout)"
+        label curr1     "COMEX-VREG VCORE,VCCSA Vin Curr (iin)"
+        label curr2     "COMEX-VREG VCORE Vout Curr (out1)"
+        label curr3     "COMEX-VREG VCCSA Vout Curr (out2)"
         ignore curr3
         ignore curr4
         ignore curr5

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -274,7 +274,7 @@ find_eeprom_name()
 	addr=$2
 	i2c_bus_def_off_eeprom_cpu=$(< $i2c_bus_def_off_eeprom_cpu_file)
 	if [ "$bus" -eq "$i2c_bus_def_off_eeprom_vpd" ]; then
-		if [ "$board_type" == "VMOD0017" ] && [ "$addr" -ne "$vpd_i2c_addr" ]; then
+		if [ "$board_type" == "VMOD0017" ] && [ "$addr" != "$vpd_i2c_addr" ]; then
 			eeprom_name=ipmi_info
 		else
 			eeprom_name=vpd_info

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -208,11 +208,11 @@ declare -A pwr_type0_alternatives=(["pmbus_0"]="pmbus 0x10 4 pwr_conv1" \
 				   ["icp201xx_1"]="icp201xx 0x64 4 press_sens2" \
 				   ["max11603_0"]="max11603 0x6d 4 pwrb_a2d")
 
-declare -A pwr_type1_alternatives=(["pmbus_0"]="pmbus 0x10 4 pdb_pwr_conv1" \
-				   ["lm5066_0"]="lm5066 0x11 4 pdb_hotswap1" \
-				   ["pmbus_1"]="pmbus 0x12 4 pdb_pwr_conv2" \
-				   ["pmbus_2"]="pmbus 0x13 4 pdb_pwr_conv3" \
-				   ["pmbus_3"]="pmbus 0x16 4 pdb_pwr_conv4" \
+declare -A pwr_type1_alternatives=(["lm5066_0"]="lm5066 0x11 4 pdb_hotswap1" \
+				   ["pmbus_0"]="pmbus 0x12 4 pdb_pwr_conv1" \
+				   ["pmbus_1"]="pmbus 0x13 4 pdb_pwr_conv2" \
+				   ["pmbus_2"]="pmbus 0x16 4 pdb_pwr_conv3" \
+				   ["pmbus_3"]="pmbus 0x17 4 pdb_pwr_conv4" \
 				   ["pmbus_4"]="pmbus 0x1b 4 pdb_pwr_conv5" \
 				   ["tmp75_0"]="tmp75 0x4d 4 pdb_temp1" \
 				   ["adt75_0"]="tmp75 0x4d 4 pdb_temp1" \

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -449,29 +449,30 @@ p4262_base_connect_table=( \
 	pmbus 0x12 4 \
 	pmbus 0x13 4 \
 	pmbus 0x16 4 \
+	pmbus 0x17 4 \
 	pmbus 0x1b 4 \
 	tmp75 0x4d 4 \
 	tmp75 0x4e 4 \
 	24c502 0x50 4 \
-	tmp75 0x48 7 \
-	tmp75 0x49 7 \
-	tmp75 0x4a 7 \
-	tmp75 0x4b 7 \
-	tmp75 0x4c 7 \
-	tmp75 0x4d 7 \
-	tmp75 0x4e 7 \
-	tmp75 0x4f 7 \
+	adt75 0x48 7 \
+	adt75 0x49 7 \
+	adt75 0x4a 7 \
+	adt75 0x4b 7 \
+	adt75 0x4c 7 \
+	adt75 0x4d 7 \
+	adt75 0x4e 7 \
+	adt75 0x4f 7 \
 	24c502 0x50 7 \
 	24c512 0x51 8 \
 	24c512 0x52 8 )
 
 # TBD MS. Check exact components
 p4262_dynamic_i2c_bus_connect_table=( \
-	mp2975 0x62 26 voltmon1 \
-	mp2975 0x65 26 voltmon2 \
-	mp2975 0x67 26 voltmon3 \
-	mp2975 0x62 29 voltmon4 \
-	mp2975 0x65 29 voltmon5 )
+	mp2975 0x21 26 voltmon1 \
+	mp2975 0x23 26 voltmon2 \
+	mp2975 0x2a 26 voltmon3 \
+	mp2975 0x21 29 voltmon4 \
+	mp2975 0x23 29 voltmon5 )
 
 # I2C busses naming.
 cfl_come_named_busses=( come-vr 15 come-amb 15 come-fru 16 )


### PR DESCRIPTION
1. Update types and adresses of components.
2. Update sensors.conf components and their labels.
3. Fix VPD and IPMI EEPROMs link creation.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
