### PR TITLE
Add mlxbf-ptm driver load. This driver implements debugfs interface for sodimm, cpu_core temperature reading on Bluefield systems

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2243,6 +2243,12 @@ load_modules()
 			modprobe drivetemp
 		fi
 	fi
+
+	if ! lsmod | grep -q "mlxbf-ptm"; then
+		if [ -f /lib/modules/`uname -r`/kernel/drivers/platform/mellanox/mlxbf-ptm.ko ]; then
+			modprobe mlxbf-ptm
+		fi
+	fi
 }
 
 set_config_data()


### PR DESCRIPTION
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
