### PR TITLE
hw-mgmt: fan: Fix tacho order for whe systems with inversed FAN order

### DIFF
--- a/usr/etc/hw-management-sensors/msn2010_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2010_sensors.conf
@@ -25,6 +25,10 @@ chip "tps53679-*"
     label iout2 "TPS iout2"
 
 chip "mlxsw-*"
+    label fan3 "fan1"
+    label fan4 "fan2"
+    label fan1 "fan3"
+    label fan2 "fan4"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/etc/hw-management-sensors/msn2100_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2100_sensors.conf
@@ -27,6 +27,10 @@ chip "lm75-i2c-17-49"
     label temp1 "Ambient Board Temp"
 
 chip "mlxsw-*"
+    label fan3 "fan1"
+    label fan4 "fan2"
+    label fan1 "fan3"
+    label fan2 "fan4"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/etc/hw-management-sensors/msn2410_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2410_sensors.conf
@@ -27,6 +27,14 @@ chip "lm75-i2c-17-49"
     label temp1 "Ambient Board Temp"
 
 chip "mlxsw-*"
+    label fan7 "fan1"
+    label fan8 "fan2"
+    label fan5 "fan3"
+    label fan6 "fan4"
+    label fan3 "fan5"
+    label fan4 "fan6"
+    label fan1 "fan7"
+    label fan2 "fan8"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/etc/hw-management-sensors/msn2700_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2700_sensors.conf
@@ -27,6 +27,18 @@ chip "lm75-i2c-17-49"
     label temp1 "Ambient Board Temp"
 
 chip "mlxsw-*"
+
+
+
+chip "mlxsw-*"
+    label fan7 "fan1"
+    label fan8 "fan2"
+    label fan5 "fan3"
+    label fan6 "fan4"
+    label fan3 "fan5"
+    label fan4 "fan6"
+    label fan1 "fan7"
+    label fan2 "fan8"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/etc/hw-management-sensors/msn2740_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2740_sensors.conf
@@ -28,6 +28,10 @@ chip "lm75-i2c-17-49"
     label temp1 "Ambient Board Temp"
 
 chip "mlxsw-*"
+    label fan3 "fan1"
+    label fan4 "fan2"
+    label fan1 "fan3"
+    label fan2 "fan4"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -975,7 +975,7 @@ msn274x_specific()
 	echo 1500 > $config_path/fan_min_speed
 	echo 18000 > $config_path/psu_fan_max
 	echo 2000 > $config_path/psu_fan_min
-	echo "4 3 2 1" > $config_path/fan_inversed
+	echo "3 4 1 2" > $config_path/fan_inversed
 	echo 2 > $config_path/cpld_num
 	echo 24c02 > $config_path/psu_eeprom_type
 	lm_sensors_config="$lm_sensors_configs_path/msn2740_sensors.conf"
@@ -995,7 +995,7 @@ msn21xx_specific()
 	echo 1500 > $config_path/fan_min_speed
 	echo 13000 > $config_path/psu_fan_max
 	echo 1040 > $config_path/psu_fan_min
-	echo "4 3 2 1" > $config_path/fan_inversed
+	echo "3 4 1 2" > $config_path/fan_inversed
 	echo 2 > $config_path/cpld_num
 	lm_sensors_config="$lm_sensors_configs_path/msn2100_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2100.json"
@@ -1121,7 +1121,7 @@ msn201x_specific()
 	echo 4500 > $config_path/fan_min_speed
 	echo 13000 > $config_path/psu_fan_max
 	echo 1040 > $config_path/psu_fan_min
-	echo "4 3 2 1" > $config_path/fan_inversed
+	echo "3 4 1 2" > $config_path/fan_inversed
 	echo 2 > $config_path/cpld_num
 	lm_sensors_config="$lm_sensors_configs_path/msn2010_sensors.conf"
 	thermal_control_config="$thermal_control_configs_path/tc_config_msn2010.json"


### PR DESCRIPTION
Fix tacho order for whe systems with inversed FAN order
bug: 3560591

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
