### PR TITLE
hw-mgmt: thermal: TC code improvement

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -1515,9 +1515,7 @@ class psu_fan_sensor(system_device):
         # if PSU is plugged in then PSU fan missing is not an error
         psu_status = self._get_status()
         rpm_file_name = "thermal/{}".format(self.file_input)
-        if psu_status == 0:
-            self.handle_reading_file_err(rpm_file_name)
-        elif self.check_file(rpm_file_name):
+        if psu_status == 1:
             try:
                 value = int(self.read_file(rpm_file_name))
                 self.handle_reading_file_err(rpm_file_name, reset=True)
@@ -1996,7 +1994,7 @@ class ambiant_thermal_sensor(system_device):
                     self.value_dict[file_name] = int(temperature)
                     self.log.debug("{} {} value {}".format(self.name, sens_file_name, temperature))
                 except BaseException:
-                    self.log.error("Error value reading from file: {}".format(self.base_file_name))
+                    self.log.error("Error value reading from file: {}".format(sens_file_name))
                     self.handle_reading_file_err(sens_file_name)
             # in case of multiple error - set sesor to ignore
             if sens_file_name in self.check_reading_file_err():
@@ -2388,7 +2386,7 @@ class ThermalManagement(hw_managemet_file_op):
             self._update_psu_fan_speed(pwm)
             self.pwm_target = pwm
             if self.pwm_worker_timer:
-                self.pwm_worker_timer.start(True)
+                self.pwm_worker_timer.start( self.pwm_target > self.pwm )
             else:
                 self.pwm = pwm
                 self._update_chassis_fan_speed(self.pwm)


### PR DESCRIPTION
1. Fix log sensor name for ambient sensor. Add failed file path instead
of just print sensor name

2. Fixed psu fan reading error.
If PSU not present no sense to add sensor_reading error for psu fan

3. Set pwm update worker immediate run only for hight PWM trend
It will make pwm_max_reduction timing more accurate in case several sensors
want to set pwm less pwm_max_reduction each but more than pwm_max_reduction in sum.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
