### PR TITLE
hw-mgmt: patches: 5.10: Update Mellanox platform driver XDR patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.2970) unstable; urgency=low
+hw-management (1.mlnx.7.0030.2971) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 25 Dec 2023 12:00:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 26 Dec 2023 12:00:00 +0300

--- a/recipes-kernel/linux/linux-5.10/0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch
+++ b/recipes-kernel/linux/linux-5.10/0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch
@@ -1,13 +1,14 @@
-From f194151e386cb26826766dcfe8a2a0c5fba2799e Mon Sep 17 00:00:00 2001
+From 97a6b1404a78992f137aa30c5f68560f7b49abf7 Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 4 Sep 2023 18:28:37 +0000
-Subject: [PATCH] From 92a3877be169c1083cf2ccdbe2e25a4591ed89aa Mon Sep 17
- 00:00:00 2001 Subject: [PATCH] From e1431c088b27f877747f9a74e07c8b158db7ec66
- Mon Sep 17  00:00:00 2001 Subject: [PATCH 1/4] From 
- f25ad1918eb613aa315805717603a0960f42e6df Mon Sep 17  00:00:00 2001 Subject: 
- [PATCH] platform: mellanox: mlx-platform: Add support  for new XDR  systems 
- X-NVConfidentiality: public X-NVConfidentiality: public X-NVConfidentiality:
- public
+Subject: [PATCH] From f194151e386cb26826766dcfe8a2a0c5fba2799e Mon Sep 17
+ 00:00:00 2001 Subject: [PATCH] From 92a3877be169c1083cf2ccdbe2e25a4591ed89aa
+ Mon Sep 17  00:00:00 2001 Subject: [PATCH] From
+ e1431c088b27f877747f9a74e07c8b158db7ec66  Mon Sep 17  00:00:00 2001 Subject:
+ [PATCH 1/4] From  f25ad1918eb613aa315805717603a0960f42e6df Mon Sep 17 
+ 00:00:00 2001 Subject:  [PATCH] platform: mellanox: mlx-platform: Add support
+  for new XDR  systems  X-NVConfidentiality: public X-NVConfidentiality:
+ public X-NVConfidentiality:  public X-NVConfidentiality: public
 X-NVConfidentiality: public
 
 Add support for QM3400 and QM3000, Nvidia XDR switches.
@@ -37,11 +38,11 @@ QM3000 Features:
 Signed-off-by: Felix Radensky <fradensky@nvidia.com>
 Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 1067 +++++++++++++++++++++-
