### PR TITLE
hw-mgmt: scripts: add new reset ready attribute.

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -730,6 +730,17 @@ handle_cpld_versions()
 	echo "$str" > $system_path/cpld
 }
 
+check_reset_attrs()
+{
+	attrname="$1"
+	if [[ "$attrname" == "reset_"* ]]; then
+		reset_attr_count=$((reset_attr_count+1))
+		if [ $reset_attr_count -eq $reset_attr_num ]; then
+			check_n_init $config_path/reset_attr_ready 1
+		fi
+	fi
+}
+
 if [ "$1" == "add" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then
@@ -950,6 +961,8 @@ if [ "$1" == "add" ]; then
 		$led_path/led_"$name"_state
 	fi
 	if [ "$2" == "regio" ]; then
+		reset_attr_num=$(< $config_path/reset_attr_num)
+		reset_attrr_count=0
 		linecard=0
 		# Detect if it belongs to line card or to main board.
 		# For main board dirname mlxreg-io, for linecard - mlxreg-io.{bus_num}.
@@ -980,6 +993,7 @@ if [ "$1" == "add" ]; then
 				   [ "$attrname" != "uevent" ] &&
 				   [ "$attrname" != "name" ] && [ "$take" -ne 0 ] ; then
 					ln -sf "$3""$4"/"$attrname" $system_path/"$attrname"
+					check_reset_attrs "$attrname"
 				fi
 			done
 			handle_cpld_versions "$cpld_num"

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -101,6 +101,7 @@ nv4_rev_a1_pci_id=22a4
 leakage_count=0
 asic_chipup_retry=2
 chipup_log_size=4096
+reset_dflt_attr_num=18
 
 # Topology description and driver specification for ambient sensors and for
 # ASIC I2C driver per system class. Specific system class is obtained from DMI
@@ -957,6 +958,7 @@ msn274x_specific()
 	echo 2 > $config_path/cpld_num
 	echo 24c02 > $config_path/psu_eeprom_type
 	lm_sensors_config="$lm_sensors_configs_path/msn2740_sensors.conf"
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn21xx_specific()
@@ -978,6 +980,7 @@ msn21xx_specific()
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2100.json"
 	echo 4 > $config_path/fan_drwr_num
 	echo 1 > $config_path/fixed_fans_system
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn24xx_specific()
@@ -1011,6 +1014,7 @@ msn24xx_specific()
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
 	set_spc1_port_cpld
 	cpld=$(< $config_path/cpld_port)
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn27xx_msb_msx_specific()
@@ -1062,6 +1066,7 @@ msn27xx_msb_msx_specific()
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2700_msb7x00.json"
 	lm_sensors_config="$lm_sensors_configs_path/msn2700_sensors.conf"
 	get_i2c_bus_frequency_default
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn201x_specific()
@@ -1083,6 +1088,7 @@ msn201x_specific()
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2010.json"
 	echo 4 > $config_path/fan_drwr_num
 	echo 1 > $config_path/fixed_fans_system
+	echo 8 > $config_path/reset_attr_num
 }
 
 connect_msn3700()
@@ -1157,6 +1163,7 @@ mqmxxx_msn37x_msn34x_specific()
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
 	get_i2c_bus_frequency_default
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 sn3750sx_specific()
@@ -1194,6 +1201,7 @@ msn3420_specific()
 	echo 24c02 > $config_path/psu_eeprom_type
 	lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn3420.json"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn_xh3000_specific()
@@ -1229,6 +1237,7 @@ msn38xx_specific()
 	echo 4 > $config_path/cpld_num
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn3800.json"
 	lm_sensors_config="$lm_sensors_configs_path/msn3800_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn24102_specific()
@@ -1251,6 +1260,7 @@ msn24102_specific()
 	i2c_bus_def_off_eeprom_cpu=24
 	echo 24c02 > $config_path/psu_eeprom_type
 	get_i2c_bus_frequency_default
+	echo 8 > $config_path/reset_attr_num
 }
 
 msn27002_msb78002_specific()
@@ -1275,6 +1285,7 @@ msn27002_msb78002_specific()
 	lm_sensors_config="$lm_sensors_configs_path/msn27002_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2700_msb7x00.json"
 	get_i2c_bus_frequency_default
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 connect_msn4700_msn4600()
@@ -1379,6 +1390,7 @@ msn46xx_specific()
 	echo 23000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn3510_specific()
@@ -1394,6 +1406,7 @@ msn3510_specific()
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
 	lm_sensors_config="$lm_sensors_configs_path/msn3700_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 mqm97xx_specific()
@@ -1471,6 +1484,7 @@ mqm97xx_specific()
 	echo 23000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 mqm9510_specific()
@@ -1603,6 +1617,7 @@ p4697_specific()
 	echo 4 > $config_path/cpld_num
 	thermal_control_config="$thermal_control_configs_path/tc_config_not_supported.json"
 	lm_sensors_config="$lm_sensors_configs_path/p4697_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn_spc2_common()
@@ -1642,6 +1657,7 @@ msn_spc2_common()
 			mqmxxx_msn37x_msn34x_specific
 			;;
 	esac
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn_spc3_common()
@@ -1672,6 +1688,7 @@ msn_spc3_common()
 			msn47xx_specific
 		;;
 	esac
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 bf3_common()
@@ -1704,6 +1721,7 @@ bf3_common()
 		fi
 		check_n_link /sys/devices/platform/MLNXBF49:00/mlxreg-io/hwmon/hwmon*/jtag_enable $jtag_path/jtag_enable
 	fi
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 msn48xx_specific()
@@ -1727,6 +1745,7 @@ msn48xx_specific()
 	echo 14 > $config_path/cx_default_i2c_bus
 	lm_sensors_config="$lm_sensors_configs_path/msn4800_sensors.conf"
 	lm_sensors_config_lc="$lm_sensors_configs_path/msn4800_sensors_lc.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 sn2201_specific()
@@ -1763,6 +1782,7 @@ sn2201_specific()
 	sed -i "s/label temp14/label temp$id1/g" $lm_sensors_configs_path/sn2201_sensors.conf
 	lm_sensors_config="$lm_sensors_configs_path/sn2201_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2201.json"
+	echo 13 > $config_path/reset_attr_num
 }
 
 p2317_specific()
@@ -1776,6 +1796,7 @@ p2317_specific()
 	echo 1 > $config_path/global_wp_wait_step
 	echo 20 > $config_path/global_wp_timeout
 	lm_sensors_config="$lm_sensors_configs_path/p2317_sensors.conf"
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 sn56xx_specific()
@@ -1827,6 +1848,7 @@ sn_spc4_common()
 			sn56xx_specific
 		;;
 	esac
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 p4262_specific()
@@ -1855,6 +1877,7 @@ p4262_specific()
 	named_busses+=(${p4262_named_busses[@]})
 	add_come_named_busses $ndr_cpu_bus_offset
 	echo -n "${named_busses[@]}" > $config_path/named_busses
+	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 }
 
 check_system()


### PR DESCRIPTION
New reset_attr_ready file is created and set to 1 when all reset cause links
for this system are created. It can be used as a trigger in other services
that they can check reset reason.

Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
Signed-off-by: Michael Shych <mshych@nvidia.com>
