### PR TITLE
hw-mgmt: scripts: fix missing fan attributes on Panther-Comex system

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.0958) unstable; urgency=low
+hw-management (1.mlnx.7.0030.0959) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Wed, 5 Jul 2023 11:30:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 10 Jul 2023 11:30:00 +0300

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -390,14 +390,12 @@ if [ "$1" == "add" ]; then
 			check_n_link "$3""$4"/pwm"$i" $thermal_path/pwm"$i"
 		done
 		if [ -f $config_path/fan_inversed ]; then
-			inv=$(< $config_path/fan_inversed)
+			declare -a fan_map="($(< $config_path/fan_inversed))"
+		else
+			fan_map=(${FAN_MAP_DEF[@]})
 		fi
 		for ((i=1; i<=max_tachos; i+=1)); do
-			if [ -z "$inv" ] || [ "${inv}" -eq 0 ]; then
-				j=$i
-			else
-				j=$((inv - i))
-			fi
+			j=${fan_map[i-1]}
 			if [ -f "$3""$4"/fan"$i"_input ]; then
 				check_n_link "$3""$4"/fan"$i"_input $thermal_path/fan"$j"_speed_get
 				check_n_link "$3""$4"/pwm1 $thermal_path/fan"$j"_speed_set

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1264,7 +1264,6 @@ msn27002_msb78002_specific()
 	echo 1500 > $config_path/fan_min_speed
 	echo 18000 > $config_path/psu_fan_max
 	echo 2000 > $config_path/psu_fan_min
-	echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
 	echo 4 > $config_path/cpld_num
 	i2c_comex_mon_bus_default=23
 	i2c_bus_def_off_eeprom_cpu=24


### PR DESCRIPTION
1. Fix fan_map usage in case of mlxreg-fan.
2. Remove fan inversed settings for MSN27002.
   It's now fixed in new HW carrier board.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
