### PR TITLE
hw-mgmt: Extend i2c trace logging support

### DIFF
--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -84,6 +84,7 @@ if [ -z $MODE ] || [ $MODE != "compact" ]; then
 fi
 
 [ -f /var/log/tc_log ] && cp /var/log/tc_* $DUMP_FOLDER/
+[ -f /var/log/chipup_i2c_trace_log ] && cp /var/log/chipup_i2c_trace_* $DUMP_FOLDER/
 uname -a > $DUMP_FOLDER/sys_version
 mkdir $DUMP_FOLDER/bin/
 cp /usr/bin/hw?management* $DUMP_FOLDER/bin/


### PR DESCRIPTION
Add i2c trace to hw-management dump.
Add i2c trace log rotation.