### PR TITLE
hw-mgmt: thermal: Add PSU mask flag option

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn5400.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn5400.json
@@ -46,6 +46,7 @@
 		"drivetemp":      {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
 		"ibc\\d+":         {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!110000", "poll_time": 60}
 	},
+	"error_mask" : {"psu" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "cpu", "drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "ibc1", "ibc2", "ibc3", "ibc4", "psu1", "psu2", 
 	"sensor_amb", "sodimm1", "sodimm2", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_qm3000.json
+++ b/usr/etc/hw-management-thermal/tc_config_qm3000.json
@@ -31,6 +31,7 @@
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"connectx8" :{"pwm_min": 30, "pwm_max" : 100, "val_min": "70000", "val_max": 105000, "poll_time": 3}
 	},
+	"error_mask" : {"psu" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "asic2", "asic4", "asic4", "ctx_amb", "cpu", 
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "drwr8", "drwr9", "drwr10",
 					"psu1", "psu2", "psu3", "psu4", "psu5", "psu6", "psu7", "psu8", "sodimm1",

--- a/usr/etc/hw-management-thermal/tc_config_qm3400.json
+++ b/usr/etc/hw-management-thermal/tc_config_qm3400.json
@@ -31,6 +31,7 @@
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"ctx_amb" :{"pwm_min": 30, "pwm_max" : 100, "val_min": "70000", "val_max": 105000, "poll_time": 3}
 	},
+	"error_mask" : {"psu" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "asic2", "ctx_amb", "cpu", 
 	"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5",
 	"psu1", "psu2",  "psu3", "psu4", "sensor_amb", "sodimm1",


### PR DESCRIPTION
Add PSU [present, direction] error mask flag option for systems:
- SN5400
- QM3000
- QM3400

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
