### PR TITLE
hw-mgmt: kernel v5.10: Add new patches

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0020.5040) unstable; urgency=low
+hw-management (1.mlnx.7.0020.5041) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Tue, 28 Feb 2023 12:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 01 Mar 2023 12:55:00 +0300

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -437,6 +437,8 @@ Kernel-5.10
 |0269-platform-mellanox-Cosmetic-changes.patch                           |                                            |                                                 |                                                              |
 |0270-platform-mellanox-Fix-order-in-exit-flow.patch                     |                                            |                                                 |                                                              |
 |0271-platform-mellanox-Add-new-attributes.patch                         |                                            |                                                 |                                                              |
+|0272-platform-mellanox-Change-register-offset-addresses.patch           |                                            |                                                 |                                                              |
+|0273-platform-mellanox-Add-field-upgrade-capability-regis.patch         |                                            |                                                 |                                                              |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  

--- a/recipes-kernel/linux/linux-5.10/0272-platform-mellanox-Change-register-offset-addresses.patch
+++ b/recipes-kernel/linux/linux-5.10/0272-platform-mellanox-Change-register-offset-addresses.patch
@@ -1,0 +1,43 @@
+From 020ab13e16f943bb66da221507f83634a7d9ca05 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 1 Mar 2023 17:21:48 +0000
+Subject: [PATCH backport 5.10 4/5] platform: mellanox: Change register offset
+ addresses
+
+Move debug register offsets to different location due to hardware changes.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 4eb327720..b5d51673f 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -66,10 +66,6 @@
+ #define MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET	0x37
+ #define MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET	0x3a
+ #define MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET	0x3b
+-#define MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET	0x3c
+-#define MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET	0x3d
+-#define MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET	0x3e
+-#define MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET	0x3f
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET	0x40
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET	0x41
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET	0x42
+@@ -130,6 +126,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET	0xaa
+ #define MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET	0xab
+ #define MLXPLAT_CPLD_LPC_REG_LC_PWR_ON		0xb2
++#define MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET	0xb6
++#define MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET	0xb7
++#define MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET	0xb8
++#define MLXPLAT_CPLD_LPC_REG_DBG4_OFFSET	0xb9
+ #define MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET	0xc2
+ #define MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT	0xc3
+ #define MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET	0xc7
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-5.10/0273-platform-mellanox-Add-field-upgrade-capability-regis.patch
+++ b/recipes-kernel/linux/linux-5.10/0273-platform-mellanox-Add-field-upgrade-capability-regis.patch
@@ -1,0 +1,72 @@
+From c376b57d8d7c8aacb1389f4936f3324736fd5f7d Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 1 Mar 2023 17:49:08 +0000
+Subject: [PATCH backport 5.10 5/5] platform: mellanox: Add field upgrade
+ capability register
+
+Add new register to indicate the method of FPGA/CPLD field upgrade
+supported on the specific system.
+Currently two masks are available:
+b00 - filed upgrade through LPC gateway (new method introduced to
+      accelerate field upgrade process).
+b11 - filed upgrade through CPU GPIO pins (old method).
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index b5d51673f..f674d9173 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -66,6 +66,7 @@
+ #define MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET	0x37
+ #define MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET	0x3a
+ #define MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET	0x3b
++#define MLXPLAT_CPLD_LPC_REG_FU_CAP_OFFSET	0x3c
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET	0x40
+ #define MLXPLAT_CPLD_LPC_REG_AGGRLO_MASK_OFFSET	0x41
+ #define MLXPLAT_CPLD_LPC_REG_AGGRCO_OFFSET	0x42
+@@ -241,6 +242,7 @@
+ #define MLXPLAT_CPLD_VOLTREG_UPD_MASK	GENMASK(5, 4)
+ #define MLXPLAT_CPLD_GWP_MASK		GENMASK(0, 0)
+ #define MLXPLAT_CPLD_EROT_MASK		GENMASK(1, 0)
++#define MLXPLAT_CPLD_FU_CAP_MASK	GENMASK(1, 0)
+ #define MLXPLAT_CPLD_PWR_BUTTON_MASK	BIT(0)
+ #define MLXPLAT_CPLD_LATCH_RST_MASK	BIT(5)
+ #define MLXPLAT_CPLD_THERMAL1_PDB_MASK	BIT(3)
+@@ -3956,6 +3958,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(5),
+ 		.mode = 0200,
+ 	},
++	{
++		.label = "jtag_cap",
++		.reg = MLXPLAT_CPLD_LPC_REG_FU_CAP_OFFSET,
++		.mask = MLXPLAT_CPLD_FU_CAP_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "jtag_enable",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
+@@ -5424,6 +5433,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_FU_CAP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET:
+@@ -5582,6 +5592,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	case MLXPLAT_CPLD_LPC_SAFE_BIOS_WP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_AGGR_MASK_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_FU_CAP_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_DBG3_OFFSET:
+-- 
+2.20.1
+


### PR DESCRIPTION
Add patches:
0272-platform-mellanox-Change-register-offset-addresses.patch 0273-platform-mellanox-Add-field-upgrade-capability-regis.patch

Update patch table.