### PR TITLE
hw-mgmt: init: Fix hw-management init

### DIFF
--- a/usr/usr/bin/hw-management-ready.sh
+++ b/usr/usr/bin/hw-management-ready.sh
@@ -58,8 +58,15 @@ VMOD0014)
 	fi
 	;;
 *)
-	if [ ! -d /sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon ]; then
-		timeout 180 bash -c 'until [ -d /sys/devices/platform/mlxplat/mlxreg-hotplug/hwmon ]; do sleep 0.2; done'
+	arch=$(uname -m)
+	if [ "$arch" = "aarch64" ]; then
+		plat_path=/sys/devices/platform/MLNXBF49:00
+	else
+		plat_path=/sys/devices/platform/mlxplat
+	fi
+	if [ ! -d ${plat_path}/mlxreg-hotplug/hwmon ]; then
+		export plat_path
+		timeout 180 bash -c 'until [ -d ${plat_path}/mlxreg-hotplug/hwmon ]; do sleep 0.2; done'
 	fi
 	;;
 esac


### PR DESCRIPTION
Fix hw-management init issue. It took sometimes tool much time ~ 180sec

Bug:#3485095

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
