### PR TITLE
hw-mgmt: thermal: TC fix file reading issue

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -735,14 +735,12 @@ class hw_managemet_file_op(object):
         @param scale: scale factor multiply with file value
         @return: int value
         """
-        val = None
+        val = def_val
         if self.check_file(filename):
             try:
                 val = int(self.read_file(filename)) / scale
-            except ValueError:
+            except:
                 pass
-        if val is None:
-            val = def_val
         return val
 
     # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixed file reading issue in TC: "[Errno 19] No such device"

Bug #3534779 "hw-management-tc failed to start after cold reboot and no automatic restart"

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
