### PR TITLE
hw-mgmt: scripts: Prevent udev handling before hw-mgmt basic init is …

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -685,13 +685,14 @@ check_reset_attrs()
 	fi
 }
 
+# Don't process udev events until service is started and directories are created
+if [ ! -f ${udev_ready} ]; then
+	exit 0
+fi
+
 trace_udev_events "$0: ACTION=$1 $2 $3 $4 $5"
 
 if [ "$1" == "add" ]; then
-	# Don't process udev events until service is started and directories are created
-	if [ ! -f ${udev_ready} ]; then
-		exit 0
-	fi
 	if [ "$2" == "a2d" ]; then
 		# Detect if it belongs to line card or to main board.
 		iio_name=$5

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -252,13 +252,14 @@ get_psu_fan_direction()
 	fi
 }
 
+# Don't process udev events until service is started and directories are created
+if [ ! -f ${udev_ready} ]; then
+	exit 0
+fi
+
 trace_udev_events "$0: ACTION=$1 $2 $3 $4 $5"
 
 if [ "$1" == "add" ]; then
-	# Don't process udev events until service is started and directories are created
-	if [ ! -f ${udev_ready} ]; then
-		exit 0
-	fi
 	case "$2" in
 		fan_amb | port_amb | cx_amb | lr1_amb | swb_amb | cpu_amb | pdb_temp1 | pdb_temp2 | tempX )
 		# Verify if this is COMEX sensor


### PR DESCRIPTION
…done

Make sure to always exit udev handling scripts before hw-management is ready to handle udev events.