### PR TITLE
hw-mgmt: thermal: Fix TC system name in qm3000 thermal data

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_qm3000.json
+++ b/usr/etc/hw-management-thermal/tc_config_qm3000.json
@@ -1,5 +1,5 @@
  {
-	"name": "qm3400",
+	"name": "qm3000",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {


### PR DESCRIPTION
Fix TC system name in qm3000 thermal data
"qm3400" changed to "qm3000"

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
