### PR TITLE
Fix for Github action script

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -264,64 +264,71 @@ Kernel-5.10
 |0095-hwmon-mlxreg-fan-Fix-out-of-bounds-read-on-array-fan.patch  | 000cc5bc49aa       | Feature upstream                         |            |                                                |
 |0096-hwmon-mlxreg-fan-Modify-PWM-connectivity-validation.patch   | b1c24237341f       | Feature upstream                         |            |                                                |
 |0097-hwmon-mlxreg-fan-Support-distinctive-names-per-diffe.patch  | b2be2422c0c9       | Feature upstream                         |            |                                                |
-|0099-mlxsw-core_hwmon-Fix-variable-names-for-hwmon-attrib.patch  | bed8f4197cb2       | Feature upstream                         |            | Modular SN4800                                 |
-|0100-mlxsw-core_thermal-Rename-labels-according-to-naming.patch  | 009da9fad567       | Feature upstream                         |            | Modular SN4800                                 |
-|0101-mlxsw-core_thermal-Remove-obsolete-API-for-query-res.patch  | bfb82c9cceac       | Feature upstream                         |            | Modular SN4800                                 |
-|0102-mlxsw-reg-Add-mgpir_-prefix-to-MGPIR-fields-comments.patch  | 719fc0662cdc       | Feature upstream                         |            | Modular SN4800                                 |
-|0103-mlxsw-core-Remove-unnecessary-asserts.patch                 | af9911c569d5       | Feature upstream                         |            | Modular SN4800                                 |
-|0104-mlxsw-reg-Extend-MTMP-register-with-new-slot-number-.patch  | d30bed29a718       | Feature upstream                         |            | Modular SN4800                                 |
-|0105-mlxsw-reg-Extend-MTBR-register-with-new-slot-number-.patch  | c6e6ad703ed2       | Feature upstream                         |            | Modular SN4800                                 |
-|0106-mlxsw-reg-Extend-MCIA-register-with-new-slot-number-.patch  | 89dd6fcd07f9       | Feature upstream                         |            | Modular SN4800                                 |
-|0107-mlxsw-reg-Extend-MCION-register-with-new-slot-number.patch  | 655cbb1d7530       | Feature upstream                         |            | Modular SN4800                                 |
-|0108-mlxsw-reg-Extend-PMMP-register-with-new-slot-number-.patch  | 7cb85d3c696e       | Feature upstream                         |            | Modular SN4800                                 |
-|0109-mlxsw-reg-Extend-MGPIR-register-with-new-slot-fields.patch  | b691602c6f96       | Feature upstream                         |            | Modular SN4800                                 |
-|0110-mlxsw-core_env-Pass-slot-index-during-PMAOS-register.patch  | 64e65a540e6d       | Feature upstream                         |            | Modular SN4800                                 |
-|0111-mlxsw-reg-Add-new-field-to-Management-General-Periph.patch  | e94295e0ed27       | Feature upstream                         |            | Modular SN4800                                 |
-|0112-mlxsw-core-Extend-interfaces-for-cable-info-access-w.patch  | 349454526f5f       | Feature upstream                         |            | Modular SN4800                                 |
-|0113-mlxsw-core-Extend-port-module-data-structures-for-li.patch  | e5b6a5bac8cc       | Feature upstream                         |            | Modular SN4800                                 |
-|0114-mlxsw-core-Move-port-module-events-enablement-to-a-s.patch  | b244143a085e       | Feature upstream                         |            | Modular SN4800                                 |
-|0115-mlxsw-core_hwmon-Split-gearbox-initialization.patch         |                    | Feature accepted                         |            | Modular SN4800 squashed (required rebasing)    |
-|0116-mlxsw-core_hwmon-Extend-internal-structures-to-suppo.patch  | b890ad418e1f       | Feature upstream                         |            | Modular SN4800                                 |
-|0117-mlxsw-core_hwmon-Introduce-slot-parameter-in-hwmon-i.patch  | fd27849dd6fd       | Feature upstream                         |            | Modular SN4800                                 |
-|0118-mlxsw-core_hwmon-Extend-hwmon-device-with-gearbox-ma.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0119-mlxsw-core_thermal-Extend-internal-structures-to-sup.patch  | ef0df4fa324a       | Feature upstream                         |            | Modular SN4800                                 |
-|0120-mlxsw-core_thermal-Split-gearbox-initialization.patch       |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0121-mlxsw-core_thermal-Extend-thermal-area-with-gearbox-.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0122-mlxsw-core_thermal-Add-line-card-id-prefix-to-line-c.patch  | 6d94449a7d7d       | Feature upstream                         |            | Modular SN4800                                 |
-|0123-mlxsw-core_thermal-Use-exact-name-of-cooling-devices.patch  | 739d56bc635e       | Feature upstream                         |            | Modular SN4800                                 |
-|0124-mlxsw-core_thermal-Use-common-define-for-thermal-zon.patch  | 03978fb88b06       | Feature upstream                         |            | Modular SN4800                                 |
-|0125-devlink-add-support-to-create-line-card-and-expose-t.patch  | c246f9b5fd61       | Feature upstream                         |            | Modular SN4800                                 |
-|0126-devlink-implement-line-card-provisioning.patch              | fcdc8ce23a30       | Feature upstream                         |            | Modular SN4800                                 |
-|0127-devlink-implement-line-card-active-state.patch              | fc9f50d5b366       | Feature upstream                         |            | Modular SN4800                                 |
-|0128-devlink-add-port-to-line-card-relationship-set.patch        | b83758598538       | Feature upstream                         |            | Modular SN4800                                 |
-|0129-devlink-introduce-linecard-info-get-message.patch           | 276910aecc6a       | Feature upstream                         |            | Modular SN4800                                 |
-|0130-devlink-introduce-linecard-info-get-message.patch           |                    | Feature upstream                         |            | Modular SN4800                                 |
-|0131-mlxsw-reg-Add-Ports-Mapping-event-Configuration-Regi.patch  | ebf0c5341731       | Feature upstream                         |            | Modular SN4800                                 |
-|0132-mlxsw-reg-Add-Management-DownStream-Device-Query-Reg.patch  | 505f524dc660       | Feature upstream                         |            | Modular SN4800                                 |
-|0133-mlxsw-reg-Add-Management-DownStream-Device-Control-R.patch  | 5290a8ff2e11       | Feature upstream                         |            | Modular SN4800                                 |
-|0134-mlxsw-reg-Add-Management-Binary-Code-Transfer-Regist.patch  | 5bade5aa4afc       | Feature upstream                         |            | Modular SN4800                                 |
-|0135-mlxsw-core_linecards-Add-line-card-objects-and-imple.patch  | b217127e5e4e       | Feature upstream                         |            | Modular SN4800                                 |
-|0136-mlxsw-core_linecards-Implement-line-card-activation-.patch  | ee7a70fa671b       | Feature upstream                         |            | Modular SN4800                                 |
-|0137-mlxsw-core-Extend-driver-ops-by-remove-selected-port.patch  | 45bf3b7267e0       | Feature upstream                         |            | Modular SN4800                                 |
-|0138-mlxsw-spectrum-Add-port-to-linecard-mapping.patch           | 6445eef0f600       | Feature upstream                         |            | Modular SN4800                                 |
-|0139-mlxsw-reg-Introduce-Management-Temperature-Extended-.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0140-mlxsw-core-Add-APIs-for-thermal-sensor-mapping.patch        |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0141-mlxsw-reg-Add-Management-DownStream-Device-Tunneling.patch  | 8f9b0513a950       | Feature upstream                         |            | Modular SN4800                                 |
-|0142-mlxsw-core_linecards-Probe-devices-for-provisioned-l.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0143-mlxsw-core_linecards-Expose-device-FW-version-over-d.patch  | e932b4bdbd7c       | Feature upstream                         |            | Modular SN4800                                 |
-|0144-mlxsw-core-Introduce-flash-update-components.patch          |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0145-mlxfw-Get-the-PSID-value-using-op-instead-of-passing.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0146-mlxsw-core_linecards-Implement-line-card-device-flas.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0147-mlxsw-core_linecards-Introduce-ops-for-linecards-sta.patch  |                    | Feature upstream                         |            | Modular SN4800                                 |
-|0148-mlxsw-core-Add-interfaces-for-line-card-initializati.patch  | 06a0fc43bb10       | Feature upstream                         |            | Modular SN4800                                 |
-|0149-mlxsw-core_thermal-Add-interfaces-for-line-card-init.patch  | f11a323da46c       | Feature upstream                         |            | Modular SN4800                                 |
-|0150-mlxsw-core_hwmon-Add-interfaces-for-line-card-initia.patch  | 99a03b3193f6       | Feature upstream                         |            | Modular SN4800                                 |
-|0151-mlxsw-minimal-Prepare-driver-for-modular-system-supp.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0152-mlxsw-core-Extend-bus-init-function-with-event-handl.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0153-mlxsw-i2c-Add-support-for-system-events-handling.patch      | 33fa6909a263       | Feature upstream                         |            | Modular SN4800                                 |
-|0154-mlxsw-core-Export-line-card-API.patch                       |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0155-mlxsw-minimal-Add-system-event-handler.patch                |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
-|0156-mlxsw-minimal-Add-interfaces-for-line-card-initializ.patch  |                    | Feature upstream                         |            | Modular SN4800 squashed (required rebasing)    |
+|0097-1-mlxsw-Use-u16-for-local_port-field.patch                  |                    | Feature pending                          |            |                                                |
+|0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch                    |                    | Feature pending                          |            |                                                |
+|0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch          |                    | Feature pending                          |            |                                                |
+|0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch           |                    | Downstream                               |            |                                                |
+|0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch             |                    | Downstream                               |            |                                                |
+|0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch   |                    | Downstream                               |            |                                                |
+|0099-mlxsw-core_hwmon-Fix-variable-names-for-hwmon-attrib.patch  | bed8f4197cb2       | Downstream                               |            | Modular SN4800                                 |
+|0100-mlxsw-core_thermal-Rename-labels-according-to-naming.patch  | 009da9fad567       | Downstream                               |            | Modular SN4800                                 |
+|0101-mlxsw-core_thermal-Remove-obsolete-API-for-query-res.patch  | bfb82c9cceac       | Downstream                               |            | Modular SN4800                                 |
+|0102-mlxsw-reg-Add-mgpir_-prefix-to-MGPIR-fields-comments.patch  | 719fc0662cdc       | Downstream                               |            | Modular SN4800                                 |
+|0103-mlxsw-core-Remove-unnecessary-asserts.patch                 | af9911c569d5       | Downstream                               |            | Modular SN4800                                 |
+|0104-mlxsw-reg-Extend-MTMP-register-with-new-slot-number-.patch  | d30bed29a718       | Downstream                               |            | Modular SN4800                                 |
+|0105-mlxsw-reg-Extend-MTBR-register-with-new-slot-number-.patch  | c6e6ad703ed2       | Downstream                               |            | Modular SN4800                                 |
+|0106-mlxsw-reg-Extend-MCIA-register-with-new-slot-number-.patch  | 89dd6fcd07f9       | Downstream                               |            | Modular SN4800                                 |
+|0107-mlxsw-reg-Extend-MCION-register-with-new-slot-number.patch  | 655cbb1d7530       | Downstream                               |            | Modular SN4800                                 |
+|0108-mlxsw-reg-Extend-PMMP-register-with-new-slot-number-.patch  | 7cb85d3c696e       | Downstream                               |            | Modular SN4800                                 |
+|0109-mlxsw-reg-Extend-MGPIR-register-with-new-slot-fields.patch  | b691602c6f96       | Downstream                               |            | Modular SN4800                                 |
+|0110-mlxsw-core_env-Pass-slot-index-during-PMAOS-register.patch  | 64e65a540e6d       | Downstream                               |            | Modular SN4800                                 |
+|0111-mlxsw-reg-Add-new-field-to-Management-General-Periph.patch  | e94295e0ed27       | Downstream                               |            | Modular SN4800                                 |
+|0112-mlxsw-core-Extend-interfaces-for-cable-info-access-w.patch  | 349454526f5f       | Downstream                               |            | Modular SN4800                                 |
+|0113-mlxsw-core-Extend-port-module-data-structures-for-li.patch  | e5b6a5bac8cc       | Downstream                               |            | Modular SN4800                                 |
+|0114-mlxsw-core-Move-port-module-events-enablement-to-a-s.patch  | b244143a085e       | Downstream                               |            | Modular SN4800                                 |
+|0115-mlxsw-core_hwmon-Split-gearbox-initialization.patch         |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0116-mlxsw-core_hwmon-Extend-internal-structures-to-suppo.patch  | b890ad418e1f       | Downstream                               |            | Modular SN4800                                 |
+|0117-mlxsw-core_hwmon-Introduce-slot-parameter-in-hwmon-i.patch  | fd27849dd6fd       | Downstream                               |            | Modular SN4800                                 |
+|0118-mlxsw-core_hwmon-Extend-hwmon-device-with-gearbox-ma.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0119-mlxsw-core_thermal-Extend-internal-structures-to-sup.patch  | ef0df4fa324a       | Downstream                               |            | Modular SN4800                                 |
+|0120-mlxsw-core_thermal-Split-gearbox-initialization.patch       |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0121-mlxsw-core_thermal-Extend-thermal-area-with-gearbox-.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0122-mlxsw-core_thermal-Add-line-card-id-prefix-to-line-c.patch  | 6d94449a7d7d       | Downstream                               |            | Modular SN4800                                 |
+|0123-mlxsw-core_thermal-Use-exact-name-of-cooling-devices.patch  | 739d56bc635e       | Downstream                               |            | Modular SN4800                                 |
+|0124-mlxsw-core_thermal-Use-common-define-for-thermal-zon.patch  | 03978fb88b06       | Downstream                               |            | Modular SN4800                                 |
+|0125-devlink-add-support-to-create-line-card-and-expose-t.patch  | c246f9b5fd61       | Downstream                               |            | Modular SN4800                                 |
+|0126-devlink-implement-line-card-provisioning.patch              | fcdc8ce23a30       | Downstream                               |            | Modular SN4800                                 |
+|0127-devlink-implement-line-card-active-state.patch              | fc9f50d5b366       | Downstream                               |            | Modular SN4800                                 |
+|0128-devlink-add-port-to-line-card-relationship-set.patch        | b83758598538       | Downstream                               |            | Modular SN4800                                 |
+|0129-devlink-introduce-linecard-info-get-message.patch           | 276910aecc6a       | Downstream                               |            | Modular SN4800                                 |
+|0130-devlink-introduce-linecard-info-get-message.patch           |                    | Downstream                               |            | Modular SN4800                                 |
+|0131-mlxsw-reg-Add-Ports-Mapping-event-Configuration-Regi.patch  | ebf0c5341731       | Downstream                               |            | Modular SN4800                                 |
+|0132-mlxsw-reg-Add-Management-DownStream-Device-Query-Reg.patch  | 505f524dc660       | Downstream                               |            | Modular SN4800                                 |
+|0133-mlxsw-reg-Add-Management-DownStream-Device-Control-R.patch  | 5290a8ff2e11       | Downstream                               |            | Modular SN4800                                 |
+|0134-mlxsw-reg-Add-Management-Binary-Code-Transfer-Regist.patch  | 5bade5aa4afc       | Downstream                               |            | Modular SN4800                                 |
+|0135-mlxsw-core_linecards-Add-line-card-objects-and-imple.patch  | b217127e5e4e       | Downstream                               |            | Modular SN4800                                 |
+|0136-mlxsw-core_linecards-Implement-line-card-activation-.patch  | ee7a70fa671b       | Downstream                               |            | Modular SN4800                                 |
+|0137-mlxsw-core-Extend-driver-ops-by-remove-selected-port.patch  | 45bf3b7267e0       | Downstream                               |            | Modular SN4800                                 |
+|0138-mlxsw-spectrum-Add-port-to-linecard-mapping.patch           | 6445eef0f600       | Downstream                               |            | Modular SN4800                                 |
+|0139-mlxsw-reg-Introduce-Management-Temperature-Extended-.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0140-mlxsw-core-Add-APIs-for-thermal-sensor-mapping.patch        |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0141-mlxsw-reg-Add-Management-DownStream-Device-Tunneling.patch  | 8f9b0513a950       | Downstream                               |            | Modular SN4800                                 |
+|0142-mlxsw-core_linecards-Probe-devices-for-provisioned-l.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0143-mlxsw-core_linecards-Expose-device-FW-version-over-d.patch  | e932b4bdbd7c       | Downstream                               |            | Modular SN4800                                 |
+|0144-mlxsw-core-Introduce-flash-update-components.patch          |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0145-mlxfw-Get-the-PSID-value-using-op-instead-of-passing.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0146-mlxsw-core_linecards-Implement-line-card-device-flas.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0147-mlxsw-core_linecards-Introduce-ops-for-linecards-sta.patch  |                    | Downstream                               |            | Modular SN4800                                 |
+|0148-mlxsw-core-Add-interfaces-for-line-card-initializati.patch  | 06a0fc43bb10       | Downstream                               |            | Modular SN4800                                 |
+|0149-mlxsw-core_thermal-Add-interfaces-for-line-card-init.patch  | f11a323da46c       | Downstream                               |            | Modular SN4800                                 |
+|0150-mlxsw-core_hwmon-Add-interfaces-for-line-card-initia.patch  | 99a03b3193f6       | Downstream                               |            | Modular SN4800                                 |
+|0151-mlxsw-minimal-Prepare-driver-for-modular-system-supp.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0152-mlxsw-core-Extend-bus-init-function-with-event-handl.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0152-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch      |                    | Downstream accepted                      |            | Sonic/ISSU                                     |
+|0153-mlxsw-i2c-Add-support-for-system-events-handling.patch      | 33fa6909a263       | Downstream                               |            | Modular SN4800                                 |
+|0154-mlxsw-core-Export-line-card-API.patch                       |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0155-mlxsw-minimal-Add-system-event-handler.patch                |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
+|0156-mlxsw-minimal-Add-interfaces-for-line-card-initializ.patch  |                    | Downstream                               |            | Modular SN4800 squashed (required rebasing)    |
 |0157-platform-x86-mlx-platform-Make-activation-of-some-dr.patch  | e05d6b658fcd       | Feature upstream                         |            | E3597                                          |
 |0158-platform-x86-mlx-platform-Add-cosmetic-changes-for-a.patch  | 7bf8a14dedaf       | Feature upstream                         |            | E3597                                          |
 |0159-mlx-platform-Add-support-for-systems-equipped-with-t.patch  | 08fdb6f3acae       | Feature upstream                         |            | E3597                                          |
