### PR TITLE
hw-mgmt: Cleanup attributes

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -830,27 +830,21 @@ if [ "$1" == "add" ]; then
 				prefix="voltmon6"
 			fi
 
-			if [[ $sku == "HI130" ]]; then
-				for i in {1..2}; do
-					check_n_link "$3""$4"/temp"$i"_input $thermal_path/"$prefix"_temp"$i"_input
-					check_n_link "$3""$4"/temp"$i"_max $thermal_path/"$prefix"_temp"$i"_max
-					check_n_link "$3""$4"/temp"$i"_crit $thermal_path/"$prefix"_temp"$i"_crit
-					check_n_link "$3""$4"/temp"$i"_lcrit $thermal_path/"$prefix"_temp"$i"_lcrit
-				done
-			fi
-			check_n_link "$3""$4"/temp1_input $thermal_path/"$prefix"_temp_input
-			check_n_link "$3""$4"/temp1_max $thermal_path/"$prefix"_temp_max
+			# Creating links for only temp1 attribute. Skipping temp2 and others
+			check_n_link "$3""$4"/temp1_input $thermal_path/"$prefix"_temp1_input
+			check_n_link "$3""$4"/temp1_max $thermal_path/"$prefix"_temp1_max
+			check_n_link "$3""$4"/temp1_crit $thermal_path/"$prefix"_temp1_crit
+			check_n_link "$3""$4"/temp1_lcrit $thermal_path/"$prefix"_temp1_lcrit
+			check_n_link "$3""$4"/temp1_max_alarm $alarm_path/"$prefix"_temp1_max_alarm
+			check_n_link "$3""$4"/temp1_crit_alarm $alarm_path/"$prefix"_temp1_crit_alarm
 
 			for i in {1..3}; do
 				find_sensor_by_label "$3""$4" "in" "${VOLTMON_SENS_LABEL[$i]}"
 				sensor_id=$?
 				if [ ! $sensor_id -eq 0 ]; then
 					check_n_link "$3""$4"/in"$sensor_id"_input $environment_path/"$prefix"_in"$i"_input
-
-                                        if [[ $sku == "HI130" ]]; then
-                                            check_n_link "$3""$4"/in"$sensor_id"_crit $environment_path/"$prefix"_in"$i"_crit
-                                            check_n_link "$3""$4"/in"$sensor_id"_lcrit $environment_path/"$prefix"_in"$i"_lcrit
-                                        fi
+					check_n_link "$3""$4"/in"$sensor_id"_crit $environment_path/"$prefix"_in"$i"_crit
+					check_n_link "$3""$4"/in"$sensor_id"_lcrit $environment_path/"$prefix"_in"$i"_lcrit
 					if [ -f "$3""$4"/in"$sensor_id"_alarm ]; then
 						check_n_link "$3""$4"/in"$sensor_id"_alarm $alarm_path/"$prefix"_in"$i"_alarm
 					elif [ -f "$3""$4"/in"$sensor_id"_crit_alarm ]; then
@@ -898,19 +892,19 @@ if [ "$1" == "add" ]; then
 						check_n_link "$3""$4"/curr"$i"_max_alarm $alarm_path/"$prefix"_curr"$i"_alarm
 					fi
 
