### PR TITLE
hw-mgmt: scripts: Fix asic health attribute

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.2934) unstable; urgency=low
+hw-management (1.mlnx.7.0030.2935) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Wed, 14 Dec 2023 13:44:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Tue, 19 Dec 2023 13:44:00 +0300

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -643,19 +643,16 @@ if [ "$1" == "add" ]; then
 		else
 			asic_num=$(< $config_path/asic_num)
 		fi
+		if [ ! -d /sys/module/mlxsw_minimal ]; then
+			modprobe mlxsw_minimal
+		fi
 		for ((i=1; i<=asic_num; i+=1)); do
 			asic_health=0
 			if [ -f "$3""$4"/asic"$i" ]; then
 				asic_health=$(< "$3""$4"/asic"$i")
 			fi
-			if [ "$asic_health" -ne 2 ]; then
-				exit 0
-			fi
-			if [ ! -d /sys/module/mlxsw_minimal ]; then
-				modprobe mlxsw_minimal
-			fi
 			# Run automatic chipup based on ASIC health event only in special CI/verification OSes.
-			if [ -f /etc/autochipup ]; then
+			if [ -f /etc/autochipup ] && [ "$asic_health" -eq 2 ]; then
 				sleep 3
 				/usr/bin/hw-management.sh chipup "$i"
 			fi


### PR DESCRIPTION
In SimX environment asic_health is 3. This will cause the minimal driver not to load. This patch will probe minimal always and run chipup only for those with good health.