@@ -334,9 +341,8 @@ Kernel-5.10
 |0166-DS-leds-leds-mlxreg-Send-udev-event-from-leds-mlxreg.patch  |                    | Downstream accepted                      |            | SN2201                                         |
 |0167-DS-lan743x-Add-support-for-fixed-phy.patch                  |                    | Downstream                               |            | P2317 only                                     |
 |0168-TMP-mlxsw-minimal-Ignore-error-reading-SPAD-register.patch  |                    | Downstream                               |            | MQM8700 only                                   |
-|0169-TMP-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |
 |0170-i2c-mlxcpld-Fix-register-setting-for-400KHz-frequenc.patch  | e1f77ecc75aa       | Feature upstream                         |            |                                                |
-|0171-platform-mellanox-mlxreg-lc-Fix-cleanup-on-failure-a.patch  | 52e01c0b1d80       | Feature upstream                         |            | Modular SN4800                                 |
+|0171-platform-mellanox-mlxreg-lc-Fix-cleanup-on-failure-a.patch  | 52e01c0b1d80       | Downstream                               |            | Modular SN4800                                 |
 |0172-DS-platform-mlx-platform-Add-SPI-path-for-rack-switc.patch  |                    | Downstream accepted                      |            | P4697                                          |
 |0173-mlxsw-core-Add-support-for-OSFP-transceiver-modules.patch   | f881c4ab37db       | Feature upstream                         |            |                                                |
 |0174-DS-mlxsw-core_linecards-Skip-devlink-and-provisionin.patch  |                    | Downstream                               |            | SN4800                                         |
@@ -347,110 +353,111 @@ Kernel-5.10
 |0179-hwmon-mlxreg-fan-TMP-Do-not-return-negative-value-fo.patch  |                    | Rejected                                 |            | (temporary fix until new TC)                   |
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch  | 525dd5aed67a       | Feature upstream                         |            |                                                |
 |0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch   |                    | Downstream                               |            | disable upstream patch, must exist from 5.10.74|
-|0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
-|0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                       |
-|0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                       |
-|0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Feature upstream                         |            |                                                |
+|0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Downstream                               |            | P4262                                          |
+|0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Downstream                               |            | BF3-COME                                       |
+|0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Downstream                               |            | BF3-COME                                       |
+|0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Downstream                               |            |                                                |
 |0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch  | 26e118ea98cf       | Feature upstream                         |            |                                                |
-|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Feature upstream                         |            | BF3-COME                                       |
-|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Feature pending                          |            | BF3-COME                                       |
-|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0190-i2c-mlxcpld-Modify-base-address-type.patch                  |                    | Feature pending                          |            | BF3-COME                                       |
-|0191-i2c-mlxcpld-Allow-to-configure-base-address-of-regis.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc7815660      | Feature upstream                         |            | BF3-COME                                       |
-|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357e      | Feature upstream                         |            | BF3-COME                                       |
-|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Downstream                               |            | BF3-COME                                       |
+|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Downstream                               |            | BF3-COME                                       |
+|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0190-i2c-mlxcpld-Modify-base-address-type.patch                  |                    | Downstream                               |            | BF3-COME                                       |
+|0191-i2c-mlxcpld-Allow-to-configure-base-address-of-regis.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc7815660      | Downstream                               |            | BF3-COME                                       |
+|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357e      | Downstream                               |            | BF3-COME                                       |
+|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch  |                    | Downstream                               |            | BF3-COME                                       |
 |0195-platform-x86-MLX_PLATFORM-select-REGMAP-instead-of-d.patch  |                    | Bugfix upstream                          | 5.10.175   | BF3-COME accepted in 6.1                       |
-|0196-platform-mellanox-Relocate-mlx-platform-driver.patch        |                    | Feature pending                          |            | BF3-COME                                       |
-|0197-platform-mellanox-Add-initial-support-for-PCIe-based.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0198-platform-mellanox-Introduce-support-for-switches-bas.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0199-platform-mellanox-mlx-platform-Add-reset-and-extend-.patch  |                    | Feature pending                          |            | BF3-COME and P4262                             |
-|0200-dt-bindings-i2c-mellanox-i2c-mlxbf-convert-txt-to-YA.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0196-platform-mellanox-Relocate-mlx-platform-driver.patch        |                    | Downstream                               |            | BF3-COME                                       |
+|0197-platform-mellanox-Add-initial-support-for-PCIe-based.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0198-platform-mellanox-Introduce-support-for-switches-bas.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0199-platform-mellanox-mlx-platform-Add-reset-and-extend-.patch  |                    | Downstream                               |            | BF3-COME and P4262                             |
+|0200-dt-bindings-i2c-mellanox-i2c-mlxbf-convert-txt-to-YA.patch  |                    | Downstream                               |            | BF3-COME                                       |
 |0201-i2c-mlxbf-incorrect-base-address-passed-during-io-wr.patch  | 2a5be6d1340c       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
 |0202-i2c-mlxbf-prevent-stack-overflow-in-mlxbf_i2c_smbus_.patch  | de24aceb07d4       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
-|0203-i2c-mlxbf-remove-IRQF_ONESHOT.patch                         | 92be2c122e49       | Feature upstream                         |            | BF3-COME                                       |
+|0203-i2c-mlxbf-remove-IRQF_ONESHOT.patch                         | 92be2c122e49       | Downstream                               |            | BF3-COME                                       |
 |0204-i2c-mlxbf-Fix-frequency-calculation.patch                   | 37f071ec327b       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
 |0205-i2c-mlxbf-support-lock-mechanism.patch                      | 86067ccfa142       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
-|0206-i2c-mlxbf-add-multi-slave-functionality.patch               | bdc4af281b70       | Feature upstream                         |            | BF3-COME                                       |
-|0207-i2c-mlxbf-support-BlueField-3-SoC.patch                     | 19e13e1330c6       | Feature upstream                         |            | BF3-COME                                       |
-|0208-i2c-mlxbf-remove-device-tree-support.patch                  | be18c5ede25d       | Feature upstream                         |            | BF3-COME                                       |
-|0209-UBUNTU-SAUCE-i2c-mlxbf.c-Add-driver-version.patch           |                    | Feature pending                          |            | BF3-COME                                       |
-|0210-platform-mellanox-Typo-fix-in-the-file-mlxbf-bootctl.patch  | 04cdaf6d8f52       | Feature upstream                         |            | BF3-COME                                       |
-|0211-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-boot.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0212-platform-mellanox-mlxbf-pmc-Add-Mellanox-BlueField-P.patch  | 1a218d312e65       | Feature upstream                         |            | BF3-COME                                       |
-|0213-platform-mellanox-mlxbf-pmc-fix-kernel-doc-notation.patch   | 0c59e612c0b6       | Feature upstream                         |            | BF3-COME                                       |
-|0214-platform-mellanox-mlxbf-pmc-Fix-an-IS_ERR-vs-NULL-bu.patch  | 804034c4ffc5       | Feature upstream                         |            | BF3-COME                                       |
-|0215-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-pmc.patch   |                    | Feature pending                          |            | BF3-COME                                       |
-|0216-UBUNTU-SAUCE-mlxbf_pmc-Fix-references-to-sprintf.patch      |                    | Feature pending                          |            | BF3-COME                                       |
-|0217-UBUNTU-SAUCE-mlxbf-pmc-Fix-error-when-reading-unprog.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0218-UBUNTU-SAUCE-platform-mellanox-Add-mlx-trio-driver.patch    |                    | Feature pending                          |            | BF3-COME                                       |
-|0219-UBUNTU-SAUCE-platform-mellanox-mlxbf-tmfifo-Add-Blue.patch  | bc05ea63b394       | Feature upstream                         |            | BF3-COME                                       |
-|0220-UBUNTU-SAUCE-pka-Add-pka-driver.patch                       |                    | Feature pending                          |            | BF3-COME                                       |
-|0221-UBUNTU-SAUCE-platform-mellanox-Add-mlxbf-livefish-dr.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0222-workqueue-Add-resource-managed-version-of-delayed-wo.patch  | 0341ce544394       | Feature upstream                         |            | BF3-COME                                       |
-|0223-devm-helpers-Fix-devm_delayed_work_autocancel-kernel.patch  | a943d76352db       | Feature upstream                         |            | BF3-COME                                       |
-|0224-devm-helpers-Add-resource-managed-version-of-work-in.patch  | 7a2c4cc537fa       | Feature upstream                         |            | BF3-COME                                       |
-|0225-UBUNTU-SAUCE-Add-support-to-pwr-mlxbf.c-driver.patch        |                    | Feature pending                          |            | BF3-COME                                       |
-|0226-Add-Mellanox-BlueField-Gigabit-Ethernet-driver.patch        | f92e1869d74e       | Feature upstream                         |            | BF3-COME                                       |
-|0227-mlxbf_gige-clear-valid_polarity-upon-open.patch             | ee8a9600b539       | Feature upstream                         |            | BF3-COME                                       |
-|0228-net-mellanox-mlxbf_gige-Replace-non-standard-interru.patch  | 6c2a6ddca763       | Feature upstream                         |            | BF3-COME                                       |
-|0229-mlxbf_gige-increase-MDIO-polling-rate-to-5us.patch          | 0a02e282bad4       | Feature upstream                         |            | BF3-COME                                       |
-|0230-mlxbf_gige-remove-driver-managed-interrupt-counts.patch     | f4826443f4d6       | Feature upstream                         |            | BF3-COME                                       |
-|0231-mlxbf_gige-remove-own-module-name-define-and-use-KBU.patch  | cfbc80e34e3a       | Feature upstream                         |            | BF3-COME                                       |
-|0232-UBUNTU-SAUCE-mlxbf_gige-add-ethtool-mlxbf_gige_set_r.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0233-UBUNTU-SAUCE-Fix-OOB-handling-RX-packets-in-heavy-tr.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0234-UBUNTU-SAUCE-mlxbf_gige-add-validation-of-ACPI-table.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0235-UBUNTU-SAUCE-mlxbf_gige-set-driver-version-to-1.27.patch    |                    | Feature pending                          |            | BF3-COME                                       |
-|0236-UBUNTU-SAUCE-mlxbf_gige-clear-MDIO-gateway-lock-afte.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0237-mlxbf_gige-compute-MDIO-period-based-on-i1clk.patch         | 3a1a274e933f       | Feature upstream                         |            | BF3-COME                                       |
-|0238-net-mlxbf_gige-Fix-an-IS_ERR-vs-NULL-bug-in-mlxbf_gi.patch  | 4774db8dfc6a       | Feature upstream                         |            | BF3-COME                                       |
-|0239-UBUNTU-SAUCE-mlxbf_gige-add-MDIO-support-for-BlueFie.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0240-UBUNTU-SAUCE-mlxbf_gige-support-10M-100M-1G-speeds-o.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0241-UBUNTU-SAUCE-mlxbf_gige-add-BlueField-3-Serdes-confi.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0242-UBUNTU-SAUCE-mlxbf_gige-add-BlueField-3-ethtool_ops.patch   |                    | Feature pending                          |            | BF3-COME                                       |
-|0243-UBUNTU-SAUCE-bluefield_edac-Add-SMC-support.patch           |                    | Feature pending                          |            | BF3-COME                                       |
-|0244-UBUNTU-SAUCE-bluefield_edac-Update-license-and-copyr.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0245-gpio-mlxbf2-Convert-to-device-PM-ops.patch                  | dabe57c3a32d       | Feature upstream                         |            | BF3-COME                                       |
-|0246-gpio-mlxbf2-Drop-wrong-use-of-ACPI_PTR.patch                | 603607e70e36       | Feature upstream                         |            | BF3-COME                                       |
-|0247-gpio-mlxbf2-Use-devm_platform_ioremap_resource.patch        | 4e6864f8563d       | Feature upstream                         |            | BF3-COME                                       |
-|0248-gpio-mlxbf2-Use-DEFINE_RES_MEM_NAMED-helper-macro.patch     | d0ef631d40ba       | Feature upstream                         |            | BF3-COME                                       |
-|0249-gpio-mlxbf2-Introduce-IRQ-support.patch                     |                    | Feature pending                          |            | BF3-COME                                       |
-|0250-UBUNTU-SAUCE-gpio-mlxbf2.c-support-driver-version.patch     |                    | Feature pending                          |            | BF3-COME                                       |
-|0251-mmc-sdhci-of-dwcmshc-add-rockchip-platform-support.patch    | 08f3dff799d4       | Feature upstream                         |            | BF3-COME                                       |
-|0252-mmc-sdhci-of-dwcmshc-add-ACPI-support-for-BlueField-.patch  | eb81ed518079       | Feature upstream                         |            | BF3-COME                                       |
-|0253-mmc-sdhci-of-dwcmshc-fix-error-return-code-in-dwcmsh.patch  | 34884c4f6483       | Feature upstream                         |            | BF3-COME                                       |
-|0254-mmc-sdhci-of-dwcmshc-set-MMC_CAP_WAIT_WHILE_BUSY.patch      | 57ac3084f598       | Feature upstream                         |            | BF3-COME                                       |
-|0255-mmc-sdhci-of-dwcmshc-Re-enable-support-for-the-BlueF.patch  | a0753ef66c34       | Feature upstream                         |            | BF3-COME                                       |
-|0256-UBUNTU-SAUCE-Support-BlueField-3-GPIO-driver.patch          |                    | Feature pending                          |            | BF3-COME                                       |
-|0257-regmap-debugfs-Enable-writing-to-the-regmap-debugfs-.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0258-UBUNTU-SAUCE-mlx-bootctl-support-icm-carveout-eeprom.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0259-mmc-sdhci-of-dwcmshc-Enable-host-V4-support-for-Blue.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0260-UBUNTU-SAUCE-mlxbf-pka-Fix-kernel-crash-with-pka-TRN.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0261-mlxbf-ptm-power-and-thermal-management-debugfs-drive.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0262-UBUNTU-SAUCE-mlxbf-pmc-Fix-event-string-typo.patch          | b0b698b80c56       | Feature upstream                         |            | BF3-COME                                       |
-|0263-UBUNTU-SAUCE-mlxbf-pmc-Support-for-BlueField-3-perfo.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0264-UBUNTU-SAUCE-platform-mellanox-Add-ctrl-message-and-.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0206-i2c-mlxbf-add-multi-slave-functionality.patch               | bdc4af281b70       | Downstream                               |            | BF3-COME                                       |
+|0207-i2c-mlxbf-support-BlueField-3-SoC.patch                     | 19e13e1330c6       | Downstream                               |            | BF3-COME                                       |
+|0208-i2c-mlxbf-remove-device-tree-support.patch                  | be18c5ede25d       | Downstream                               |            | BF3-COME                                       |
+|0209-UBUNTU-SAUCE-i2c-mlxbf.c-Add-driver-version.patch           |                    | Downstream                               |            | BF3-COME                                       |
+|0210-platform-mellanox-Typo-fix-in-the-file-mlxbf-bootctl.patch  | 04cdaf6d8f52       | Downstream                               |            | BF3-COME                                       |
+|0211-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-boot.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0212-platform-mellanox-mlxbf-pmc-Add-Mellanox-BlueField-P.patch  | 1a218d312e65       | Downstream                               |            | BF3-COME                                       |
+|0213-platform-mellanox-mlxbf-pmc-fix-kernel-doc-notation.patch   | 0c59e612c0b6       | Downstream                               |            | BF3-COME                                       |
+|0214-platform-mellanox-mlxbf-pmc-Fix-an-IS_ERR-vs-NULL-bu.patch  | 804034c4ffc5       | Downstream                               |            | BF3-COME                                       |
+|0215-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-pmc.patch   |                    | Downstream                               |            | BF3-COME                                       |
+|0216-UBUNTU-SAUCE-mlxbf_pmc-Fix-references-to-sprintf.patch      |                    | Downstream                               |            | BF3-COME                                       |
+|0217-UBUNTU-SAUCE-mlxbf-pmc-Fix-error-when-reading-unprog.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0218-UBUNTU-SAUCE-platform-mellanox-Add-mlx-trio-driver.patch    |                    | Downstream                               |            | BF3-COME                                       |
+|0219-UBUNTU-SAUCE-platform-mellanox-mlxbf-tmfifo-Add-Blue.patch  | bc05ea63b394       | Downstream                               |            | BF3-COME                                       |
+|0220-UBUNTU-SAUCE-pka-Add-pka-driver.patch                       |                    | Downstream                               |            | BF3-COME                                       |
+|0221-UBUNTU-SAUCE-platform-mellanox-Add-mlxbf-livefish-dr.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0222-workqueue-Add-resource-managed-version-of-delayed-wo.patch  | 0341ce544394       | Downstream                               |            | BF3-COME                                       |
+|0223-devm-helpers-Fix-devm_delayed_work_autocancel-kernel.patch  | a943d76352db       | Downstream                               |            | BF3-COME                                       |
+|0224-devm-helpers-Add-resource-managed-version-of-work-in.patch  | 7a2c4cc537fa       | Downstream                               |            | BF3-COME                                       |
+|0225-UBUNTU-SAUCE-Add-support-to-pwr-mlxbf.c-driver.patch        |                    | Downstream                               |            | BF3-COME                                       |
+|0226-Add-Mellanox-BlueField-Gigabit-Ethernet-driver.patch        | f92e1869d74e       | Downstream                               |            | BF3-COME                                       |
+|0227-mlxbf_gige-clear-valid_polarity-upon-open.patch             | ee8a9600b539       | Downstream                               |            | BF3-COME                                       |
+|0228-net-mellanox-mlxbf_gige-Replace-non-standard-interru.patch  | 6c2a6ddca763       | Downstream                               |            | BF3-COME                                       |
+|0229-mlxbf_gige-increase-MDIO-polling-rate-to-5us.patch          | 0a02e282bad4       | Downstream                               |            | BF3-COME                                       |
+|0230-mlxbf_gige-remove-driver-managed-interrupt-counts.patch     | f4826443f4d6       | Downstream                               |            | BF3-COME                                       |
+|0231-mlxbf_gige-remove-own-module-name-define-and-use-KBU.patch  | cfbc80e34e3a       | Downstream                               |            | BF3-COME                                       |
+|0232-UBUNTU-SAUCE-mlxbf_gige-add-ethtool-mlxbf_gige_set_r.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0233-UBUNTU-SAUCE-Fix-OOB-handling-RX-packets-in-heavy-tr.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0234-UBUNTU-SAUCE-mlxbf_gige-add-validation-of-ACPI-table.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0235-UBUNTU-SAUCE-mlxbf_gige-set-driver-version-to-1.27.patch    |                    | Downstream                               |            | BF3-COME                                       |
+|0236-UBUNTU-SAUCE-mlxbf_gige-clear-MDIO-gateway-lock-afte.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0237-mlxbf_gige-compute-MDIO-period-based-on-i1clk.patch         | 3a1a274e933f       | Downstream                               |            | BF3-COME                                       |
+|0238-net-mlxbf_gige-Fix-an-IS_ERR-vs-NULL-bug-in-mlxbf_gi.patch  | 4774db8dfc6a       | Downstream                               |            | BF3-COME                                       |
+|0239-UBUNTU-SAUCE-mlxbf_gige-add-MDIO-support-for-BlueFie.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0240-UBUNTU-SAUCE-mlxbf_gige-support-10M-100M-1G-speeds-o.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0241-UBUNTU-SAUCE-mlxbf_gige-add-BlueField-3-Serdes-confi.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0242-UBUNTU-SAUCE-mlxbf_gige-add-BlueField-3-ethtool_ops.patch   |                    | Downstream                               |            | BF3-COME                                       |
+|0243-UBUNTU-SAUCE-bluefield_edac-Add-SMC-support.patch           |                    | Downstream                               |            | BF3-COME                                       |
+|0244-UBUNTU-SAUCE-bluefield_edac-Update-license-and-copyr.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0245-gpio-mlxbf2-Convert-to-device-PM-ops.patch                  | dabe57c3a32d       | Downstream                               |            | BF3-COME                                       |
+|0246-gpio-mlxbf2-Drop-wrong-use-of-ACPI_PTR.patch                | 603607e70e36       | Downstream                               |            | BF3-COME                                       |
+|0247-gpio-mlxbf2-Use-devm_platform_ioremap_resource.patch        | 4e6864f8563d       | Downstream                               |            | BF3-COME                                       |
+|0248-gpio-mlxbf2-Use-DEFINE_RES_MEM_NAMED-helper-macro.patch     | d0ef631d40ba       | Downstream                               |            | BF3-COME                                       |
+|0249-gpio-mlxbf2-Introduce-IRQ-support.patch                     |                    | Downstream                               |            | BF3-COME                                       |
+|0250-UBUNTU-SAUCE-gpio-mlxbf2.c-support-driver-version.patch     |                    | Downstream                               |            | BF3-COME                                       |
+|0251-mmc-sdhci-of-dwcmshc-add-rockchip-platform-support.patch    | 08f3dff799d4       | Downstream                               |            | BF3-COME                                       |
+|0252-mmc-sdhci-of-dwcmshc-add-ACPI-support-for-BlueField-.patch  | eb81ed518079       | Downstream                               |            | BF3-COME                                       |
+|0253-mmc-sdhci-of-dwcmshc-fix-error-return-code-in-dwcmsh.patch  | 34884c4f6483       | Downstream                               |            | BF3-COME                                       |
+|0254-mmc-sdhci-of-dwcmshc-set-MMC_CAP_WAIT_WHILE_BUSY.patch      | 57ac3084f598       | Downstream                               |            | BF3-COME                                       |
+|0255-mmc-sdhci-of-dwcmshc-Re-enable-support-for-the-BlueF.patch  | a0753ef66c34       | Downstream                               |            | BF3-COME                                       |
+|0256-UBUNTU-SAUCE-Support-BlueField-3-GPIO-driver.patch          |                    | Downstream                               |            | BF3-COME                                       |
+|0257-regmap-debugfs-Enable-writing-to-the-regmap-debugfs-.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0258-UBUNTU-SAUCE-mlx-bootctl-support-icm-carveout-eeprom.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0259-mmc-sdhci-of-dwcmshc-Enable-host-V4-support-for-Blue.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0260-UBUNTU-SAUCE-mlxbf-pka-Fix-kernel-crash-with-pka-TRN.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0261-mlxbf-ptm-power-and-thermal-management-debugfs-drive.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0262-UBUNTU-SAUCE-mlxbf-pmc-Fix-event-string-typo.patch          | b0b698b80c56       | Downstream                               |            | BF3-COME                                       |
+|0263-UBUNTU-SAUCE-mlxbf-pmc-Support-for-BlueField-3-perfo.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0264-UBUNTU-SAUCE-platform-mellanox-Add-ctrl-message-and-.patch  |                    | Downstream                               |            | BF3-COME                                       |
 |0265-hwmon-mlxreg-fan-Return-zero-speed-for-broken-fan.patch     |                    | Bugfix upstream                          | 5.10.173   |                                                |
