### PR TITLE
V.7.0020.4100 BR

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -64,7 +64,7 @@ Kernel-4.19
 |0064-platform-mellanox-mlxreg-io-Fix-read-access-of-n-byt.patch         |                                            |                                                 | MQM8700 and E3597                                            |
 |0065-i2c-mlxcpld-Fix-criteria-for-frequency-setting.patch               |                                            |  accepted as bugfix                             | Modular SN4800                                               |
 |0066-i2c-mlxcpld-Reduce-polling-time-for-performance-impr.patch         |                                            |  accepted for i2c-next                          | Modular SN4800                                               |
-|0067-i2c-mlxcpld-Allow-flexible-polling-time-setting-for-.patch         |                                            |  accepted for i2c-next                          | Modular SN4800                                               |
+|0067-i2c-mlxcpld-Allow-flexible-polling-time-setting-for-.patch         |                                            |  accepted for i2c-next                          | Modular SN4800                                               
 |0068-hwmon-pmbus-mp2975-Add-missed-POUT-attribute-for-pag.patch         |                                            |  accepted, applied as bug fix                   |                                                              |
 |0069-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch         |                                            |  pending approval                               | Modular SN4800                                               |
 |0070-leds-mlxreg-Skip-setting-LED-color-during-initializa.patch         |                                            |  pending approval                               | Modular SN4800                                               |
@@ -347,6 +347,7 @@ Kernel-5.10
 |0179-DS-iio-pressure-icp20100-add-driver-for-InvenSense-ICP-.patch      |                                            | downstream for OPT-OS use only                  | SN5600                                                       |
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch         | 525dd5aed67a2f4f7278116fb92a24e6a53e2622   | accepted                                       |                                                              |
 |0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch          |                                            | pending                                         | for kernel >= 5.10.74 only                                   |
+|0265-hwmon-mlxreg-fan-Return-zero-speed-for-broken-fan.patch            |                                            | Pending                                         | Bugfix                                                       |
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
  

