### PR TITLE
hw-mgmt: scripts: Set pwm value to default on hw-management init

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -56,6 +56,7 @@ fan_drwr_num=0
 # 46 - F, 52 - R
 fan_direction_exhaust=46
 fan_direction_intake=52
+pwm_min_level=51
 
 FAN_MAP_DEF=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20)
 
@@ -323,6 +324,11 @@ if [ "$1" == "add" ]; then
 
 				if [ -f "$3""$4"/pwm1 ]; then
 					ln -sf  "$3""$4"/pwm1 "$tpath"/pwm1
+					pwm_level=$(< "$thermal_path/pwm1")
+					# If PWM level less then minimum then set it to default value
+					if [ $pwm_level -lt $pwm_min_level ]; then
+						echo $pwm_min_level > $thermal_path/pwm1
+					fi
 					echo "$name" > "$cpath"/cooling_name
 				fi
 				if [ -f "$cpath"/fan_inversed ]; then
@@ -394,6 +400,11 @@ if [ "$1" == "add" ]; then
 		name=$(< "$3""$4"/name)
 		echo "$name" > $config_path/cooling_name
 		check_n_link "$3""$4"/pwm1 $thermal_path/pwm1
+		pwm_level=$(< "$thermal_path/pwm1")
+		# If PWM level less then minimum then set it to default value
+		if [ $pwm_level -lt $pwm_min_level ]; then
+			echo $pwm_min_level > $thermal_path/pwm1
+		fi
 		for ((i=1; i<=max_pwm; i+=1)); do
 			check_n_link "$3""$4"/pwm"$i" $thermal_path/pwm"$i"
 		done

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2139,6 +2139,7 @@ class ThermalManagement(hw_managemet_file_op):
             while not self.is_pwm_exists():
                 self.log.notice("Wait...")
                 self.exit.wait(10)
+            self.log.notice("PWM control activated", 1)
 
         # Set PWM to the default state while we are waiting for system configuration
         self.log.notice("Set FAN PWM {}".format(self.pwm_target), 1)
@@ -2522,7 +2523,7 @@ class ThermalManagement(hw_managemet_file_op):
         """
         ret = True
         if self.sys_config[CONST.SYS_CONF_ASIC_PARAM]["1"]["pwm_control"] is True:
-            if not self.read_pwm():
+            if self.read_pwm() == None:
                 ret = False
         return ret
 


### PR DESCRIPTION
Set pwm value to default (20%) on hw-management init

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
