### PR TITLE
Fix for Voltmon temperature attribute in Gorilla

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -837,10 +837,9 @@ if [ "$1" == "add" ]; then
 					check_n_link "$3""$4"/temp"$i"_crit $thermal_path/"$prefix"_temp"$i"_crit
 					check_n_link "$3""$4"/temp"$i"_lcrit $thermal_path/"$prefix"_temp"$i"_lcrit
 				done
-			else
-				check_n_link "$3""$4"/temp1_input $thermal_path/"$prefix"_temp_input
-				check_n_link "$3""$4"/temp1_max $thermal_path/"$prefix"_temp_max
 			fi
+			check_n_link "$3""$4"/temp1_input $thermal_path/"$prefix"_temp_input
+			check_n_link "$3""$4"/temp1_max $thermal_path/"$prefix"_temp_max
 
 			for i in {1..3}; do
 				find_sensor_by_label "$3""$4" "in" "${VOLTMON_SENS_LABEL[$i]}"


### PR DESCRIPTION
The attributes voltmon*_temp_input is not created and this patch fixes that.

Issue# 3530045