### PR TITLE
hw-mgmt: patches: Add fix to FPGA patches

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0317-platform-mellanox-Introduce-support-for-switches-equ.patch
+++ b/recipes-kernel/linux/linux-5.10/0317-platform-mellanox-Introduce-support-for-switches-equ.patch
@@ -87,7 +87,7 @@ index c4a4afff7..e303b8e5a 100644
 +		.parent = 1,
 +		.chan_ids = mlxplat_default_regmap_mux_chan,
 +		.num_adaps = ARRAY_SIZE(mlxplat_default_regmap_mux_chan),
-+		.sel_reg_addr = MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET,
++		.sel_reg_addr = MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET,
 +		.reg_size = 1,
 +	},
 +

--- a/recipes-kernel/linux/linux-6.1/0057-platform-mellanox-Introduce-support-for-switches-equ.patch
+++ b/recipes-kernel/linux/linux-6.1/0057-platform-mellanox-Introduce-support-for-switches-equ.patch
@@ -87,7 +87,7 @@ index 04be8aeb23e9..bf1fc139e397 100644
 +		.parent = 1,
 +		.chan_ids = mlxplat_default_regmap_mux_chan,
 +		.num_adaps = ARRAY_SIZE(mlxplat_default_regmap_mux_chan),
-+		.sel_reg_addr = MLXPLAT_CPLD_LPC_REG_I2C_CH3_OFFSET,
++		.sel_reg_addr = MLXPLAT_CPLD_LPC_REG_I2C_CH2_OFFSET,
 +		.reg_size = 1,
 +	},
 +


### PR DESCRIPTION
Fix mux selector in v5.10 #0317 and v6.1 #0057 patches.

Reviewed-by: Felix Radensky <fradensky@nvidia.com>