### PR TITLE
hw-mgmt: topology: Add helper function to detect ASIC hwmon existence

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -311,6 +311,7 @@ disconnect_device()
 # - $2 - retry timeout delay window.
 # - $3 - retry counter.
 # - $4 - user log to be produced if user function failed (optional).
+# - $5 - user parameter to execute.
 # Output:
 # - return code (0 - success; 1 - failure).
 # Example:
@@ -321,9 +322,10 @@ function retry_helper()
 	local retry_to="$2"
 	local retry_cnt="$3"
 	local user_log="$4"
+	local user_param="$5"
 
 	for ((i=0; i<${retry_cnt}; i+=1)); do
-		$user_func
+		$user_func $user_param
 		if [ $? -eq 0 ]; then
 			return 0
 		fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2606,6 +2606,15 @@ do_stop()
 	fi
 }
 
+function find_asic_hwmon_path()
+{
+	local path=$1
+	if [ ! -d "$path" ]; then
+		return 1
+	fi
+	return 0
+}
+
 do_chip_up_down()
 {
 	action=$1
@@ -2708,8 +2717,8 @@ do_chip_up_down()
 			set_i2c_bus_frequency_400KHz
 			echo mlxsw_minimal $i2c_asic_addr > /sys/bus/i2c/devices/i2c-"$bus"/new_device
 			restore_i2c_bus_frequency_default
-
-			if [ ! -d /sys/bus/i2c/devices/"$bus"-"$i2c_asic_addr_name"/hwmon ]; then
+			retry_helper find_asic_hwmon_path 0.2 3 "chip hwmon object" /sys/bus/i2c/devices/"$bus"-"$i2c_asic_addr_name"/hwmon
+			if [ $? -ne 0 ]; then
 				# chipup command failed.
 				unlock_service_state_change
 				return 1


### PR DESCRIPTION
Add helper function for ASIC hwmon detection.
On some systems, like SN2201 this process can take more time due to slower CPU.
So, make sure that hwmon obecect is exist in chipup flow.