### PR TITLE
hw-mgmt: scripts: ui: Fix naming for sensors

### DIFF
--- a/usr/etc/hw-management-sensors/qm3000_sensors_labels.json
+++ b/usr/etc/hw-management-sensors/qm3000_sensors_labels.json
@@ -1,9 +1,9 @@
 {
 	"name": "qm3000",
 	"labels_HI158_rev1_array" : {
-		"asic_amb" : "Ambient ASIC Temp",
-		"fan_amb" : "Ambient Fan Side Temp (air intake)",
-		"port_amb" : "Ambient Port Side Temp (air exhaust)",
+		"asic_amb" : "Ambient+ASIC+Temp",
+		"fan_amb" : "Ambient+Fan+Side+Temp",
+		"port_amb" : "Ambient+Port+Side+Temp",
 		"sbw1_voltmon1_in1" : "PMIC-1+12V_VDD_ASIC1+Vol+In+1",
 		"sbw1_voltmon1_in2" : "PMIC-1+ASIC1_VDD+Vol+Out+1",
 		"sbw1_voltmon1_temp1" : "PMIC-1++Temp+1",

--- a/usr/etc/hw-management-sensors/qm3400_sensors_labels.json
+++ b/usr/etc/hw-management-sensors/qm3400_sensors_labels.json
@@ -1,9 +1,9 @@
 {
 	"name": "qm3400",
 	"labels_HI157_rev1_array" : {
-		"asic_amb" : "Ambient ASIC Temp",
-		"fan_amb" : "Ambient Fan Side Temp (air intake)",
-		"port_amb" : "Ambient Port Side Temp (air exhaust)",
+		"asic_amb" : "Ambient+ASIC+Temp",
+		"fan_amb" : "Ambient+Fan+Side+Temp",
+		"port_amb" : "Ambient+Port+Side+Temp",
 		"voltmon1_in1" : "PMIC-1+12V_VDD_ASIC1+Vol+In+1",
 		"voltmon1_in2" : "PMIC-1+ASIC1_VDD+Vol+Out+1",
 		"voltmon1_temp1" : "PMIC-1++Temp+1",


### PR DESCRIPTION
Correct the names for temperature sensors in the json file to match with the new naming format.