### PR TITLE
hw-mgmt: scripts: SMBIOS BOM mechanism stts temp sensor fixes.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.0503) unstable; urgency=low
+hw-management (1.mlnx.7.0030.0938) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 3 May 2023 15:01:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Sun, 7 May 2023 15:01:00 +0300

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -39,7 +39,7 @@ declare -A board_arr=(["C"]="cpu_board" ["S"]="switch_board" ["F"]="fan_board" [
 
 declare -A category_arr=(["T"]="thermal" ["R"]="regulator" ["A"]="a2d" ["P"]="pressure" ["E"]="eeprom")
 
-declare -A thermal_arr=(["0"]="dummy" ["a"]="lm75" ["b"]="tmp102" ["c"]="adt75" ["d"]="stts375" ["e"]="tmp75")
+declare -A thermal_arr=(["0"]="dummy" ["a"]="lm75" ["b"]="tmp102" ["c"]="adt75" ["d"]="stts751" ["e"]="tmp75")
 
 declare -A regulator_arr=(["0"]="dummy" ["a"]="mp2975" ["b"]="mp2888" ["c"]="tps53679" ["d"]="xdpe12284" ["e"]="152x4")
 
@@ -160,7 +160,8 @@ declare -A sn5600_alternatives=(["max11603_0"]="max11603 0x6d 5 swb_a2d" \
 				["xdpe15284_9"]="xdpe15284 0x6b 5 voltmon10" \
 				["xdpe15284_10"]="xdpe15284 0x6e 5 voltmon11" \
 				["tmp102_0"]="tmp102 0x4a 7 port_amb" \
-				["adt75_0"]="tmp102 0x4a 7 port_amb" \
+				["adt75_0"]="adt75 0x4a 7 port_amb" \
+				["stts751_0"]="stts751 0x4a 7 port_amb" \
 				["24c512_0"]="24c512 0x51 8 system_eeprom")
 
 declare -A p4262_alternatives=(["tmp75_0"]="tmp75 0x48 7 port_temp1" \


### PR DESCRIPTION
1. Change driver to right name stts751 instead stts375
2. Add as additional alternative to Moose.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
