### PR TITLE
hw-mgmt: patches kernel 5.10: fix timing issue of add FAN EEPROMs on SN2201.

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -349,6 +349,7 @@ Kernel-5.10
 |0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch   |                    | Downstream                               |            | disable upstream patch, must exist from 5.10.74|
 |0265-hwmon-mlxreg-fan-Return-zero-speed-for-broken-fan.patch     |                    | Bugfix upstream                          | 5.10.173   |                                                |
 |0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch  |                    | Feature pending                          |            | SN3750SX                                       |
+|0285-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch  |                    | Bugfix pending                           |            | SN2201                                         |
 |9000-DS-OPT-iio-pressure-icp20100-add-driver-for-InvenSense-.patch|                   | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-DS-OPT-e1000e-skip-NVM-checksum.patch                       |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream                               |            |                                                |

--- a/recipes-kernel/linux/linux-5.10/0285-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
+++ b/recipes-kernel/linux/linux-5.10/0285-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
@@ -1,0 +1,66 @@
+From d5c83dcdf0f59656513c0af647f3b0889a9a0110 Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Wed, 12 Jul 2023 14:26:38 +0000
+Subject: [PATCH v1 1/1] platform: mellanox: nvsw-sn2201: change fans i2c
+ busses.
+
+Define the exact i2c bus (adapter number) of fans on the SN2201 system.
+This will cause fan's EEPROMs be connected already from nvsw-sn2201
+platform driver and not from user space after receiving udev events.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/nvsw-sn2201.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
+index 51da240ce..65b677690 100644
+--- a/drivers/platform/mellanox/nvsw-sn2201.c
++++ b/drivers/platform/mellanox/nvsw-sn2201.c
+@@ -84,6 +84,10 @@
+ #define NVSW_SN2201_MAIN_MUX_CH5_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 5)
+ #define NVSW_SN2201_MAIN_MUX_CH6_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 6)
+ #define NVSW_SN2201_MAIN_MUX_CH7_NR	(NVSW_SN2201_MAIN_MUX_CH0_NR + 7)
++#define NVSW_SN2201_2ND_MUX_CH0_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 1)
++#define NVSW_SN2201_2ND_MUX_CH1_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 2)
++#define NVSW_SN2201_2ND_MUX_CH2_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 3)
++#define NVSW_SN2201_2ND_MUX_CH3_NR	(NVSW_SN2201_MAIN_MUX_CH7_NR + 4)
+ 
+ #define NVSW_SN2201_CPLD_NR		NVSW_SN2201_MAIN_MUX_CH0_NR
+ #define NVSW_SN2201_NR_NONE		-1
+@@ -425,28 +429,28 @@ static struct mlxreg_core_data nvsw_sn2201_fan_items_data[] = {
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(0),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[0],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH0_NR,
+ 	},
+ 	{
+ 		.label = "fan2",
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(1),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[1],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH1_NR,
+ 	},
+ 	{
+ 		.label = "fan3",
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(2),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[2],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH2_NR,
+ 	},
+ 	{
+ 		.label = "fan4",
+ 		.reg = NVSW_SN2201_FAN_PRSNT_STATUS_OFFSET,
+ 		.mask = BIT(3),
+ 		.hpdev.brdinfo = &nvsw_sn2201_fan_devices[3],
+-		.hpdev.nr = NVSW_SN2201_NR_NONE,
++		.hpdev.nr = NVSW_SN2201_2ND_MUX_CH3_NR,
+ 	},
+ };
+ 
+-- 
+2.14.1
+


### PR DESCRIPTION
Define the exact i2c bus (adapter number) of fans on the SN2201 system.
This will cause fan's EEPROMs be connected already from nvsw-sn2201
platform driver and not from user space after receiving udev events.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
