### PR TITLE
hw-mgmt: thermal: Add replacement for kernel tz attributes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.2000) unstable; urgency=low
+hw-management (1.mlnx.7.0030.3031) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Thu, 28 Sept 2023 15:44:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Thu, 16 Oct 2023 13:44:00 +0300

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -319,6 +319,7 @@ if [ "$1" == "add" ]; then
 			if [ "$name" == "mlxsw" ]; then
 				ln -sf "$3$4" $cpath/asic_hwmon
 				ln -sf "$3""$4"/temp1_input "$tpath"/asic
+				echo 120000 > $tpath/asic_temp_trip_crit
 				echo 105000 > $tpath/asic_temp_emergency
 				echo 85000 > $tpath/asic_temp_crit
 				echo 75000 > $tpath/asic_temp_norm
@@ -386,6 +387,10 @@ if [ "$1" == "add" ]; then
 								change_file_counter "$config_path"/gearbox_counter 1
 							fi
 							check_n_link "$3""$4"/temp"$i"_input "$tpath"/gearbox"$gearbox_counter"_temp_input
+							echo 120000 > $tpath/gearbox"$gearbox_counter"_temp_trip_crit
+							echo 105000 > $tpath/gearbox"$gearbox_counter"_temp_emergency
+							echo 85000 > $tpath/gearbox"$gearbox_counter"_temp_crit
+							echo 75000 > $tpath/gearbox"$gearbox_counter"_temp_norm
 							unlock_service_state_change
 							;;
 						*)


### PR DESCRIPTION
Add replacement for kernel tz attributes:

./mlxsw/temp_trip_crit=> ./asic_temp_trip_crit

./mlxsw-module{X}/temp_trip_crit=> ./module{X}_temp_trip_crit

./mlxsw-gearbox{X}/temp_trip_norm => ./gearbox{X}_temp_norm
./mlxsw-gearbox{X}/temp_trip_high => ./gearbox{X}_temp_crit
./mlxsw-gearbox{X}/temp_trip_hot =>  ./gearbox{X}_temp_emergency
./mlxsw-gearbox{X}/temp_trip_crit=> ./gearbox{X}_temp_trip_crit

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
