### PR TITLE
hw-mgmt: thermal: Add missing replacement for tz attributes

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -372,7 +372,10 @@ if [ "$1" == "add" ]; then
 							check_n_link "$3""$4"/temp"$i"_fault "$tpath"/module"$j"_temp_fault
 							check_n_link "$3""$4"/temp"$i"_crit "$tpath"/module"$j"_temp_crit
 							check_n_link "$3""$4"/temp"$i"_emergency "$tpath"/module"$j"_temp_emergency
-							lock_service_state_change
+							if [ -f "$tpath"/module"$j"_temp_input ]; then
+								echo 120000 > $tpath/module"$j"_temp_trip_crit
+							fi
+							lock_service_sxtate_change
 							change_file_counter "$cpath"/module_counter 1
 							if [ "$lcmatch" == "linecard" ]; then
 								change_file_counter "$config_path"/module_counter 1
@@ -387,10 +390,12 @@ if [ "$1" == "add" ]; then
 								change_file_counter "$config_path"/gearbox_counter 1
 							fi
 							check_n_link "$3""$4"/temp"$i"_input "$tpath"/gearbox"$gearbox_counter"_temp_input
-							echo 120000 > $tpath/gearbox"$gearbox_counter"_temp_trip_crit
-							echo 105000 > $tpath/gearbox"$gearbox_counter"_temp_emergency
-							echo 85000 > $tpath/gearbox"$gearbox_counter"_temp_crit
-							echo 75000 > $tpath/gearbox"$gearbox_counter"_temp_norm
+							if [ -f "$tpath"/gearbox"$gearbox_counter"_temp_input ]; then
+								echo 120000 > $tpath/gearbox"$gearbox_counter"_temp_trip_crit
+								echo 105000 > $tpath/gearbox"$gearbox_counter"_temp_emergency
+								echo 85000 > $tpath/gearbox"$gearbox_counter"_temp_crit
+								echo 75000 > $tpath/gearbox"$gearbox_counter"_temp_norm
+							fi
 							unlock_service_state_change
 							;;
 						*)


### PR DESCRIPTION
Add missing replacement for tz attributes

mlxsw/temp_trip_crit
mlxsw-gearbox{}/temp_trip_hot
mlxsw-gearbox{}/temp_trip_crit

Bug: 634579
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
