### PR TITLE
hw-mgmt: scripts: Move loading of BF3 PTM driver into config file

### DIFF
--- a/usr/etc/modules-load.d/05-hw-management-modules-arm64.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules-arm64.conf
@@ -20,3 +20,4 @@ gpio-pca953x
 pmbus
 i2c-mux-mlxcpld
 lm25066
+mlxbf-ptm

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2210,12 +2210,6 @@ load_modules()
 			modprobe drivetemp
 		fi
 	fi
-
-	if ! lsmod | grep -q "mlxbf-ptm"; then
-		if [ -f /lib/modules/`uname -r`/kernel/drivers/platform/mellanox/mlxbf-ptm.ko ]; then
-			modprobe mlxbf-ptm
-		fi
-	fi
 }
 
 set_config_data()


### PR DESCRIPTION
Move loading of BF3 specific PTM driver into ARM specific module loading configuration file.