### PR TITLE
Fix PSU attribute values for virtual platforms

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -57,6 +57,8 @@ l1_switch_health_events=("intrusion" "pwm_pg" "thermal1_pdb" "thermal2_pdb")
 ui_tree_sku=`cat $sku_file`
 ui_tree_archive="/etc/hw-management-sensors/ui_tree_$ui_tree_sku.tar.gz"
 udev_event_log="/var/log/udev_events.log"
+vm_sku=`cat $sku_file`
+vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
 
 # Thermal type constants
 thermal_type_t1=1
@@ -366,4 +368,13 @@ psu_set_fan_speed()
 
 	# Set fan speed
 	i2cset -f -y "$bus" "$addr" "$fan_command" "${speed}" wp
+}
+
+is_virtual_machine()
+{
+    if [ -n "$(lspci -vvv | grep SimX)" ]; then
+        return 0
+    else
+        return 1
+    fi
 }

--- a/usr/usr/bin/hw-management-ps-vpd.sh
+++ b/usr/usr/bin/hw-management-ps-vpd.sh
@@ -34,10 +34,6 @@
 
 #set -x
 
-sku_file=/sys/devices/virtual/dmi/id/product_sku
-vm_sku=`cat $sku_file`
-vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
-
 VERSION="1.1"
 VPD_POINTER_ADDR=0xe8
 VPD_POINTER_LEN=16
@@ -391,15 +387,6 @@ function read_pmbus_ps_vpd ( )
 	done
 }
 
-is_virtual_machine()
-{
-    if [ -n "$(lspci -vvv | grep SimX)" ]; then
-        return 0
-    else
-        return 1
-    fi
-}
-
 while [ $# -gt 0 ]; do
 	if [[ $1 == *"--"* ]]; then
 		param="${1/--/}"
@@ -459,17 +446,13 @@ Author: Mykola Kostenok <c_mykolak@mellanox.com>'
 		exit 0
 		;;
 	dump)
-		if is_virtual_machine; then
-			cat $vm_vpd_path/psu_vpd > "$VPD_OUTPUT_FILE"
-		else
-			read_pmbus_ps_vpd
-			echo CALC_CRC: "${crc16_arr[*]}" >> "$VPD_OUTPUT_FILE"
-			if [ "${crc16_str}" != "${read_crc16_str}" ];
-			then
-				exit 1
-			fi
-			exit 0
+		read_pmbus_ps_vpd
+		echo CALC_CRC: "${crc16_arr[*]}" >> "$VPD_OUTPUT_FILE"
+		if [ "${crc16_str}" != "${read_crc16_str}" ];
+		then
+			exit 1
 		fi
+		exit 0
 		;;
 	*)
 		echo "No command specified, use hw-management-ps-vpd.sh --help to print usage example."

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -863,6 +863,14 @@ if [ "$1" == "add" ]; then
 			hw-management-parse-eeprom.sh --conv --eeprom_path $eeprom_path/"$psu_name"_info > $eeprom_path/"$psu_name"_vpd
 			if [ $? -ne 0 ]; then
 				# EEPROM failed.
+				if is_virtual_machine; then
+					if [ -f $vm_vpd_path/psu_vpd ]; then
+						cat $vm_vpd_path/psu_vpd > $eeprom_path/"$psu_name"_vpd
+					else
+						echo "Failed to read PSU VPD" > $eeprom_path/"$psu_name"_vpd
+					fi
+					exit 0
+				fi
 				echo "Failed to read PSU VPD" > $eeprom_path/"$psu_name"_vpd
 				exit 0
 			else


### PR DESCRIPTION
While the platforms are running in virtual environment, there is some timing issue with loading the i2c traces for PSU and hence the initial reads of PSU attributes are wrong. This is a workaround to fix the issue by not changing the workflow for PSU initialization when creating PSU vpd.