### PR TITLE
hw-mgmt: sensors: Ignore PSU fan2, fan3 on multiple systems.

### DIFF
--- a/usr/etc/hw-management-sensors/e3597_sensors.conf
+++ b/usr/etc/hw-management-sensors/e3597_sensors.conf
@@ -153,6 +153,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-2(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(L) Temp 1"
         label temp2 "PSU-2(L) Temp 2"
         label temp3 "PSU-2(L) Temp 3"
@@ -165,6 +167,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"

--- a/usr/etc/hw-management-sensors/mqm9510_sensors.conf
+++ b/usr/etc/hw-management-sensors/mqm9510_sensors.conf
@@ -147,6 +147,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-2(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(L) Temp 1"
         label temp2 "PSU-2(L) Temp 2"
         label temp3 "PSU-2(L) Temp 3"
@@ -159,6 +161,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"

--- a/usr/etc/hw-management-sensors/mqm9520_sensors.conf
+++ b/usr/etc/hw-management-sensors/mqm9520_sensors.conf
@@ -123,6 +123,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-1(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(L) Temp 1"
         label temp2 "PSU-2(L) Temp 2"
         label temp3 "PSU-2(L) Temp 3"
@@ -135,6 +137,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"

--- a/usr/etc/hw-management-sensors/msn27002_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn27002_sensors.conf
@@ -133,6 +133,8 @@ chip "dps460-i2c-*-58"
     label in1 "PSU-2(R) 220V Rail (in)"
     label in2 "PSU-2(R) 12V Rail (out)"
     label fan1 "PSU-2(R) Fan 1"
+    ignore fan2
+    ignore fan3
     label temp1 "PSU-2(R) Temp 1"
     label temp2 "PSU-2(R) Temp 2"
     label power1 "PSU-2(R) 220V Rail Pwr (in)"
@@ -144,6 +146,8 @@ chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     label in2 "PSU-1(L) 12V Rail (out)"
     label fan1 "PSU-1(L) Fan 1"
+    ignore fan2
+    ignore fan3
     label temp1 "PSU-1(L) Temp 1"
     label temp2 "PSU-1(L) Temp 2"
     label power1 "PSU-1(L) 220V Rail Pwr (in)"

--- a/usr/etc/hw-management-sensors/msn3420_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn3420_sensors.conf
@@ -74,6 +74,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label in1 "PSU-2 220V Rail (in)"
         label in2 "PSU-2 12V Rail (out)"
         label fan1 "PSU-2 Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2 Temp 1"
         label temp2 "PSU-2 Temp 2"
         label temp3 "PSU-2 Temp 3"
@@ -85,6 +87,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label in1 "PSU-1 220V Rail (in)"
         label in2 "PSU-1 12V Rail (out)"
         label fan1 "PSU-1 Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1 Temp 1"
         label temp2 "PSU-1 Temp 2"
         label temp3 "PSU-1 Temp 3"

--- a/usr/etc/hw-management-sensors/msn4800_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4800_sensors.conf
@@ -160,6 +160,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"
@@ -172,6 +174,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
         label fan1 "PSU-2(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(R) Temp 1"
         label temp2 "PSU-2(R) Temp 2"
         label temp3 "PSU-2(R) Temp 3"
@@ -184,6 +188,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-3(L) 12V Rail (out)"
         label fan1 "PSU-3(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-3(L) Temp 1"
         label temp2 "PSU-3(L) Temp 2"
         label temp3 "PSU-3(L) Temp 3"
@@ -196,6 +202,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-4(L) 12V Rail (out)"
         label fan1 "PSU-4(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-4(L) Temp 1"
         label temp2 "PSU-4(L) Temp 2"
         label temp3 "PSU-4(L) Temp 3"

--- a/usr/etc/hw-management-sensors/msn4800_sensors_lc.conf
+++ b/usr/etc/hw-management-sensors/msn4800_sensors_lc.conf
@@ -160,6 +160,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"
@@ -172,6 +174,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(R) 12V Rail (out)"
         label fan1 "PSU-2(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(R) Temp 1"
         label temp2 "PSU-2(R) Temp 2"
         label temp3 "PSU-2(R) Temp 3"
@@ -184,6 +188,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-3(L) 12V Rail (out)"
         label fan1 "PSU-3(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-3(L) Temp 1"
         label temp2 "PSU-3(L) Temp 2"
         label temp3 "PSU-3(L) Temp 3"
@@ -196,6 +202,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-4(L) 12V Rail (out)"
         label fan1 "PSU-4(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-4(L) Temp 1"
         label temp2 "PSU-4(L) Temp 2"
         label temp3 "PSU-4(L) Temp 3"

--- a/usr/etc/hw-management-sensors/p4697_sensors.conf
+++ b/usr/etc/hw-management-sensors/p4697_sensors.conf
@@ -164,6 +164,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-2(L) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2(L) Temp 1"
         label temp2 "PSU-2(L) Temp 2"
         label temp3 "PSU-2(L) Temp 3"
@@ -176,6 +178,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         ignore in2
         label in3 "PSU-1(R) 12V Rail (out)"
         label fan1 "PSU-1(R) Fan 1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1(R) Temp 1"
         label temp2 "PSU-1(R) Temp 2"
         label temp3 "PSU-1(R) Temp 3"

--- a/usr/etc/hw-management-sensors/qm3000_sensors.conf
+++ b/usr/etc/hw-management-sensors/qm3000_sensors.conf
@@ -172,6 +172,8 @@ chip "dps460-i2c-*-59"
     ignore in2
     label in3 "PSU-1 12V Rail (out)"
     label fan1 "PSU-1 Fan 1"
+    ignore fan2
+    ignore fan3
     label temp1 "PSU-1 Temp 1"
     label temp2 "PSU-1 Temp 2"
     label temp3 "PSU-1 Temp 3"
@@ -184,6 +186,8 @@ chip "dps460-i2c-*-58"
     ignore in2
     label in3 "PSU-2 12V Rail (out)"
     label fan1 "PSU-2 Fan 1"
+    ignore fan2
+    ignore fan3
     label temp1 "PSU-2 Temp 1"
     label temp2 "PSU-2 Temp 2"
     label temp3 "PSU-2 Temp 3"

--- a/usr/etc/hw-management-sensors/qm3400_sensors.conf
+++ b/usr/etc/hw-management-sensors/qm3400_sensors.conf
@@ -102,6 +102,8 @@ chip "dps460-i2c-*-59"
     ignore in2
     label in3 "PSU-1 12V Rail (out)"
     label fan1 "PSU-1 Fan 1"
+    ignore fan2
+    ignore fan3
     label temp1 "PSU-1 Temp 1"
     label temp2 "PSU-1 Temp 2"
     label temp3 "PSU-1 Temp 3"
@@ -114,6 +116,8 @@ chip "dps460-i2c-*-58"
     ignore in2
     label in3 "PSU-2 12V Rail (out)"
     label fan1 "PSU-2 Fan 1"
+    ignore fan2
+    ignore fan3
     label temp1 "PSU-2 Temp 1"
     label temp2 "PSU-2 Temp 2"
     label temp3 "PSU-2 Temp 3"

--- a/usr/etc/hw-management-sensors/sn2201_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn2201_sensors.conf
@@ -129,6 +129,8 @@ bus "i2c-3" "i2c-1-mux (chan_id 1)"
         label in2 "PSU-1 12V Rail(out)"
         ignore in3
         label fan1 "PSU-1 fan1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-1 temp1"
         label temp2 "PSU-1 temp2"
         label temp3 "PSU-1 temp3"
@@ -145,6 +147,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 2)"
         label in2 "PSU-2 12V Rail(out)"
         ignore in3
         label fan1 "PSU-2 fan1"
+        ignore fan2
+        ignore fan3
         label temp1 "PSU-2 temp1"
         label temp2 "PSU-2 temp2"
         label temp3 "PSU-2 temp3"

--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -380,6 +380,8 @@ chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
     label in3 "PSU-1(L) 12V Rail (out)"
+    ignore fan2
+    ignore fan3
     label fan1 "PSU-1(L) Fan 1"
     label temp1 "PSU-1(L) Temp 1"
     label temp2 "PSU-1(L) Temp 2"
@@ -393,6 +395,8 @@ chip "dps460-i2c-*-5a"
     label in1 "PSU-2(R) 220V Rail (in)"
     ignore in2
     label in3 "PSU-2(R) 12V Rail (out)"
+    ignore fan2
+    ignore fan3
     label fan1 "PSU-2(R) Fan 1"
     label temp1 "PSU-2(R) Temp 1"
     label temp2 "PSU-2(R) Temp 2"


### PR DESCRIPTION
PSUs on multiple systems occasionally report errors for FAN2 and FAN3 although only PSU FAN1 exists. Ignore PSU FAN2 and FAN3 to avoid errors.

Fixes: #3723906