### PR TITLE
hw-mgmt: Remove ICP201xx pressure sensors from SMBIOS BOM mechanism.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.0939) unstable; urgency=low
+hw-management (1.mlnx.7.0030.0940) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Sun, 9 May 2023 15:01:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Thu, 11 May 2023 15:01:00 +0300

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -202,12 +202,15 @@ declare -A fan_type1_alternatives=(["tmp102_0"]="tmp102 0x49 6 fan_amb" \
 declare -A clk_type0_alternatives=(["24c128_0"]="24c128 0x54 5 clk_eeprom1" \
 				   ["24c128_1"]="24c128 0x57 5 clk_eeprom2")
 
+# Remove ICP201xx pressure sensors from SMBIOS BOM mechanism
+# These pressure sensors don't have upstream kernel driver.
+# They will be instantiated manually in OPT-OS only.
 declare -A pwr_type0_alternatives=(["pmbus_0"]="pmbus 0x10 4 pwr_conv1" \
 				   ["pmbus_1"]="pmbus 0x11 4 pwr_conv2" \
 				   ["pmbus_2"]="pmbus 0x13 4 pwr_conv3" \
 				   ["pmbus_3"]="pmbus 0x15 4 pwr_conv4" \
-				   ["icp201xx_0"]="icp201xx 0x63 4 press_sens1" \
-				   ["icp201xx_1"]="icp201xx 0x64 4 press_sens2" \
+#				   ["icp201xx_0"]="icp201xx 0x63 4 press_sens1" \
+#				   ["icp201xx_1"]="icp201xx 0x64 4 press_sens2" \
 				   ["max11603_0"]="max11603 0x6d 4 pwrb_a2d")
 
 declare -A pwr_type1_alternatives=(["lm5066_0"]="lm5066 0x11 4 pdb_hotswap1" \


### PR DESCRIPTION
These pressure sensors don't have upstream kernel driver.
They will be instantiated manually in OPT-OS only.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
