### PR TITLE
hw-mgmt: thermal: Add TC service start by default

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -34,6 +34,7 @@ override_dh_installinit:
 
 override_dh_systemd_enable:
 	dh_systemd_enable --name=hw-management
+	dh_systemd_enable --name=hw-management-tc
 
 override_dh_systemd_start:
 	dh_systemd_start --name=hw-management


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
