### PR TITLE
hw-mgmt: sensors: ignore PSU fan2, fan3 on SN4600/SN4700 systems.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.0957) unstable; urgency=low
+hw-management (1.mlnx.7.0030.0958) unstable; urgency=low
   [ MLNX ] 
 
  -- MellanoxBSP <system-sw-low-level@mellanox.com> Wed, 5 Jul 2023 11:30:00 +0300

--- a/usr/etc/hw-management-sensors/msn4700_respin_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4700_respin_sensors.conf
@@ -259,6 +259,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(L) 12V Rail (out)"
         label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(L) Temp 1"
         label temp2 "PSU-1(L) Temp 2"
         label temp3 "PSU-1(L) Temp 3"
@@ -271,6 +273,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
         label fan1 "PSU-2(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(R) Temp 1"
         label temp2 "PSU-2(R) Temp 2"
         label temp3 "PSU-2(R) Temp 3"

--- a/usr/etc/hw-management-sensors/msn4700_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4700_sensors.conf
@@ -185,6 +185,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(L) 12V Rail (out)"
         label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(L) Temp 1"
         label temp2 "PSU-1(L) Temp 2"
         label temp3 "PSU-1(L) Temp 3"
@@ -197,6 +199,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
         label fan1 "PSU-2(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(R) Temp 1"
         label temp2 "PSU-2(R) Temp 2"
         label temp3 "PSU-2(R) Temp 3"


### PR DESCRIPTION
PSUs on SN4600/SN4700 systems reports on weird way FAN2 and FAN3
spite that only FAN1 exists. Ignore them.
Bug RMID# 3522603.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
