### PR TITLE
hw-mgmt: dump: Remove i2cdetect from dump

### DIFF
--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 ##################################################################################
-# Copyright (c) 2020 - 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020 - 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -109,10 +109,6 @@ dump_cmd "sensors" "sensors" "20"
 dump_cmd "iio_info" "iio_info" "5"
 dump_cmd "cat $REGMAP_FILE 2>/dev/null" "cpld_dump" "5"
 
-if [ -x "$(command -v i2cdetect)" ];   then
-    run_cmd="for i in {0..17} ; do echo i2c bus \$i; i2cdetect -y \$i 2>/dev/null; done > $DUMP_FOLDER/i2c_scan"
-    timeout 60 bash -c "$run_cmd"
-fi
 
 tar czf /tmp/hw-mgmt-dump.tar.gz -C $DUMP_FOLDER .
 rm -rf $DUMP_FOLDER


### PR DESCRIPTION
Remove i2cdetect from dump, since access to some
busses causes collision between SW and FW.

Fixes: [SONIC - Design] Bug SW #3447830: [Functional-DOA] [I2C] | I2C bus is getting stuck, recovered only by a power cycle

Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>