### PR TITLE
hw-mgmt: patches: Add patches for v6.1

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -587,7 +587,8 @@ Kernel-6.1
 |8005-leds-leds-mlxreg-Downstream-Send-udev-event-from-led.patch  |                    | Downstream accepted                      |            | SN2201                                         |
 |8006-i2c-mlxcpld-Downstream-WA-to-avoid-error-for-SMBUS-r.patch  |                    | Downstream accepted                      |            | HW bug WA: MUST for all systems until HW fix   |
 |8007-hwmon-mlxreg-fan-Downstream-Allow-fan-speed-setting-.patch  |                    | Downstream accepted                      |            | Fix for mlreg-fan cooling level granularity    |
-|8008-hwmon-emc2305-Downstream-Allow-fan-speed-setting-gra.patch  |                    | Downstream accepted                      |            | Fix for emc2305 cooling level granularity    |
+|8008-hwmon-emc2305-Downstream-Allow-fan-speed-setting-gra.patch  |                    | Downstream accepted                      |            | Fix for emc2305 cooling level granularity      |
+|8009-hwmon-mlxsw-Downstream-Allow-fan-speed-setting-granu.patch  |                    | Downstream accepted                      |            | Fix for mlxminimal cooling level granularity   |
 |9000-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-regmap-debugfs-FT-Enable-writing-to-the-regmap-debug.patch  |                    | Downstream;skip[ALL];take[opt]           |            | BF3 (FT purpose)                               |

--- a/recipes-kernel/linux/linux-6.1/8009-hwmon-mlxsw-Downstream-Allow-fan-speed-setting-granu.patch
+++ b/recipes-kernel/linux/linux-6.1/8009-hwmon-mlxsw-Downstream-Allow-fan-speed-setting-granu.patch
@@ -1,0 +1,52 @@
+From 38c77b2f033deb8957aaf1017d0067717b8853cf Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 8 Nov 2023 14:52:38 +0200
+Subject: [PATCH] hwmon: (mlxsw): Downstream: Allow fan speed setting 
+ granularity of 1 PWM
+
+Currently PWM setting is allowed with 10 percent stepping.
+Such configuration is aligned with thermal drivers, which are used to be
+bound to "mlxsw" driver.
+
+This binding happens when the cooling instances created by the driver are
+bound to some kernel thermal driver.
+
+In case system is not using kernel thermal control and the cooling
+instances created by the driver are not bound to any thermal driver, the
+driver still does not allow setting of PWM granularity less than 10
+percent.
+
+Allow setting fan with one percent granularity, thus any user space
+thermal application will be able to set PWM to any allowed value in range
+from 51 PWM to 255 PWM.
+
+Note: this is downstream patch, since it can affect functionality for
+the Nvidia users running kernel thermal control. So, it is not going to be
+submitted to up-stream.
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index d062034..cbc9ac2 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -21,8 +21,13 @@
+ #define MLXSW_THERMAL_ASIC_TEMP_HOT	105000	/* 105C */
+ #define MLXSW_THERMAL_HYSTERESIS_TEMP	5000	/* 5C */
+ #define MLXSW_THERMAL_MODULE_TEMP_SHIFT	(MLXSW_THERMAL_HYSTERESIS_TEMP * 2)
++#ifdef CONFIG_MLXSW_CORE_THERMAL
+ #define MLXSW_THERMAL_MAX_STATE	10
+ #define MLXSW_THERMAL_MIN_STATE	2
++#else
++#define MLXSW_THERMAL_MAX_STATE	255
++#define MLXSW_THERMAL_MIN_STATE	51	/* 20 percent */
++#endif
+ #define MLXSW_THERMAL_MAX_DUTY	255
+ 
+ /* External cooling devices, allowed for binding to mlxsw thermal zones. */
+-- 
+2.8.4
+


### PR DESCRIPTION
Add patches to allow fan speed setting granularity of 1 PWM for
mlxminimal driver

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
