### PR TITLE
hw-mgmt: thermal: Update TC voltmon sensor name

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2199,7 +2199,7 @@ class ThermalManagement(hw_managemet_file_op):
         # Find voltmon temp sensors
         file_list = os.listdir("{}/thermal".format(self.cmd_arg[CONST.HW_MGMT_ROOT]))
         for fname in file_list:
-            res = re.match(r'(voltmon[0-9]+_temp)_input', fname)
+            res = re.match(r'(voltmon[0-9]+_temp1)_input', fname)
             if res:
                 self.voltmon_file_list.append(res.group(1))
         self.log.info("voltmon count:{}".format(len(self.voltmon_file_list)))


### PR DESCRIPTION
This patch updates the voltmon temperature sensor
attribute name from voltmon_temp_input to
voltmon_temp1_input.

Reviewed-by: Oleksandr Shamray <oleksandrs@nvidia.com>