### PR TITLE
hw-mgmt: patches: Add  patches for v6.1

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -586,6 +586,8 @@ Kernel-6.1
 |8004-mlxsw-minimal-Downstream-Ignore-error-reading-SPAD-r.patch  |                    | Downstream                               |            | IB only                                        |
 |8005-leds-leds-mlxreg-Downstream-Send-udev-event-from-led.patch  |                    | Downstream accepted                      |            | SN2201                                         |
 |8006-i2c-mlxcpld-Downstream-WA-to-avoid-error-for-SMBUS-r.patch  |                    | Downstream accepted                      |            | HW bug WA: MUST for all systems until HW fix   |
+|8007-hwmon-mlxreg-fan-Downstream-Allow-fan-speed-setting-.patch  |                    | Downstream accepted                      |            | Fix for mlreg-fan cooling level granularity    |
+|8008-hwmon-emc2305-Downstream-Allow-fan-speed-setting-gra.patch  |                    | Downstream accepted                      |            | Fix for emc2305 cooling level granularity    |
 |9000-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-regmap-debugfs-FT-Enable-writing-to-the-regmap-debug.patch  |                    | Downstream;skip[ALL];take[opt]           |            | BF3 (FT purpose)                               |

--- a/recipes-kernel/linux/linux-6.1/8007-hwmon-mlxreg-fan-Downstream-Allow-fan-speed-setting-.patch
+++ b/recipes-kernel/linux/linux-6.1/8007-hwmon-mlxreg-fan-Downstream-Allow-fan-speed-setting-.patch
@@ -1,0 +1,57 @@
+From f897ae50422b9fbff200051419ebb3f5fa280bd8 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 2 Nov 2023 11:42:47 +0000
+Subject: [PATCH v6.1.42 downstream 1/2] hwmon: (mlxreg-fan): Downstream: Allow
+ fan speed setting granularity of 1 PWM
+
+Currently PWM setting is allowed with 10 percent stepping.
+Such configuration is aligned with thermal drivers, which are used to be
+bound to "mlxreg-fan" driver.
+
+This binding happens when the cooling instances created by the driver are
+bound to some kernel thermal driver.
+
+In case system is not using kernel thermal control and the cooling
+instances created by the driver are not bound to any thermal driver, the
+driver still does not allow setting of PWM granularity less than 10
+percent.
+
+Allow setting fan with one percent granularity, thus any user space
+thermal application will be able to set PWM to any allowed value in range
+from 51 PWM to 255 PWM.
+
+Note: this is downstream patch, since it can affect functionality for
+the Nvidia users running kernel thermal control. So, it is not going to be
+submitted to up-stream.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/hwmon/mlxreg-fan.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index b48bd7c961d6..ca9b1b27e5d2 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -15,10 +15,15 @@
+ #define MLXREG_FAN_MAX_TACHO		24
+ #define MLXREG_FAN_MAX_PWM		4
+ #define MLXREG_FAN_PWM_NOT_CONNECTED	0xff
+-#define MLXREG_FAN_MAX_STATE		10
++#ifdef CONFIG_MLXSW_CORE_THERMAL
++#define MLXREG_FAN_MAX_STATE            10
++#define MLXREG_FAN_SPEED_MIN_LEVEL      2       /* 20 percent */
++#else
++#define MLXREG_FAN_MAX_STATE            255
++#define MLXREG_FAN_SPEED_MIN_LEVEL      51       /* 20 percent */
++#endif
+ #define MLXREG_FAN_MIN_DUTY		51	/* 20% */
+ #define MLXREG_FAN_MAX_DUTY		255	/* 100% */
+-#define MLXREG_FAN_SPEED_MIN_LEVEL		2	/* 20 percent */
+ #define MLXREG_FAN_TACHO_SAMPLES_PER_PULSE_DEF	44
+ #define MLXREG_FAN_TACHO_DIV_MIN		283
+ #define MLXREG_FAN_TACHO_DIV_DEF		(MLXREG_FAN_TACHO_DIV_MIN * 4)
+-- 
+-- 
+2.20.1
+

--- a/recipes-kernel/linux/linux-6.1/8008-hwmon-emc2305-Downstream-Allow-fan-speed-setting-gra.patch
+++ b/recipes-kernel/linux/linux-6.1/8008-hwmon-emc2305-Downstream-Allow-fan-speed-setting-gra.patch
@@ -1,0 +1,51 @@
+From 93a52030e9545368c5dee5d38cb939d8efc796ce Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Thu, 2 Nov 2023 12:18:22 +0000
+Subject: [PATCH v6.1.42 downstream 2/2] hwmon: (emc2305): Downstream: Allow
+ fan speed setting granularity of 1 PWM
+
+Currently PWM setting is allowed with 10 percent stepping.
+Such configuration is aligned with thermal drivers, which are used to be
+bound to "emc2305" driver.
+
+This binding happens when the cooling instances created by the driver are
+bound to some kernel thermal driver.
+
+In case system is not using kernel thermal control and the cooling
+instances created by the driver are not bound to any thermal driver, the
+driver still does not allow setting of PWM granularity less than 10
+percent.
+
+Allow setting fan with one percent granularity, thus any user space
+thermal application will be able to set PWM to any allowed value in range
+from 0 PWM to 255 PWM.
+
+Note: this is downstream patch, since it can affect functionality for
+the Nvidia users running kernel thermal control. So, it is not going to be
+submitted to up-stream.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/hwmon/emc2305.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/hwmon/emc2305.c b/drivers/hwmon/emc2305.c
+index aa1f25add0b6..70be61d32089 100644
+--- a/drivers/hwmon/emc2305.c
++++ b/drivers/hwmon/emc2305.c
+@@ -19,7 +19,11 @@ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_EN
+ #define EMC2305_REG_VENDOR		0xfe
+ #define EMC2305_FAN_MAX			0xff
+ #define EMC2305_FAN_MIN			0x00
+-#define EMC2305_FAN_MAX_STATE		10
++#ifdef CONFIG_MLXSW_CORE_THERMAL
++#define EMC2305_FAN_MAX_STATE		10
++#else
++#define EMC2305_FAN_MAX_STATE		255
++#endif
+ #define EMC2305_DEVICE			0x34
+ #define EMC2305_VENDOR			0x5d
+ #define EMC2305_REG_PRODUCT_ID		0xfd
+-- 
+2.20.1
+


### PR DESCRIPTION
Add patches to allow fan speed setting granularity of 1 PWM for
mlxreg-fan and emc2305 drivers

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
