### PR TITLE
hw-mgmt: thermal: Fix bug ' object has no attribute 'fan_drwr_num'

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.0934) unstable; urgency=low
+hw-management (1.mlnx.7.0030.0936) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 24 Apr 2023 14:00:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 27 Apr 2023 12:00:00 +0300


### PR DESCRIPTION
Fix for bug which can happens on stop TC when it in INIT state.

AttributeError: 'ThermalManagement' object has no attribute 'fan_drwr_num'

Bug: #3446102

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
