### PR TITLE
Fix performance issue in less powerful cpu systems

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -168,6 +168,15 @@ unlock_service_state_change()
     /usr/bin/flock -u ${LOCKFD}
 }
 
+check_labels_enabled()
+{
+    if [ "$ui_tree_sku" = "HI130" ] && [ ! -e "$ui_tree_archive" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Check if file exists and create soft link
 # $1 - file path
 # $2 - link path
@@ -177,7 +186,7 @@ check_n_link()
     if [ -f "$1" ];
     then
         ln -sf "$1" "$2"
-        if [ ! -e "$ui_tree_archive" ]; then
+        if  check_labels_enabled; then
             hw-management-labels-maker.sh "$2" "link" > /dev/null 2>&1 &
         fi
     fi
@@ -191,7 +200,7 @@ check_n_unlink()
     if [ -L "$1" ];
     then
         unlink "$1"
-        if [ ! -e "$ui_tree_archive" ]; then
+        if check_labels_enabled; then
 	    hw-management-labels-maker.sh "$1" "unlink" > /dev/null 2>&1 &
         fi
     fi

--- a/usr/usr/bin/hw-management-labels-maker.sh
+++ b/usr/usr/bin/hw-management-labels-maker.sh
@@ -174,13 +174,3 @@ make_labels()
 		[ -f "$label_dir"/scale ] && rm -f "$label_dir"/scale
 	fi
 }
-
-# Check SKU and run the below only for relevant.
-case $sku in
-	HI130)
-		# Only for Gorilla 
-		make_labels "$1" "$2"
-		;;
-	*)
-		# Do nothing
-esac


### PR DESCRIPTION
Label maker script is invoked while creating the symbolic links during the udev events. In old systems which are having less powerful cpu, it's creating some performance
overhead. This patch moves the sku check to one levl above so that label maker script process will not be invoked.