### PR TITLE
V.7.0020.5100 BR

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0020.5044) unstable; urgency=low
+hw-management (1.mlnx.7.0020.5054) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com>  Wed, 11 Mar 2023 12:55:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com>  Mon, 27 Mar 2023 12:55:00 +0300

--- a/recipes-kernel/linux/linux-5.10/9001-DS-OPT-e1000e-skip-NVM-checksum.patch
+++ b/recipes-kernel/linux/linux-5.10/9001-DS-OPT-e1000e-skip-NVM-checksum.patch
@@ -1,0 +1,45 @@
+From ab9c16088e31d45ecef2c46401d876344aa0c8fc Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Thu, 23 Mar 2023 17:59:25 +0000
+Subject: [PATCH v1 1/1] e1000e: skip NVM checksum.
+
+NVM checksum is reported as bad in many cases after full
+BIOS SPI flash including GbE section burn by Dediprog.
+This happened in the early steps of production flow before
+EEPROM / NVM info will be customized and the checksum will
+be recalculated. Just skip this check.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/net/ethernet/intel/e1000e/netdev.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/drivers/net/ethernet/intel/e1000e/netdev.c b/drivers/net/ethernet/intel/e1000e/netdev.c
+index d0c4de023112..611a76ae2e75 100644
+--- a/drivers/net/ethernet/intel/e1000e/netdev.c
++++ b/drivers/net/ethernet/intel/e1000e/netdev.c
+@@ -7514,6 +7514,12 @@ static int e1000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 	/* systems with ASPM and others may see the checksum fail on the first
+ 	 * attempt. Let's give it a few tries
+ 	 */
++	/* NVIDIA >>>
++	 * NVM checksum is reported as bad in many cases after full
++	 * BIOS SPI flash including GbE section burn by Dediprog.
++	 * This happened in the early steps of production flow before
++	 * EEPROM / NVM info will be customized and the checksum will
++	 * be recalculated. Just skip this check.
+ 	for (i = 0;; i++) {
+ 		if (e1000_validate_nvm_checksum(&adapter->hw) >= 0)
+ 			break;
+@@ -7523,6 +7529,8 @@ static int e1000_probe(struct pci_dev *pdev, const struct pci_device_id *ent)
+ 			goto err_eeprom;
+ 		}
+ 	}
++	 * NVIDIA <<<
++	 */
+ 
+ 	e1000_eeprom_checks(adapter);
+ 
+-- 
+2.14.1
+

--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -160,7 +160,7 @@ chip "mp2975-i2c-*-6a"
     ignore curr4
     ignore curr5
     ignore curr6
-chip "mp2975-i2c-*-6b"
+chip "mp2975-i2c-*-6c"
     label in1      "PMIC-10 PSU 13V5 Rail (in1)"
     label in2      "PMIC-10 HVDD_T03 1V2 Rail (out1)"
     label in3      "PMIC-10 HVDD_T47 1V2 Rail (out2)"
@@ -230,8 +230,8 @@ chip "pmbus-i2c-*-10"
     ignore in2
     ignore in3
     label temp1    	"IBC-1 Temp 1"
-    label curr1 	"IBC-1 13V5 Rail Curr (out)"
-    ignore curr2
+    ignore curr1
+    label curr2 	"IBC-1 13V5 Rail Curr (out)"
 chip "pmbus-i2c-*-11"
     label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
     ignore in2

