### PR TITLE
hw-mgmt: thermal: Fix PWM set 255 on ASIC disable

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2516,6 +2516,19 @@ do_chip_up_down()
 	case $action in
 	0)
 		lock_service_state_change
+
+		# If FAN PWM is controllded by ASIC - set it to 100%
+		pwm_link=$thermal_path/pwm1
+		if [ -L ${pwm_link} ] && [ -e ${pwm_link} ];
+		then
+			pwm_src=$(readlink -f ${pwm_link})
+			asic_i2c_add=/sys/devices/platform/mlxplat/i2c_mlxcpld.1/i2c-1/i2c-"$bus"/"$bus"-"$i2c_asic_addr_name"
+			if [[ "$pwm_src" == *"$asic_i2c_add"* ]]; then
+				echo  255 > $pwm_link
+				log_info "Set PWM to maximum speed prior fan driver removing."
+			fi
+		fi
+
 		chipup_delay=$(< $config_path/chipup_delay)
 		if [ -d /sys/bus/i2c/devices/"$bus"-"$i2c_asic_addr_name" ]; then
 			chipdown_delay=$(< $config_path/chipdown_delay)

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2394,7 +2394,7 @@ class ThermalManagement(hw_managemet_file_op):
             self.pwm_validate_timeout = current_milli_time() + CONST.PWM_VALIDATE_TIME * 1000
             pwm_real = self.read_pwm()
             if not pwm_real:
-                self.log.error("Read PWM error. Possible hw-management is not running", 1)
+                self.log.warn("Read PWM error. Possible hw-management is not running", 1)
                 return
 
             if pwm_real != self.pwm:
@@ -2407,7 +2407,7 @@ class ThermalManagement(hw_managemet_file_op):
         if self.pwm_target == self.pwm:
             pwm_real = self.read_pwm()
             if not pwm_real:
-                self.log.error("Read PWM error. Possible hw-management is not running", 1)
+                self.log.warn("Read PWM error. Possible hw-management is not running", 1)
                 return
 
             if pwm_real != self.pwm:


### PR DESCRIPTION
On systems with ASIC FAN control (SPC1), TC will not be able to change PWNM
after ASIC is disabled. To prevent system overheating, added set PWM
to maximum (255) when ASIC state changed to disabled.

Bug: #3586921

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
