### PR TITLE
hw-mgmt: patches: Fix error message produced by BF3 GPIO driver

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -490,6 +490,7 @@ Kernel-5.10
 |0326-platform-mellanox-mlxreg-hotplug-Add-support-for-new.patch  |                    | Downstream                               |            |                                                |
 |0327-platform-mellanox-mlx-platform-Change-register-name.patch   |                    | Downstream                               |            |                                                |
 |0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch  |                    | Downstream                               |            |                                                |
+|0329-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream                               |            | BF3-COME                                       |
 |9000-DS-OPT-iio-pressure-icp20100-add-driver-for-InvenSense-.patch|                   | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-DS-OPT-e1000e-skip-NVM-checksum.patch                       |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream                               |            |                                                |
@@ -579,6 +580,7 @@ Kernel-6.1
 |0083-UBUNTU-SAUCE-mlxbf-ptm-update-module-version.patch          |                    | Downstream                               |            | BF3                                            |
 |0084-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Downstream                               |            | BF3                                            |
 |0085-hwmon-mlxreg-fan-Separate-methods-of-fan-setting-com.patch  |                    | Bugfix pending                           |            |                                                |
+|0086-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream                               |            | BF3                                            |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream                               |            | Disable FW update                              |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |
 |8004-mlxsw-minimal-Downstream-Ignore-error-reading-SPAD-r.patch  |                    | Downstream                               |            | IB only                                        |

--- a/recipes-kernel/linux/linux-5.10/0329-gpio-mlxbf3-Fix-error-message.patch
+++ b/recipes-kernel/linux/linux-5.10/0329-gpio-mlxbf3-Fix-error-message.patch
@@ -1,0 +1,37 @@
+From 3ce9346f449fb7cb5a47fb84dd27bb27b409cec4 Mon Sep 17 00:00:00 2001
+From: Felix Radensky <fradensky@nvidia.com>
+Date: Mon, 16 Oct 2023 16:51:48 +0000
+Subject: [PATCH] gpio: mlxbf3: Fix error message
+X-NVConfidentiality: public
+
+Fix the following error message produced by gpio-mlxbf3 driver:
+
+mlxbf3_gpio MLNXBF33:01: IRQ index 0 not found
+
+Bluefield-3 SOC has 2 GPIO controllers, but only one of them
+is configured in ACPI table to support GPIO interrupts. By using
+platform_get_irq_optional() the error message regarding missing
+IRQ support is avoided.
+
+Signed-off-by: Felix Radensky <fradensky@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/gpio/gpio-mlxbf3.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpio/gpio-mlxbf3.c b/drivers/gpio/gpio-mlxbf3.c
+index 51dce3ae1..75ec26a68 100644
+--- a/drivers/gpio/gpio-mlxbf3.c
++++ b/drivers/gpio/gpio-mlxbf3.c
+@@ -220,7 +220,7 @@ static int mlxbf3_gpio_probe(struct platform_device *pdev)
+ 	gc->owner = THIS_MODULE;
+ 	gc->init_valid_mask = mlxbf3_gpio_init_valid_mask;
+ 
+-	irq = platform_get_irq(pdev, 0);
++	irq = platform_get_irq_optional(pdev, 0);
+ 	if (irq >= 0) {
+ 		girq = &gs->gc.irq;
+ 		girq->chip = &gpio_mlxbf3_irqchip;
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-6.1/0086-gpio-mlxbf3-Fix-error-message.patch
+++ b/recipes-kernel/linux/linux-6.1/0086-gpio-mlxbf3-Fix-error-message.patch
@@ -1,0 +1,37 @@
+From d0a9112753248b67e8ad8c09e554866f1a74119c Mon Sep 17 00:00:00 2001
+From: Felix Radensky <fradensky@nvidia.com>
+Date: Mon, 16 Oct 2023 17:21:03 +0000
+Subject: [PATCH] gpio: mlxbf3: Fix error message
+X-NVConfidentiality: public
+
+Fix the following error message produced by gpio-mlxbf3 driver:
+
+mlxbf3_gpio MLNXBF33:01: IRQ index 0 not found
+
+Bluefield-3 SOC has 2 GPIO controllers, but only one of them
+is configured in ACPI table to support GPIO interrupts. By using
+platform_get_irq_optional() the error message regarding missing
+IRQ support is avoided.
+
+Signed-off-by: Felix Radensky <fradensky@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/gpio/gpio-mlxbf3.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpio/gpio-mlxbf3.c b/drivers/gpio/gpio-mlxbf3.c
+index e30cee1..f40bab9 100644
+--- a/drivers/gpio/gpio-mlxbf3.c
++++ b/drivers/gpio/gpio-mlxbf3.c
+@@ -198,7 +198,7 @@ static int mlxbf3_gpio_probe(struct platform_device *pdev)
+ 	gc->free = gpiochip_generic_free;
+ 	gc->owner = THIS_MODULE;
+ 
+-	irq = platform_get_irq(pdev, 0);
++	irq = platform_get_irq_optional(pdev, 0);
+ 	if (irq >= 0) {
+ 		girq = &gs->gc.irq;
+ 		gpio_irq_chip_set_chip(girq, &gpio_mlxbf3_irqchip);
+-- 
+2.14.1
+


### PR DESCRIPTION
Add 5.10 and 6.1 kernel patches to fix the following error message produced by BF3 GPIO driver:

mlxbf3_gpio MLNXBF33:01: IRQ index 0 not found

Fixes: #3632297


Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>