### PR TITLE
hw-mgmt: patches 5.10: Fix for asic sensor count

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -448,6 +448,8 @@ Kernel-5.10
 |0279-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            | P4262                                          |
 |0280-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch  |                    | Feature pending                          |            | P4262                                          |
 |0281-platform-mellanox-mlx-platform-Modify-health-and-pow.patch  |                    | Feature pending                          |            | P4262                                          |
+|0282-platform-mellanox-mlx-platform-add-support-of-5th-CP.patch  |                    | Feature pending                          |            | P4262                                          |
+|0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch  |                    | Feature pending                          |            | SN3750SX                                       |
 |9000-DS-OPT-iio-pressure-icp20100-add-driver-for-InvenSense-.patch|                   | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-DS-OPT-e1000e-skip-NVM-checksum.patch                       |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream                               |            |                                                |

--- a/recipes-kernel/linux/linux-5.10/0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch
+++ b/recipes-kernel/linux/linux-5.10/0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch
@@ -1,0 +1,50 @@
+From 41dd6c60de14f70908fc03ed2c20aa35ae0d1596 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 19 Jun 2023 09:53:41 +0000
+Subject: [PATCH backport 5.10 3/3] mlxsw: core_hwmon: Align modules label name
+ assignment according to the MTCAP sensor counter
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+For some new devices MTCAP register provides the counter of ASIC
+ambient sensors plus additional number of platform sensors.
+In such case 'sensor count' will be greater then 1 and modules labels
+will be shifted by the number of platform sensors.
+
+Thus utilities sensors will expose incorrect modules labels.
+For example, temperatures for module#1, module#2 will be exposed like:
+front panel 002:  +37.0°C  (crit = +70.0°C, emerg = +75.0°C)
+front panel 003:  +47.0°C  (crit = +70.0°C, emerg = +75.0°C)
+instead of:
+front panel 001:  +37.0°C  (crit = +70.0°C, emerg = +75.0°C)
+front panel 002:  +47.0°C  (crit = +70.0°C, emerg = +75.0°C)
+
+Set 'index' used in label name according to the 'sensor_count' value.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index a27146cca..f80050cec 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -412,6 +412,13 @@ mlxsw_hwmon_module_temp_label_show(struct device *dev,
+ 	int index = mlxsw_hwmon_attr->type_index;
+ 
+ 	mlxsw_hwmon_dev = mlxsw_hwmon_attr->mlxsw_hwmon_dev;
++	/* For some devices 'sensor count' provides the number of ASIC sensor
++	 * plus additional platform sensors. Set 'index' used in label name
++	 * according to the 'sensor_count' value to align label name with the
++	 * module index.
++	 */
++	if (mlxsw_hwmon_dev->sensor_count > 1)
++		index += 1 - mlxsw_hwmon_dev->sensor_count;
+ 	if (strlen(mlxsw_hwmon_dev->name))
+ 		index += 1;
+ 
+-- 
+2.20.1
+

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -344,7 +344,11 @@ if [ "$1" == "add" ]; then
 						case $label in
 						*front*)
 							if [ "$name" == "mlxsw" ]; then
-								j=$((i-1))
+								# For some new platforms MTCAP register provides the count of
+								# ASIC sensors plus additional platform sensors. So its better
+								# to extract the module number from label which will contain the
+								# string "front panel xxx". 'xxx' is the module number.
+								j=$(echo $label | awk '{print $3}' | sed 's/^0*//')
 							else
 								j="$i"
 							fi


### PR DESCRIPTION
In newer platforms like Komodo there is an additional OCXO temperature sensor. This sensor is enabled in the firmware and the platform driver returns the SFP module number which starts with three and causes the
module*_temperature attributes to start with module2. This patch fixes the numbering issue.