### PR TITLE
Fix the log level of thermal control NOTICE messages

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -478,6 +478,7 @@ class Logger(object):
         self.logger = None
         logging.basicConfig(level=logging.DEBUG)
         logging.addLevelName(logging.INFO + 5, "NOTICE")
+        SysLogHandler.priority_map["NOTICE"] = "notice"
         self.logger = logging.getLogger("main")
         self.logger.setLevel(logging.DEBUG)
         self.logger.propagate = False


### PR DESCRIPTION
When adding a new log level, SysLogHandler needs to know to which syslog level it is mapped, otherwise messages printed with the new log level will always be printed as WARNING.
Reference: https://docs.python.org/3/library/logging.handlers.html#logging.handlers.SysLogHandler.mapPriority

This fixes the log level inconsistency for NOTICE messages, such as:
    WARNING hw-management-tc: NOTICE - ********************************
    WARNING hw-management-tc: NOTICE - Init thermal control ver: v.2.0.1
    WARNING hw-management-tc: NOTICE - ********************************
    WARNING hw-management-tc: NOTICE - Thermal control state changed
    UNCONFIGURED -> RUNNING reason:init
    WARNING hw-management-tc: NOTICE - ********************************
    WARNING hw-management-tc: NOTICE - Thermal control is running
    WARNING hw-management-tc: NOTICE - ********************************