### PR TITLE
hw-mgmt: init: Fix hw-management init

### DIFF
--- a/usr/usr/bin/hw-management-ready.sh
+++ b/usr/usr/bin/hw-management-ready.sh
@@ -65,6 +65,7 @@ VMOD0014)
 		plat_path=/sys/devices/platform/mlxplat
 	fi
 	if [ ! -d ${plat_path}/mlxreg-hotplug/hwmon ]; then
+		export plat_path
 		timeout 180 bash -c 'until [ -d ${plat_path}/mlxreg-hotplug/hwmon ]; do sleep 0.2; done'
 	fi
 	;;


### PR DESCRIPTION
Fix hw-management init issue. It took sometimes tool much time ~ 180sec

Bug:#3485095

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>

4#	usr/usr/bin/thermal_data_grabber.py
