### PR TITLE
hw-mgmt: scripts: Fix sku variable for SimX check

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.2933) unstable; urgency=low
+hw-management (1.mlnx.7.0030.2934) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Wed, 13 Dec 2023 13:44:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Wed, 14 Dec 2023 13:44:00 +0300

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -203,7 +203,7 @@ check_labels_enabled()
 # This function checks if the platform is having BSP emulation support.
 check_if_simx_supported_platform()
 {
-	case $sku in
+	case $vm_sku in
 		HI130|HI122|HI144|HI147|HI157|HI112|MSN2700-CS2FO|MSN2410-CB2F|MSN2100)
 			return 0
 			;;


### PR DESCRIPTION
This patch fixes the wrong variable which was used for checking the platform sku when running in the SimX environment.