### PR TITLE
hw-mgmt: thermal: Fix TC voltmon2 missing issue on MSN3750 system

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn3750.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3750.json
@@ -46,5 +46,5 @@
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon3"]
 }


### PR DESCRIPTION
Fix voltmon2 missing issue on msn3750 system. This system have voltmon1
and voltmon3 sensors (voltmon2 renamed to voltmon 3)

Bug: 3647742

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