--- a/recipes-kernel/linux/linux-5.10/0265-hwmon-mlxreg-fan-Return-zero-speed-for-broken-fan.patch
+++ b/recipes-kernel/linux/linux-5.10/0265-hwmon-mlxreg-fan-Return-zero-speed-for-broken-fan.patch
@@ -1,0 +1,40 @@
+From 0bb5bbc78316970c3bde085f091a70799b39b262 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Sun, 5 Feb 2023 09:34:20 +0200
+Subject: [PATCH hwmon backport 5.10 1/1] hwmon: (mlxreg-fan) Return zero speed
+ for broken fan
+
+Currently for broken fan driver returns value calculated based on error
+code (0xFF) in related fan speed register.
+Thus, for such fan user gets fan{n}_fault to 1 and fan{n}_input with
+misleading value.
+
+Add check for fan fault prior return speed value and return zero if
+fault is detected.
+
+Fixes: 65afb4c8e7e4 ("hwmon: (mlxreg-fan) Add support for Mellanox FAN driver")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/hwmon/mlxreg-fan.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index acba9d688..b999ca648 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -158,6 +158,12 @@ mlxreg_fan_read(struct device *dev, enum hwmon_sensor_types type, u32 attr,
+ 			if (err)
+ 				return err;
+ 
++			if (MLXREG_FAN_GET_FAULT(regval, tacho->mask)) {
++				/* FAN is broken - return zero for FAN speed. */
++				*val = 0;
++				return 0;
++			}
++
+ 			*val = MLXREG_FAN_GET_RPM(regval, fan->divider,
+ 						  fan->samples);
+ 			break;
+-- 
+2.20.1
+

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -50,7 +50,7 @@ dump_cmd () {
 	if [ -x "$(command -v $cmd_name)" ];
 	then
 		# ignore shellcheck message SC2016. Arguments should be single-quoted (')
-		run_cmd="$cmd & > $DUMP_FOLDER/$output_fname"
+		run_cmd="$cmd &> $DUMP_FOLDER/$output_fname"
 		timeout "$timeout" bash -c "$run_cmd"
 	fi
 }

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -50,7 +50,7 @@ dump_cmd () {
 	if [ -x "$(command -v $cmd_name)" ];
 	then
 		# ignore shellcheck message SC2016. Arguments should be single-quoted (')
-		run_cmd="$cmd > $DUMP_FOLDER/$output_fname"
+		run_cmd="$cmd & > $DUMP_FOLDER/$output_fname"
 		timeout "$timeout" bash -c "$run_cmd"
 	fi
 }
@@ -62,7 +62,9 @@ ls -Rla /sys/ > $DUMP_FOLDER/sysfs_tree
 if [ -d $HW_MGMT_FOLDER ]; then
     ls -Rla $HW_MGMT_FOLDER > $DUMP_FOLDER/hw-management_tree
     run_cmd="find -L $HW_MGMT_FOLDER -maxdepth 4 -exec ls -la {} \; -exec cat {} \; > $DUMP_FOLDER/hw-management_val 2> /dev/null"
-    timeout 60 bash -c "$run_cmd"
+    timeout 60 bash -c "$run_cmd" &> /dev/null
+    run_cmd="find $HW_MGMT_FOLDER/eeprom/  -name *info  -exec ls -la {} \; -exec hexdump -C {} \; > $DUMP_FOLDER/hw-management_fru_dump 2> /dev/null"
+    timeout 60 bash -c "$run_cmd" &> /dev/null
 fi
 
 if [ -z $MODE ] || [ $MODE != "compact" ]; then

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -50,7 +50,7 @@ dump_cmd () {
 	if [ -x "$(command -v $cmd_name)" ];
 	then
 		# ignore shellcheck message SC2016. Arguments should be single-quoted (')
-		run_cmd="$cmd &> $DUMP_FOLDER/$output_fname"
+		run_cmd="$cmd 1> $DUMP_FOLDER/$output_fname 2> $DUMP_FOLDER/$output_fname"
 		timeout "$timeout" bash -c "$run_cmd"
 	fi
 }
@@ -74,6 +74,7 @@ if [ -z $MODE ] || [ $MODE != "compact" ]; then
 	dump_cmd "sx_sdk --version" "sx_sdk_ver" "10"
 fi
 
+[ -f /var/log/tc_log ] && cp /var/log/tc_* $DUMP_FOLDER/
 uname -a > $DUMP_FOLDER/sys_version
 mkdir $DUMP_FOLDER/bin/
 cp /usr/bin/hw-management* $DUMP_FOLDER/bin/

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -37,6 +37,7 @@
 DUMP_FOLDER="/tmp/hw-mgmt-dump"
 HW_MGMT_FOLDER="/var/run/hw-management/"
 board_type=`cat /sys/devices/virtual/dmi/id/board_name`
+REGMAP_FILE="/sys/kernel/debug/regmap/mlxplat/registers"
 
 MODE=$1
 
@@ -103,6 +104,7 @@ dump_cmd "lspci -vvv" "lspci" "5"
 dump_cmd "top -SHb -n 1 | tail -n +8 | sort -nrk 11" "top" "5"
 dump_cmd "sensors" "sensors" "20"
 dump_cmd "iio_info" "iio_info" "5"
+dump_cmd "cat $REGMAP_FILE 2>/dev/null" "cpld_dump" "5"
 
 if [ -x "$(command -v i2cdetect)" ];   then
     run_cmd="for i in {0..17} ; do echo i2c bus \$i; i2cdetect -y \$i 2>/dev/null; done > $DUMP_FOLDER/i2c_scan"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -208,8 +208,8 @@ get_fixed_fans_direction()
 # Input parameters:
 # 1 - "$psu_name"
 # Return FAN direction
-# 0 - Forward (C2P)
-# 1 - Reverse (P2C)
+# 0 - Reverse (C2P)
+# 1 - Forward(P2C)
 # 2 - unknown (read error or field missing)
 get_psu_fan_direction()
 {
@@ -230,9 +230,9 @@ get_psu_fan_direction()
 			dir_char="${BASH_REMATCH[1]}"
 		fi
 	fi
-	if [ $dir_char == "F" ]; then
+	if [ $dir_char == "R" ]; then
 		return 0
-	elif [ $dir_char == "R" ]; then
+	elif [ $dir_char == "F" ]; then
 		return 1
 	else
 		return 2

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -626,31 +626,34 @@ if [ "$1" == "add" ]; then
 	fi
 	# Max index of SN2201 cputemp is 14.
 	if [ "$2" == "cputemp" ]; then
-		if [ "$board_type" == "VMOD0014" ]; then
-			sn2201_find_cpu_core_temp_ids
-		fi
 		for i in {1..16}; do
 			if [ -f "$3""$4"/temp"$i"_input ]; then
 				if [ $i -eq 1 ]; then
 					name="pack"
 				else
-					if [ "$board_type" != "VMOD0014" ]; then
-						id=$((i - 2))
-					else
+					id=$((i - 2))
+					if [ "$board_type" == "VMOD0014" ]; then
 					# Denverton CPU on SN2201 has ridicolous CPU Core numbers 6, 12 instead 0, 1
 					# These core id numbers also can differ in various CPU batches.
-						if [ "$i" == "$core0_temp_id" ]; then
-							id=0
-						elif [ "$i" == "$core1_temp_id" ]; then
-							id=1
+					# This was fixed in later version of coretemp driver e.g. in kernel 5.10.162 
+					# and core temperature is reported as in other Intel CPUs, core0 - temp2_input
+					# core1 - temp3_input. Check this case.
+						sn2201_find_cpu_core_temp_ids
+						if [ -f "$3""$4"/temp"$core0_temp_id"_input ] ||
+						   [ -f "$3""$4"/temp"$core1_temp_id"_input ]; then
+							if [ "$i" == "$core0_temp_id" ]; then
+								id=0
+							elif [ "$i" == "$core1_temp_id" ]; then
+								id=1
+							fi
 						fi
 					fi
 					name="core$id"
 				fi
-				ln -sf "$3""$4"/temp"$i"_input $thermal_path/cpu_$name
-				ln -sf "$3""$4"/temp"$i"_crit $thermal_path/cpu_"$name"_crit
-				ln -sf "$3""$4"/temp"$i"_max $thermal_path/cpu_"$name"_max
-				ln -sf "$3""$4"/temp"$i"_crit_alarm $alarm_path/cpu_"$name"_crit_alarm
+				check_n_link "$3""$4"/temp"$i"_input $thermal_path/cpu_$name
+				check_n_link "$3""$4"/temp"$i"_crit $thermal_path/cpu_"$name"_crit
+				check_n_link "$3""$4"/temp"$i"_max $thermal_path/cpu_"$name"_max
+				check_n_link "$3""$4"/temp"$i"_crit_alarm $alarm_path/cpu_"$name"_crit_alarm
 			fi
 		done
 	fi

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -866,8 +866,16 @@ if [ "$1" == "add" ]; then
 		elif echo $mfr | grep -iq "Delta"; then
 			# Support FW update only for specific Delta PSU capacities
 			fw_ver="N/A"
+			fw_primary_ver="N/A"
 			if [ "$cap" == "550" -o "$cap" == "2000" -o "$cap" == "3000" ]; then
-				fw_ver=$(hw_management_psu_fw_update_delta.py -v -b $bus -a $psu_addr)
+				fw_ver_all=$(hw_management_psu_fw_update_delta.py -v -b $bus -a $psu_addr | tr -dc '[[:print:]]')
+				if [ "$cap" == "550" ]; then
+					fw_primary_ver=$(echo $fw_ver_all | cut -d. -f2)
+					fw_ver=$(echo $fw_ver_all | cut -d. -f3)
+				else
+					fw_primary_ver=$(echo $fw_ver_all | cut -d. -f1)
+					fw_ver=$(echo $fw_ver_all | cut -d. -f2)
+				fi
 				if [ "$cap" == "3000" ] && [ "$board_type" == "VMOD0013" ]; then
 					if [ ! -e "$config_path"/amb_tmp_warn_limit ]; then
 						echo 38000 > "$config_path"/amb_tmp_warn_limit
@@ -880,6 +888,7 @@ if [ "$1" == "add" ]; then
 				fi
 			fi
 			echo $fw_ver > $fw_path/"$psu_name"_fw_ver
+			echo $fw_primary_ver > $fw_path/"$psu_name"_fw_primary_ver
 		fi
 
 	fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2333,6 +2333,7 @@ Options:
 			thermal control.
 	restart
 	force-reload	Performs hw-management 'stop' and the 'start.
+	reset-cause	Output system reset cause.
 "
 
 case $ACTION in
@@ -2391,6 +2392,11 @@ case $ACTION in
 		do_stop
 		sleep 3
 		do_start
+	;;
+	reset-cause)
+		for f in $system_path/reset_*;
+			do v=`cat $f`; attr=$(basename $f); if [ $v -eq 1 ]; then echo $attr; fi;
+		done
 	;;
 	*)
 		echo "$__usage"

