### PR TITLE
Disable hw-mgmt on SimX platforms

### DIFF
--- a/usr/usr/bin/hw-management-ready.sh
+++ b/usr/usr/bin/hw-management-ready.sh
@@ -40,6 +40,7 @@
 #              Report start of hw-management service to console and logger.
 
 board_type=`cat /sys/devices/virtual/dmi/id/board_name`
+product_sku=`cat /sys/devices/virtual/dmi/id/product_sku`
 
 if systemctl is-active --quiet hw-management; then
         echo "Error: HW management service is already active."
@@ -49,6 +50,26 @@ fi
 
 if [ -d /var/run/hw-management ]; then
 	rm -fr /var/run/hw-management
+fi
+
+# If the BSP emulation is not available for the platforms that run in the SimX
+# environment, TC need to be stopped.
+if [ -n "$(lspci -vvv | grep SimX)" ]; then
+	case $product_sku in
+		HI130|HI122)
+			# Let the TC continue to run
+			;;
+		*)
+			if systemctl is-enabled --quiet hw-management-tc; then
+				echo "Stopping and disabling hw-management-tc on SimX"
+				systemctl stop hw-management-tc
+				systemctl disable hw-management-tc
+			fi
+			echo "Start Chassis HW management service."
+			logger -t hw-management -p daemon.notice "Start Chassis HW management service."
+			exit 0
+			;;
+	esac
 fi
 
 case $board_type in

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2519,6 +2519,20 @@ do_chip_up_down()
 	esac
 }
 
+check_simx()
+{
+	case $sku in
+		HI130|HI122)
+			# Let the initialization go through
+			;;
+		*)
+			if [ -n "$(lspci -vvv | grep SimX)" ]; then
+				exit 0
+			fi
+			;;
+	esac
+}
+
 do_chip_down()
 {
 	# Delete ASIC device
@@ -2550,6 +2564,8 @@ Options:
 	force-reload	Performs hw-management 'stop' and the 'start.
 	reset-cause	Output system reset cause.
 "
+
+check_simx
 
 case $ACTION in
 	start)


### PR DESCRIPTION
This patch disables the hw-mgmt and hw-mgmt-tc
on the platforms where BSP platform emulation is
not supported.