### PR TITLE
hw-mgmt: scripts: add new reset ready attribute.

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -730,6 +730,17 @@ handle_cpld_versions()
 	echo "$str" > $system_path/cpld
 }
 
+check_reset_attrs()
+{
+	attrname="$1"
+	if [[ "$attrname" == "reset_"* ]]; then
+		reset_attr_count=$((reset_attr_count+1))
+		if [ $reset_attr_count -eq $reset_attr_num ]; then
+			check_n_init $config_path/reset_attr_ready 1
+		fi
+	fi
+}
+
 if [ "$1" == "add" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then
@@ -955,6 +966,8 @@ if [ "$1" == "add" ]; then
 		$led_path/led_"$name"_state
 	fi
 	if [ "$2" == "regio" ]; then
+		reset_attr_num=$(< $config_path/reset_attr_num)
+		reset_attrr_count=0
 		linecard=0
 		# Detect if it belongs to line card or to main board.
 		# For main board dirname mlxreg-io, for linecard - mlxreg-io.{bus_num}.
@@ -985,6 +998,7 @@ if [ "$1" == "add" ]; then
 				   [ "$attrname" != "uevent" ] &&
 				   [ "$attrname" != "name" ] && [ "$take" -ne 0 ] ; then
 					ln -sf "$3""$4"/"$attrname" $system_path/"$attrname"
+					check_reset_attrs "$attrname"
 				fi
 			done
 			handle_cpld_versions "$cpld_num"

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -101,6 +101,7 @@ nv4_rev_a1_pci_id=22a4
 leakage_count=0
 asic_chipup_retry=2
 chipup_log_size=4096
+reset_dflt_attr_num=19
 
 # Topology description and driver specification for ambient sensors and for
 # ASIC I2C driver per system class. Specific system class is obtained from DMI
@@ -956,6 +957,7 @@ msn274x_specific()
 	echo 2 > $config_path/cpld_num
 	echo 24c02 > $config_path/psu_eeprom_type
 	lm_sensors_config="$lm_sensors_configs_path/msn2740_sensors.conf"
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn21xx_specific()
@@ -977,6 +979,7 @@ msn21xx_specific()
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2100.json"
 	echo 4 > $config_path/fan_drwr_num
 	echo 1 > $config_path/fixed_fans_system
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn24xx_specific()
@@ -1010,6 +1013,7 @@ msn24xx_specific()
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
 	set_spc1_port_cpld
 	cpld=$(< $config_path/cpld_port)
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn27xx_msb_msx_specific()
@@ -1061,6 +1065,7 @@ msn27xx_msb_msx_specific()
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2700_msb7x00.json"
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
 	get_i2c_bus_frequency_default
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn201x_specific()
@@ -1082,6 +1087,7 @@ msn201x_specific()
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2010.json"
 	echo 4 > $config_path/fan_drwr_num
 	echo 1 > $config_path/fixed_fans_system
+	echo 8 > $config_path/reset_attr_num
 }
 
 connect_msn3700()
@@ -1156,6 +1162,7 @@ mqmxxx_msn37x_msn34x_specific()
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
 	get_i2c_bus_frequency_default
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 sn3750sx_specific()
@@ -1192,6 +1199,7 @@ msn3420_specific()
 	echo 24c02 > $config_path/psu_eeprom_type
 	lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn3420.json"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn_xh3000_specific()
@@ -1227,6 +1235,7 @@ msn38xx_specific()
 	echo 4 > $config_path/cpld_num
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn3800.json"
 	lm_sensors_config="$lm_sensors_configs_path/msn3800_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn24102_specific()
@@ -1249,6 +1258,7 @@ msn24102_specific()
 	i2c_bus_def_off_eeprom_cpu=24
 	echo 24c02 > $config_path/psu_eeprom_type
 	get_i2c_bus_frequency_default
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn27002_msb78002_specific()
@@ -1273,6 +1283,7 @@ msn27002_msb78002_specific()
 	lm_sensors_config="$lm_sensors_configs_path/msn27002_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2700_msb7x00.json"
 	get_i2c_bus_frequency_default
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 connect_msn4700_msn4600()
@@ -1377,6 +1388,7 @@ msn46xx_specific()
 	echo 23000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn3510_specific()
@@ -1392,6 +1404,7 @@ msn3510_specific()
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
 	lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 mqm97xx_specific()
@@ -1469,6 +1482,7 @@ mqm97xx_specific()
 	echo 23000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 mqm9510_specific()
@@ -1601,6 +1615,7 @@ p4697_specific()
 	echo 4 > $config_path/cpld_num
 	thermal_control_config="$thermal_control_configs_path/tc_config_not_supported.json"
 	lm_sensors_config="$lm_sensors_configs_path/p4697_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn_spc2_common()
@@ -1640,6 +1655,7 @@ msn_spc2_common()
 			mqmxxx_msn37x_msn34x_specific
 			;;
 	esac
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn_spc3_common()
@@ -1686,6 +1702,7 @@ bf3_common()
 			exit 0
 			;;
 	esac
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn48xx_specific()
@@ -1709,6 +1726,7 @@ msn48xx_specific()
 	echo 14 > $config_path/pcie_default_i2c_bus
 	lm_sensors_config="$lm_sensors_configs_path/msn4800_sensors.conf"
 	lm_sensors_config_lc="$lm_sensors_configs_path/msn4800_sensors_lc.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 sn2201_specific()
@@ -1745,6 +1763,7 @@ sn2201_specific()
 	sed -i "s/label temp14/label temp$id1/g" $lm_sensors_configs_path/sn2201_sensors.conf
 	lm_sensors_config="$lm_sensors_configs_path/sn2201_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2201.json"
+	echo 13 > $config_path/reset_attr_num
 }
 
 p2317_specific()
@@ -1758,6 +1777,7 @@ p2317_specific()
 	echo 1 > $config_path/global_wp_wait_step
 	echo 20 > $config_path/global_wp_timeout
 	lm_sensors_config="$lm_sensors_configs_path/p2317_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 sn56xx_specific()
@@ -1809,6 +1829,7 @@ sn_spc4_common()
 			sn56xx_specific
 		;;
 	esac
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 p4262_specific()
@@ -1837,6 +1858,7 @@ p4262_specific()
 	named_busses+=(${p4262_named_busses[@]})
 	add_come_named_busses $ndr_cpu_bus_offset
 	echo -n "${named_busses[@]}" > $config_path/named_busses
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 check_system()


### PR DESCRIPTION
New reset_attr_ready file is created and set to 1 when all reset cause links
for this system are created. It can be used as a trigger in other services
that they can check reset reason.

Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
Signed-off-by: Michael Shych <mshych@nvidia.com>
