### PR TITLE
hw-mgmt: sensors: Add sensors.conf for msn4600C sysid=2

### DIFF
--- a/usr/etc/hw-management-sensors/msn4600c_2_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4600c_2_sensors.conf
@@ -1,0 +1,228 @@
+##################################################################################
+# Copyright (c) 2019 - 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Platform specific sensors config for SN4700
+##################################################################################
+
+# Temperature sensors
+bus "i2c-2" "i2c-1-mux (chan_id 1)"
+    chip "mlxsw-i2c-*-48"
+        label temp1 "Ambient ASIC Temp"
+
+bus "i2c-7" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-*-49"
+        label temp1 "Ambient Fan Side Temp (air intake)"
+    chip "tmp102-i2c-*-4a"
+        label temp1 "Ambient Port Side Temp (air exhaust)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tmp102-i2c-15-49"
+        label temp1 "Ambient COMEX Temp"
+
+# Power controllers
+bus "i2c-5" "i2c-1-mux (chan_id 4)"
+    chip "xdpe12284-i2c-*-62"
+        label in1 "PMIC-1 PSU 12V Rail (in1)"
+        ignore in2 
+        label in3 "PMIC-1 ASIC VCORE_MAIN Rail (out1)"
+        ignore in4 
+        label temp1 "PMIC-1 ASIC VCORE_MAIN Temp 1"
+        ignore temp2 
+        label power1 "PMIC-1 12V ASIC VCORE_MAIN Rail Pwr (in)"
+        ignore power2 
+        label power3 "PMIC-1 ASIC VCORE_MAIN Rail Pwr (out1)"
+        ignore power4 
+        label curr1 "PMIC-1 12V ASIC VCORE_MAIN Rail Curr (in1)"
+        ignore curr2 
+        label curr3 "PMIC-1 ASIC VCORE_MAIN Rail Curr (out1)"
+        ignore curr4
+    chip "xdpe12284-i2c-*-64"
+        label in1 "PMIC-2 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-2 ASIC 1.8V_MAIN Rail (out1)"
+        label in4 "PMIC-2 ASIC 1.2V_MAIN Rail (out2)"
+        label temp1 "PMIC-2 ASIC 1.8V_MAIN Temp 1"
+        label temp2 "PMIC-2 ASIC 1.2V_MAIN Temp 2"
+        label power1 "PMIC-2 12V ASIC 1.8V_1.2V_MAIN Rail Pwr (in)"
+        ignore power2 
+        label power3 "PMIC-2 ASIC 1.8V_MAIN Rail Pwr (out1)"
+        label power4 "PMIC-2 ASIC 1.2V_MAIN Rail Pwr (out2)"
+        label curr1 "PMIC-2 12V ASIC 1.8V_MAIN Rail Curr (in1)"
+        label curr2 "PMIC-2 12V ASIC 1.2V_MAIN Rail Curr (in2)"
+        label curr3 "PMIC-2 ASIC 1.8V_MAIN Rail Curr (out1)"
+        label curr4 "PMIC-2 ASIC 1.2V_MAIN Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-66"
+        label in1 "PMIC-3 PSU 12V Rail (in1)"
+        label in2 "PMIC-2 PSU 12V Rail (in2)"
+        label in3 "PMIC-3 ASIC VCORE_T0_1 Rail (out1)"
+        label in4 "PMIC-3 ASIC 1.8V_T0_1 Rail (out2)"
+        label temp1 "PMIC-3 ASIC VCORE_T0_1 Temp 1"
+        label temp2 "PMIC-3 ASIC 1.8V_T0_1 Temp 2"
+        label power1 "PMIC-3 12V ASIC VCORE_1.8V_T0_1 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-3 ASIC VCORE_T0_1 Rail Pwr (out1)"
+        label power4 "PMIC-3 ASIC 1.8V_T0_1 Rail Pwr (out2)"
+        label curr1 "PMIC-3 12V ASIC VCORE_T0_1 Rail Curr (in1)"
+        label curr2 "PMIC-3 12V ASIC 1.8V_T0_1 Rail Curr (in2)"
+        label curr3 "PMIC-3 ASIC VCORE_T0_1 Rail Curr (out1)"
+        label curr4 "PMIC-3 ASIC 1.8V_T0_1 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-68"
+        label in1 "PMIC-4 PSU 12V Rail (in1)"
+        label in2 "PMIC-4 PSU 12V Rail (in2)"
+        label in3 "PMIC-4 ASIC VCORE_T2_3 Rail (out1)"
+        label in4 "PMIC-4 ASIC 1.8V_T2_3 Rail (out2)"
+        label temp1 "PMIC-4 ASIC VCORE_T2_3 Temp 1"
+        label temp2 "PMIC-4 ASIC 1.8V_T2_3 Temp 2"
+        label power1 "PMIC-4 12V ASIC VCORE_1.8V_T2_3 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-4 ASIC VCORE_T2_3 Rail Pwr (out1)"
+        label power4 "PMIC-4 ASIC 1.8V_T2_3 Rail Pwr (out2)"
+        label curr1 "PMIC-4 12V ASIC VCORE_T2_3 Rail Curr (in1)"
+        label curr2 "PMIC-4 12V ASIC 1.8V_T2_3 Rail Curr (in2)"
+        label curr3 "PMIC-4 ASIC VCORE_T2_3 Rail Curr (out1)"
+        label curr4 "PMIC-4 ASIC 1.8V_T2_3 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-6a"
+        label in1 "PMIC-5 PSU 12V Rail (in1)"
+        label in2 "PMIC-5 PSU 12V Rail (in2)"
+        label in3 "PMIC-5 ASIC VCORE_T4_5 Rail (out1)"
+        label in4 "PMIC-5 ASIC 1.8V_T4_5 Rail (out2)"
+        label temp1 "PMIC-5 ASIC VCORE_T4_5 Temp 1"
+        label temp2 "PMIC-5 ASIC 1.8V_T4_5 Temp 2"
+        label power1 "PMIC-5 12V ASIC VCORE_1.8V_T4_5 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-5 ASIC VCORE_T4_5 Rail Pwr (out1)"
+        label power4 "PMIC-5 ASIC 1.8V_T4_5 Rail Pwr (out2)"
+        label curr1 "PMIC-5 12V ASIC VCORE_T4_5 Rail Curr (in1)"
+        label curr2 "PMIC-5 12V ASIC 1.8V_T4_5 Rail Curr (in2)"
+        label curr3 "PMIC-5 ASIC VCORE_T4_5 Rail Curr (out1)"
+        label curr4 "PMIC-5 ASIC 1.8V_T4_5 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-6c"
+        label in1 "PMIC-6 PSU 12V Rail (in1)"
+        label in2 "PMIC-6 PSU 12V Rail (in2)"
+        label in3 "PMIC-6 ASIC VCORE_T6_7 Rail (out1)"
+        label in4 "PMIC-6 ASIC 1.8V_T6_7 Rail (out2)"
+        label temp1 "PMIC-6 ASIC VCORE_T6_7 Temp 1"
+        label temp2 "PMIC-6 ASIC 1.8V_T6_7 Temp 2"
+        label power1 "PMIC-6 12V ASIC VCORE_1.8V_T6_7 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-6 ASIC VCORE_T6_7 Rail Pwr (out1)"
+        label power4 "PMIC-6 ASIC 1.8V_T6_7 Rail Pwr (out2)"
+        label curr1 "PMIC-6 12V ASIC VCORE_T6_7 Rail Curr (in1)"
+        label curr2 "PMIC-6 12V ASIC 1.8V_T6_7 Rail Curr (in2)"
+        label curr3 "PMIC-6 ASIC VCORE_T6_7 Rail Curr (out1)"
+        label curr4 "PMIC-6 ASIC 1.8V_T6_7 Rail Curr (out2)"
+    chip "xdpe12284-i2c-*-6e"
+        label in1 "PMIC-7 PSU 12V Rail (in1)"
+        label in2 "PMIC-7 PSU 12V Rail (in2)"
+        label in3 "PMIC-7 ASIC 1.2V_T0_3 Rail (out1)"
+        label in4 "PMIC-7 ASIC 1.2V_T4_7 Rail (out2)"
+        label temp1 "PMIC-7 ASIC 1.2V_T0_3 Temp 1"
+        label temp2 "PMIC-7 ASIC 1.2V_T4_7 Temp 2"
+        label power1 "PMIC-7 12V ASIC 1.2V_T0_3_T4_7 Rail Pwr (in) "
+        ignore power2 
+        label power3 "PMIC-7 ASIC 1.2V_T0_3 Rail Pwr (out1)"
+        label power4 "PMIC-7 ASIC 1.2V_T4_7 Rail Pwr (out2)"
+        label curr1 "PMIC-7 12V ASIC 1.2V_T0_3 Rail Curr (in1)"
+        label curr2 "PMIC-7 12V ASIC 1.2V_T4_7 Rail Curr (in2)"
+        label curr3 "PMIC-7 ASIC 1.2V_T0_3 Rail Curr (out1)"
+        label curr4 "PMIC-7 ASIC 1.2V_T4_7 Rail Curr (out2)"
+
+bus "i2c-15" "i2c-1-mux (chan_id 6)"
+    chip "tps53679-i2c-*-58"
+        label in1 "PMIC-8 PSU 12V Rail (in1)"
+        label in2 "PMIC-8 PSU 12V Rail (in2)"
+        label in3 "PMIC-8 COMEX 1.8V Rail (out1)"
+        label in4 "PMIC-8 COMEX 1.05V Rail (out2)"
+        label temp1 "PMIC-8 Temp 1"
+        label temp2 "PMIC-8 Temp 2"
+        label power1 "PMIC-8 COMEX 1.8V Rail Pwr (out1)"
+        label power2 "PMIC-8 COMEX 1.05V Rail Pwr (out2)"
+        label curr1 "PMIC-8 COMEX 1.8V Rail Curr (out1)"
+        label curr2 "PMIC-8 COMEX 1.05V Rail Curr (out2)"
+    chip "tps53679-i2c-*-61"
+        label in1 "PMIC-9 PSU 12V Rail (in1)"
+        label in2 "PMIC-9 PSU 12V Rail (in2)"
+        label in3 "PMIC-9 COMEX 1.2V Rail (out)"
+        ignore in4
+        label temp1 "PMIC-9 Temp 1"
+        label temp2 "PMIC-9 Temp 2"
+        label power1 "PMIC-9 COMEX 1.2V Rail Pwr (out1)"
+        ignore power2 
+        label curr1 "PMIC-9 COMEX 1.2V Rail Curr (out1)"
+        ignore curr2 
+
+    chip "mp2975-i2c-*-6a"
+        label in1 "PMIC-8 PSU 12V Rail (in1)"
+        label in2 "PMIC-8 COMEX 1.8V Rail (out)"
+        label in3 "PMIC-8 COMEX 1.05V Rail (out)"
+        label temp1 "PMIC-8 Temp 1"
+        label power1 "PMIC-8 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-8 COMEX 1.8V Rail Pwr (out)"
+        label power3 "PMIC-8 COMEX 1.05V Rail Pwr (out)"
+        label curr1 "PMIC-8 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-8 COMEX 1.8V Rail Curr (out)"
+        ignore curr3
+        ignore curr4
+        label curr5 "PMIC-8 COMEX 1.05V Rail Curr (out)"
+        ignore curr6
+
+    chip "mp2975-i2c-*-61"
+        label in1 "PMIC-9 PSU 12V Rail (in1)"
+        label in2 "PMIC-9 COMEX 1.2V Rail (out)"
+        label temp1 "PMIC-9 Temp 1"
+        label temp2 "PMIC-9 Temp 2"
+        label power1 "PMIC-9 COMEX 12V Rail Pwr (in)"
+        label power2 "PMIC-9 COMEX 1.2V Rail Pwr (out)"
+        label curr1 "PMIC-9 COMEX 12V Rail Curr (in)"
+        label curr2 "PMIC-9 COMEX 1.2V Rail Curr (out)"
+        ignore curr3
+
+# Power supplies
+bus "i2c-4" "i2c-1-mux (chan_id 3)"
+    chip "dps460-i2c-*-58"
+        label in1 "PSU-1(L) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-1(L) 12V Rail (out)"
+        label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-1(L) Temp 1"
+        label temp2 "PSU-1(L) Temp 2"
+        label temp3 "PSU-1(L) Temp 3"
+        label power1 "PSU-1(L) 220V Rail Pwr (in)"
+        label power2 "PSU-1(L) 12V Rail Pwr (out)"
+        label curr1 "PSU-1(L) 220V Rail Curr (in)"
+        label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    chip "dps460-i2c-*-59"
+        label in1 "PSU-2(R) 220V Rail (in)"
+        ignore in2
+        label in3 "PSU-2(R) 12V Rail (out)"
+        label fan1 "PSU-2(R) Fan 1"
+        ignore fan2
+        ignore fan3
+        label temp1 "PSU-2(R) Temp 1"
+        label temp2 "PSU-2(R) Temp 2"
+        label temp3 "PSU-2(R) Temp 3"
+        label power1 "PSU-2(R) 220V Rail Pwr (in)"
+        label power2 "PSU-2(R) 12V Rail Pwr (out)"
+        label curr1 "PSU-2(R) 220V Rail Curr (in)"
+        label curr2 "PSU-2(R) 12V Rail Curr (out)"
+
+# Chassis fans
+chip "mlxreg_fan-isa-*"
+    label fan1 "Chassis Fan Drawer-1 Tach 1"
+    label fan2 "Chassis Fan Drawer-1 Tach 2"
+    label fan3 "Chassis Fan Drawer-2 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 2"
+    label fan5 "Chassis Fan Drawer-3 Tach 1"
+    label fan6 "Chassis Fan Drawer-3 Tach 2"
+    label fan7 "Chassis Fan Drawer-4 Tach 1"
+    label fan8 "Chassis Fan Drawer-4 Tach 2"
+    label fan9 "Chassis Fan Drawer-5 Tach 1"
+    label fan10 "Chassis Fan Drawer-5 Tach 2"
+    label fan11 "Chassis Fan Drawer-6 Tach 1"
+    label fan12 "Chassis Fan Drawer-6 Tach 2"
+
+# Miscellaneous
+chip "*-virtual-*"
+    ignore temp1

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1349,6 +1349,10 @@ msn46xx_specific()
 				1|3)
 					connect_msn4700_msn4600_A1
 				;;
+				2)
+					connect_msn4700_msn4600
+					lm_sensors_config="$lm_sensors_configs_path/msn4600c_2_sensors.conf"
+				;;
 				*)
 					connect_msn4700_msn4600
 				;;


### PR DESCRIPTION
Add sensors.conf support for msn4600C sysid=2

Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
Reviewed-by: Yehuda Yehudai <yyehudai@mellanox.com>
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
