### PR TITLE
hw-mgmt: sensors: Fix configuration for P4262

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0278-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch
+++ b/recipes-kernel/linux/linux-5.10/0278-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch
@@ -1,4 +1,4 @@
-From 48da50331ff198b1d8e8d337465d9b131b04f59f Mon Sep 17 00:00:00 2001
+From 8b83fb501ac77d60e1cc30fac63e71f469ba0992 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Fri, 10 Mar 2023 09:15:35 +0000
 Subject: [PATCH backport v.5.10 1/1] platform: mellanox: mlx-platform: Modify
@@ -17,7 +17,7 @@ Reviewed-by: Michael Shych <michaelsh@nvidia.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 67865636e..497fbf990 100644
+index 67865636e..55afb4c90 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -227,7 +227,7 @@
@@ -25,7 +25,7 @@ index 67865636e..497fbf990 100644
  #define MLXPLAT_CPLD_LOW_AGGR_MASK_LOW	0xc1
  #define MLXPLAT_CPLD_LOW_AGGR_MASK_ASIC2	BIT(2)
 -#define MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT	BIT(4)
-+#define MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT	BIT(5)
++#define MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT	GENMASK(5,4)
  #define MLXPLAT_CPLD_LOW_AGGR_MASK_I2C	BIT(6)
  #define MLXPLAT_CPLD_PSU_MASK		GENMASK(1, 0)
  #define MLXPLAT_CPLD_PWR_MASK		GENMASK(1, 0)

--- a/usr/etc/hw-management-sensors/p4262_sensors.conf
+++ b/usr/etc/hw-management-sensors/p4262_sensors.conf
@@ -99,7 +99,7 @@ bus "i2c-29" "NVIDIA LS10 i2c adapter 0 at 2:00.0"
         label in1      "ASIC-2 VDD Vin Volt (in1)"
         label in2      "ASIC_2 VDD Vout Volt (out1)"
         ignore in3
-        label temp1    "ASIC-2 VDD Temp"
+        label temp1    "ASIC-2 VDD Temp1"
         ignore temp2
         label power1   "ASIC-2 VDD Vout Pwr (in)"
         label power2   "ASIC-2 VDD Vin Pwr (out1)"
@@ -133,25 +133,19 @@ bus "i2c-29" "NVIDIA LS10 i2c adapter 0 at 2:00.0"
         ignore curr10
 
 # Hot-swap
-chip "lm5066i-i2c-*-11"
+chip "lm5066-i2c-*-11"
     label in1       "PDB-HSC VinDC Volt (in)"
-    label in2       "PDB-HSC Vout Volt (out)"
-    label in3
-    label temp1     "PDB-HSC Temp"
+    label in3       "PDB-HSC Vout Volt (out)"
     label power1    "PDB-HSC VinDC Pwr (in)"
-    label power2    "PDB-HSC Vout Pwr (out)"
     label curr1     "PDB-HSC VinDC Curr (in)"
-    label curr2     "PDB-HSC Vout Curr (out)"
 
 # Power converters
 #54V_HSC to 12V_Main
 chip "pmbus-i2c-*-13"
     label in1       "PDB-MAIN1 VinDC Volt (in)"
     label in2       "PDB-MAIN1 Vout Volt (out)"
-    label in3
-    label temp1     "PDB-MAIN1 Temp"
-    label temp2
-    label temp3
+    label temp1     "PDB-MAIN1 Temp1"
+    label temp2     "PDB-MAIN1 Temp2"
     label power1    "PDB-MAIN1 VinDC Pwr (in)"
     label power2    "PDB-MAIN1 Vout Pwr (out)"
     label curr1     "PDB-MAIN1 VinDC Curr (in)"
@@ -160,10 +154,9 @@ chip "pmbus-i2c-*-13"
 chip "pmbus-i2c-*-17"
     label in1       "PDB-MAIN2 VinDC Volt (in)"
     label in2       "PDB-MAIN2 Vout Volt (out)"
-    label in3
-    label temp1     "PDB-MAIN2 Temp"
-    label temp2
-    label temp3
+    label temp1     "PDB-MAIN2 Temp1"
+    label temp2     "PDB-MAIN2 Temp2"
+    label temp3     "PDB-MAIN2 Temp3"
     label power1    "PDB-MAIN2 VinDC Pwr (in)"
     label power2    "PDB-MAIN2 Vout Pwr (out)"
     label curr1     "PDB-MAIN2 VinDC Curr (in)"