-|0266-UBUNTU-SAUCE-mlxbf-pmc-Bug-fix-for-BlueField-3-count.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0267-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0266-UBUNTU-SAUCE-mlxbf-pmc-Bug-fix-for-BlueField-3-count.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0267-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch  |                    | Downstream                               |            | BF3-COME                                       |
 |0268-DS-mlxsw-core_linecards-Disable-firmware-bundling-ma.patch  |                    | Downstream                               |            |                                                |
-|0269-platform-mellanox-Cosmetic-changes.patch                    |                    | Feature pending                          |            | P4262                                          |
-|0270-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Feature pending                          |            | P4262                                          |
-|0271-platform-mellanox-Add-new-attributes.patch                  |                    | Feature pending                          |            | P4262                                          |
-|0272-platform-mellanox-Change-register-offset-addresses.patch    |                    | Feature pending                          |            | P4262                                          |
-|0273-platform-mellanox-Add-field-upgrade-capability-regis.patch  |                    | Feature pending                          |            | P4262                                          |
-|0274-platform-mellanox-Modify-reset-causes-description.patch     |                    | Feature pending                          |            |                                                |
-|0275-mlxsw-Use-u16-for-local_port-field-instead-of-u8.patch      | c934757d9000       | Feature upstream                         |            | SN5600                                         |
-|0276-mlxsw-minimal-Change-type-for-local-port.patch              |                    | Feature pending                          |            | SN5600                                         |
-|0277-mlxsw-i2c-Fix-chunk-size-setting-in-output-mailbox-b.patch  |                    | Bugfix pending                           |            | SN5600                                         |
-|0278-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Feature pending                          |            | SN5600                                         |
-|0279-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            | P4262                                          |
-|0280-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch  |                    | Feature pending                          |            | P4262                                          |
-|0281-platform-mellanox-mlx-platform-Modify-health-and-pow.patch  |                    | Feature pending                          |            | P4262                                          |
-|0282-platform-mellanox-mlx-platform-add-support-of-5th-CP.patch  |                    | Feature pending                          |            | P4262                                          |
-|0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch  |                    | Feature pending                          |            | SN3750SX                                       |
-|0284-platform-mellanox-mlx-platform-fix-CPLD4-PN-report.patch    |                    | Bugfix pending                           |            | SN5600                                         |
+|0269-platform-mellanox-Cosmetic-changes.patch                    |                    | Downstream                               |            | P4262                                          |
+|0270-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Downstream                               |            | P4262                                          |
+|0271-platform-mellanox-Add-new-attributes.patch                  |                    | Downstream                               |            | P4262                                          |
+|0272-platform-mellanox-Change-register-offset-addresses.patch    |                    | Downstream                               |            | P4262                                          |
+|0273-platform-mellanox-Add-field-upgrade-capability-regis.patch  |                    | Downstream                               |            | P4262                                          |
+|0274-platform-mellanox-Modify-reset-causes-description.patch     |                    | Downstream                               |            |                                                |
+|0275-mlxsw-Use-u16-for-local_port-field-instead-of-u8.patch      | c934757d9000       | Downstream                               |            | SN5600                                         |
+|0276-mlxsw-minimal-Change-type-for-local-port.patch              |                    | Downstream                               |            | SN5600                                         |
+|0277-mlxsw-i2c-Fix-chunk-size-setting-in-output-mailbox-b.patch  |                    | Downstream                               |            | SN5600                                         |
+|0278-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Downstream                               |            | P4262                                          |
+|0279-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Downstream                               |            | P4262                                          |
+|0280-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch  |                    | Downstream                               |            | P4262                                          |
+|0281-platform-mellanox-mlx-platform-Modify-health-and-pow.patch  |                    | Downstream                               |            | P4262                                          |
+|0282-platform-mellanox-mlx-platform-add-support-of-5th-CP.patch  |                    | Downstream                               |            | P4262                                          |
+|0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch  |                    | Downstream                               |            | SN3750SX                                       |
+|0284-platform-mellanox-mlx-platform-fix-CPLD4-PN-report.patch    |                    | Downstream                               |            | SN5600                                         |
+|0285-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch  |                    | Feature pending                          |            | SN2201                                         |
 |9000-DS-OPT-iio-pressure-icp20100-add-driver-for-InvenSense-.patch|                   | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-DS-OPT-e1000e-skip-NVM-checksum.patch                       |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream                               |            |                                                |

