### PR TITLE
hw-mgmt: sensors: ignore PSU fan2, fan3 on MQM9700 systems.

### DIFF
--- a/usr/etc/hw-management-sensors/mqm9700_rev1_sensors.conf
+++ b/usr/etc/hw-management-sensors/mqm9700_rev1_sensors.conf
@@ -275,6 +275,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-2(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(L) Temp 1"
         label temp2 "PSU-2(L) Temp 2"
         label temp3 "PSU-2(L) Temp 3"
@@ -287,6 +289,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"

--- a/usr/etc/hw-management-sensors/mqm9700_sensors.conf
+++ b/usr/etc/hw-management-sensors/mqm9700_sensors.conf
@@ -122,6 +122,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-2(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(L) Temp 1"
         label temp2 "PSU-2(L) Temp 2"
         label temp3 "PSU-2(L) Temp 3"
@@ -134,6 +136,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"


### PR DESCRIPTION
PSUs on MQM9700 systems occasionally report errors for FAN2 and FAN3 although only FAN1 exists. Ignore FAN2 and FAN3 to avoid errors.