### PR TITLE
hw-mgmt: thermal: Add drivetemp and ibc sensors support to TC

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_mqm9700.json
+++ b/usr/etc/hw-management-thermal/tc_config_mqm9700.json
@@ -45,5 +45,6 @@
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 40, "val_min": 30000, "val_max": 50000, "poll_time": 30}
 	},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon3", "voltmon4", "voltmon5", "voltmon6"]
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "psu1", "psu2",
+	"sensor_amb", "sodimm1", "voltmon1", "voltmon3", "voltmon4", "voltmon5", "voltmon6"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2010.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2010.json
@@ -46,5 +46,5 @@
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
 	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "voltmon1", "voltmon2"]  
+	"sensor_list" : ["asic1", "sodimm1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "voltmon1", "voltmon2"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2100.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2100.json
@@ -46,5 +46,5 @@
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
 	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "voltmon1", "voltmon2", "voltmon6"]
+	"sensor_list" : ["asic1", "sodimm1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "voltmon1", "voltmon2", "voltmon6"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn2201.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201.json
@@ -46,5 +46,5 @@
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
 	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb"]
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "sodimm1", "voltmon2"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_msn5600.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn5600.json
@@ -42,7 +42,10 @@
 		"module\\d+":     {"pwm_min": 30, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 30, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
-		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
+		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
+		"drivetemp":      {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
+		"ibc\\d+":         {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!110000", "poll_time": 60}
 	},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"]
+	"sensor_list" : ["asic1", "cpu", "drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "ibc1", "ibc2", "ibc3", "ibc4", "psu1", "psu2", 
+	"sensor_amb", "sodimm1", "sodimm2", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"]
 }

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -256,7 +256,14 @@ SENSOR_DEF_CONFIG = {
     r'voltmon\d+_temp': {"type": "thermal_sensor",
                          "pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 3,
                          "input_suffix": "_input"
-                        }
+                        },
+    r'drivetemp':       {"type": "thermal_sensor",
+                         "pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60
+                        },
+    r'ibc\d+':          {"type": "thermal_sensor",
+                         "pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!110000", "poll_time": 60,
+                         "input_suffix": "_input"
+                        },
 }
 
 
@@ -2056,7 +2063,7 @@ class ThermalManagement(hw_managemet_file_op):
             Main class of thermal algorithm.
             Provide system monitoring and thermal control
     """
-    
+
     """
     functions which adding sensor configuration by the sensor name
     """
@@ -2067,7 +2074,9 @@ class ThermalManagement(hw_managemet_file_op):
                           r'voltmon\d+':"add_voltmon_sensor",
                           r'asic\d+':"add_asic_sensor",
                           r'sodimm\d+':"add_sodimm_sensor",
-                          r'sensor_amb':"add_amb_sensor"
+                          r'sensor_amb':"add_amb_sensor",
+                          r'drivetemp':"add_drivetemp_sensor",
+                          r'ibc\d*':"add_ibc_sensor"
                          }
 
     def __init__(self, cmd_arg, tc_logger):
@@ -2225,16 +2234,23 @@ class ThermalManagement(hw_managemet_file_op):
             if res:
                 sensor_list.append(res.group(1))
 
+            res = re.match(r'pwr_conv([0-9]+)_temp1_input', fname)
+            if res:
+                sensor_list.append("ibc{}".format(res.group(1)))
+
         # Add cpu sensor
         if "cpu" not in sensor_list:
             sensor_list.append("cpu")
 
         # Collect sodimm sensors
         for sodimm_idx in range(1, 5):
-            if self.check_file("thermal/sodimm{}_input".format(sodimm_idx)):
+            if self.check_file("thermal/sodimm{}_temp_input".format(sodimm_idx)):
                 sensor_list.append("sodimm{}".format(sodimm_idx))
 
         sensor_list.append("sensor_amb")
+
+        if self.check_file("thermal/drivetemp"):
+            sensor_list.append("drivetemp")
         # remove duplications & soort
         sensor_list = list(set(sensor_list))
         sensor_list.sort()
@@ -2335,7 +2351,7 @@ class ThermalManagement(hw_managemet_file_op):
         """
         self.log.info("Update chassis FAN PWM {}".format(pwm_val))
         if not self.is_pwm_exists():
-            self.log.warn("Missing PWM link".format(pwm_val))
+            self.log.warn("Missing PWM link {}".format(pwm_val))
             return
         for drwr_idx in range(1, self.fan_drwr_num + 1):
             fan_obj = self._get_dev_obj("drwr{}.*".format(drwr_idx))
@@ -2528,9 +2544,9 @@ class ThermalManagement(hw_managemet_file_op):
     # ----------------------------------------------------------------------
     def module_scan(self):
         """
-        @summary: scanning available SFP module sensors 
-        and dynamically adding/removing module sensors 
-        """        
+        @summary: scanning available SFP module/gearboxes
+        and dynamically adding/removing module sensors
+        """
         module_count = int(self.get_file_val("config/module_counter", 0))
         if module_count != self.module_counter:
             self.log.info("Module counter changed {} -> {}".format(self.module_counter, module_count))
@@ -2675,7 +2691,7 @@ class ThermalManagement(hw_managemet_file_op):
         self._sensor_add_config("fan_sensor", name, {"base_file_name": name, "drwr_id": drwr_idx, "tacho_cnt": self.fan_drwr_capacity})
 
     # ----------------------------------------------------------------------
-    def add_cpu_sensor(self, name):
+    def add_cpu_sensor(self, *_):
         if self.check_file("thermal/cpu_pack"):
             self._sensor_add_config("thermal_sensor", "cpu_pack", {"base_file_name": "thermal/cpu_pack"})
         elif self.check_file("thermal/cpu_core1"):
@@ -2707,13 +2723,25 @@ class ThermalManagement(hw_managemet_file_op):
     def add_amb_sensor(self, name):
         self._sensor_add_config("ambiant_thermal_sensor", name)
 
-# ----------------------------------------------------------------------
+    # ----------------------------------------------------------------------
+    def add_drivetemp_sensor(self, name):
+        in_file = "thermal/{}".format(name)
+        self._sensor_add_config("thermal_sensor", name, {"base_file_name": in_file})
+
+    # ----------------------------------------------------------------------
+    def add_ibc_sensor(self, name):
+        idx = name[3:]
+        in_file = "thermal/pwr_conv{}_temp1".format(idx)
+        sensor_name = "{}".format(name)
+        self._sensor_add_config("thermal_sensor", sensor_name, {"base_file_name": in_file})
+
+    # ----------------------------------------------------------------------
     def add_sensors(self):
         """
         @summary: Add sensor configuration based on sensor list
-        """   
+        """
         for sensor_name in self.sys_config[CONST.SYS_CONF_SENSOR_LIST_PARAM]:
-            for config_handler_mask in self.ADD_SENSOR_HANDLER.keys():
+            for config_handler_mask in self.ADD_SENSOR_HANDLER:
                 if re.match(config_handler_mask, sensor_name):
                     fn_name = self.ADD_SENSOR_HANDLER[config_handler_mask]
                     init_fn = getattr(self, fn_name)
@@ -2735,7 +2763,7 @@ class ThermalManagement(hw_managemet_file_op):
 
         self.log.debug("System config dump\n{}".format(json.dumps(self.sys_config, sort_keys=True, indent=4)))
 
-        for key, val in self.sys_config[CONST.SYS_CONF_SENSORS_CONF].items():
+        for key, _ in self.sys_config[CONST.SYS_CONF_SENSORS_CONF].items():
             dev_obj = self._add_dev_obj(key)
             if not dev_obj:
                 self.log.error("{} create failed".format(key))


### PR DESCRIPTION
1. Add drivetemp and ibc sensors support to TC
2. Add voltmon2 sensor to MSN2210 thermal data

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
