### PR TITLE
hw-mgmt: kernel patches: Fix deploy patch tool sort rule

### DIFF
--- a/recipes-kernel/linux/deploy_kernel_patches.py
+++ b/recipes-kernel/linux/deploy_kernel_patches.py
@@ -85,7 +85,7 @@ class CONST(object):
 # Local const
 #############################
 
-PATCH_RULES = {"feature upstream": {CONST.FILTER : "copy_to_candidate_filter"},
+PATCH_RULES = {"feature upstream": {CONST.FILTER : "copy_to_accepted_filter"},
                "feature accepted": {CONST.FILTER : "copy_to_candidate_filter"},
                "feature pending":  {CONST.FILTER : "copy_to_candidate_filter"},
                "downstream":       {CONST.FILTER : "copy_to_candidate_filter"},


### PR DESCRIPTION
Change sort rule for "feature upstream" patches from "candidate" to "accepted"

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
