### PR TITLE
hw-mgmt: Add indicator for VPD parsing completion

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1054,6 +1054,10 @@ if [ "$1" == "add" ]; then
 				esac
 			fi
 			;;
+		vpd_info)
+			hw-management-vpd-parser.py -t SYSTEM_VPD -i "$3""$4"/eeprom -o "$eeprom_path"/vpd_data
+			echo 1 > $config_path/events_ready
+			;;
 		*)
 			;;
 		esac

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2163,6 +2163,7 @@ do_start()
 	connect_platform
 	sleep 1
 	enable_vpd_wp
+	echo 0 > $config_path/events_ready
 	/usr/bin/hw-management-start-post.sh
 
 	if [ -f $config_path/max_tachos ]; then


### PR DESCRIPTION
Set attributes "events_ready" to 1 after VPD parsing is
done.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