@@ -173,10 +166,9 @@ chip "pmbus-i2c-*-17"
 chip "pmbus-i2c-*-16"
     label in1       "PDB-STBY1 VinDC Volt (in)"
     label in2       "PDB-STBY1 Vout Volt (out)"
-    label in3
-    label temp1     "PDB-STBY1 Temp"
-    label temp2
-    label temp3
+    label temp1     "PDB-STBY1 Temp1"
+    label temp2     "PDB-STBY1 Temp2"
+    label temp3     "PDB-STBY1 Temp3"
     label power1    "PDB-STBY1 VinDC Pwr (in)"
     label power2    "PDB-STBY1 Vout Pwr (out)"
     label curr1     "PDB-STBY1 VinDC Curr (in)"
@@ -185,10 +177,9 @@ chip "pmbus-i2c-*-16"
 chip "pmbus-i2c-*-12"
     label in1       "PDB-STBY2 VinDC Volt (in)"
     label in2       "PDB-STBY2 Vout Volt (out)"
-    label in3
-    label temp1     "PDB-STBY2 Temp"
-    label temp2
-    label temp3
+    label temp1     "PDB-STBY2 Temp1"
+    label temp2     "PDB-STBY2 Temp2"
+    label temp3     "PDB-STBY2 Temp3"
     label power1    "PDB-STBY2 VinDC Pwr (in)"
     label power2    "PDB-STBY2 Vout Pwr (out)"
     label curr1     "PDB-STBY2 VinDC Curr (in)"
@@ -198,12 +189,9 @@ chip "pmbus-i2c-*-12"
 chip "pmbus-i2c-*-1b"
     label in1       "PDB-FAN VinDC Volt (in)"
     label in2       "PDB-FAN Vout Volt (out)"
-    label in3
-    label temp1     "PDB-FAN Temp"
-    label temp2
-    label temp3
-    label power1    "PDB-FAN VinDC Pwr (in)"
-    label power2    "PDB-FAN Vout Pwr (out)"
+    label temp1     "PDB-FAN Temp1"
+    label temp2     "PDB-FAN Temp2"
+    label temp3     "PDB-FAN Temp3"
     label curr1     "PDB-FAN VinDC Curr (in)"
     label curr2     "PDB-FAN Vout Curr (out)"
 

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -900,10 +900,10 @@ if [ "$1" == "add" ]; then
 		name=$(echo "$5" | cut -d':' -f2)
 		# In newer switches the LED color is amber. This is a workaround
 		# to avoid driver changes.
+		color=$(echo "$5" | cut -d':' -f3)
 		if [ "$color" == "orange" ]; then
 			color="amber"
 		fi
-		color=$(echo "$5" | cut -d':' -f3)
 		ln -sf "$3""$4"/brightness $led_path/led_"$name"_"$color"
 		ln -sf "$3""$4"/trigger  $led_path/led_"$name"_"$color"_trigger
 		ln -sf "$3""$4"/delay_on  $led_path/led_"$name"_"$color"_delay_on

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2463,6 +2463,7 @@ Options:
 			thermal control.
 	restart
 	force-reload	Performs hw-management 'stop' and the 'start.
+	reset-cause	Output system reset cause.
 "
 
 case $ACTION in
@@ -2521,6 +2522,11 @@ case $ACTION in
 		do_stop
 		sleep 3
 		do_start
+	;;
+	reset-cause)
+		for f in $system_path/reset_*;
+			do v=`cat $f`; attr=$(basename $f); if [ $v -eq 1 ]; then echo $attr; fi;
+		done
 	;;
 	*)
 		echo "$__usage"

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -96,6 +96,7 @@ spc4_pci_id=cf80
 quantum2_pci_id=d2f2
 nv3_pci_id=1af1
 nv4_pci_id=22a3
+nv4_rev_a1_pci_id=22a4
 leakage_count=0
 
 # Topology description and driver specification for ambient sensors and for
@@ -2160,6 +2161,10 @@ set_asic_pci_id()
 		;;
 	HI142|HI143|HI152)
 		asic_pci_id=$nv4_pci_id
+		check_asics=`lspci -nn | grep $asic_pci_id | awk '{print $1}'`
+		if [ -z "$check_asics" ]; then
+			asic_pci_id=$nv4_rev_a1_pci_id
+		fi
 		;;
 	*)
 		echo 1 > "$config_path"/asic_num


### PR DESCRIPTION
Remove empty labels.
Fix hotswap config.