### PR TITLE
hw-mgmt: fan: Fix tacho order for inversed FAN order

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -57,6 +57,8 @@ fan_drwr_num=0
 fan_direction_exhaust=46
 fan_direction_intake=52
 
+FAN_MAP_DEF=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20)
+
 if [ "$board_type" == "VMOD0014" ]; then
 	i2c_bus_max=14
 	i2c_asic_bus_default=6
@@ -316,14 +318,12 @@ if [ "$1" == "add" ]; then
 					echo "$name" > "$cpath"/cooling_name
 				fi
 				if [ -f "$cpath"/fan_inversed ]; then
-					inv=$(< "$cpath"/fan_inversed)
+					declare -a fan_map="($(< $cpath/fan_inversed))"
+				else
+					fan_map=(${FAN_MAP_DEF[@]})
 				fi
 				for ((i=1; i<=max_tachos; i+=1)); do
-					if [ -z "$inv" ] || [ "${inv}" -eq 0 ]; then
-						j=$i
-					else
-						j=$((inv - i))
-					fi
+					j=${fan_map[i-1]}
 					if [ -f "$3""$4"/fan"$i"_input ]; then
 						ln -sf "$3""$4"/fan"$i"_input "$tpath"/fan"$j"_speed_get
 						ln -sf "$3""$4"/pwm1 "$tpath"/fan"$j"_speed_set

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -927,7 +927,7 @@ msn274x_specific()
 	echo 1500 > $config_path/fan_min_speed
 	echo 18000 > $config_path/psu_fan_max
 	echo 2000 > $config_path/psu_fan_min
-	echo 5 > $config_path/fan_inversed
+	echo "4 3 2 1" > $config_path/fan_inversed
 	echo 2 > $config_path/cpld_num
 	echo 24c02 > $config_path/psu_eeprom_type
 	lm_sensors_config="$lm_sensors_configs_path/msn2740_sensors.conf"
@@ -946,7 +946,7 @@ msn21xx_specific()
 	echo 1500 > $config_path/fan_min_speed
 	echo 13000 > $config_path/psu_fan_max
 	echo 1040 > $config_path/psu_fan_min
-	echo 5 > $config_path/fan_inversed
+	echo "4 3 2 1" > $config_path/fan_inversed
 	echo 2 > $config_path/cpld_num
 	lm_sensors_config="$lm_sensors_configs_path/msn2100_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2100.json"
@@ -973,7 +973,7 @@ msn24xx_specific()
 			echo 5400 > $config_path/fan_min_speed
 			echo 18000 > $config_path/psu_fan_max
 			echo 2000 > $config_path/psu_fan_min
-			echo 9 > $config_path/fan_inversed
+			echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
 			echo 24c02 > $config_path/psu_eeprom_type
 			;;
 	esac
@@ -1015,7 +1015,7 @@ msn27xx_msb_msx_specific()
 			echo 1500 > $config_path/fan_min_speed
 			echo 18000 > $config_path/psu_fan_max
 			echo 2000 > $config_path/psu_fan_min
-			echo 9 > $config_path/fan_inversed
+			echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
 			echo 24c02 > $config_path/psu_eeprom_type
 			;;
 	esac
@@ -1051,7 +1051,7 @@ msn201x_specific()
 	echo 4500 > $config_path/fan_min_speed
 	echo 13000 > $config_path/psu_fan_max
 	echo 1040 > $config_path/psu_fan_min
-	echo 5 > $config_path/fan_inversed
+	echo "4 3 2 1" > $config_path/fan_inversed
 	echo 2 > $config_path/cpld_num
 	lm_sensors_config="$lm_sensors_configs_path/msn2010_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2010.json"
@@ -1216,7 +1216,7 @@ msn24102_specific()
 	echo 5400 > $config_path/fan_min_speed
 	echo 18000 > $config_path/psu_fan_max
 	echo 2000 > $config_path/psu_fan_min
-	echo 9 > $config_path/fan_inversed
+	echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
 	echo 4 > $config_path/cpld_num
 	i2c_comex_mon_bus_default=23
 	i2c_bus_def_off_eeprom_cpu=24
@@ -1238,7 +1238,7 @@ msn27002_msb78002_specific()
 	echo 1500 > $config_path/fan_min_speed
 	echo 18000 > $config_path/psu_fan_max
 	echo 2000 > $config_path/psu_fan_min
-	echo 9 > $config_path/fan_inversed
+	echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
 	echo 4 > $config_path/cpld_num
 	i2c_comex_mon_bus_default=23
 	i2c_bus_def_off_eeprom_cpu=24


### PR DESCRIPTION
Fix tacho order for inversed FAN order

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
