### PR TITLE
Tracing support for udev events

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,8 @@ override_dh_auto_install:
 	cp usr/etc/modules-load.d/* debian/$(pname)/etc/modules-load.d
 	dh_installdirs -p$(pname) usr/bin
 	cp usr/usr/bin/* debian/$(pname)/usr/bin
+	dh_installdirs -p$(pname) etc/logrotate.d
+	cp usr/etc/logrotate.d/* debian/$(pname)/etc/logrotate.d
 ifeq ($(DEB_HOST_ARCH),arm64)
 	rm -f debian/$(pname)/usr/bin/iorw
 	dh_installdirs -p$(pname) lib/systemd/system-shutdown

--- a/usr/etc/logrotate.d/udev
+++ b/usr/etc/logrotate.d/udev
@@ -1,0 +1,12 @@
+"/var/log/udev_events.log" {
+    size 1M
+    rotate 3
+    olddir /var/log/
+    copytruncate
+    compress
+    delaycompress
+    dateext
+    dateformat -%Y%m%d%H%M%S
+    missingok
+    notifempty
+}

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -741,6 +741,8 @@ check_reset_attrs()
 	fi
 }
 
+trace_udev_events "$0: ACTION=$1 $2 $3 $4 $5"
+
 if [ "$1" == "add" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -85,6 +85,7 @@ fi
 
 [ -f /var/log/tc_log ] && cp /var/log/tc_* $DUMP_FOLDER/
 [ -f /var/log/chipup_i2c_trace_log ] && cp /var/log/chipup_i2c_trace_* $DUMP_FOLDER/
+[ -f /var/log/udev_events.log ] && cp -a /var/log/udev* $DUMP_FOLDER/
 uname -a > $DUMP_FOLDER/sys_version
 mkdir $DUMP_FOLDER/bin/
 cp /usr/bin/hw?management* $DUMP_FOLDER/bin/

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -56,6 +56,7 @@ i2c_comex_mon_bus_default_file=$config_path/i2c_comex_mon_bus_default
 l1_switch_health_events=("intrusion" "pwm_pg" "thermal1_pdb" "thermal2_pdb")
 ui_tree_sku=`cat $sku_file`
 ui_tree_archive="/etc/hw-management-sensors/ui_tree_$ui_tree_sku.tar.gz"
+udev_event_log="/var/log/udev_events.log"
 
 # Thermal type constants
 thermal_type_t1=1
@@ -108,6 +109,12 @@ log_err()
 log_info()
 {
     logger -t hw-management -p daemon.info "$@"
+}
+
+trace_udev_events()
+{
+	echo "[$(date '+%Y-%m-%d %H:%M:%S.%3N')] $@" >> $udev_event_log
+	return 0
 }
 
 check_cpu_type()

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -252,6 +252,8 @@ get_psu_fan_direction()
 	fi
 }
 
+trace_udev_events "$0: ACTION=$1 $2 $3 $4 $5"
+
 if [ "$1" == "add" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then


### PR DESCRIPTION
This patch set enables udev event tracing. The logs are captured in /var/log/udev_events.log. It also adds the log rotation support using logrotate command.