### PR TITLE
hw-mgmt: scripts: LED color attribute change

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -898,6 +898,11 @@ if [ "$1" == "add" ]; then
 			;;
 		esac
 		name=$(echo "$5" | cut -d':' -f2)
+		# In newer switches the LED color is amber. This is a workaround
+		# to avoid driver changes.
+		if [ "$color" == "orange" ]; then
+			color="amber"
+		fi
 		color=$(echo "$5" | cut -d':' -f3)
 		ln -sf "$3""$4"/brightness $led_path/led_"$name"_"$color"
 		ln -sf "$3""$4"/trigger  $led_path/led_"$name"_"$color"_trigger
@@ -1256,6 +1261,11 @@ else
 		esac
 		name=$(echo "$5" | cut -d':' -f2)
 		color=$(echo "$5" | cut -d':' -f3)
+		# In newer switches the LED color is amber. This is a workaround
+		# to avoid driver changes.
+		if [ "$color" == "orange" ]; then
+			color="amber"
+		fi
 		unlink $led_path/led_"$name"_"$color"
 		unlink $led_path/led_"$name"_"$color"_delay_on
 		unlink $led_path/led_"$name"_"$color"_delay_off


### PR DESCRIPTION
In newer switches, the LED color is amber and not orange. This patch renames the LED attributes that contains the string 'orange' to 'amber'. Also updates the capability string from 'orange' to 'amber'.

Issue addressed: #3234522

**Unit Test**

```
root@r-leopard-29:/var/run/hw-management/led# ls
led_fan1                  led_fan2_capability       led_fan3_state            led_fan5_amber_trigger    led_fan6_green_trigger      led_status_amber_delay_on
led_fan1_amber            led_fan2_green            led_fan4                  led_fan5_capability       led_fan6_state              led_status_amber_trigger
led_fan1_amber_delay_off  led_fan2_green_delay_off  led_fan4_amber            led_fan5_green            led_psu                     led_status_capability
led_fan1_amber_delay_on   led_fan2_green_delay_on   led_fan4_amber_delay_off  led_fan5_green_delay_off  led_psu_amber               led_status_green
led_fan1_amber_trigger    led_fan2_green_trigger    led_fan4_amber_delay_on   led_fan5_green_delay_on   led_psu_amber_delay_off     led_status_green_delay_off
led_fan1_capability       led_fan2_state            led_fan4_amber_trigger    led_fan5_green_trigger    led_psu_amber_delay_on      led_status_green_delay_on
led_fan1_green            led_fan3                  led_fan4_capability       led_fan5_state            led_psu_amber_trigger       led_status_green_trigger
led_fan1_green_delay_off  led_fan3_amber            led_fan4_green            led_fan6                  led_psu_capability          led_status_state
led_fan1_green_delay_on   led_fan3_amber_delay_off  led_fan4_green_delay_off  led_fan6_amber            led_psu_green               led_uid
led_fan1_green_trigger    led_fan3_amber_delay_on   led_fan4_green_delay_on   led_fan6_amber_delay_off  led_psu_green_delay_off     led_uid_blue
led_fan1_state            led_fan3_amber_trigger    led_fan4_green_trigger    led_fan6_amber_delay_on   led_psu_green_delay_on      led_uid_blue_delay_off
led_fan2                  led_fan3_capability       led_fan4_state            led_fan6_amber_trigger    led_psu_green_trigger       led_uid_blue_delay_on
led_fan2_amber            led_fan3_green            led_fan5                  led_fan6_capability       led_psu_state               led_uid_blue_trigger
led_fan2_amber_delay_off  led_fan3_green_delay_off  led_fan5_amber            led_fan6_green            led_status                  led_uid_capability
led_fan2_amber_delay_on   led_fan3_green_delay_on   led_fan5_amber_delay_off  led_fan6_green_delay_off  led_status_amber            led_uid_state
led_fan2_amber_trigger    led_fan3_green_trigger    led_fan5_amber_delay_on   led_fan6_green_delay_on   led_status_amber_delay_off
```

```
root@r-leopard-29:/var/run/hw-management/led# echo 1 > led_fan1_amber
root@r-leopard-29:/var/run/hw-management/led# ./led_fan1_state 
root@r-leopard-29:/var/run/hw-management/led# cat led_fan1
amber

```