### PR TITLE
hw-mgmt: scripts: Increase the max number of PSUs and tachos

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -81,7 +81,7 @@ thermal_type_def=0
 thermal_type_full=100
 
 base_cpu_bus_offset=10
-max_tachos=14
+max_tachos=20
 i2c_asic_bus_default=2
 i2c_asic2_bus_default=3
 i2c_bus_max=26

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -38,7 +38,7 @@ sku=$(< $sku_file)
 
 # Local variables
 fan_psu_default=$config_path/fan_psu_default
-max_psus=4
+max_psus=8
 max_pwm=4
 max_lcs=8
 max_erots=2


### PR DESCRIPTION
On XDR systems the max number of PSUs is 8, max number of tachos is 20.