### PR TITLE
hw-mgmt: patches; Add WA patch for kernel v6.1

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -364,7 +364,7 @@ Kernel-5.10
 |0196-platform-mellanox-Cosmetic-changes.patch                    |                    | Feature pending                          |            |                                                |
 |0197-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            |                                                |
 |0198-platform-mellanox-Add-new-attributes.patch                  |                    | Feature pending                          |            |                                                |
-|0199-platform-mellanox-Change-register-offset-addresses.patch    |                    | Feature pending                          |            | P4262                                          |
+|0199-platform-mellanox-Change-register-offset-addresses.patch    |                    | Bugfix pending                           |            | P4262                                          |
 |0200-dt-bindings-i2c-mellanox-i2c-mlxbf-convert-txt-to-YA.patch  |                    | Feature pending                          |            | BF3-COME                                       |
 |0201-i2c-mlxbf-incorrect-base-address-passed-during-io-wr.patch  | 2a5be6d1340c       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
 |0202-i2c-mlxbf-prevent-stack-overflow-in-mlxbf_i2c_smbus_.patch  | de24aceb07d4       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
@@ -435,7 +435,7 @@ Kernel-5.10
 |0275-mlxsw-Use-u16-for-local_port-field-instead-of-u8.patch      | c934757d9000       | Feature upstream                         |            | SN5600                                         |
 |0276-mlxsw-minimal-Change-type-for-local-port.patch              |                    | Feature pending                          |            | SN5600                                         |
 |0277-mlxsw-i2c-Fix-chunk-size-setting-in-output-mailbox-b.patch  |                    | Bugfix pending                           |            | SN5600                                         |
-|0278-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Feature pending                          |            | SN5600                                         |
+|0278-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Bugfix pending                           |            | SN5600                                         |
 |0279-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            | P4262                                          |
 |0280-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch  |                    | Feature pending                          |            | P4262                                          |
 |0281-platform-mellanox-mlx-platform-Modify-health-and-pow.patch  |                    | Feature pending                          |            | P4262                                          |
@@ -502,11 +502,11 @@ Kernel-6.1
 |0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream                         |            | BF3-COME                                       |
 |0012-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            |                                                |
 |0013-platform-mellanox-Add-new-attributes.patch                  |                    | Feature pending                          |            |                                                |
-|0014-platform-mellanox-Change-register-offset-addresses.patch    |                    | Feature pending                          |            |                                                |
+|0014-platform-mellanox-Change-register-offset-addresses.patch    |                    | Bugfix pending                           |            |                                                |
 |0015-platform-mellanox-Add-field-upgrade-capability-regis.patch  |                    | Feature pending                          |            |                                                |
 |0016-platform-mellanox-Modify-reset-causes-description.patch     |                    | Feature pending                          |            |                                                |
-|0017-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Feature pending                          |            |                                                |
-|0018-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Feature pending                          |            |                                                |
+|0017-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Bugfix pending                           |            |                                                |
+|0018-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            |                                                |
 |0019-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch  |                    | Feature pending                          |            |                                                |
 |0020-platform-mellanox-mlx-platform-Modify-health-and-pow.patch  |                    | Feature pending                          |            |                                                |
 |0021-platform-mellanox-mlx-platform-Add-reset-cause-attri.patch  |                    | Feature pending                          |            |                                                |
@@ -572,6 +572,7 @@ Kernel-6.1
 |0082-UBUNTU-SAUCE-mlxbf-ptm-add-atx-debugfs-nodes.patch          |                    | Feature pending                          |            | BF3                                            |
 |0083-UBUNTU-SAUCE-mlxbf-ptm-update-module-version.patch          |                    | Feature pending                          |            | BF3                                            |
 |0084-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Bugfix pending                           |            | BF3                                            |
+|0085-i2c-mlxcpld-Downstream-WA-to-avoid-error-for-SMBUS-r.patch  |                    | Downstream accepted                      |            | WA for hw bug                                  |
 |9000-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/recipes-kernel/linux/linux-6.1/0085-i2c-mlxcpld-Downstream-WA-to-avoid-error-for-SMBUS-r.patch
+++ b/recipes-kernel/linux/linux-6.1/0085-i2c-mlxcpld-Downstream-WA-to-avoid-error-for-SMBUS-r.patch
@@ -1,0 +1,30 @@
+From 63d8c9838b10472bd5e3c6e5a41596d6d44dd1c8 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 10 Aug 2023 12:03:31 +0000
+Subject: [PATCH backport 6.1.42 1/1] i2c: mlxcpld: Downstream WA to avoid
+ error for SMBUS read block command
+
+Due to hardware bug in I2C controller skip handling SMBUS_READ_BLOCK
+command.
+Remove this patch after bug in I2C controller is fixed.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/i2c/busses/i2c-mlxcpld.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/i2c/busses/i2c-mlxcpld.c b/drivers/i2c/busses/i2c-mlxcpld.c
+index 2ce2c324ea4f..fd9def469132 100644
+--- a/drivers/i2c/busses/i2c-mlxcpld.c
++++ b/drivers/i2c/busses/i2c-mlxcpld.c
+@@ -398,6 +398,7 @@ static int mlxcpld_i2c_wait_for_tc(struct mlxcpld_i2c_priv *priv)
+ 		mlxcpld_i2c_read_comm(priv, MLXCPLD_LPCI2C_NUM_ADDR_REG, &val,
+ 				      1);
+ 		if (priv->smbus_block && (val & MLXCPLD_I2C_SMBUS_BLK_BIT)) {
++			return 0;
+ 			mlxcpld_i2c_read_comm(priv, MLXCPLD_LPCI2C_NUM_DAT_REG,
+ 					      &datalen, 1);
+ 			if (unlikely(datalen > I2C_SMBUS_BLOCK_MAX)) {
+-- 
+2.20.1
+


### PR DESCRIPTION
Add WA patch to avoid errors for read block command. Fix to be removed after CPLD fix for read block.

Reviewed-by: Felix Radensky <fradensky@nvidia.com>