### PR TITLE
hw-mgmt: scripts: Add system_flow_capability attribute for XDR systems

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.2963) unstable; urgency=low
+hw-management (1.mlnx.7.0030.2965) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Sun, 10 Dec 2023 13:44:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Sun, 11 Dec 2023 15:09:00 +0300

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1948,6 +1948,8 @@ qm3xxx_specific()
 	echo 21800 > $config_path/fan_max_speed
 	# Set as 20% of max speed
 	echo 4360 > $config_path/fan_min_speed
+	# Only reverse fans are supported
+	echo C2P > $config_path/system_flow_capability
 	echo 27500 > $config_path/psu_fan_max
 	# Set as 20% of max speed
 	echo 5500 > $config_path/psu_fan_min


### PR DESCRIPTION
XDR systems support only reverse fan direction, system_flow_capability attribute is required by TC on systems with single flow direction.