### PR TITLE
hw-mgmt: sensors: Update sensor configs for XDR systems

### DIFF
--- a/usr/etc/hw-management-sensors/qm3000_sensors.conf
+++ b/usr/etc/hw-management-sensors/qm3000_sensors.conf
@@ -30,6 +30,7 @@ chip "mp2891-i2c-*-66"
     label vout1    "PMIC-1 VDD Volt (out1)"
     ignore vout2    
     label temp1    "PMIC-1 Temp 1"
+    ignore temp2
     label pin      "PMIC-1 12V VDD Pwr (in)"
     label pout1    "PMIC-1 VDD Pwr (out1)"
     ignore pout2    
@@ -65,6 +66,7 @@ chip "xdpe1a2g7-i2c-*-66"
     label vout1    "PMIC-1 VDD Volt (out1)"
     ignore vout2    
     label temp1    "PMIC-1 Temp 1"
+    ignore temp2
     label pin      "PMIC-1 12V VDD Pwr (in)"
     label pout1    "PMIC-1 VDD Pwr (out1)"
     ignore pout2    

--- a/usr/etc/hw-management-sensors/qm3400_sensors.conf
+++ b/usr/etc/hw-management-sensors/qm3400_sensors.conf
@@ -30,6 +30,7 @@ chip "mp2891-i2c-*-66"
     label vout1    "PMIC-1 VDD Volt (out1)"
     ignore vout2    
     label temp1    "PMIC-1 Temp 1"
+    ignore temp2
     label pin      "PMIC-1 12V VDD Pwr (in)"
     label pout1    "PMIC-1 VDD Pwr (out1)"
     ignore pout2    
@@ -65,6 +66,7 @@ chip "xdpe1a2g7-i2c-*-66"
     label vout1    "PMIC-1 VDD Volt (out1)"
     ignore vout2    
     label temp1    "PMIC-1 Temp 1"
+    ignore temp2
     label pin      "PMIC-1 12V VDD Pwr (in)"
     label pout1    "PMIC-1 VDD Pwr (out1)"
     ignore pout2    


### PR DESCRIPTION
Ignore temp2 sensors on MP2891 VRs where these sensors are not connected.