### PR TITLE
hw-mgmt: scripts: fix fan direction setting on Panther-comex system.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.2006) unstable; urgency=low
+hw-management (1.mlnx.7.0030.2007) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Fri, 3 Nov 2023 15:44:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Wed, 8 Nov 2023 15:44:00 +0300

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -420,6 +420,9 @@ function set_fan_direction()
 		if [ ! -f $system_path/fan_dir ]; then
 			return
 		fi
+		if [[ "$sku" == "HI117" ]]; then
+			return
+		fi
 		fan_dir=$(< $system_path/fan_dir)
 		fandirhex=$(printf "%x\n" "$fan_dir")
 		fan_bit_index=$(( ${attribute:3} - 1 ))
@@ -1101,7 +1104,7 @@ if [ "$1" == "add" ]; then
 				fan_dir_offset=$fan_dir_offset_in_vpd_eeprom_pn
 			fi
 			# We need to read FAN direction from eeprom if cpld fan direction exists
-			if [ ! -f $system_path/fan_dir ]; then
+			if [[ ! -f $system_path/fan_dir ]] || [[ "$sku" == "HI117" ]]; then
 				fan_direction=$(xxd -u -p -l 1 -s $fan_dir_offset $eeprom_path/$eeprom_name)
 				fan_prefix=$(echo $eeprom_name | cut -d_ -f1)
 				case $fan_direction in


### PR DESCRIPTION
This is fix for bug# 3660884

Panther-comex is combined system, it has new CPLD fan control but fan direction
is still should be checked in old way from fan EEPROM.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
