### PR TITLE
hw-mgmt: thermal: Fixed TC FAN DRWR number for MSN3700C system

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn3700C.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3700C.json
@@ -46,5 +46,5 @@
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
 }


### PR DESCRIPTION
Fixed FAN drwr count for msn3700C system. Was defined: 6, should be: 4

Bug: 3649678

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