-					check_n_link "$3""$4"/power"$i"_alarm $environment_path/"$2"_power"$i"_alarm
-					check_n_link "$3""$4"/in"$i"_lcrit $environment_path/"$2"_in"$i"_lcrit
-					check_n_link "$3""$4"/in"$i"_min $environment_path/"$2"_in"$i"_min
-					check_n_link "$3""$4"/in"$i"_max $environment_path/"$2"_in"$i"_max
-					check_n_link "$3""$4"/in"$i"_crit $environment_path/"$2"_in"$i"_crit
-					check_n_link "$3""$4"/curr"$i"_lcrit $environment_path/"$2"_curr"$i"_lcrit
-					check_n_link "$3""$4"/curr"$i"_min $environment_path/"$2"_curr"$i"_min
-					check_n_link "$3""$4"/curr"$i"_max $environment_path/"$2"_curr"$i"_max
-					check_n_link "$3""$4"/curr"$i"_crit $environment_path/"$2"_curr"$i"_crit
-					check_n_link "$3""$4"/power"$i"_lcrit $environment_path/"$2"_power"$i"_lcrit
-					check_n_link "$3""$4"/power"$i"_min $environment_path/"$2"_power"$i"_min
-					check_n_link "$3""$4"/power"$i"_max $environment_path/"$2"_power"$i"_max
-					check_n_link "$3""$4"/power"$i"_crit $environment_path/"$2"_power"$i"_crit
+					check_n_link "$3""$4"/power"$i"_alarm $environment_path/"$prefix"_power"$i"_alarm
+					check_n_link "$3""$4"/in"$i"_lcrit $environment_path/"$prefix"_in"$i"_lcrit
+					check_n_link "$3""$4"/in"$i"_min $environment_path/"$prefix"_in"$i"_min
+					check_n_link "$3""$4"/in"$i"_max $environment_path/"$prefix"_in"$i"_max
+					check_n_link "$3""$4"/in"$i"_crit $environment_path/"$prefix"_in"$i"_crit
+					check_n_link "$3""$4"/curr"$i"_lcrit $environment_path/"$prefix"_curr"$i"_lcrit
+					check_n_link "$3""$4"/curr"$i"_min $environment_path/"$prefix"_curr"$i"_min
+					check_n_link "$3""$4"/curr"$i"_max $environment_path/"$prefix"_curr"$i"_max
+					check_n_link "$3""$4"/curr"$i"_crit $environment_path/"$prefix"_curr"$i"_crit
+					check_n_link "$3""$4"/power"$i"_lcrit $environment_path/"$prefix"_power"$i"_lcrit
+					check_n_link "$3""$4"/power"$i"_min $environment_path/"$prefix"_power"$i"_min
+					check_n_link "$3""$4"/power"$i"_max $environment_path/"$prefix"_power"$i"_max
+					check_n_link "$3""$4"/power"$i"_crit $environment_path/"$prefix"_power"$i"_crit
 				fi
 			done
 			;;

--- a/usr/usr/bin/hw-management-labels-maker.sh
+++ b/usr/usr/bin/hw-management-labels-maker.sh
@@ -33,7 +33,6 @@
 source hw-management-helpers.sh
 set -x
 sku=$(< $sku_file)
-hw_management_path=/var/run/hw-management
 ui_path=$hw_management_path/ui 
 
 # Obtain label file (/var/run/hw-management/config/lm_sensors_labels).
@@ -174,3 +173,5 @@ make_labels()
 		[ -f "$label_dir"/scale ] && rm -f "$label_dir"/scale
 	fi
 }
+
+make_labels "$1" "$2"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -754,12 +754,12 @@ if [ "$1" == "add" ]; then
 		# Set default fan speed
 		psu_set_fan_speed "$psu_name" $(< $fan_psu_default)
 		# Add thermal attributes
-		check_n_link "$5""$3"/temp1_input $thermal_path/"$psu_name"_temp
-		check_n_link "$5""$3"/temp1_max $thermal_path/"$psu_name"_temp_max
-		check_n_link "$5""$3"/temp1_max_alarm $thermal_path/"$psu_name"_temp_max_alarm
+		check_n_link "$5""$3"/temp1_input $thermal_path/"$psu_name"_temp1
+		check_n_link "$5""$3"/temp1_max $thermal_path/"$psu_name"_temp1_max
+		check_n_link "$5""$3"/temp1_max_alarm $alarm_path/"$psu_name"_temp1_max_alarm
 		check_n_link "$5""$3"/temp2_input $thermal_path/"$psu_name"_temp2
 		check_n_link "$5""$3"/temp2_max $thermal_path/"$psu_name"_temp2_max
-		check_n_link "$5""$3"/temp2_max_alarm $thermal_path/"$psu_name"_temp2_max_alarm
+		check_n_link "$5""$3"/temp2_max_alarm $alarm_path/"$psu_name"_temp2_max_alarm
 		check_n_link "$5""$3"/fan1_alarm $alarm_path/"$psu_name"_fan1_alarm
 		check_n_link "$5""$3"/power1_alarm $alarm_path/"$psu_name"_power1_alarm
 		check_n_link "$5""$3"/fan1_input $thermal_path/"$psu_name"_fan1_speed_get


### PR DESCRIPTION
This PR does the following:
     - Fix for the temperature sensor attribute index. Replace
       temp_input attribute to temp1_input to match with the
       attribute name created by driver in the hwmon directory.
     - Thers are voltmonX attributes which were reduntant and
       pointing to already created attributes. This commit fixes
     - Fix for PSU temperature alarm path
     - Change 'psu_temp' attribute name to 'psu_temp1'
     - Minor update to labels creation script
