### PR TITLE
hw-mgmt: scripts: Update SimX supported platforms

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -200,6 +200,30 @@ check_labels_enabled()
     fi
 }
 
+# This function checks if the platform is having BSP emulation support.
+check_if_simx_supported_platform()
+{
+	case $sku in
+		HI130|HI122|HI144|HI147|HI157|HI112|MSN2700-CS2FO|MSN2410-CB2F|MSN2100)
+			return 0
+			;;
+
+		*)
+			return 1
+			;;
+	esac
+}
+
+# It also checks if the environment is SimX.
+check_simx()
+{
+	if [ -n "$(lspci -vvv | grep SimX)" ]; then
+		return 0
+	else
+		return 1
+	fi
+}
+
 # Check if file exists and create soft link
 # $1 - file path
 # $2 - link path

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2837,19 +2837,6 @@ do_chip_up_down()
 	esac
 }
 
-check_simx()
-{
-	case $sku in
-		HI130|HI122|HI144|HI147|HI157)
-			# Let the initialization go through
-			;;
-		*)
-			if [ -n "$(lspci -vvv | grep SimX)" ]; then
-				exit 0
-			fi
-			;;
-	esac
-}
 
 do_chip_down()
 {
@@ -2883,7 +2870,13 @@ Options:
 	reset-cause	Output system reset cause.
 "
 
-check_simx
+# Check if BSP supports platform in SimX. If the platform is supported continue with
+# normal initialization. Otherwise exit from the initialization
+if check_simx; then
+	if ! check_if_simx_supported_platform; then
+		exit 0
+	fi
+fi
 
 case $ACTION in
 	start)


### PR DESCRIPTION
This patch set adds more platforms to SimX support. Also it re-organizes the check_simx() function to take the list of platforms from a single variable. It also enables the TC explicitly for SimX platforms.

Bug #3696439