--- a/usr/usr/bin/hw_management_psu_fw_update_common.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_common.py
@@ -167,7 +167,6 @@ def pmbus_read_mfr_id(i2c_bus, i2c_addr):
     ret = pmbus_read_block(i2c_bus, i2c_addr, 0x99)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())[1:]
-        print(ascii_str)
         return ascii_str
     return ''
 
@@ -178,7 +177,6 @@ def pmbus_read_mfr_model(i2c_bus, i2c_addr):
     ret = pmbus_read_block(i2c_bus, i2c_addr, 0x9a)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())[1:]
-        print(ascii_str)
         return ascii_str
     return ''
 
@@ -189,7 +187,6 @@ def pmbus_read_mfr_revision(i2c_bus, i2c_addr):
     ret = pmbus_read_block(i2c_bus, i2c_addr, 0x9b)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())[1:]
-        print(ascii_str)
         return ascii_str
     return ''
 

--- a/usr/usr/bin/hw_management_psu_fw_update_delta.py
+++ b/usr/usr/bin/hw_management_psu_fw_update_delta.py
@@ -60,11 +60,17 @@ MFR_FWUPLOAD_REVISION = 0xd5
 MFR_MODEL_3000AB_10G = "DPS-3000AB-10 G"
 MFR_FWUPLOAD_STATUS_3000AB_10G = 0xd8
 
