### PR TITLE
hw-mgmt: system events: ASIC init complition done

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -242,6 +242,33 @@ change_file_counter()
 	echo $counter > $file_name
 }
 
+# Update counter, match attribute, unlock.
+# $1 - file with counter
+# $2 - value to update counter ( 1 increase, -1 decrease)
+# $3 - file to match with the counter
+# $4 - file to set according to the match ( 0 not matched, 1 matched)
+unlock_service_state_change_update_and_match()
+{
+	update_file_name=$1
+	val=$2
+	match_file_name=$3
+	set_file_name=$4
+	local counter
+	local match
+
+	change_file_counter "$update_file_name" "$val"
+	if [ ! -z "$3" ] && [ ! -z "$4" ]; then
+		counter=$(< $update_file_name)
+		match=$(< $match_file_name)
+		if [ $counter -eq $match ]; then
+			echo 1 > $set_file_name
+		else
+			echo 0 > $set_file_name
+		fi
+	fi
+	/usr/bin/flock -u ${LOCKFD}
+}
+
 connect_device()
 {
 	find_i2c_bus

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2523,9 +2523,12 @@ do_chip_up_down()
 			set_i2c_bus_frequency_400KHz
 			echo $i2c_asic_addr > /sys/bus/i2c/devices/i2c-"$bus"/delete_device
 			restore_i2c_bus_frequency_default
+		else
+			unlock_service_state_change
+			return 0
 		fi
 		echo 0 > $config_path/sfp_counter
-		unlock_service_state_change
+		unlock_service_state_change_update_and_match $config_path/asic_chipup_completed -1 $config_path/asic_num $config_path/asics_init_done
 		;;
 	1)
 		lock_service_state_change
@@ -2561,7 +2564,13 @@ do_chip_up_down()
 			unlock_service_state_change
 			return 0
 		fi
-		unlock_service_state_change
+		if [ ! -f "$config_path/asic_chipup_completed" ]; then
+			echo 0 > "$config_path/asic_chipup_completed"
+		fi
+		if [ ! -f "$config_path/asics_init_done" ]; then
+			echo 0 > "$config_path/asics_init_done"
+		fi
+		unlock_service_state_change_update_and_match "$config_path/asic_chipup_completed" 1 "$config_path/asic_num" "$config_path/asics_init_done"
 		return 0
 		;;
 	*)


### PR DESCRIPTION
Add two new attributes:
/var/run/hw-management/config/asic_chipup_completed /var/run/hw-management/config/asics_init_done

'asic_chipup_completed' carries counter of completed ASIC devices probing.
'asics_init_done' is to be set to one, when 'asic_chipup_completed' attribute matches 'asic_num' attribute.

Motivation is to use 'asics_init_done' as criteria of system infrastructure readiness.


Reviwed-by: Felix Radensky <fradensky@nvidia.com>
Reviwed-by: Michael Shych <michaelsh@nvidia.com>