### PR TITLE
hw-mgmt: thermal: Add static sensor support

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_default.json
+++ b/usr/etc/hw-management-thermal/tc_config_default.json
@@ -1,4 +1,5 @@
  {
+	"name": "default",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:120": 100},

--- a/usr/etc/hw-management-thermal/tc_config_mqm8700.json
+++ b/usr/etc/hw-management-thermal/tc_config_mqm8700.json
@@ -1,4 +1,5 @@
  {
+	"name": "mqm8700",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:25": 20, "26:40": 30, "41:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_mqm9700.json
+++ b/usr/etc/hw-management-thermal/tc_config_mqm9700.json
@@ -44,5 +44,6 @@
 		"voltmon\\d+_temp":{"pwm_min": 30, "pwm_max" : 100, "val_min": "!85000", "val_max": "!125000", "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 40, "val_min": 30000, "val_max": 50000, "poll_time": 30}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon3", "voltmon4", "voltmon5", "voltmon6"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2010.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2010.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn2010",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:15": 20, "16:20": 30, "21:30": 40, "31:35": 40, "36:120": 60},
@@ -44,5 +45,6 @@
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}}
+	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "voltmon1", "voltmon2"]  
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2100.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2100.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn2100",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:15": 20, "16:20": 30, "21:30": 40, "31:35": 40, "36:120": 60},
@@ -44,5 +45,6 @@
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}}
+	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "voltmon1", "voltmon2", "voltmon6"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2201.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn2210",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:20": 30, "21:25": 40, "26:30": 50, "31:35": 60, "36:40": 70, "41:120": 80},
@@ -44,5 +45,6 @@
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}}
+	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2700_msb7x00.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2700_msb7x00.json
@@ -45,7 +45,8 @@
 		"voltmon\\d+_temp": {"pwm_min": 30, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}}
+	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon6"]
 }
 
  

--- a/usr/etc/hw-management-thermal/tc_config_msn3420.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3420.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn34200",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:25": 20, "26:40": 30, "41:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn3700.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3700.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn3700",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:25": 20, "26:40": 30, "41:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn3700C.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3700C.json
@@ -1,4 +1,5 @@
- {
+{
+	"name": "msn3700C",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:25": 20, "26:40": 30, "41:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn3800.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3800.json
@@ -1,4 +1,5 @@
- {
+{
+	"name": "msn3800",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {
@@ -44,5 +45,6 @@
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"gearbox\\d+":    {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 20}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn4410.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn4410.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn4410",
 	"dmin" : {
 		"C2P": {
 			"untrusted": {"-127:25": 20, "26:40": 30, "41:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn4600.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn4600.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn4600",
 	"dmin" : {
 		"C2P": {
 			"untrusted":  {"-127:25": 20, "26:35": 30, "36:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 40, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon5", "voltmon7"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn4600C.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn4600C.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn4600C",
 	"dmin" : {
 		"C2P": {
 			"untrusted":  {"-127:25": 20, "26:35": 30, "36:120": 40},
@@ -44,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 40, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon5", "voltmon7"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn4700.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn4700.json
@@ -45,5 +45,6 @@
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn5600.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn5600.json
@@ -1,4 +1,5 @@
  {
+	"name": "msn5600",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {
@@ -42,5 +43,6 @@
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 30, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_not_supported.json
+++ b/usr/etc/hw-management-thermal/tc_config_not_supported.json
@@ -1,3 +1,4 @@
 {
+	"name": "unsupported platform",
 	"platform_support" : 0
 }


### PR DESCRIPTION
On init flow, TC scans available sensors and adds them to DB. Some sensors can be present or not depending on system types. For example sodimm2_temp present not in all systems, and sensors scan will add it only if exists sensor link in sysfs. But if the system should have sodimm2 but it is broken, we will not recognize such an issue.

Static sensor - a sensor that should be added, even if HW is not present or broken. Static sensor list can be added to TC system data JSON file:

"static_sensor_list": ["sodimm2", "sensor_amb", "cpu_pack"]

Bug: #3569409