### PR TITLE
hw-mgmt: thermal: Fix adding sensors to block

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2261,8 +2261,9 @@ class ThermalManagement(hw_managemet_file_op):
 
         fault_cnt = 0
         for dev_obj in self.dev_obj_list:
-            if dev_obj.get_fault_list():
-                fault_cnt += 1
+            if dev_obj.state == CONST.RUNNING:
+                if dev_obj.get_fault_list():
+                    fault_cnt += 1
         return fault_cnt
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixed issue when ensors errors was handled even if sensor is blocked.

BUG: #3438388

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
