### PR TITLE
hw-mgmt: kernel modules: Extend list of not allowed modules

### DIFF
--- a/usr/etc/modprobe.d/hw-management.conf
+++ b/usr/etc/modprobe.d/hw-management.conf
@@ -11,3 +11,4 @@ blacklist ee1004
 blacklist nvidia
 blacklist nvidia_modeset
 blacklist nvidia_drm
+blacklist pcspkr


### PR DESCRIPTION
Add 'pcspkr'.


Reviewed-by: Ciju Rajan K <crajank@nvidia.com>