- 1 file changed, 1052 insertions(+), 15 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 1067 +++++++++++++++++++++++++++++-
+ 1 file changed, 1048 insertions(+), 19 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 4efd06eaf..88d42bf66 100644
+index 4efd06eaf..7a544ec3c 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -51,6 +51,7 @@
@@ -666,12 +667,21 @@ index 4efd06eaf..88d42bf66 100644
  static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
  	{
  		.label = "pwr1",
-@@ -3398,32 +3922,206 @@ static struct mlxreg_core_data mlxplat_mlxcpld_l1_switch_led_data[] = {
- 		.bit = BIT(3),
- 	},
- 	{
--		.label = "fan5:green",
--		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
+@@ -3388,42 +3912,216 @@ static struct mlxreg_core_data mlxplat_mlxcpld_l1_switch_led_data[] = {
+ 		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
+ 		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
+ 		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
+-		.bit = BIT(3),
++		.bit = BIT(3),
++	},
++	{
++		.label = "fan4:orange",
++		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
++		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.bit = BIT(3),
++	},
++	{
 +		.label = "fan5:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
 +		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
@@ -823,15 +833,20 @@ index 4efd06eaf..88d42bf66 100644
 +		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
 +		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
 +		.slot = 7,
-+	},
-+	{
+ 	},
+ 	{
+-		.label = "fan4:orange",
+-		.reg = MLXPLAT_CPLD_LPC_REG_LED3_OFFSET,
 +		.label = "fan7:amber",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED6_OFFSET,
-+		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
-+		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
+ 		.mask = MLXPLAT_CPLD_LED_HI_NIBBLE_MASK,
+ 		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
+-		.bit = BIT(3),
 +		.slot = 7,
-+	},
-+	{
+ 	},
+ 	{
+-		.label = "fan5:green",
+-		.reg = MLXPLAT_CPLD_LPC_REG_LED4_OFFSET,
 +		.label = "fan8:green",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LED7_OFFSET,
  		.mask = MLXPLAT_CPLD_LED_LO_NIBBLE_MASK,
@@ -1003,7 +1018,7 @@ index 4efd06eaf..88d42bf66 100644
  	{
  		.label = "fan_dir",
  		.reg = MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION,
-@@ -5129,6 +5897,193 @@ static struct mlxreg_core_platform_data mlxplat_qmb8700_fan_data = {
+@@ -5129,6 +5897,185 @@ static struct mlxreg_core_platform_data mlxplat_qmb8700_fan_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_qmb8700_fan_data),
  };
  
@@ -1012,18 +1027,6 @@ index 4efd06eaf..88d42bf66 100644
 +	{
 +		.label = "pwm1",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET,
-+	},
-+	{
-+		.label = "pwm2",
-+		.reg = MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET,
-+	},
-+	{
-+		.label = "pwm3",
-+		.reg = MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET,
-+	},
-+	{
-+		.label = "pwm4",
-+		.reg = MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET,
 +	},
 +	{
 +		.label = "tacho1",
@@ -1185,6 +1188,10 @@ index 4efd06eaf..88d42bf66 100644
 +		.slot = 20,
 +		.reg_prsnt = MLXPLAT_CPLD_LPC_REG_FAN2_OFFSET,
 +	},
++	{
++		.label = "conf",
++		.capability = MLXPLAT_CPLD_LPC_REG_TACHO_SPEED_OFFSET,
++	},
 +};
 +
 +static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
@@ -1197,7 +1204,7 @@ index 4efd06eaf..88d42bf66 100644
  /* Watchdog type1: hardware implementation version1
   * (MSN2700, MSN2410, MSN2740, MSN2100 and MSN2140 systems).
   */
-@@ -5361,6 +6316,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -5361,6 +6308,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED5_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
@@ -1205,7 +1212,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -5388,12 +6344,18 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -5388,12 +6336,18 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_ASIC_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET:
@@ -1224,7 +1231,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROTE_EVENT_OFFSET:
-@@ -5451,6 +6413,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5451,6 +6405,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
@@ -1232,7 +1239,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -5461,6 +6424,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5461,6 +6416,8 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
@@ -1241,7 +1248,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
-@@ -5473,6 +6438,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5473,6 +6430,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED5_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
@@ -1249,7 +1256,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -5510,6 +6476,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5510,6 +6468,12 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET:
@@ -1262,7 +1269,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_PSU_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
-@@ -5519,6 +6491,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5519,6 +6483,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -1272,7 +1279,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_EROT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
-@@ -5592,6 +6567,13 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -5592,6 +6559,13 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_TACHO12_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO13_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO14_OFFSET:
@@ -1286,7 +1293,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_CAP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET:
-@@ -5617,6 +6599,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5617,6 +6591,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
@@ -1294,7 +1301,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -5627,6 +6610,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5627,6 +6602,8 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
@@ -1303,7 +1310,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP4_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
-@@ -5639,6 +6624,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5639,6 +6616,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED5_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
@@ -1311,7 +1318,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -5674,6 +6660,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5674,6 +6652,12 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_ASIC2_MASK_OFFSET:
@@ -1324,7 +1331,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_PSU_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PSU_MASK_OFFSET:
-@@ -5683,6 +6675,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5683,6 +6667,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_FAN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_MASK_OFFSET:
@@ -1334,7 +1341,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_EROT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROT_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_EROT_MASK_OFFSET:
-@@ -5750,6 +6745,13 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -5750,6 +6737,13 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_TACHO12_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO13_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_TACHO14_OFFSET:
@@ -1348,7 +1355,7 @@ index 4efd06eaf..88d42bf66 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_CAP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_FAN_CAP2_OFFSET:
-@@ -6471,6 +7473,35 @@ static int __init mlxplat_dmi_bf3_comex_default_matched(const struct dmi_system_
+@@ -6471,6 +7465,35 @@ static int __init mlxplat_dmi_bf3_comex_default_matched(const struct dmi_system_
  	return 1;
  }
  
@@ -1384,7 +1391,7 @@ index 4efd06eaf..88d42bf66 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -6578,6 +7609,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -6578,6 +7601,12 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0017"),
  		},
  	},
@@ -1398,5 +1405,5 @@ index 4efd06eaf..88d42bf66 100644
  		.callback = mlxplat_dmi_msn274x_matched,
  		.matches = {
 -- 
-2.20.1
+2.14.1
 


### PR DESCRIPTION
Add missing tacho speed divider and remove unsupported fan PWM features.