### PR TITLE
hw-mgmt: thermal: Update ambiant sensor logic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.0951) unstable; urgency=low
+hw-management (1.mlnx.7.0030.0953) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Tue, 21 June 2023 11:30:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Tue, 27 June 2023 11:30:00 +0300


### PR DESCRIPTION
1. If one of amb_sensor read error - ignore it and set "sensor_read" error
   (after 3 times)
2. If >1 of amb sensors read error - set PWM to max (100%)

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