--- a/usr/etc/hw-management-thermal/tc_config_msn2101.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2101.json
@@ -1,0 +1,47 @@
+ {
+	"dmin" : {
+		"C2P": {
+			"untrusted": {"-127:20": 30, "21:25": 40, "26:30": 50, "31:35": 60, "36:40": 70, "41:120": 80},
+			"fan_err": {
+				"tacho": {"-127:120": 50},
+				"present": {"-127:120": 50},
+				"direction": {"-127:125": 50}
+			},
+			"psu_err":  {
+				"present": {"-127:120": 50},
+				"direction": {"-127:120": 50}
+			},
+			"sensor_read_error" : {"-127:120": 50}
+		},
+		"P2C": {
+			"untrusted":{"-127:15": 30, "16:20": 40, "21:25": 50, "26:30": 60, "31:35": 70, "36:40": 80, "41:120": 90},
+			"fan_err": {
+				"tacho": {"-127:25": 120},
+				"present": {"-127:25": 120},
+				"direction": {"-127:125": 50}
+			},
+			"psu_err":  {
+				"present": {"-127:25": 120},
+				"direction": {"-127:25": 120}
+			},
+			"sensor_read_error":{"-127:20": 20, "21:30": 30, "31:40": 40, "41:120": 50}
+		}
+	},
+	"psu_fan_pwm_decode" : {"0:10": 10, "11:21": 20, "21:30": 30, "31:40": 40, "41:50": 50, "51:60": 60, "61:70": 70, "71:80": 80, "81:90": 90, "91:100": 100},
+	"fan_trend" : {
+		"C2P": {
+			"0" : {"rpm_min":6300, "rpm_max":25000, "slope": 234, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
+			"1" : {"rpm_min":6300, "rpm_max":25000, "slope": 234, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}},
+		"P2C": {
+			"0" : {"rpm_min":6300, "rpm_max":25000, "slope": 234, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
+			"1" : {"rpm_min":6300, "rpm_max":25000, "slope": 234, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}}
+	},
+	"dev_parameters" : {
+		"asic":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3}, 
+		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 20, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3},
+		"module\\d+":     {"pwm_min": 20, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
+		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
+		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
+		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
+	}
+}

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -146,7 +146,7 @@ declare -A sn5600_alternatives=(["max11603_0"]="max11603 0x6d 5 swb_a2d" \
 				["mp2975_6"]="mp2975 0x68 5 voltmon7" \
 				["mp2975_7"]="mp2975 0x69 5 voltmon8" \
 				["mp2975_8"]="mp2975 0x6a 5 voltmon9" \
-				["mp2975_9"]="mp2975 0x6b 5 voltmon10" \
+				["mp2975_9"]="mp2975 0x6c 5 voltmon10" \
 				["mp2975_10"]="mp2975 0x6e 5 voltmon11" \
 				["xdpe15284_0"]="xdpe15284 0x62 5 voltmon1" \
 				["xdpe15284_1"]="xdpe15284 0x63 5 voltmon2" \

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -435,7 +435,7 @@ sn5600_base_connect_table=( \
 	mp2975 0x68 5 \
 	mp2975 0x69 5 \
 	mp2975 0x6a 5 \
-	mp2975 0x6b 5 \
+	mp2975 0x6c 5 \
 	mp2975 0x6e 5 \
 	tmp102 0x49 6 \
 	tmp102 0x4a 7 \
@@ -1033,7 +1033,7 @@ msn27xx_msb_msx_specific()
 
 	set_spc1_port_cpld
 
-dcx	thermal_control_config="$thermal_control_configs_path/tc_config_msn2700_msb7x00.json"
+	thermal_control_config="$thermal_control_configs_path/tc_config_msn2700_msb7x00.json"
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
 	get_i2c_bus_frequency_default
 }
@@ -1097,8 +1097,8 @@ mqmxxx_msn37x_msn34x_specific()
 			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 			thermal_control_config="$thermal_control_configs_path/tc_config_msn3700C.json"
 		;;
-		HI112|HI116)
-			# msn3700/msn3700C
+		HI112)
+			# msn3700
 			connect_msn3700
 			thermal_control_config="$thermal_control_configs_path/tc_config_msn3700.json"
 		;;


### PR DESCRIPTION
- hw-mgmt: thermal: Initial commit for new thermal_control
- hw-mgmt: thermal: Cleanup and fix issues
- hw-mgmt: fan: Fix fan dir attribute for systems without CPLD fan direction attribute
- hw-mgmt: thermal: removed unnecessary "fault" error case from dmin table
- hw-mgmt: thermal: Fixed thermal data for msn4600, mqm9700
- hw-mgmt: patch 5.10: replace frequent pr_info to pr_devel in ICP201xx driver
- Update Changelog 7.0030.0002
- hw-mgmt: scripts: comment out old systems from SMBIOS BOM support.
- hw-mgmt: scripts: make ii0 a2d link just in case that file exist.
- Update Changelog V.7.0030.0050
- hw-mgmt: psu: Fix reporting of Delta 550 FW version
- hw-mgmt: psu: Add reporting of Delta PSU primary FW version
- Update hw-mgmt package version.
- Merge fixes from thermal branch
- hw-mgmt: sensors: Add WA for unsupported PSU command in SN5600 config
- Fix crash if FAN not present
- hw-mgmt: Add configuration for JTAG offsets
- hw-mgmt: patches: v5.10: Temporary - backport patch from V.7.0020.5100_BR
- Update hw-mgmt package version.
- hw-mgmt: kernel 5.10: temp workaround of bad FW MGPIR report.
- hw-mgmt: kernel 5.10: Moose BU temp workaround of incorrect reported max_num.
- hw-mgmt: kernel 5.10: modify reported reset causes.
- hw-mgmt: patches 5.10: Add and remove patches
- Update hw-mgmt package version.
- hw-mgmt: topology: change address of mp2975 on Moose main board from 0x6B to 0x6C
- hw-mgmt: sensors conf: Fix weird negative current value on IBC-1 power converter on SN5600.
- hw-mgmt: kernel 5.10: Fix production issue of missing mgmt ifc.
