### PR TITLE
hw-mgmt: thermal: Update default config for PWM/FAN control

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -314,7 +314,7 @@ TABLE_DEFAULT = {
     }
 }
 
-ASIC_CONF_DEFAULT = {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": True, "fan_control": True}}
+ASIC_CONF_DEFAULT = {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": False, "fan_control": False}}
 
 # ----------------------------------------------------------------------
 def str2bool(val):


### PR DESCRIPTION
Set PWM/FAN config to not use ASIC control by default

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
