### PR TITLE
hw-mgmt: Add ARM version of kernel loadable module config file

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,13 +15,14 @@ override_dh_auto_install:
 	dh_installdirs -p$(pname) etc/modprobe.d
 	cp usr/etc/modprobe.d/* debian/$(pname)/etc/modprobe.d
 	dh_installdirs -p$(pname) etc/modules-load.d
-	cp usr/etc/modules-load.d/* debian/$(pname)/etc/modules-load.d
+	cp usr/etc/modules-load.d/05-hw-management-modules.conf debian/$(pname)/etc/modules-load.d
 	dh_installdirs -p$(pname) usr/bin
 	cp usr/usr/bin/* debian/$(pname)/usr/bin
 	dh_installdirs -p$(pname) etc/logrotate.d
 	cp usr/etc/logrotate.d/* debian/$(pname)/etc/logrotate.d
 ifeq ($(DEB_HOST_ARCH),arm64)
 	mv debian/$(pname)/usr/bin/iorw.sh debian/$(pname)/usr/bin/iorw
+	cp usr/etc/modules-load.d/05-hw-management-modules-arm64.conf debian/$(pname)/etc/modules-load.d/05-hw-management-modules.conf
 	dh_installdirs -p$(pname) lib/systemd/system-shutdown
 	cp usr/usr/bin/hw-management-kexec-notifier.sh debian/$(pname)/lib/systemd/system-shutdown
 endif

--- a/usr/etc/modules-load.d/05-hw-management-modules-arm64.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules-arm64.conf
@@ -1,0 +1,22 @@
+##################################################################################
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+i2c-dev
+pmbus
+tps53679
+max1363
+lm75
+tmp102
+ledtrig-timer
+at24
+xdpe12284
+mp2975
+mp2888
+i2c-mux-pca954x
+emc2305
+ti-ads1015
+powr1220
+gpio-pca953x
+pmbus
+i2c-mux-mlxcpld
+lm25066


### PR DESCRIPTION
Some kernel loadable modules for X86 platforms are not available on ARM platforms, this causes errors during module loading time. Create ARM specific version of kernel module configuration file to avoid errors.

Fixes: #3632299