### PR TITLE
hw-mgmt: thermal: Add list of supported PSU PN to extract fan direction.

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -60,6 +60,19 @@ ui_tree_archive="/etc/hw-management-sensors/ui_tree_$ui_tree_sku.tar.gz"
 vm_sku=`cat $sku_file`
 vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
 
+declare -A psu_fan_pn=(["00KX1W"]=R ["00MP582"]=F ["00MP592"]=R ["00WT061"]=F ["00WT062"]=R ["00WT199"]=F ["01FT674"]=F ["01FT691"]=F ["01LL976"]=F ["01PG798"]=F \
+["01PG800"]=F ["02YF120"]=R ["02YF121"]=R ["03GX980"]=F ["03GX981"]=F ["03KH192"]=R ["03KH193"]=F ["03KH194"]=R ["03KH195"]=F ["03LE223"]=R \
+["03LE224"]=F ["071-000-203-01"]=R ["071-000-588"]=F ["07XY0Y"]=F ["08WP7W"]=F ["0YX5GR"]=F ["105-575-071-00"]=R ["105-575-072-00"]=F \
+["105-575-074-00"]=F ["304643"]=F ["322285"]=R ["326013"]=R ["326146"]=R ["326329"]=R ["675170-001"]=R ["675171-001"]=F ["841985-001"]=R \
+["841986-001"]=F ["90Y3770"]=R ["90Y3780"]=F ["90Y3800"]=R ["90Y3802"]=F ["930-9SPSU-00RA-00A"]=R ["930-9SPSU-00RA-00B"]=R ["9802A00E"]=R \
+["98Y6356"]=R ["98Y6357"]=F ["MGA100-PS"]=F ["MSX60-PF"]=F ["MSX60-PR"]=F ["MTDF-PS-A"]=R ["MTDF-PS-B"]=F ["MTEF-PSF-AC-A"]=F ["MTEF-PSF-AC-B"]=F \
+["MTEF-PSF-AC-C"]=F ["MTEF-PSF-AC-E"]=F ["MTEF-PSF-AC-F"]=F ["MTEF-PSF-AC-G"]=F ["MTEF-PSF-AC-I"]=F ["MTEF-PSF-AC-K"]=F ["MTEF-PSF-AC-L"]=F \
+["MTEF-PSF-AC-M"]=F ["MTEF-PSF-DC-A"]=F ["MTEF-PSF-DC-B"]=F ["MTEF-PSF-DC-C"]=F ["MTEF-PSF-DC-L"]=F ["MTEF-PSR-AC-A"]=F ["MTEF-PSR-AC-C"]=R \
+["MTEF-PSR-AC-E"]=R ["MTEF-PSR-AC-F"]=R ["MTEF-PSR-AC-G"]=R ["MTEF-PSR-AC-I"]=R ["MTEF-PSR-AC-K"]=R ["MTEF-PSR-AC-L"]=R ["MTEF-PSR-AC-M"]=R \
+["MTEF-PSR-DC-B"]=R ["MTEF-PSR-DC-C"]=R ["MTEF-PSR-DC-D"]=R ["MUA90-PF"]=R ["MUA96-PF"]=F ["P10613-001"]=R ["PSU-AC-150-B"]=F ["PSU-AC-150-F"]=F \
+["PSU-AC-150W-B"]=R ["PSU-AC-150W-F"]=F ["PSU-AC-400-B"]=R ["PSU-AC-400-F"]=F ["PSU-AC-650A-B"]=R ["PSU-AC-650A-F"]=F ["PSU-AC-850A-B"]=R \
+["PSU-AC-850A-F"]=F ["PSU-AC-920-F"]=R ["PSU-AC-920W-F"]=R ["YM-1151D-A02R"]=R ["YM-1151D-A03R"]=F ["YM-1921A-A01R"]=R ["SP57B0808724"]=R)
+
 # Thermal type constants
 thermal_type_t1=1
 thermal_type_t2=2

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -223,7 +223,7 @@ get_psu_fan_direction()
 {
 	vpd_file=$1
 	dir_char=""
-	pn="$(grep PN_VPD_FIELD $vpd_file)"
+	pn=$(grep PN_VPD_FIELD $vpd_file | grep -oE "[^ ]+$")
 	if [ -z $pn ]; then
 		if [ -f $config_path/fixed_fans_dir ]; then
 			dir=$(< $config_path/fixed_fans_dir) 
@@ -233,16 +233,9 @@ get_psu_fan_direction()
 		fi
 		return $dir
 	fi
-	MLX_REGEXP="MTEF-PS([R,F])"
-	NV_REGEXP="930-9SPSU-\S{2}([R,F])\S-\S{3}"
-	[[ $pn =~ $MLX_REGEXP ]]
-	if [[ ! -z "${BASH_REMATCH[1]}" ]]; then
-		dir_char="${BASH_REMATCH[1]}"
-	else
-		[[ $pn =~ $NV_REGEXP ]]
-		if [[ ! -z "${BASH_REMATCH[1]}" ]]; then
-			dir_char="${BASH_REMATCH[1]}"
-		fi
+	
+	if [ ! ${psu_fan_pn[$pn]}_ = _ ]; then
+		dir_char=${psu_fan_pn[$pn]}
 	fi
 	if [ $dir_char == "R" ]; then
 		return 0


### PR DESCRIPTION
Add list of supported PSU PN to extract fan direction.

bug #3706151

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
