### PR TITLE
hw-mgmt: patches 5.10: Add patchwork folder

### DIFF
--- a/recipes-kernel/linux/linux-5.10/patchwork/0188-i2c-mux-Add-register-map-based-mux-driver.patch.txt
+++ b/recipes-kernel/linux/linux-5.10/patchwork/0188-i2c-mux-Add-register-map-based-mux-driver.patch.txt
@@ -1,0 +1,1 @@
+patchwork_link: https://patchwork.ozlabs.org/project/linux-i2c/patch/20230215195322.21955-1-vadimp@nvidia.com/


### PR DESCRIPTION
Add "patchwork" whgich contains links for patchwork discussions
per patch name.

./recipes-kernel/linux/linux-<major_ver>/patchwork/<patch_name>.txt

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
