### PR TITLE
hw-mgmt: patches 5.10: indicate deferred I2C bus creation for a hot-plug driver on SN2201

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -490,6 +490,7 @@ Kernel-5.10
 |0326-platform-mellanox-mlxreg-hotplug-Add-support-for-new.patch  |                    | Downstream                               |            |                                                |
 |0327-platform-mellanox-mlx-platform-Change-register-name.patch   |                    | Downstream                               |            |                                                |
 |0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch  |                    | Downstream                               |            |                                                |
+|0329-platform-mellanox-indicate-deferred-I2C-bus-creation.patch  |                    | Bugfix pending                           |            | SN2201                                         |
 |9000-DS-OPT-iio-pressure-icp20100-add-driver-for-InvenSense-.patch|                   | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-DS-OPT-e1000e-skip-NVM-checksum.patch                       |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream                               |            |                                                |

--- a/recipes-kernel/linux/linux-5.10/0329-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
+++ b/recipes-kernel/linux/linux-5.10/0329-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
@@ -1,0 +1,31 @@
+From ab5040e2b99cc3eb57eaa266b90877bcc38c28ed Mon Sep 17 00:00:00 2001
+From: Michael Shych <michaelsh@nvidia.com>
+Date: Wed, 29 Nov 2023 13:12:38 +0000
+Subject: [PATCH v1 1/1] platform: mellanox: indicate deferred I2C bus creation
+ for a hot-plug driver
+
+It fixes timing issue when during initialization hot-plug driver
+attempts to attach a component to I2C bus, which is still not created.
+Setting deferred bus parameter will force hot-plug driver to wait
+until the bus is available.
+
+Signed-off-by: Michael Shych <michaelsh@nvidia.com>
+---
+ drivers/platform/mellanox/nvsw-sn2201.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
+index 65b677690..79e4d0619 100644
+--- a/drivers/platform/mellanox/nvsw-sn2201.c
++++ b/drivers/platform/mellanox/nvsw-sn2201.c
+@@ -520,6 +520,7 @@ struct mlxreg_core_hotplug_platform_data nvsw_sn2201_hotplug = {
+ 	.counter = ARRAY_SIZE(nvsw_sn2201_items),
+ 	.cell = NVSW_SN2201_SYS_INT_STATUS_OFFSET,
+ 	.mask = NVSW_SN2201_CPLD_AGGR_MASK_DEF,
++	.deferred_nr = NVSW_SN2201_2ND_MUX_CH3_NR,
+ };
+ 
+ /* SN2201 static devices. */
+-- 
+2.14.1
+


### PR DESCRIPTION
This is fix for bug# 3650418

It fixes timing issue when during initialization hot-plug driver
attempts to attach a component to I2C bus, which is still not created.
Setting deferred bus parameter will force hot-plug driver to wait
until the bus is available.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