--- a/recipes-kernel/linux/linux-5.10/0097-1-mlxsw-Use-u16-for-local_port-field.patch
+++ b/recipes-kernel/linux/linux-5.10/0097-1-mlxsw-Use-u16-for-local_port-field.patch
@@ -1,0 +1,784 @@
+From 0639995c2017338c563db36f631e94d19ae45c74 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 15 Aug 2023 07:52:25 +0000
+Subject: mlxsw: Use u16 for local_port field instead of u8
+
+Upstream commit c934757d90000a9d3779d2b436a70e3d060ef693
+
+Currently, local_port field is saved as u8, which means that maximum 256
+ports can be used.
+
+As preparation for Spectrum-4, which will support more than 256 ports,
+local_port field should be extended.
+
+Save local_port as u16 to allow use of additional ports.
+
+Signed-off-by: Amit Cohen <amcohen@nvidia.com>
+Reviewed-by: Petr Machata <petrm@nvidia.com>
+Signed-off-by: Ido Schimmel <idosch@nvidia.com>
+Signed-off-by: David S. Miller <davem@davemloft.net>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c    |  32 ++++----
+ drivers/net/ethernet/mellanox/mlxsw/core.h    |  34 ++++-----
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c |   6 +-
+ drivers/net/ethernet/mellanox/mlxsw/reg.h     | 106 +++++++++++++-------------
+ 4 files changed, 89 insertions(+), 89 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index 7938bad70e37..631c19222fc4 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -47,7 +47,7 @@ static struct workqueue_struct *mlxsw_owq;
+ struct mlxsw_core_port {
+ 	struct devlink_port devlink_port;
+ 	void *port_driver_priv;
+-	u8 local_port;
++	u16 local_port;
+ };
+ 
+ void *mlxsw_core_port_driver_priv(struct mlxsw_core_port *mlxsw_core_port)
+@@ -669,7 +669,7 @@ static void mlxsw_emad_process_response(struct mlxsw_core *mlxsw_core,
+ }
+ 
+ /* called with rcu read lock held */
+-static void mlxsw_emad_rx_listener_func(struct sk_buff *skb, u8 local_port,
++static void mlxsw_emad_rx_listener_func(struct sk_buff *skb, u16 local_port,
+ 					void *priv)
+ {
+ 	struct mlxsw_core *mlxsw_core = priv;
+@@ -2094,7 +2094,7 @@ int mlxsw_core_skb_transmit(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ EXPORT_SYMBOL(mlxsw_core_skb_transmit);
+ 
+ void mlxsw_core_ptp_transmitted(struct mlxsw_core *mlxsw_core,
+-				struct sk_buff *skb, u8 local_port)
++				struct sk_buff *skb, u16 local_port)
+ {
+ 	if (mlxsw_core->driver->ptp_transmitted)
+ 		mlxsw_core->driver->ptp_transmitted(mlxsw_core, skb,
+@@ -2172,7 +2172,7 @@ mlxsw_core_rx_listener_state_set(struct mlxsw_core *mlxsw_core,
+ 	rxl_item->enabled = enabled;
+ }
+ 
+-static void mlxsw_core_event_listener_func(struct sk_buff *skb, u8 local_port,
++static void mlxsw_core_event_listener_func(struct sk_buff *skb, u16 local_port,
+ 					   void *priv)
+ {
+ 	struct mlxsw_event_listener_item *event_listener_item = priv;
+@@ -2599,7 +2599,7 @@ void mlxsw_core_skb_receive(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ {
+ 	struct mlxsw_rx_listener_item *rxl_item;
+ 	const struct mlxsw_rx_listener *rxl;
+-	u8 local_port;
++	u16 local_port;
+ 	bool found = false;
+ 
+ 	if (rx_info->is_lag) {
+@@ -2657,7 +2657,7 @@ static int mlxsw_core_lag_mapping_index(struct mlxsw_core *mlxsw_core,
+ }
+ 
+ void mlxsw_core_lag_mapping_set(struct mlxsw_core *mlxsw_core,
+-				u16 lag_id, u8 port_index, u8 local_port)
++				u16 lag_id, u8 port_index, u16 local_port)
+ {
+ 	int index = mlxsw_core_lag_mapping_index(mlxsw_core,
+ 						 lag_id, port_index);
+@@ -2677,7 +2677,7 @@ u8 mlxsw_core_lag_mapping_get(struct mlxsw_core *mlxsw_core,
+ EXPORT_SYMBOL(mlxsw_core_lag_mapping_get);
+ 
+ void mlxsw_core_lag_mapping_clear(struct mlxsw_core *mlxsw_core,
+-				  u16 lag_id, u8 local_port)
++				  u16 lag_id, u16 local_port)
+ {
+ 	int i;
+ 
+@@ -2705,7 +2705,7 @@ u64 mlxsw_core_res_get(struct mlxsw_core *mlxsw_core,
+ }
+ EXPORT_SYMBOL(mlxsw_core_res_get);
+ 
+-static int __mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
++static int __mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 				  enum devlink_port_flavour flavour,
+ 				  u32 port_number, bool split,
+ 				  u32 split_port_subnumber,
+@@ -2736,7 +2736,7 @@ static int __mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 	return err;
+ }
+ 
+-static void __mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port)
++static void __mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+ 					&mlxsw_core->ports[local_port];
+@@ -2746,7 +2746,7 @@ static void __mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port)
+ 	memset(mlxsw_core_port, 0, sizeof(*mlxsw_core_port));
+ }
+ 
+-int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
++int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			 u32 port_number, bool split,
+ 			 u32 split_port_subnumber,
+ 			 bool splittable, u32 lanes,
+@@ -2761,7 +2761,7 @@ int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
+ }
+ EXPORT_SYMBOL(mlxsw_core_port_init);
+ 
+-void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port)
++void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port)
+ {
+ 	__mlxsw_core_port_fini(mlxsw_core, local_port);
+ }
+@@ -2794,7 +2794,7 @@ void mlxsw_core_cpu_port_fini(struct mlxsw_core *mlxsw_core)
+ }
+ EXPORT_SYMBOL(mlxsw_core_cpu_port_fini);
+ 
+-void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u8 local_port,
++void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			     void *port_driver_priv, struct net_device *dev)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+@@ -2806,7 +2806,7 @@ void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u8 local_port,
+ }
+ EXPORT_SYMBOL(mlxsw_core_port_eth_set);
+ 
+-void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u8 local_port,
++void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			    void *port_driver_priv)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+@@ -2818,7 +2818,7 @@ void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u8 local_port,
+ }
+ EXPORT_SYMBOL(mlxsw_core_port_ib_set);
+ 
+-void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u8 local_port,
++void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			   void *port_driver_priv)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+@@ -2831,7 +2831,7 @@ void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u8 local_port,
+ EXPORT_SYMBOL(mlxsw_core_port_clear);
+ 
+ enum devlink_port_type mlxsw_core_port_type_get(struct mlxsw_core *mlxsw_core,
+-						u8 local_port)
++						u16 local_port)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+ 					&mlxsw_core->ports[local_port];
+@@ -2844,7 +2844,7 @@ EXPORT_SYMBOL(mlxsw_core_port_type_get);
+ 
+ struct devlink_port *
+ mlxsw_core_port_devlink_port_get(struct mlxsw_core *mlxsw_core,
+-				 u8 local_port)
++				 u16 local_port)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+ 					&mlxsw_core->ports[local_port];
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.h b/drivers/net/ethernet/mellanox/mlxsw/core.h
+index 56efb8e48022..1fc783174292 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.h
+@@ -49,7 +49,7 @@ int mlxsw_core_bus_device_register(const struct mlxsw_bus_info *mlxsw_bus_info,
+ void mlxsw_core_bus_device_unregister(struct mlxsw_core *mlxsw_core, bool reload);
+ 
+ struct mlxsw_tx_info {
+-	u8 local_port;
++	u16 local_port;
+ 	bool is_emad;
+ };
+ 
+@@ -58,11 +58,11 @@ bool mlxsw_core_skb_transmit_busy(struct mlxsw_core *mlxsw_core,
+ int mlxsw_core_skb_transmit(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ 			    const struct mlxsw_tx_info *tx_info);
+ void mlxsw_core_ptp_transmitted(struct mlxsw_core *mlxsw_core,
+-				struct sk_buff *skb, u8 local_port);
++				struct sk_buff *skb, u16 local_port);
+ 
+ struct mlxsw_rx_listener {
+-	void (*func)(struct sk_buff *skb, u8 local_port, void *priv);
+-	u8 local_port;
++	void (*func)(struct sk_buff *skb, u16 local_port, void *priv);
++	u16 local_port;
+ 	u8 mirror_reason;
+ 	u16 trap_id;
+ };
+@@ -194,35 +194,35 @@ void mlxsw_core_skb_receive(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ 			    struct mlxsw_rx_info *rx_info);
+ 
+ void mlxsw_core_lag_mapping_set(struct mlxsw_core *mlxsw_core,
+-				u16 lag_id, u8 port_index, u8 local_port);
++				u16 lag_id, u8 port_index, u16 local_port);
+ u8 mlxsw_core_lag_mapping_get(struct mlxsw_core *mlxsw_core,
+ 			      u16 lag_id, u8 port_index);
+ void mlxsw_core_lag_mapping_clear(struct mlxsw_core *mlxsw_core,
+-				  u16 lag_id, u8 local_port);
++				  u16 lag_id, u16 local_port);
+ 
+ void *mlxsw_core_port_driver_priv(struct mlxsw_core_port *mlxsw_core_port);
+-int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
++int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			 u32 port_number, bool split, u32 split_port_subnumber,
+ 			 bool splittable, u32 lanes,
+ 			 const unsigned char *switch_id,
+ 			 unsigned char switch_id_len);
+-void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port);
++void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port);
+ int mlxsw_core_cpu_port_init(struct mlxsw_core *mlxsw_core,
+ 			     void *port_driver_priv,
+ 			     const unsigned char *switch_id,
+ 			     unsigned char switch_id_len);
+ void mlxsw_core_cpu_port_fini(struct mlxsw_core *mlxsw_core);
+-void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u8 local_port,
++void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			     void *port_driver_priv, struct net_device *dev);
+-void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u8 local_port,
++void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			    void *port_driver_priv);
+-void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u8 local_port,
++void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			   void *port_driver_priv);
+ enum devlink_port_type mlxsw_core_port_type_get(struct mlxsw_core *mlxsw_core,
+-						u8 local_port);
++						u16 local_port);
+ struct devlink_port *
+ mlxsw_core_port_devlink_port_get(struct mlxsw_core *mlxsw_core,
+-				 u8 local_port);
++				 u16 local_port);
+ struct mlxsw_env *mlxsw_core_env(const struct mlxsw_core *mlxsw_core);
+ int mlxsw_core_module_max_width(struct mlxsw_core *mlxsw_core, u8 module);
+ 
+@@ -290,11 +290,11 @@ struct mlxsw_driver {
+ 		    struct netlink_ext_ack *extack);
+ 	void (*fini)(struct mlxsw_core *mlxsw_core);
+ 	int (*basic_trap_groups_set)(struct mlxsw_core *mlxsw_core);
+-	int (*port_type_set)(struct mlxsw_core *mlxsw_core, u8 local_port,
++	int (*port_type_set)(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			     enum devlink_port_type new_type);
+-	int (*port_split)(struct mlxsw_core *mlxsw_core, u8 local_port,
++	int (*port_split)(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			  unsigned int count, struct netlink_ext_ack *extack);
+-	int (*port_unsplit)(struct mlxsw_core *mlxsw_core, u8 local_port,
++	int (*port_unsplit)(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 			    struct netlink_ext_ack *extack);
+ 	int (*sb_pool_get)(struct mlxsw_core *mlxsw_core,
+ 			   unsigned int sb_index, u16 pool_index,
+@@ -368,7 +368,7 @@ struct mlxsw_driver {
+ 	 * is responsible for freeing the passed-in SKB.
+ 	 */
+ 	void (*ptp_transmitted)(struct mlxsw_core *mlxsw_core,
+-				struct sk_buff *skb, u8 local_port);
++				struct sk_buff *skb, u16 local_port);
+ 
+ 	u8 txhdr_len;
+ 	const struct mlxsw_config_profile *profile;
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+index 3d07c2dcf08d..1ddd11320b99 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+@@ -38,7 +38,7 @@ struct mlxsw_m {
+ struct mlxsw_m_port {
+ 	struct net_device *dev;
+ 	struct mlxsw_m *mlxsw_m;
+-	u8 local_port;
++	u16 local_port;
+ 	u8 module;
+ };
+ 
+@@ -201,7 +201,7 @@ mlxsw_m_port_dev_addr_get(struct mlxsw_m_port *mlxsw_m_port)
+ }
+ 
+ static int
+-mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u8 local_port, u8 module)
++mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u16 local_port, u8 module)
+ {
+ 	struct mlxsw_m_port *mlxsw_m_port;
+ 	struct net_device *dev;
+@@ -264,7 +264,7 @@ mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u8 local_port, u8 module)
+ 	return err;
+ }
+ 
+-static void mlxsw_m_port_remove(struct mlxsw_m *mlxsw_m, u8 local_port)
++static void mlxsw_m_port_remove(struct mlxsw_m *mlxsw_m, u16 local_port)
+ {
+ 	struct mlxsw_m_port *mlxsw_m_port = mlxsw_m->ports[local_port];
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index a9119451d999..2ec9ec6078e2 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -161,7 +161,7 @@ MLXSW_ITEM32(reg, sspr, sub_port, 0x00, 8, 8);
+  */
+ MLXSW_ITEM32(reg, sspr, system_port, 0x04, 0, 16);
+ 
+-static inline void mlxsw_reg_sspr_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_sspr_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(sspr, payload);
+ 	mlxsw_reg_sspr_m_set(payload, 1);
+@@ -407,7 +407,7 @@ static inline void mlxsw_reg_sfd_uc_pack(char *payload, int rec_index,
+ 					 enum mlxsw_reg_sfd_rec_policy policy,
+ 					 const char *mac, u16 fid_vid,
+ 					 enum mlxsw_reg_sfd_rec_action action,
+-					 u8 local_port)
++					 u16 local_port)
+ {
+ 	mlxsw_reg_sfd_rec_pack(payload, rec_index,
+ 			       MLXSW_REG_SFD_REC_TYPE_UNICAST, mac, action);
+@@ -419,7 +419,7 @@ static inline void mlxsw_reg_sfd_uc_pack(char *payload, int rec_index,
+ 
+ static inline void mlxsw_reg_sfd_uc_unpack(char *payload, int rec_index,
+ 					   char *mac, u16 *p_fid_vid,
+-					   u8 *p_local_port)
++					   u16 *p_local_port)
+ {
+ 	mlxsw_reg_sfd_rec_mac_memcpy_from(payload, rec_index, mac);
+ 	*p_fid_vid = mlxsw_reg_sfd_uc_fid_vid_get(payload, rec_index);
+@@ -685,7 +685,7 @@ MLXSW_ITEM32_INDEXED(reg, sfn, mac_system_port, MLXSW_REG_SFN_BASE_LEN, 0, 16,
+ 
+ static inline void mlxsw_reg_sfn_mac_unpack(char *payload, int rec_index,
+ 					    char *mac, u16 *p_vid,
+-					    u8 *p_local_port)
++					    u16 *p_local_port)
+ {
+ 	mlxsw_reg_sfn_rec_mac_memcpy_from(payload, rec_index, mac);
+ 	*p_vid = mlxsw_reg_sfn_mac_fid_get(payload, rec_index);
+@@ -800,7 +800,7 @@ enum mlxsw_reg_spms_state {
+  */
+ MLXSW_ITEM_BIT_ARRAY(reg, spms, state, 0x04, 0x400, 2);
+ 
+-static inline void mlxsw_reg_spms_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_spms_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(spms, payload);
+ 	mlxsw_reg_spms_local_port_set(payload, local_port);
+@@ -840,7 +840,7 @@ MLXSW_ITEM32(reg, spvid, sub_port, 0x00, 8, 8);
+  */
+ MLXSW_ITEM32(reg, spvid, pvid, 0x04, 0, 12);
+ 
+-static inline void mlxsw_reg_spvid_pack(char *payload, u8 local_port, u16 pvid)
++static inline void mlxsw_reg_spvid_pack(char *payload, u16 local_port, u16 pvid)
+ {
+ 	MLXSW_REG_ZERO(spvid, payload);
+ 	mlxsw_reg_spvid_local_port_set(payload, local_port);
+@@ -929,7 +929,7 @@ MLXSW_ITEM32_INDEXED(reg, spvm, rec_vid,
+ 		     MLXSW_REG_SPVM_BASE_LEN, 0, 12,
+ 		     MLXSW_REG_SPVM_REC_LEN, 0, false);
+ 
+-static inline void mlxsw_reg_spvm_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_spvm_pack(char *payload, u16 local_port,
+ 				       u16 vid_begin, u16 vid_end,
+ 				       bool is_member, bool untagged)
+ {
+@@ -991,7 +991,7 @@ MLXSW_ITEM32(reg, spaft, allow_prio_tagged, 0x04, 30, 1);
+  */
+ MLXSW_ITEM32(reg, spaft, allow_tagged, 0x04, 29, 1);
+ 
+-static inline void mlxsw_reg_spaft_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_spaft_pack(char *payload, u16 local_port,
+ 					bool allow_untagged)
+ {
+ 	MLXSW_REG_ZERO(spaft, payload);
+@@ -1317,7 +1317,7 @@ MLXSW_ITEM32(reg, sldr, num_ports, 0x04, 24, 8);
+ MLXSW_ITEM32_INDEXED(reg, sldr, system_port, 0x08, 0, 16, 4, 0, false);
+ 
+ static inline void mlxsw_reg_sldr_lag_add_port_pack(char *payload, u8 lag_id,
+-						    u8 local_port)
++						    u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(sldr, payload);
+ 	mlxsw_reg_sldr_op_set(payload, MLXSW_REG_SLDR_OP_LAG_ADD_PORT_LIST);
+@@ -1327,7 +1327,7 @@ static inline void mlxsw_reg_sldr_lag_add_port_pack(char *payload, u8 lag_id,
+ }
+ 
+ static inline void mlxsw_reg_sldr_lag_remove_port_pack(char *payload, u8 lag_id,
+-						       u8 local_port)
++						       u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(sldr, payload);
+ 	mlxsw_reg_sldr_op_set(payload, MLXSW_REG_SLDR_OP_LAG_REMOVE_PORT_LIST);
+@@ -1501,7 +1501,7 @@ MLXSW_ITEM32(reg, slcor, lag_id, 0x00, 0, 10);
+ MLXSW_ITEM32(reg, slcor, port_index, 0x04, 0, 10);
+ 
+ static inline void mlxsw_reg_slcor_pack(char *payload,
+-					u8 local_port, u16 lag_id,
++					u16 local_port, u16 lag_id,
+ 					enum mlxsw_reg_slcor_col col)
+ {
+ 	MLXSW_REG_ZERO(slcor, payload);
+@@ -1511,7 +1511,7 @@ static inline void mlxsw_reg_slcor_pack(char *payload,
+ }
+ 
+ static inline void mlxsw_reg_slcor_port_add_pack(char *payload,
+-						 u8 local_port, u16 lag_id,
++						 u16 local_port, u16 lag_id,
+ 						 u8 port_index)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+@@ -1520,21 +1520,21 @@ static inline void mlxsw_reg_slcor_port_add_pack(char *payload,
+ }
+ 
+ static inline void mlxsw_reg_slcor_port_remove_pack(char *payload,
+-						    u8 local_port, u16 lag_id)
++						    u16 local_port, u16 lag_id)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+ 			     MLXSW_REG_SLCOR_COL_LAG_REMOVE_PORT);
+ }
+ 
+ static inline void mlxsw_reg_slcor_col_enable_pack(char *payload,
+-						   u8 local_port, u16 lag_id)
++						   u16 local_port, u16 lag_id)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+ 			     MLXSW_REG_SLCOR_COL_LAG_COLLECTOR_ENABLED);
+ }
+ 
+ static inline void mlxsw_reg_slcor_col_disable_pack(char *payload,
+-						    u8 local_port, u16 lag_id)
++						    u16 local_port, u16 lag_id)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+ 			     MLXSW_REG_SLCOR_COL_LAG_COLLECTOR_ENABLED);
+@@ -1581,7 +1581,7 @@ enum mlxsw_reg_spmlr_learn_mode {
+  */
+ MLXSW_ITEM32(reg, spmlr, learn_mode, 0x04, 30, 2);
+ 
+-static inline void mlxsw_reg_spmlr_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_spmlr_pack(char *payload, u16 local_port,
+ 					enum mlxsw_reg_spmlr_learn_mode mode)
+ {
+ 	MLXSW_REG_ZERO(spmlr, payload);
+@@ -1666,7 +1666,7 @@ MLXSW_ITEM32(reg, svfa, counter_set_type, 0x08, 24, 8);
+  */
+ MLXSW_ITEM32(reg, svfa, counter_index, 0x08, 0, 24);
+ 
+-static inline void mlxsw_reg_svfa_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_svfa_pack(char *payload, u16 local_port,
+ 				       enum mlxsw_reg_svfa_mt mt, bool valid,
+ 				       u16 fid, u16 vid)
+ {
+@@ -1705,7 +1705,7 @@ MLXSW_ITEM32(reg, svpe, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, svpe, vp_en, 0x00, 8, 1);
+ 
+-static inline void mlxsw_reg_svpe_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_svpe_pack(char *payload, u16 local_port,
+ 				       bool enable)
+ {
+ 	MLXSW_REG_ZERO(svpe, payload);
+@@ -1838,7 +1838,7 @@ MLXSW_ITEM32_INDEXED(reg, spvmlr, rec_learn_enable, MLXSW_REG_SPVMLR_BASE_LEN,
+ MLXSW_ITEM32_INDEXED(reg, spvmlr, rec_vid, MLXSW_REG_SPVMLR_BASE_LEN, 0, 12,
+ 		     MLXSW_REG_SPVMLR_REC_LEN, 0x00, false);
+ 
+-static inline void mlxsw_reg_spvmlr_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_spvmlr_pack(char *payload, u16 local_port,
+ 					 u16 vid_begin, u16 vid_end,
+ 					 bool learn_enable)
+ {
+@@ -1907,7 +1907,7 @@ MLXSW_ITEM32_INDEXED(reg, cwtp, profile_max, MLXSW_REG_CWTP_BASE_LEN,
+ #define MLXSW_REG_CWTP_MAX_PROFILE 2
+ #define MLXSW_REG_CWTP_DEFAULT_PROFILE 1
+ 
+-static inline void mlxsw_reg_cwtp_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_cwtp_pack(char *payload, u16 local_port,
+ 				       u8 traffic_class)
+ {
+ 	int i;
+@@ -2025,7 +2025,7 @@ MLXSW_ITEM32(reg, cwtpm, ntcp_r, 64, 0, 2);
+ 
+ #define MLXSW_REG_CWTPM_RESET_PROFILE 0
+ 
+-static inline void mlxsw_reg_cwtpm_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_cwtpm_pack(char *payload, u16 local_port,
+ 					u8 traffic_class, u8 profile,
+ 					bool wred, bool ecn)
+ {
+@@ -2116,7 +2116,7 @@ MLXSW_ITEM32(reg, ppbt, acl_info, 0x10, 0, 16);
+ 
+ static inline void mlxsw_reg_ppbt_pack(char *payload, enum mlxsw_reg_pxbt_e e,
+ 				       enum mlxsw_reg_pxbt_op op,
+-				       u8 local_port, u16 acl_info)
++				       u16 local_port, u16 acl_info)
+ {
+ 	MLXSW_REG_ZERO(ppbt, payload);
+ 	mlxsw_reg_ppbt_e_set(payload, e);
+@@ -3260,7 +3260,7 @@ enum mlxsw_reg_qpts_trust_state {
+  */
+ MLXSW_ITEM32(reg, qpts, trust_state, 0x04, 0, 3);
+ 
+-static inline void mlxsw_reg_qpts_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_qpts_pack(char *payload, u16 local_port,
+ 				       enum mlxsw_reg_qpts_trust_state ts)
+ {
+ 	MLXSW_REG_ZERO(qpts, payload);
+@@ -3476,7 +3476,7 @@ MLXSW_ITEM32(reg, qtct, switch_prio, 0x00, 0, 4);
+  */
+ MLXSW_ITEM32(reg, qtct, tclass, 0x04, 0, 4);
+ 
+-static inline void mlxsw_reg_qtct_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_qtct_pack(char *payload, u16 local_port,
+ 				       u8 switch_prio, u8 tclass)
+ {
+ 	MLXSW_REG_ZERO(qtct, payload);
+@@ -3643,7 +3643,7 @@ MLXSW_ITEM32(reg, qeec, max_shaper_bs, 0x1C, 0, 6);
+ #define MLXSW_REG_QEEC_LOWEST_SHAPER_BS_SP2	11
+ #define MLXSW_REG_QEEC_LOWEST_SHAPER_BS_SP3	11
+ 
+-static inline void mlxsw_reg_qeec_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_qeec_pack(char *payload, u16 local_port,
+ 				       enum mlxsw_reg_qeec_hr hr, u8 index,
+ 				       u8 next_index)
+ {
+@@ -3654,7 +3654,7 @@ static inline void mlxsw_reg_qeec_pack(char *payload, u8 local_port,
+ 	mlxsw_reg_qeec_next_element_index_set(payload, next_index);
+ }
+ 
+-static inline void mlxsw_reg_qeec_ptps_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_qeec_ptps_pack(char *payload, u16 local_port,
+ 					    bool ptps)
+ {
+ 	MLXSW_REG_ZERO(qeec, payload);
+@@ -3692,7 +3692,7 @@ MLXSW_ITEM32(reg, qrwe, dscp, 0x04, 1, 1);
+  */
+ MLXSW_ITEM32(reg, qrwe, pcp, 0x04, 0, 1);
+ 
+-static inline void mlxsw_reg_qrwe_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_qrwe_pack(char *payload, u16 local_port,
+ 				       bool rewrite_pcp, bool rewrite_dscp)
+ {
+ 	MLXSW_REG_ZERO(qrwe, payload);
+@@ -3772,7 +3772,7 @@ MLXSW_ITEM32_INDEXED(reg, qpdsm, prio_entry_color2_dscp,
+ 		     MLXSW_REG_QPDSM_BASE_LEN, 8, 6,
+ 		     MLXSW_REG_QPDSM_PRIO_ENTRY_REC_LEN, 0x00, false);
+ 
+-static inline void mlxsw_reg_qpdsm_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_qpdsm_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(qpdsm, payload);
+ 	mlxsw_reg_qpdsm_local_port_set(payload, local_port);
+@@ -3813,7 +3813,7 @@ MLXSW_ITEM32(reg, qpdp, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, qpdp, switch_prio, 0x04, 0, 4);
+ 
+-static inline void mlxsw_reg_qpdp_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_qpdp_pack(char *payload, u16 local_port,
+ 				       u8 switch_prio)
+ {
+ 	MLXSW_REG_ZERO(qpdp, payload);
+@@ -3859,7 +3859,7 @@ MLXSW_ITEM16_INDEXED(reg, qpdpm, dscp_entry_prio,
+ 		     MLXSW_REG_QPDPM_BASE_LEN, 0, 4,
+ 		     MLXSW_REG_QPDPM_DSCP_ENTRY_REC_LEN, 0x00, false);
+ 
+-static inline void mlxsw_reg_qpdpm_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_qpdpm_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(qpdpm, payload);
+ 	mlxsw_reg_qpdpm_local_port_set(payload, local_port);
+@@ -3901,7 +3901,7 @@ MLXSW_ITEM32(reg, qtctm, local_port, 0x00, 16, 8);
+ MLXSW_ITEM32(reg, qtctm, mc, 0x04, 0, 1);
+ 
+ static inline void
+-mlxsw_reg_qtctm_pack(char *payload, u8 local_port, bool mc)
++mlxsw_reg_qtctm_pack(char *payload, u16 local_port, bool mc)
+ {
+ 	MLXSW_REG_ZERO(qtctm, payload);
+ 	mlxsw_reg_qtctm_local_port_set(payload, local_port);
+@@ -4065,7 +4065,7 @@ MLXSW_ITEM32_INDEXED(reg, pmlp, tx_lane, 0x04, 16, 4, 0x04, 0x00, false);
+  */
+ MLXSW_ITEM32_INDEXED(reg, pmlp, rx_lane, 0x04, 24, 4, 0x04, 0x00, false);
+ 
+-static inline void mlxsw_reg_pmlp_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_pmlp_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(pmlp, payload);
+ 	mlxsw_reg_pmlp_local_port_set(payload, local_port);
+@@ -4112,7 +4112,7 @@ MLXSW_ITEM32(reg, pmtu, admin_mtu, 0x08, 16, 16);
+  */
+ MLXSW_ITEM32(reg, pmtu, oper_mtu, 0x0C, 16, 16);
+ 
+-static inline void mlxsw_reg_pmtu_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_pmtu_pack(char *payload, u16 local_port,
+ 				       u16 new_mtu)
+ {
+ 	MLXSW_REG_ZERO(pmtu, payload);
+@@ -4306,7 +4306,7 @@ enum mlxsw_reg_ptys_connector_type {
+  */
+ MLXSW_ITEM32(reg, ptys, connector_type, 0x2C, 0, 4);
+ 
+-static inline void mlxsw_reg_ptys_eth_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_ptys_eth_pack(char *payload, u16 local_port,
+ 					   u32 proto_admin, bool autoneg)
+ {
+ 	MLXSW_REG_ZERO(ptys, payload);
+@@ -4316,7 +4316,7 @@ static inline void mlxsw_reg_ptys_eth_pack(char *payload, u8 local_port,
+ 	mlxsw_reg_ptys_an_disable_admin_set(payload, !autoneg);
+ }
+ 
+-static inline void mlxsw_reg_ptys_ext_eth_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_ptys_ext_eth_pack(char *payload, u16 local_port,
+ 					       u32 proto_admin, bool autoneg)
+ {
+ 	MLXSW_REG_ZERO(ptys, payload);
+@@ -4358,7 +4358,7 @@ static inline void mlxsw_reg_ptys_ext_eth_unpack(char *payload,
+ 			mlxsw_reg_ptys_ext_eth_proto_oper_get(payload);
+ }
+ 
+-static inline void mlxsw_reg_ptys_ib_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_ptys_ib_pack(char *payload, u16 local_port,
+ 					  u16 proto_admin, u16 link_width)
+ {
+ 	MLXSW_REG_ZERO(ptys, payload);
+@@ -4416,7 +4416,7 @@ MLXSW_ITEM32(reg, ppad, local_port, 0x00, 16, 8);
+ MLXSW_ITEM_BUF(reg, ppad, mac, 0x02, 6);
+ 
+ static inline void mlxsw_reg_ppad_pack(char *payload, bool single_base_mac,
+-				       u8 local_port)
++				       u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(ppad, payload);
+ 	mlxsw_reg_ppad_single_base_mac_set(payload, !!single_base_mac);
+@@ -4490,7 +4490,7 @@ MLXSW_ITEM32(reg, paos, ee, 0x04, 30, 1);
+  */
+ MLXSW_ITEM32(reg, paos, e, 0x04, 0, 2);
+ 
+-static inline void mlxsw_reg_paos_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_paos_pack(char *payload, u16 local_port,
+ 				       enum mlxsw_port_admin_status status)
+ {
+ 	MLXSW_REG_ZERO(paos, payload);
+@@ -4633,7 +4633,7 @@ static inline void mlxsw_reg_pfcc_prio_pack(char *payload, u8 pfc_en)
+ 	mlxsw_reg_pfcc_pfcrx_set(payload, pfc_en);
+ }
+ 
+-static inline void mlxsw_reg_pfcc_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_pfcc_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(pfcc, payload);
+ 	mlxsw_reg_pfcc_local_port_set(payload, local_port);
+@@ -5132,7 +5132,7 @@ MLXSW_ITEM64(reg, ppcnt, tc_no_buffer_discard_uc,
+ MLXSW_ITEM64(reg, ppcnt, wred_discard,
+ 	     MLXSW_REG_PPCNT_COUNTERS_OFFSET + 0x00, 0, 64);
+ 
+-static inline void mlxsw_reg_ppcnt_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_ppcnt_pack(char *payload, u16 local_port,
+ 					enum mlxsw_reg_ppcnt_grp grp,
+ 					u8 prio_tc)
+ {
+@@ -5243,7 +5243,7 @@ MLXSW_ITEM_BIT_ARRAY(reg, pptb, prio_to_buff_msb, 0x0C, 0x04, 4);
+ 
+ #define MLXSW_REG_PPTB_ALL_PRIO 0xFF
+ 
+-static inline void mlxsw_reg_pptb_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_pptb_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(pptb, payload);
+ 	mlxsw_reg_pptb_mm_set(payload, MLXSW_REG_PPTB_MM_UM);
+@@ -5340,7 +5340,7 @@ MLXSW_ITEM32_INDEXED(reg, pbmc, buf_xoff_threshold, 0x0C, 16, 16,
+ MLXSW_ITEM32_INDEXED(reg, pbmc, buf_xon_threshold, 0x0C, 0, 16,
+ 		     0x08, 0x04, false);
+ 
+-static inline void mlxsw_reg_pbmc_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_pbmc_pack(char *payload, u16 local_port,
+ 				       u16 xoff_timer_value, u16 xoff_refresh)
+ {
+ 	MLXSW_REG_ZERO(pbmc, payload);
+@@ -5398,7 +5398,7 @@ MLXSW_ITEM32(reg, pspa, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, pspa, sub_port, 0x00, 8, 8);
+ 
+-static inline void mlxsw_reg_pspa_pack(char *payload, u8 swid, u8 local_port)
++static inline void mlxsw_reg_pspa_pack(char *payload, u8 swid, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(pspa, payload);
+ 	mlxsw_reg_pspa_swid_set(payload, swid);
+@@ -5513,7 +5513,7 @@ MLXSW_ITEM32(reg, pplr, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, pplr, lb_en, 0x04, 0, 8);
+ 
+-static inline void mlxsw_reg_pplr_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_pplr_pack(char *payload, u16 local_port,
+ 				       bool phy_local)
+ {
+ 	MLXSW_REG_ZERO(pplr, payload);
+@@ -5609,7 +5609,7 @@ MLXSW_ITEM32(reg, pddr, trblsh_group_opcode, 0x08, 0, 16);
+  */
+ MLXSW_ITEM32(reg, pddr, trblsh_status_opcode, 0x0C, 0, 16);
+ 
+-static inline void mlxsw_reg_pddr_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_pddr_pack(char *payload, u16 local_port,
+ 				       u8 page_select)
+ {
+ 	MLXSW_REG_ZERO(pddr, payload);
+@@ -9160,7 +9160,7 @@ MLXSW_ITEM32(reg, mpar, enable, 0x04, 31, 1);
+  */
+ MLXSW_ITEM32(reg, mpar, pa_id, 0x04, 0, 4);
+ 
+-static inline void mlxsw_reg_mpar_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_mpar_pack(char *payload, u16 local_port,
+ 				       enum mlxsw_reg_mpar_i_e i_e,
+ 				       bool enable, u8 pa_id)
+ {
+@@ -9281,7 +9281,7 @@ MLXSW_ITEM32(reg, mlcr, beacon_duration, 0x04, 0, 16);
+  */
+ MLXSW_ITEM32(reg, mlcr, beacon_remain, 0x08, 0, 16);
+ 
+-static inline void mlxsw_reg_mlcr_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_mlcr_pack(char *payload, u16 local_port,
+ 				       bool active)
+ {
+ 	MLXSW_REG_ZERO(mlcr, payload);
+@@ -9671,7 +9671,7 @@ MLXSW_ITEM32(reg, mpsc, e, 0x04, 30, 1);
+  */
+ MLXSW_ITEM32(reg, mpsc, rate, 0x08, 0, 32);
+ 
+-static inline void mlxsw_reg_mpsc_pack(char *payload, u8 local_port, bool e,
++static inline void mlxsw_reg_mpsc_pack(char *payload, u16 local_port, bool e,
+ 				       u32 rate)
+ {
+ 	MLXSW_REG_ZERO(mpsc, payload);
+@@ -9904,7 +9904,7 @@ MLXSW_ITEM32(reg, momte, type, 0x04, 0, 8);
+  */
+ MLXSW_ITEM_BIT_ARRAY(reg, momte, tclass_en, 0x08, 0x08, 1);
+ 
+-static inline void mlxsw_reg_momte_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_momte_pack(char *payload, u16 local_port,
+ 					enum mlxsw_reg_momte_type type)
+ {
+ 	MLXSW_REG_ZERO(momte, payload);
+@@ -10574,7 +10574,7 @@ MLXSW_ITEM32(reg, tnqdr, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, tnqdr, dscp, 0x04, 0, 6);
+ 
+-static inline void mlxsw_reg_tnqdr_pack(char *payload, u8 local_port)
++static inline void mlxsw_reg_tnqdr_pack(char *payload, u16 local_port)
+ {
+ 	MLXSW_REG_ZERO(tnqdr, payload);
+ 	mlxsw_reg_tnqdr_local_port_set(payload, local_port);
+@@ -10963,7 +10963,7 @@ MLXSW_ITEM32(reg, sbcm, max_buff, 0x1C, 0, 24);
+  */
+ MLXSW_ITEM32(reg, sbcm, pool, 0x24, 0, 4);
+ 
+-static inline void mlxsw_reg_sbcm_pack(char *payload, u8 local_port, u8 pg_buff,
++static inline void mlxsw_reg_sbcm_pack(char *payload, u16 local_port, u8 pg_buff,
+ 				       enum mlxsw_reg_sbxx_dir dir,
+ 				       u32 min_buff, u32 max_buff,
+ 				       bool infi_max, u8 pool)
+@@ -11049,7 +11049,7 @@ MLXSW_ITEM32(reg, sbpm, min_buff, 0x18, 0, 24);
+  */
+ MLXSW_ITEM32(reg, sbpm, max_buff, 0x1C, 0, 24);
+ 
+-static inline void mlxsw_reg_sbpm_pack(char *payload, u8 local_port, u8 pool,
++static inline void mlxsw_reg_sbpm_pack(char *payload, u16 local_port, u8 pool,
+ 				       enum mlxsw_reg_sbxx_dir dir, bool clr,
+ 				       u32 min_buff, u32 max_buff)
+ {
+@@ -11244,7 +11244,7 @@ MLXSW_ITEM32(reg, sbib, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, sbib, buff_size, 0x08, 0, 24);
+ 
+-static inline void mlxsw_reg_sbib_pack(char *payload, u8 local_port,
++static inline void mlxsw_reg_sbib_pack(char *payload, u16 local_port,
+ 				       u32 buff_size)
+ {
+ 	MLXSW_REG_ZERO(sbib, payload);
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-5.10/0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch
+++ b/recipes-kernel/linux/linux-5.10/0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch
@@ -1,0 +1,39 @@
+From ac91378962238d34030bb4035308f88ba173165f Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 15 Aug 2023 09:22:01 +0000
+Subject: mlxsw: i2c: Fix chunk size setting in output mailbox buffer
+
+Links: https://github.com/jpirko/linux_mlxsw/commit/e4f63bb2ded0b1c812ef5cea900124b756837071
+       http://patchwork.mtl.labs.mlnx/patch/4591830/
+
+The driver reads commands output from the output mailbox. If the size
+of the output mailbox is not a multiple of the transaction /
+block size, then the driver will not issue enough read transactions
+to read the entire output, which can result in driver initialization
+errors.
+
+Fix by determining the number of transactions using DIV_ROUND_UP().
+
+Fixes: 3029a69 ("mlxsw: i2c: Allow flexible setting of I2C transactions size")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Ido Schimmel <idosch@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index b8a5c0cbb6b5..cc99ec3f4e96 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -447,7 +447,7 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+ 	} else {
+ 		/* No input mailbox is case of initialization query command. */
+ 		reg_size = MLXSW_I2C_MAX_DATA_SIZE;
+-		num = reg_size / mlxsw_i2c->block_size;
++		num = DIV_ROUND_UP(reg_size, mlxsw_i2c->block_size);
+ 
+ 		if (mutex_lock_interruptible(&mlxsw_i2c->cmd.lock) < 0) {
+ 			dev_err(&client->dev, "Could not acquire lock");
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-5.10/0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch
+++ b/recipes-kernel/linux/linux-5.10/0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch
@@ -1,0 +1,58 @@
+From 33aa62a331425d5828d417eeac7fab697eb45286 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 16 Aug 2023 11:56:51 +0000
+Subject: mlxsw: core_hwmon: Adjust module label names based on MTCAP sensor
+ counter
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Link: https://github.com/jpirko/linux_mlxsw/commit/0c604fbc8916ce220b2d30f0f75aa9566b18f496
+
+Transceiver module temperature sensors are indexed after ASIC and
+platform sensors. The current label printing method does not take this
+into account and simply prints the index of the transceiver module
+sensor.
+
+On new systems that have platform sensors this results in incorrect
+(shifted) transceiver module labels being printed:
+
+$ sensors
+[...]
+front panel 002:  +37.0°C  (crit = +70.0°C, emerg = +75.0°C)
+front panel 003:  +47.0°C  (crit = +70.0°C, emerg = +75.0°C)
+[...]
+
+Fix by taking the sensor count into account. After the fix:
+
+$ sensors
+[...]
+front panel 001:  +37.0°C  (crit = +70.0°C, emerg = +75.0°C)
+front panel 002:  +47.0°C  (crit = +70.0°C, emerg = +75.0°C)
+[...]
+
+Fixes: a53779de6a0e ("mlxsw: core: Add QSFP module temperature label attribute to hwmon")
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Reviewed-by: Ido Schimmel <idosch@nvidia.com>
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index d41afdfbd085..464787b10b73 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -377,7 +377,8 @@ mlxsw_hwmon_module_temp_label_show(struct device *dev,
+ 			container_of(attr, struct mlxsw_hwmon_attr, dev_attr);
+ 
+ 	return sprintf(buf, "front panel %03u\n",
+-		       mlwsw_hwmon_attr->type_index);
++		       mlwsw_hwmon_attr->type_index + 1 -
++		       mlwsw_hwmon_attr->hwmon->sensor_count);
+ }
+ 
+ static ssize_t
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-5.10/0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch
+++ b/recipes-kernel/linux/linux-5.10/0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch
@@ -1,0 +1,771 @@
+From 3a6322534307154e067d0596f52f287ecd0f599e Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Thu, 17 Aug 2023 10:00:25 +0000
+Subject: Revert "mlxsw: Use u16 for local_port field instead of u8"
+
+This reverts commit 0639995c2017338c563db36f631e94d19ae45c74.
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c    |  32 ++++----
+ drivers/net/ethernet/mellanox/mlxsw/core.h    |  34 ++++-----
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c |   6 +-
+ drivers/net/ethernet/mellanox/mlxsw/reg.h     | 106 +++++++++++++-------------
+ 4 files changed, 89 insertions(+), 89 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index 631c19222fc4..7938bad70e37 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -47,7 +47,7 @@ static struct workqueue_struct *mlxsw_owq;
+ struct mlxsw_core_port {
+ 	struct devlink_port devlink_port;
+ 	void *port_driver_priv;
+-	u16 local_port;
++	u8 local_port;
+ };
+ 
+ void *mlxsw_core_port_driver_priv(struct mlxsw_core_port *mlxsw_core_port)
+@@ -669,7 +669,7 @@ static void mlxsw_emad_process_response(struct mlxsw_core *mlxsw_core,
+ }
+ 
+ /* called with rcu read lock held */
+-static void mlxsw_emad_rx_listener_func(struct sk_buff *skb, u16 local_port,
++static void mlxsw_emad_rx_listener_func(struct sk_buff *skb, u8 local_port,
+ 					void *priv)
+ {
+ 	struct mlxsw_core *mlxsw_core = priv;
+@@ -2094,7 +2094,7 @@ int mlxsw_core_skb_transmit(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ EXPORT_SYMBOL(mlxsw_core_skb_transmit);
+ 
+ void mlxsw_core_ptp_transmitted(struct mlxsw_core *mlxsw_core,
+-				struct sk_buff *skb, u16 local_port)
++				struct sk_buff *skb, u8 local_port)
+ {
+ 	if (mlxsw_core->driver->ptp_transmitted)
+ 		mlxsw_core->driver->ptp_transmitted(mlxsw_core, skb,
+@@ -2172,7 +2172,7 @@ mlxsw_core_rx_listener_state_set(struct mlxsw_core *mlxsw_core,
+ 	rxl_item->enabled = enabled;
+ }
+ 
+-static void mlxsw_core_event_listener_func(struct sk_buff *skb, u16 local_port,
++static void mlxsw_core_event_listener_func(struct sk_buff *skb, u8 local_port,
+ 					   void *priv)
+ {
+ 	struct mlxsw_event_listener_item *event_listener_item = priv;
+@@ -2599,7 +2599,7 @@ void mlxsw_core_skb_receive(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ {
+ 	struct mlxsw_rx_listener_item *rxl_item;
+ 	const struct mlxsw_rx_listener *rxl;
+-	u16 local_port;
++	u8 local_port;
+ 	bool found = false;
+ 
+ 	if (rx_info->is_lag) {
+@@ -2657,7 +2657,7 @@ static int mlxsw_core_lag_mapping_index(struct mlxsw_core *mlxsw_core,
+ }
+ 
+ void mlxsw_core_lag_mapping_set(struct mlxsw_core *mlxsw_core,
+-				u16 lag_id, u8 port_index, u16 local_port)
++				u16 lag_id, u8 port_index, u8 local_port)
+ {
+ 	int index = mlxsw_core_lag_mapping_index(mlxsw_core,
+ 						 lag_id, port_index);
+@@ -2677,7 +2677,7 @@ u8 mlxsw_core_lag_mapping_get(struct mlxsw_core *mlxsw_core,
+ EXPORT_SYMBOL(mlxsw_core_lag_mapping_get);
+ 
+ void mlxsw_core_lag_mapping_clear(struct mlxsw_core *mlxsw_core,
+-				  u16 lag_id, u16 local_port)
++				  u16 lag_id, u8 local_port)
+ {
+ 	int i;
+ 
+@@ -2705,7 +2705,7 @@ u64 mlxsw_core_res_get(struct mlxsw_core *mlxsw_core,
+ }
+ EXPORT_SYMBOL(mlxsw_core_res_get);
+ 
+-static int __mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
++static int __mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 				  enum devlink_port_flavour flavour,
+ 				  u32 port_number, bool split,
+ 				  u32 split_port_subnumber,
+@@ -2736,7 +2736,7 @@ static int __mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
+ 	return err;
+ }
+ 
+-static void __mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port)
++static void __mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+ 					&mlxsw_core->ports[local_port];
+@@ -2746,7 +2746,7 @@ static void __mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port
+ 	memset(mlxsw_core_port, 0, sizeof(*mlxsw_core_port));
+ }
+ 
+-int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
++int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			 u32 port_number, bool split,
+ 			 u32 split_port_subnumber,
+ 			 bool splittable, u32 lanes,
+@@ -2761,7 +2761,7 @@ int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
+ }
+ EXPORT_SYMBOL(mlxsw_core_port_init);
+ 
+-void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port)
++void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port)
+ {
+ 	__mlxsw_core_port_fini(mlxsw_core, local_port);
+ }
+@@ -2794,7 +2794,7 @@ void mlxsw_core_cpu_port_fini(struct mlxsw_core *mlxsw_core)
+ }
+ EXPORT_SYMBOL(mlxsw_core_cpu_port_fini);
+ 
+-void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u16 local_port,
++void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			     void *port_driver_priv, struct net_device *dev)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+@@ -2806,7 +2806,7 @@ void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u16 local_port,
+ }
+ EXPORT_SYMBOL(mlxsw_core_port_eth_set);
+ 
+-void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u16 local_port,
++void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			    void *port_driver_priv)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+@@ -2818,7 +2818,7 @@ void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u16 local_port,
+ }
+ EXPORT_SYMBOL(mlxsw_core_port_ib_set);
+ 
+-void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u16 local_port,
++void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			   void *port_driver_priv)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+@@ -2831,7 +2831,7 @@ void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u16 local_port,
+ EXPORT_SYMBOL(mlxsw_core_port_clear);
+ 
+ enum devlink_port_type mlxsw_core_port_type_get(struct mlxsw_core *mlxsw_core,
+-						u16 local_port)
++						u8 local_port)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+ 					&mlxsw_core->ports[local_port];
+@@ -2844,7 +2844,7 @@ EXPORT_SYMBOL(mlxsw_core_port_type_get);
+ 
+ struct devlink_port *
+ mlxsw_core_port_devlink_port_get(struct mlxsw_core *mlxsw_core,
+-				 u16 local_port)
++				 u8 local_port)
+ {
+ 	struct mlxsw_core_port *mlxsw_core_port =
+ 					&mlxsw_core->ports[local_port];
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.h b/drivers/net/ethernet/mellanox/mlxsw/core.h
+index 1fc783174292..56efb8e48022 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.h
+@@ -49,7 +49,7 @@ int mlxsw_core_bus_device_register(const struct mlxsw_bus_info *mlxsw_bus_info,
+ void mlxsw_core_bus_device_unregister(struct mlxsw_core *mlxsw_core, bool reload);
+ 
+ struct mlxsw_tx_info {
+-	u16 local_port;
++	u8 local_port;
+ 	bool is_emad;
+ };
+ 
+@@ -58,11 +58,11 @@ bool mlxsw_core_skb_transmit_busy(struct mlxsw_core *mlxsw_core,
+ int mlxsw_core_skb_transmit(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ 			    const struct mlxsw_tx_info *tx_info);
+ void mlxsw_core_ptp_transmitted(struct mlxsw_core *mlxsw_core,
+-				struct sk_buff *skb, u16 local_port);
++				struct sk_buff *skb, u8 local_port);
+ 
+ struct mlxsw_rx_listener {
+-	void (*func)(struct sk_buff *skb, u16 local_port, void *priv);
+-	u16 local_port;
++	void (*func)(struct sk_buff *skb, u8 local_port, void *priv);
++	u8 local_port;
+ 	u8 mirror_reason;
+ 	u16 trap_id;
+ };
+@@ -194,35 +194,35 @@ void mlxsw_core_skb_receive(struct mlxsw_core *mlxsw_core, struct sk_buff *skb,
+ 			    struct mlxsw_rx_info *rx_info);
+ 
+ void mlxsw_core_lag_mapping_set(struct mlxsw_core *mlxsw_core,
+-				u16 lag_id, u8 port_index, u16 local_port);
++				u16 lag_id, u8 port_index, u8 local_port);
+ u8 mlxsw_core_lag_mapping_get(struct mlxsw_core *mlxsw_core,
+ 			      u16 lag_id, u8 port_index);
+ void mlxsw_core_lag_mapping_clear(struct mlxsw_core *mlxsw_core,
+-				  u16 lag_id, u16 local_port);
++				  u16 lag_id, u8 local_port);
+ 
+ void *mlxsw_core_port_driver_priv(struct mlxsw_core_port *mlxsw_core_port);
+-int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u16 local_port,
++int mlxsw_core_port_init(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			 u32 port_number, bool split, u32 split_port_subnumber,
+ 			 bool splittable, u32 lanes,
+ 			 const unsigned char *switch_id,
+ 			 unsigned char switch_id_len);
+-void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u16 local_port);
++void mlxsw_core_port_fini(struct mlxsw_core *mlxsw_core, u8 local_port);
+ int mlxsw_core_cpu_port_init(struct mlxsw_core *mlxsw_core,
+ 			     void *port_driver_priv,
+ 			     const unsigned char *switch_id,
+ 			     unsigned char switch_id_len);
+ void mlxsw_core_cpu_port_fini(struct mlxsw_core *mlxsw_core);
+-void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u16 local_port,
++void mlxsw_core_port_eth_set(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			     void *port_driver_priv, struct net_device *dev);
+-void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u16 local_port,
++void mlxsw_core_port_ib_set(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			    void *port_driver_priv);
+-void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u16 local_port,
++void mlxsw_core_port_clear(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			   void *port_driver_priv);
+ enum devlink_port_type mlxsw_core_port_type_get(struct mlxsw_core *mlxsw_core,
+-						u16 local_port);
++						u8 local_port);
+ struct devlink_port *
+ mlxsw_core_port_devlink_port_get(struct mlxsw_core *mlxsw_core,
+-				 u16 local_port);
++				 u8 local_port);
+ struct mlxsw_env *mlxsw_core_env(const struct mlxsw_core *mlxsw_core);
+ int mlxsw_core_module_max_width(struct mlxsw_core *mlxsw_core, u8 module);
+ 
+@@ -290,11 +290,11 @@ struct mlxsw_driver {
+ 		    struct netlink_ext_ack *extack);
+ 	void (*fini)(struct mlxsw_core *mlxsw_core);
+ 	int (*basic_trap_groups_set)(struct mlxsw_core *mlxsw_core);
+-	int (*port_type_set)(struct mlxsw_core *mlxsw_core, u16 local_port,
++	int (*port_type_set)(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			     enum devlink_port_type new_type);
+-	int (*port_split)(struct mlxsw_core *mlxsw_core, u16 local_port,
++	int (*port_split)(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			  unsigned int count, struct netlink_ext_ack *extack);
+-	int (*port_unsplit)(struct mlxsw_core *mlxsw_core, u16 local_port,
++	int (*port_unsplit)(struct mlxsw_core *mlxsw_core, u8 local_port,
+ 			    struct netlink_ext_ack *extack);
+ 	int (*sb_pool_get)(struct mlxsw_core *mlxsw_core,
+ 			   unsigned int sb_index, u16 pool_index,
+@@ -368,7 +368,7 @@ struct mlxsw_driver {
+ 	 * is responsible for freeing the passed-in SKB.
+ 	 */
+ 	void (*ptp_transmitted)(struct mlxsw_core *mlxsw_core,
+-				struct sk_buff *skb, u16 local_port);
++				struct sk_buff *skb, u8 local_port);
+ 
+ 	u8 txhdr_len;
+ 	const struct mlxsw_config_profile *profile;
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+index 1ddd11320b99..3d07c2dcf08d 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+@@ -38,7 +38,7 @@ struct mlxsw_m {
+ struct mlxsw_m_port {
+ 	struct net_device *dev;
+ 	struct mlxsw_m *mlxsw_m;
+-	u16 local_port;
++	u8 local_port;
+ 	u8 module;
+ };
+ 
+@@ -201,7 +201,7 @@ mlxsw_m_port_dev_addr_get(struct mlxsw_m_port *mlxsw_m_port)
+ }
+ 
+ static int
+-mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u16 local_port, u8 module)
++mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u8 local_port, u8 module)
+ {
+ 	struct mlxsw_m_port *mlxsw_m_port;
+ 	struct net_device *dev;
+@@ -264,7 +264,7 @@ mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u16 local_port, u8 module)
+ 	return err;
+ }
+ 
+-static void mlxsw_m_port_remove(struct mlxsw_m *mlxsw_m, u16 local_port)
++static void mlxsw_m_port_remove(struct mlxsw_m *mlxsw_m, u8 local_port)
+ {
+ 	struct mlxsw_m_port *mlxsw_m_port = mlxsw_m->ports[local_port];
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index 2ec9ec6078e2..a9119451d999 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -161,7 +161,7 @@ MLXSW_ITEM32(reg, sspr, sub_port, 0x00, 8, 8);
+  */
+ MLXSW_ITEM32(reg, sspr, system_port, 0x04, 0, 16);
+ 
+-static inline void mlxsw_reg_sspr_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_sspr_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(sspr, payload);
+ 	mlxsw_reg_sspr_m_set(payload, 1);
+@@ -407,7 +407,7 @@ static inline void mlxsw_reg_sfd_uc_pack(char *payload, int rec_index,
+ 					 enum mlxsw_reg_sfd_rec_policy policy,
+ 					 const char *mac, u16 fid_vid,
+ 					 enum mlxsw_reg_sfd_rec_action action,
+-					 u16 local_port)
++					 u8 local_port)
+ {
+ 	mlxsw_reg_sfd_rec_pack(payload, rec_index,
+ 			       MLXSW_REG_SFD_REC_TYPE_UNICAST, mac, action);
+@@ -419,7 +419,7 @@ static inline void mlxsw_reg_sfd_uc_pack(char *payload, int rec_index,
+ 
+ static inline void mlxsw_reg_sfd_uc_unpack(char *payload, int rec_index,
+ 					   char *mac, u16 *p_fid_vid,
+-					   u16 *p_local_port)
++					   u8 *p_local_port)
+ {
+ 	mlxsw_reg_sfd_rec_mac_memcpy_from(payload, rec_index, mac);
+ 	*p_fid_vid = mlxsw_reg_sfd_uc_fid_vid_get(payload, rec_index);
+@@ -685,7 +685,7 @@ MLXSW_ITEM32_INDEXED(reg, sfn, mac_system_port, MLXSW_REG_SFN_BASE_LEN, 0, 16,
+ 
+ static inline void mlxsw_reg_sfn_mac_unpack(char *payload, int rec_index,
+ 					    char *mac, u16 *p_vid,
+-					    u16 *p_local_port)
++					    u8 *p_local_port)
+ {
+ 	mlxsw_reg_sfn_rec_mac_memcpy_from(payload, rec_index, mac);
+ 	*p_vid = mlxsw_reg_sfn_mac_fid_get(payload, rec_index);
+@@ -800,7 +800,7 @@ enum mlxsw_reg_spms_state {
+  */
+ MLXSW_ITEM_BIT_ARRAY(reg, spms, state, 0x04, 0x400, 2);
+ 
+-static inline void mlxsw_reg_spms_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_spms_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(spms, payload);
+ 	mlxsw_reg_spms_local_port_set(payload, local_port);
+@@ -840,7 +840,7 @@ MLXSW_ITEM32(reg, spvid, sub_port, 0x00, 8, 8);
+  */
+ MLXSW_ITEM32(reg, spvid, pvid, 0x04, 0, 12);
+ 
+-static inline void mlxsw_reg_spvid_pack(char *payload, u16 local_port, u16 pvid)
++static inline void mlxsw_reg_spvid_pack(char *payload, u8 local_port, u16 pvid)
+ {
+ 	MLXSW_REG_ZERO(spvid, payload);
+ 	mlxsw_reg_spvid_local_port_set(payload, local_port);
+@@ -929,7 +929,7 @@ MLXSW_ITEM32_INDEXED(reg, spvm, rec_vid,
+ 		     MLXSW_REG_SPVM_BASE_LEN, 0, 12,
+ 		     MLXSW_REG_SPVM_REC_LEN, 0, false);
+ 
+-static inline void mlxsw_reg_spvm_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_spvm_pack(char *payload, u8 local_port,
+ 				       u16 vid_begin, u16 vid_end,
+ 				       bool is_member, bool untagged)
+ {
+@@ -991,7 +991,7 @@ MLXSW_ITEM32(reg, spaft, allow_prio_tagged, 0x04, 30, 1);
+  */
+ MLXSW_ITEM32(reg, spaft, allow_tagged, 0x04, 29, 1);
+ 
+-static inline void mlxsw_reg_spaft_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_spaft_pack(char *payload, u8 local_port,
+ 					bool allow_untagged)
+ {
+ 	MLXSW_REG_ZERO(spaft, payload);
+@@ -1317,7 +1317,7 @@ MLXSW_ITEM32(reg, sldr, num_ports, 0x04, 24, 8);
+ MLXSW_ITEM32_INDEXED(reg, sldr, system_port, 0x08, 0, 16, 4, 0, false);
+ 
+ static inline void mlxsw_reg_sldr_lag_add_port_pack(char *payload, u8 lag_id,
+-						    u16 local_port)
++						    u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(sldr, payload);
+ 	mlxsw_reg_sldr_op_set(payload, MLXSW_REG_SLDR_OP_LAG_ADD_PORT_LIST);
+@@ -1327,7 +1327,7 @@ static inline void mlxsw_reg_sldr_lag_add_port_pack(char *payload, u8 lag_id,
+ }
+ 
+ static inline void mlxsw_reg_sldr_lag_remove_port_pack(char *payload, u8 lag_id,
+-						       u16 local_port)
++						       u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(sldr, payload);
+ 	mlxsw_reg_sldr_op_set(payload, MLXSW_REG_SLDR_OP_LAG_REMOVE_PORT_LIST);
+@@ -1501,7 +1501,7 @@ MLXSW_ITEM32(reg, slcor, lag_id, 0x00, 0, 10);
+ MLXSW_ITEM32(reg, slcor, port_index, 0x04, 0, 10);
+ 
+ static inline void mlxsw_reg_slcor_pack(char *payload,
+-					u16 local_port, u16 lag_id,
++					u8 local_port, u16 lag_id,
+ 					enum mlxsw_reg_slcor_col col)
+ {
+ 	MLXSW_REG_ZERO(slcor, payload);
+@@ -1511,7 +1511,7 @@ static inline void mlxsw_reg_slcor_pack(char *payload,
+ }
+ 
+ static inline void mlxsw_reg_slcor_port_add_pack(char *payload,
+-						 u16 local_port, u16 lag_id,
++						 u8 local_port, u16 lag_id,
+ 						 u8 port_index)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+@@ -1520,21 +1520,21 @@ static inline void mlxsw_reg_slcor_port_add_pack(char *payload,
+ }
+ 
+ static inline void mlxsw_reg_slcor_port_remove_pack(char *payload,
+-						    u16 local_port, u16 lag_id)
++						    u8 local_port, u16 lag_id)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+ 			     MLXSW_REG_SLCOR_COL_LAG_REMOVE_PORT);
+ }
+ 
+ static inline void mlxsw_reg_slcor_col_enable_pack(char *payload,
+-						   u16 local_port, u16 lag_id)
++						   u8 local_port, u16 lag_id)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+ 			     MLXSW_REG_SLCOR_COL_LAG_COLLECTOR_ENABLED);
+ }
+ 
+ static inline void mlxsw_reg_slcor_col_disable_pack(char *payload,
+-						    u16 local_port, u16 lag_id)
++						    u8 local_port, u16 lag_id)
+ {
+ 	mlxsw_reg_slcor_pack(payload, local_port, lag_id,
+ 			     MLXSW_REG_SLCOR_COL_LAG_COLLECTOR_ENABLED);
+@@ -1581,7 +1581,7 @@ enum mlxsw_reg_spmlr_learn_mode {
+  */
+ MLXSW_ITEM32(reg, spmlr, learn_mode, 0x04, 30, 2);
+ 
+-static inline void mlxsw_reg_spmlr_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_spmlr_pack(char *payload, u8 local_port,
+ 					enum mlxsw_reg_spmlr_learn_mode mode)
+ {
+ 	MLXSW_REG_ZERO(spmlr, payload);
+@@ -1666,7 +1666,7 @@ MLXSW_ITEM32(reg, svfa, counter_set_type, 0x08, 24, 8);
+  */
+ MLXSW_ITEM32(reg, svfa, counter_index, 0x08, 0, 24);
+ 
+-static inline void mlxsw_reg_svfa_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_svfa_pack(char *payload, u8 local_port,
+ 				       enum mlxsw_reg_svfa_mt mt, bool valid,
+ 				       u16 fid, u16 vid)
+ {
+@@ -1705,7 +1705,7 @@ MLXSW_ITEM32(reg, svpe, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, svpe, vp_en, 0x00, 8, 1);
+ 
+-static inline void mlxsw_reg_svpe_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_svpe_pack(char *payload, u8 local_port,
+ 				       bool enable)
+ {
+ 	MLXSW_REG_ZERO(svpe, payload);
+@@ -1838,7 +1838,7 @@ MLXSW_ITEM32_INDEXED(reg, spvmlr, rec_learn_enable, MLXSW_REG_SPVMLR_BASE_LEN,
+ MLXSW_ITEM32_INDEXED(reg, spvmlr, rec_vid, MLXSW_REG_SPVMLR_BASE_LEN, 0, 12,
+ 		     MLXSW_REG_SPVMLR_REC_LEN, 0x00, false);
+ 
+-static inline void mlxsw_reg_spvmlr_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_spvmlr_pack(char *payload, u8 local_port,
+ 					 u16 vid_begin, u16 vid_end,
+ 					 bool learn_enable)
+ {
+@@ -1907,7 +1907,7 @@ MLXSW_ITEM32_INDEXED(reg, cwtp, profile_max, MLXSW_REG_CWTP_BASE_LEN,
+ #define MLXSW_REG_CWTP_MAX_PROFILE 2
+ #define MLXSW_REG_CWTP_DEFAULT_PROFILE 1
+ 
+-static inline void mlxsw_reg_cwtp_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_cwtp_pack(char *payload, u8 local_port,
+ 				       u8 traffic_class)
+ {
+ 	int i;
+@@ -2025,7 +2025,7 @@ MLXSW_ITEM32(reg, cwtpm, ntcp_r, 64, 0, 2);
+ 
+ #define MLXSW_REG_CWTPM_RESET_PROFILE 0
+ 
+-static inline void mlxsw_reg_cwtpm_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_cwtpm_pack(char *payload, u8 local_port,
+ 					u8 traffic_class, u8 profile,
+ 					bool wred, bool ecn)
+ {
+@@ -2116,7 +2116,7 @@ MLXSW_ITEM32(reg, ppbt, acl_info, 0x10, 0, 16);
+ 
+ static inline void mlxsw_reg_ppbt_pack(char *payload, enum mlxsw_reg_pxbt_e e,
+ 				       enum mlxsw_reg_pxbt_op op,
+-				       u16 local_port, u16 acl_info)
++				       u8 local_port, u16 acl_info)
+ {
+ 	MLXSW_REG_ZERO(ppbt, payload);
+ 	mlxsw_reg_ppbt_e_set(payload, e);
+@@ -3260,7 +3260,7 @@ enum mlxsw_reg_qpts_trust_state {
+  */
+ MLXSW_ITEM32(reg, qpts, trust_state, 0x04, 0, 3);
+ 
+-static inline void mlxsw_reg_qpts_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_qpts_pack(char *payload, u8 local_port,
+ 				       enum mlxsw_reg_qpts_trust_state ts)
+ {
+ 	MLXSW_REG_ZERO(qpts, payload);
+@@ -3476,7 +3476,7 @@ MLXSW_ITEM32(reg, qtct, switch_prio, 0x00, 0, 4);
+  */
+ MLXSW_ITEM32(reg, qtct, tclass, 0x04, 0, 4);
+ 
+-static inline void mlxsw_reg_qtct_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_qtct_pack(char *payload, u8 local_port,
+ 				       u8 switch_prio, u8 tclass)
+ {
+ 	MLXSW_REG_ZERO(qtct, payload);
+@@ -3643,7 +3643,7 @@ MLXSW_ITEM32(reg, qeec, max_shaper_bs, 0x1C, 0, 6);
+ #define MLXSW_REG_QEEC_LOWEST_SHAPER_BS_SP2	11
+ #define MLXSW_REG_QEEC_LOWEST_SHAPER_BS_SP3	11
+ 
+-static inline void mlxsw_reg_qeec_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_qeec_pack(char *payload, u8 local_port,
+ 				       enum mlxsw_reg_qeec_hr hr, u8 index,
+ 				       u8 next_index)
+ {
+@@ -3654,7 +3654,7 @@ static inline void mlxsw_reg_qeec_pack(char *payload, u16 local_port,
+ 	mlxsw_reg_qeec_next_element_index_set(payload, next_index);
+ }
+ 
+-static inline void mlxsw_reg_qeec_ptps_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_qeec_ptps_pack(char *payload, u8 local_port,
+ 					    bool ptps)
+ {
+ 	MLXSW_REG_ZERO(qeec, payload);
+@@ -3692,7 +3692,7 @@ MLXSW_ITEM32(reg, qrwe, dscp, 0x04, 1, 1);
+  */
+ MLXSW_ITEM32(reg, qrwe, pcp, 0x04, 0, 1);
+ 
+-static inline void mlxsw_reg_qrwe_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_qrwe_pack(char *payload, u8 local_port,
+ 				       bool rewrite_pcp, bool rewrite_dscp)
+ {
+ 	MLXSW_REG_ZERO(qrwe, payload);
+@@ -3772,7 +3772,7 @@ MLXSW_ITEM32_INDEXED(reg, qpdsm, prio_entry_color2_dscp,
+ 		     MLXSW_REG_QPDSM_BASE_LEN, 8, 6,
+ 		     MLXSW_REG_QPDSM_PRIO_ENTRY_REC_LEN, 0x00, false);
+ 
+-static inline void mlxsw_reg_qpdsm_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_qpdsm_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(qpdsm, payload);
+ 	mlxsw_reg_qpdsm_local_port_set(payload, local_port);
+@@ -3813,7 +3813,7 @@ MLXSW_ITEM32(reg, qpdp, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, qpdp, switch_prio, 0x04, 0, 4);
+ 
+-static inline void mlxsw_reg_qpdp_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_qpdp_pack(char *payload, u8 local_port,
+ 				       u8 switch_prio)
+ {
+ 	MLXSW_REG_ZERO(qpdp, payload);
+@@ -3859,7 +3859,7 @@ MLXSW_ITEM16_INDEXED(reg, qpdpm, dscp_entry_prio,
+ 		     MLXSW_REG_QPDPM_BASE_LEN, 0, 4,
+ 		     MLXSW_REG_QPDPM_DSCP_ENTRY_REC_LEN, 0x00, false);
+ 
+-static inline void mlxsw_reg_qpdpm_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_qpdpm_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(qpdpm, payload);
+ 	mlxsw_reg_qpdpm_local_port_set(payload, local_port);
+@@ -3901,7 +3901,7 @@ MLXSW_ITEM32(reg, qtctm, local_port, 0x00, 16, 8);
+ MLXSW_ITEM32(reg, qtctm, mc, 0x04, 0, 1);
+ 
+ static inline void
+-mlxsw_reg_qtctm_pack(char *payload, u16 local_port, bool mc)
++mlxsw_reg_qtctm_pack(char *payload, u8 local_port, bool mc)
+ {
+ 	MLXSW_REG_ZERO(qtctm, payload);
+ 	mlxsw_reg_qtctm_local_port_set(payload, local_port);
+@@ -4065,7 +4065,7 @@ MLXSW_ITEM32_INDEXED(reg, pmlp, tx_lane, 0x04, 16, 4, 0x04, 0x00, false);
+  */
+ MLXSW_ITEM32_INDEXED(reg, pmlp, rx_lane, 0x04, 24, 4, 0x04, 0x00, false);
+ 
+-static inline void mlxsw_reg_pmlp_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_pmlp_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(pmlp, payload);
+ 	mlxsw_reg_pmlp_local_port_set(payload, local_port);
+@@ -4112,7 +4112,7 @@ MLXSW_ITEM32(reg, pmtu, admin_mtu, 0x08, 16, 16);
+  */
+ MLXSW_ITEM32(reg, pmtu, oper_mtu, 0x0C, 16, 16);
+ 
+-static inline void mlxsw_reg_pmtu_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_pmtu_pack(char *payload, u8 local_port,
+ 				       u16 new_mtu)
+ {
+ 	MLXSW_REG_ZERO(pmtu, payload);
+@@ -4306,7 +4306,7 @@ enum mlxsw_reg_ptys_connector_type {
+  */
+ MLXSW_ITEM32(reg, ptys, connector_type, 0x2C, 0, 4);
+ 
+-static inline void mlxsw_reg_ptys_eth_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_ptys_eth_pack(char *payload, u8 local_port,
+ 					   u32 proto_admin, bool autoneg)
+ {
+ 	MLXSW_REG_ZERO(ptys, payload);
+@@ -4316,7 +4316,7 @@ static inline void mlxsw_reg_ptys_eth_pack(char *payload, u16 local_port,
+ 	mlxsw_reg_ptys_an_disable_admin_set(payload, !autoneg);
+ }
+ 
+-static inline void mlxsw_reg_ptys_ext_eth_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_ptys_ext_eth_pack(char *payload, u8 local_port,
+ 					       u32 proto_admin, bool autoneg)
+ {
+ 	MLXSW_REG_ZERO(ptys, payload);
+@@ -4358,7 +4358,7 @@ static inline void mlxsw_reg_ptys_ext_eth_unpack(char *payload,
+ 			mlxsw_reg_ptys_ext_eth_proto_oper_get(payload);
+ }
+ 
+-static inline void mlxsw_reg_ptys_ib_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_ptys_ib_pack(char *payload, u8 local_port,
+ 					  u16 proto_admin, u16 link_width)
+ {
+ 	MLXSW_REG_ZERO(ptys, payload);
+@@ -4416,7 +4416,7 @@ MLXSW_ITEM32(reg, ppad, local_port, 0x00, 16, 8);
+ MLXSW_ITEM_BUF(reg, ppad, mac, 0x02, 6);
+ 
+ static inline void mlxsw_reg_ppad_pack(char *payload, bool single_base_mac,
+-				       u16 local_port)
++				       u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(ppad, payload);
+ 	mlxsw_reg_ppad_single_base_mac_set(payload, !!single_base_mac);
+@@ -4490,7 +4490,7 @@ MLXSW_ITEM32(reg, paos, ee, 0x04, 30, 1);
+  */
+ MLXSW_ITEM32(reg, paos, e, 0x04, 0, 2);
+ 
+-static inline void mlxsw_reg_paos_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_paos_pack(char *payload, u8 local_port,
+ 				       enum mlxsw_port_admin_status status)
+ {
+ 	MLXSW_REG_ZERO(paos, payload);
+@@ -4633,7 +4633,7 @@ static inline void mlxsw_reg_pfcc_prio_pack(char *payload, u8 pfc_en)
+ 	mlxsw_reg_pfcc_pfcrx_set(payload, pfc_en);
+ }
+ 
+-static inline void mlxsw_reg_pfcc_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_pfcc_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(pfcc, payload);
+ 	mlxsw_reg_pfcc_local_port_set(payload, local_port);
+@@ -5132,7 +5132,7 @@ MLXSW_ITEM64(reg, ppcnt, tc_no_buffer_discard_uc,
+ MLXSW_ITEM64(reg, ppcnt, wred_discard,
+ 	     MLXSW_REG_PPCNT_COUNTERS_OFFSET + 0x00, 0, 64);
+ 
+-static inline void mlxsw_reg_ppcnt_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_ppcnt_pack(char *payload, u8 local_port,
+ 					enum mlxsw_reg_ppcnt_grp grp,
+ 					u8 prio_tc)
+ {
+@@ -5243,7 +5243,7 @@ MLXSW_ITEM_BIT_ARRAY(reg, pptb, prio_to_buff_msb, 0x0C, 0x04, 4);
+ 
+ #define MLXSW_REG_PPTB_ALL_PRIO 0xFF
+ 
+-static inline void mlxsw_reg_pptb_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_pptb_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(pptb, payload);
+ 	mlxsw_reg_pptb_mm_set(payload, MLXSW_REG_PPTB_MM_UM);
+@@ -5340,7 +5340,7 @@ MLXSW_ITEM32_INDEXED(reg, pbmc, buf_xoff_threshold, 0x0C, 16, 16,
+ MLXSW_ITEM32_INDEXED(reg, pbmc, buf_xon_threshold, 0x0C, 0, 16,
+ 		     0x08, 0x04, false);
+ 
+-static inline void mlxsw_reg_pbmc_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_pbmc_pack(char *payload, u8 local_port,
+ 				       u16 xoff_timer_value, u16 xoff_refresh)
+ {
+ 	MLXSW_REG_ZERO(pbmc, payload);
+@@ -5398,7 +5398,7 @@ MLXSW_ITEM32(reg, pspa, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, pspa, sub_port, 0x00, 8, 8);
+ 
+-static inline void mlxsw_reg_pspa_pack(char *payload, u8 swid, u16 local_port)
++static inline void mlxsw_reg_pspa_pack(char *payload, u8 swid, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(pspa, payload);
+ 	mlxsw_reg_pspa_swid_set(payload, swid);
+@@ -5513,7 +5513,7 @@ MLXSW_ITEM32(reg, pplr, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, pplr, lb_en, 0x04, 0, 8);
+ 
+-static inline void mlxsw_reg_pplr_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_pplr_pack(char *payload, u8 local_port,
+ 				       bool phy_local)
+ {
+ 	MLXSW_REG_ZERO(pplr, payload);
+@@ -5609,7 +5609,7 @@ MLXSW_ITEM32(reg, pddr, trblsh_group_opcode, 0x08, 0, 16);
+  */
+ MLXSW_ITEM32(reg, pddr, trblsh_status_opcode, 0x0C, 0, 16);
+ 
+-static inline void mlxsw_reg_pddr_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_pddr_pack(char *payload, u8 local_port,
+ 				       u8 page_select)
+ {
+ 	MLXSW_REG_ZERO(pddr, payload);
+@@ -9160,7 +9160,7 @@ MLXSW_ITEM32(reg, mpar, enable, 0x04, 31, 1);
+  */
+ MLXSW_ITEM32(reg, mpar, pa_id, 0x04, 0, 4);
+ 
+-static inline void mlxsw_reg_mpar_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_mpar_pack(char *payload, u8 local_port,
+ 				       enum mlxsw_reg_mpar_i_e i_e,
+ 				       bool enable, u8 pa_id)
+ {
+@@ -9281,7 +9281,7 @@ MLXSW_ITEM32(reg, mlcr, beacon_duration, 0x04, 0, 16);
+  */
+ MLXSW_ITEM32(reg, mlcr, beacon_remain, 0x08, 0, 16);
+ 
+-static inline void mlxsw_reg_mlcr_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_mlcr_pack(char *payload, u8 local_port,
+ 				       bool active)
+ {
+ 	MLXSW_REG_ZERO(mlcr, payload);
+@@ -9671,7 +9671,7 @@ MLXSW_ITEM32(reg, mpsc, e, 0x04, 30, 1);
+  */
+ MLXSW_ITEM32(reg, mpsc, rate, 0x08, 0, 32);
+ 
+-static inline void mlxsw_reg_mpsc_pack(char *payload, u16 local_port, bool e,
++static inline void mlxsw_reg_mpsc_pack(char *payload, u8 local_port, bool e,
+ 				       u32 rate)
+ {
+ 	MLXSW_REG_ZERO(mpsc, payload);
+@@ -9904,7 +9904,7 @@ MLXSW_ITEM32(reg, momte, type, 0x04, 0, 8);
+  */
+ MLXSW_ITEM_BIT_ARRAY(reg, momte, tclass_en, 0x08, 0x08, 1);
+ 
+-static inline void mlxsw_reg_momte_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_momte_pack(char *payload, u8 local_port,
+ 					enum mlxsw_reg_momte_type type)
+ {
+ 	MLXSW_REG_ZERO(momte, payload);
+@@ -10574,7 +10574,7 @@ MLXSW_ITEM32(reg, tnqdr, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, tnqdr, dscp, 0x04, 0, 6);
+ 
+-static inline void mlxsw_reg_tnqdr_pack(char *payload, u16 local_port)
++static inline void mlxsw_reg_tnqdr_pack(char *payload, u8 local_port)
+ {
+ 	MLXSW_REG_ZERO(tnqdr, payload);
+ 	mlxsw_reg_tnqdr_local_port_set(payload, local_port);
+@@ -10963,7 +10963,7 @@ MLXSW_ITEM32(reg, sbcm, max_buff, 0x1C, 0, 24);
+  */
+ MLXSW_ITEM32(reg, sbcm, pool, 0x24, 0, 4);
+ 
+-static inline void mlxsw_reg_sbcm_pack(char *payload, u16 local_port, u8 pg_buff,
++static inline void mlxsw_reg_sbcm_pack(char *payload, u8 local_port, u8 pg_buff,
+ 				       enum mlxsw_reg_sbxx_dir dir,
+ 				       u32 min_buff, u32 max_buff,
+ 				       bool infi_max, u8 pool)
+@@ -11049,7 +11049,7 @@ MLXSW_ITEM32(reg, sbpm, min_buff, 0x18, 0, 24);
+  */
+ MLXSW_ITEM32(reg, sbpm, max_buff, 0x1C, 0, 24);
+ 
+-static inline void mlxsw_reg_sbpm_pack(char *payload, u16 local_port, u8 pool,
++static inline void mlxsw_reg_sbpm_pack(char *payload, u8 local_port, u8 pool,
+ 				       enum mlxsw_reg_sbxx_dir dir, bool clr,
+ 				       u32 min_buff, u32 max_buff)
+ {
+@@ -11244,7 +11244,7 @@ MLXSW_ITEM32(reg, sbib, local_port, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, sbib, buff_size, 0x08, 0, 24);
+ 
+-static inline void mlxsw_reg_sbib_pack(char *payload, u16 local_port,
++static inline void mlxsw_reg_sbib_pack(char *payload, u8 local_port,
+ 				       u32 buff_size)
+ {
+ 	MLXSW_REG_ZERO(sbib, payload);
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-5.10/0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch
+++ b/recipes-kernel/linux/linux-5.10/0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch
@@ -1,0 +1,26 @@
+From 0dda3bcede5f26c2bd44edbd90c7e9f0aab9ccf0 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Thu, 17 Aug 2023 10:00:59 +0000
+Subject: Revert "mlxsw: i2c: Fix chunk size setting in output mailbox buffer"
+
+This reverts commit ac91378962238d34030bb4035308f88ba173165f.
+---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index cc99ec3f4e96..b8a5c0cbb6b5 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -447,7 +447,7 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+ 	} else {
+ 		/* No input mailbox is case of initialization query command. */
+ 		reg_size = MLXSW_I2C_MAX_DATA_SIZE;
+-		num = DIV_ROUND_UP(reg_size, mlxsw_i2c->block_size);
++		num = reg_size / mlxsw_i2c->block_size;
+ 
+ 		if (mutex_lock_interruptible(&mlxsw_i2c->cmd.lock) < 0) {
+ 			dev_err(&client->dev, "Could not acquire lock");
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-5.10/0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch
+++ b/recipes-kernel/linux/linux-5.10/0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch
@@ -1,0 +1,28 @@
+From e0f5c6c6572fd70ad8fa0d268ee95fb8aba1bd98 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Thu, 17 Aug 2023 10:01:22 +0000
+Subject: Revert "mlxsw: core_hwmon: Adjust module label names based on MTCAP
+ sensor counter"
+
+This reverts commit 33aa62a331425d5828d417eeac7fab697eb45286.
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index 464787b10b73..d41afdfbd085 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -377,8 +377,7 @@ mlxsw_hwmon_module_temp_label_show(struct device *dev,
+ 			container_of(attr, struct mlxsw_hwmon_attr, dev_attr);
+ 
+ 	return sprintf(buf, "front panel %03u\n",
+-		       mlwsw_hwmon_attr->type_index + 1 -
+-		       mlwsw_hwmon_attr->hwmon->sensor_count);
++		       mlwsw_hwmon_attr->type_index);
+ }
+ 
+ static ssize_t
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-5.10/0152-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
+++ b/recipes-kernel/linux/linux-5.10/0152-mlxsw-i2c-Prevent-transaction-execution-for-spec.patch
@@ -1,12 +1,13 @@
-From 25fccd5aed1494cc8882fe2e9f43f520bea6b734 Mon Sep 17 00:00:00 2001
-From: Vadim Pasternak <vadimp@nvidia.com>
-Date: Thu, 2 Jun 2022 15:34:53 +0300
-Subject: [PATCH backport 5.10 169/182] TMP: mlxsw: i2c: Prevent transaction
- execution for special chip states
+From fbc40a45f3688cb6be043a79556fab25bdf776d3 Mon Sep 17 00:00:00 2001
+From: Stepan Blyschak <stepanb@nvidia.com>
+Date: Mon, 20 Jun 2022 19:28:04 +0300
+Subject: =?UTF-8?q?From=20d3e0bf403d527f717a62ea328781256f999d4f95=20Mon?=
+ =?UTF-8?q?=20Sep=2017=2000:00:00=202001=0ASubject:=20[PATCH]=20mlxsw:=20i?=
+ =?UTF-8?q?2c:=20Prevent=20transaction=20execution=20for=20special=0A=20ch?=
+ =?UTF-8?q?ip=20states?=
 
 Do not run transaction in cases chip is in reset or in-service update
-states.
-In such case firmware is not accessible and will reject transaction
+states. In such case firmware is not accessible and will reject transaction
 with the relevant status "RUNNING_RESET" or "FW_ISSU_ONGOING".
 In case transaction is failed do to one of these reasons, stop sending
 transactions. In such case driver is about to be removed since it
@@ -14,9 +15,10 @@ cannot continue running after reset or in-service update. And
 re-probed again after reset or in-service update is completed.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>
 ---
  drivers/net/ethernet/mellanox/mlxsw/cmd.h |  4 ++++
- drivers/net/ethernet/mellanox/mlxsw/i2c.c | 29 ++++++++++++++++++++---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 29 ++++++++++++++++++++++++++---
  2 files changed, 30 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/cmd.h b/drivers/net/ethernet/mellanox/mlxsw/cmd.h
@@ -42,26 +44,26 @@ index 91f68fb0b420..d8ecb8c8a269 100644
  		return "BAD_PKT";
  	default:
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
-index 015f6dbe0f8a..ba31540f12a2 100644
+index ce843ea91464..b8a5c0cbb6b5 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
-@@ -76,6 +76,7 @@
-  * @sys_event_handler: system events handler callback;
-  * @irq: IRQ line number;
-  * @irq_unhandled_count: number of unhandled interrupts;
+@@ -63,6 +63,7 @@
+  * @core: switch core pointer;
+  * @bus_info: bus info block;
+  * @block_size: maximum block size allowed to pass to under layer;
 + * @status: status to indicate chip reset or in-service update;
   */
  struct mlxsw_i2c {
  	struct {
-@@ -95,6 +96,7 @@ struct mlxsw_i2c {
- 	void (*sys_event_handler)(struct mlxsw_core *mlxsw_core);
- 	int irq;
- 	atomic_t irq_unhandled_count;
+@@ -76,6 +77,7 @@ struct mlxsw_i2c {
+ 	struct mlxsw_core *core;
+ 	struct mlxsw_bus_info bus_info;
+ 	u16 block_size;
 +	u8 status;
  };
  
  #define MLXSW_I2C_READ_MSG(_client, _addr_buf, _buf, _len) {	\
-@@ -241,6 +243,19 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
+@@ -222,6 +224,19 @@ static int mlxsw_i2c_write_cmd(struct i2c_client *client,
  	return 0;
  }
  
@@ -81,7 +83,7 @@ index 015f6dbe0f8a..ba31540f12a2 100644
  /* Routine posts initialization command to ASIC through mail box. */
  static int
  mlxsw_i2c_write_init_cmd(struct i2c_client *client,
-@@ -424,6 +439,10 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+@@ -405,6 +420,10 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
  
  	WARN_ON(in_mbox_size % sizeof(u32) || out_mbox_size % sizeof(u32));
  
@@ -92,7 +94,7 @@ index 015f6dbe0f8a..ba31540f12a2 100644
  	if (in_mbox) {
  		reg_size = mlxsw_i2c_get_reg_size(in_mbox);
  		num = reg_size / mlxsw_i2c->block_size;
-@@ -498,6 +517,8 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
+@@ -479,6 +498,8 @@ mlxsw_i2c_cmd(struct device *dev, u16 opcode, u32 in_mod, size_t in_mbox_size,
  
  cmd_fail:
  	mutex_unlock(&mlxsw_i2c->cmd.lock);
@@ -101,7 +103,7 @@ index 015f6dbe0f8a..ba31540f12a2 100644
  	return err;
  }
  
-@@ -710,14 +731,16 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
+@@ -608,14 +629,16 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
  	/* Wait until go bit is cleared. */
  	err = mlxsw_i2c_wait_go_bit(client, mlxsw_i2c, &status);
  	if (err) {
@@ -122,5 +124,5 @@ index 015f6dbe0f8a..ba31540f12a2 100644
  		goto errout;
  	}
 -- 
-2.20.1
+2.14.1
 

--- a/recipes-kernel/linux/linux-5.10/0153-mlxsw-i2c-Add-support-for-system-events-handling.patch
+++ b/recipes-kernel/linux/linux-5.10/0153-mlxsw-i2c-Add-support-for-system-events-handling.patch
@@ -1,7 +1,7 @@
-From 4cc4f0a420eddc9157f8749a5ec133f998d17974 Mon Sep 17 00:00:00 2001
+From 8d7807e7b8326c537aa7db4fe31b2ca183d32248 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 19 Dec 2021 09:12:58 +0000
-Subject: [PATCH backport 5.10 153/182] mlxsw: i2c: Add support for system
+Subject: [PATCH backport v5.10.164 1/1] mlxsw: i2c: Add support for system
  events handling
 
 Extend i2c bus driver with interrupt handler to support system specific
@@ -18,7 +18,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 110 insertions(+)
 
 diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
-index 0cdb9b9d8353..015f6dbe0f8a 100644
+index cc99ec3f4e96..02f5733cfcc6 100644
 --- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
 +++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
 @@ -9,6 +9,7 @@
@@ -52,10 +52,10 @@ index 0cdb9b9d8353..015f6dbe0f8a 100644
 + * @sys_event_handler: system events handler callback;
 + * @irq: IRQ line number;
 + * @irq_unhandled_count: number of unhandled interrupts;
+  * @status: status to indicate chip reset or in-service update;
   */
  struct mlxsw_i2c {
- 	struct {
-@@ -76,6 +89,12 @@ struct mlxsw_i2c {
+@@ -77,6 +90,12 @@ struct mlxsw_i2c {
  	struct mlxsw_core *core;
  	struct mlxsw_bus_info bus_info;
  	u16 block_size;
@@ -65,10 +65,10 @@ index 0cdb9b9d8353..015f6dbe0f8a 100644
 +	void (*sys_event_handler)(struct mlxsw_core *mlxsw_core);
 +	int irq;
 +	atomic_t irq_unhandled_count;
+ 	u8 status;
  };
  
- #define MLXSW_I2C_READ_MSG(_client, _addr_buf, _buf, _len) {	\
-@@ -517,6 +536,7 @@ mlxsw_i2c_init(void *bus_priv, struct mlxsw_core *mlxsw_core,
+@@ -537,6 +556,7 @@ mlxsw_i2c_init(void *bus_priv, struct mlxsw_core *mlxsw_core,
  	int err;
  
  	mlxsw_i2c->core = mlxsw_core;
@@ -76,7 +76,7 @@ index 0cdb9b9d8353..015f6dbe0f8a 100644
  
  	mbox = mlxsw_cmd_mbox_alloc();
  	if (!mbox)
-@@ -547,6 +567,87 @@ static void mlxsw_i2c_fini(void *bus_priv)
+@@ -567,6 +587,87 @@ static void mlxsw_i2c_fini(void *bus_priv)
  	mlxsw_i2c->core = NULL;
  }
  
@@ -164,7 +164,7 @@ index 0cdb9b9d8353..015f6dbe0f8a 100644
  static const struct mlxsw_bus mlxsw_i2c_bus = {
  	.kind			= "i2c",
  	.init			= mlxsw_i2c_init,
-@@ -639,6 +740,7 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
+@@ -661,6 +762,7 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
  	mlxsw_i2c->bus_info.dev = &client->dev;
  	mlxsw_i2c->bus_info.low_frequency = true;
  	mlxsw_i2c->dev = &client->dev;
@@ -172,7 +172,7 @@ index 0cdb9b9d8353..015f6dbe0f8a 100644
  
  	err = mlxsw_core_bus_device_register(&mlxsw_i2c->bus_info,
  					     &mlxsw_i2c_bus, mlxsw_i2c, false,
-@@ -648,6 +750,12 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
+@@ -670,6 +772,12 @@ static int mlxsw_i2c_probe(struct i2c_client *client,
  		return err;
  	}
  
@@ -185,7 +185,7 @@ index 0cdb9b9d8353..015f6dbe0f8a 100644
  	return 0;
  
  errout:
-@@ -661,6 +769,8 @@ static int mlxsw_i2c_remove(struct i2c_client *client)
+@@ -683,6 +791,8 @@ static int mlxsw_i2c_remove(struct i2c_client *client)
  {
  	struct mlxsw_i2c *mlxsw_i2c = i2c_get_clientdata(client);
  

--- a/recipes-kernel/linux/linux-5.10/0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch
+++ b/recipes-kernel/linux/linux-5.10/0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch
@@ -7,6 +7,8 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
+Upstream commit 26e118ea98cf
+
 Currently hotplug configuration in logic device assumes that all items
 are provided with no holes.
 Thus, any group of hotplug events, associated with the specific

--- a/recipes-kernel/linux/linux-5.10/0274-platform-mellanox-Modify-reset-causes-description.patch
+++ b/recipes-kernel/linux/linux-5.10/0274-platform-mellanox-Modify-reset-causes-description.patch
@@ -4,6 +4,8 @@ Date: Thu, 2 Mar 2023 12:28:11 +0000
 Subject: [PATCH backport v.5.10 4/8] platform: mellanox: Modify reset causes
  description
 
+Link: https://patchwork.kernel.org/project/platform-driver-x86/patch/20230814203406.12399-4-vadimp@nvidia.com/
+
 For system of classes VMOD0005, VMOD0010:
 - remove "reset_from_comex", since this cause doesn't define specific
   reason.

--- a/recipes-kernel/linux/linux-5.10/0285-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
+++ b/recipes-kernel/linux/linux-5.10/0285-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
@@ -1,0 +1,69 @@
+From 6d9121cc262724d7a5fbc67f2c0be90fd95391d7 Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Wed, 12 Jul 2023 14:26:38 +0000
+Subject: [PATCH backport v5.10.164 4/5] platform: mellanox: nvsw-sn2201:
+ change fans i2c busses.
+
+Link: https://patchwork.kernel.org/project/platform-driver-x86/patch/20230814203406.12399-16-vadimp@nvidia.com/
+
+Define the exact i2c bus (adapter number) of fans on the SN2201 system.
+This will cause fan's EEPROMs be connected already from nvsw-sn2201
+platform driver and not from user space after receiving udev events.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/platform/mellanox/nvsw-sn2201.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
+index 51da240ce4f9..65b677690851 100644
+--- a/drivers/platform/mellanox/nvsw-sn2201.c
++++ b/drivers/platform/mellanox/nvsw-sn2201.c
+@@ -84,6 +84,10 @@
+ #define NVSW_SN2201_MAIN_MUX_CH5_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 5)
+ #define NVSW_SN2201_MAIN_MUX_CH6_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 6)
+ #define NVSW_SN2201_MAIN_MUX_CH7_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 7)
++#define NVSW_SN2201_2ND_MUX_CH0_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 1)
++#define NVSW_SN2201_2ND_MUX_CH1_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 2)
++#define NVSW_SN2201_2ND_MUX_CH2_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 3)
++#define NVSW_SN2201_2ND_MUX_CH3_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 4)
+ 
+ #define NVSW_SN2201_CPLD_NR		NVSW_SN2201_MAIN_MUX_CH0_NR
+ #define NVSW_SN2201_NR_NONE		-1
+@@ -425,28 +429,28 @@ static struct mlxreg_core_data nvsw_sn2201_fan_items_data[] = {
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(0),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[0],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH0_NR,
+ 	},
+ 	{
+ 		.label = "fan2",
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(1),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[1],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH1_NR,
+ 	},
+ 	{
+ 		.label = "fan3",
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(2),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[2],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH2_NR,
+ 	},
+ 	{
+ 		.label = "fan4",
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(3),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[3],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH3_NR,
+ 	},
+ };
+ 
+-- 
+2.20.1
+

--- a/rpm/hw-management.spec
+++ b/rpm/hw-management.spec
@@ -114,7 +114,6 @@ install -m 0755 usr/usr/bin/hw-management-helpers.sh $RPM_BUILD_ROOT/usr/bin/hw-
 install -m 0755 usr/usr/bin/hw-management-i2c-gpio-expander.sh $RPM_BUILD_ROOT/usr/bin/hw-management-i2c-gpio-expander.sh
 install -m 0755 usr/usr/bin/hw-management-if-rename.sh $RPM_BUILD_ROOT/usr/bin/hw-management-if-rename.sh
 install -m 0755 usr/usr/bin/hw-management-led-state-conversion.sh $RPM_BUILD_ROOT/usr/bin/hw-management-led-state-conversion.sh
-install -m 0755 usr/usr/bin/hw-management-liquid-cooling.sh $RPM_BUILD_ROOT/usr/bin/hw-management-liquid-cooling.sh
 install -m 0755 usr/usr/bin/hw-management-parse-eeprom.sh $RPM_BUILD_ROOT/usr/bin/hw-management-parse-eeprom.sh
 install -m 0755 usr/usr/bin/hw-management-power-helper.sh $RPM_BUILD_ROOT/usr/bin/hw-management-power-helper.sh
 install -m 0755 usr/usr/bin/hw-management-ps-vpd.sh $RPM_BUILD_ROOT/usr/bin/hw-management-ps-vpd.sh
@@ -238,7 +237,6 @@ chmod 0644 $RPM_BUILD_ROOT/usr/share/man/man8/hw-management.service.8.gz
 %attr(0755, root, root) "/usr/bin/hw-management-devtree-check.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-devtree.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-if-rename.sh"
-%attr(0755, root, root) "/usr/bin/hw-management-liquid-cooling.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-vpd-parser.py"
 %attr(0755, root, root) "/usr/bin/hw_management_thermal_control.py"
 


### PR DESCRIPTION
Updating the hw-management rpm spec file to accommodate the removal of 'hw-management-liquid-cooling.sh' script

Reviewed-by: Vadim Pasternak [vadimp@nvidia.com](mailto:vadimp@nvidia.com)
Signed-off-by: Ciju Rajan K [crajank@nvidia.com](mailto:crajank@nvidia.com)