+MFR_MODEL_500AB = "DPS-550AB"
+
 def read_mfr_fw_revision(i2c_bus, i2c_addr):
     """
     @summary: Read MFR_FW_REVISION.
     """
-    ret = psu_upd_cmn.pmbus_read(i2c_bus, i2c_addr, MFR_FWUPLOAD_REVISION, 6)
+    mfr_model = psu_upd_cmn.pmbus_read_mfr_model(i2c_bus, i2c_addr)
+    if mfr_model.startswith(MFR_MODEL_500AB):
+        ret = psu_upd_cmn.pmbus_read(i2c_bus, i2c_addr, MFR_FWUPLOAD_REVISION, 8)
+    else:
+        ret = psu_upd_cmn.pmbus_read(i2c_bus, i2c_addr, MFR_FWUPLOAD_REVISION, 6)
     if ret != '' and len(ret) > 3 and ret[:2] == '0x':
         ascii_str = ''.join(chr(int(i, 16)) for i in ret.split())
         return ascii_str


### PR DESCRIPTION
- hw-mgmt: psu: Add psuX_fan_dir attribute
- hw-mgmt: fan: Fix fan dir attribute for systems without CPLD fan direction attribute
- hw-mgmt: psu: Fix wrong direction in psuX_fan_dir attribute
- Fix unknown FAN dir for fixed systems with the custom PN
- hw-mgmt: kernel patches: Add patches for fan speed fix
- hw-mgmt: scripts: fix cpu_core temperature links creation.
- hw-mgmt: psu: Add reporting of Delta PSU primary FW version
- hw-mgmt: psu: Fix reporting of Delta 550 FW version
- Capturing cpld dump in the hw-management dump
- hw-mgmt: debug: Add vpd binary dump
- hw-mgmt: Add command to expose reset cause
