### PR TITLE
hw-mgmt: scripts; Add device probe retry support

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -113,6 +113,7 @@ lc_i2c_bus_min=34
 lc_i2c_bus_max=43
 i2c_bus_offset=0
 cpu_type=
+device_connect_delay=0.2
 
 # CPU Family + CPU Model should idintify exact CPU architecture
 # IVB - Ivy-Bridge
@@ -342,7 +343,11 @@ connect_device()
 		if [ ! -d /sys/bus/i2c/devices/$bus-00"$addr" ] &&
 		   [ ! -d /sys/bus/i2c/devices/$bus-000"$addr" ]; then
 			echo "$1" "$2" > /sys/bus/i2c/devices/i2c-$bus/new_device
-			return $?
+			sleep ${device_connect_delay}
+			if [ ! -L /sys/bus/i2c/devices/$bus-00"$addr"/driver ] &&
+			   [ ! -L /sys/bus/i2c/devices/$bus-000"$addr"/driver ]; then
+				return 1
+			fi
 		fi
 	fi
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -108,6 +108,7 @@ dpu_bf3_pci_id=c2d5
 leakage_count=0
 leakage_rope_count=0
 asic_chipup_retry=2
+device_connect_retry=2
 chipup_log_size=4096
 reset_dflt_attr_num=18
 
@@ -2428,8 +2429,14 @@ connect_platform()
 	fi
 
 	for ((i=0; i<${#connect_table[@]}; i+=$dev_step)); do
-		connect_device "${connect_table[i]}" "${connect_table[i+1]}" \
-				"${connect_table[i+2]}"
+		for ((j=0; j<${device_connect_retry}; j++)); do
+			connect_device "${connect_table[i]}" "${connect_table[i+1]}" \
+					"${connect_table[i+2]}"
+			if [ $? -eq 0 ]; then
+				break;
+			fi
+			disconnect_device "${connect_table[i+1]}" "${connect_table[i+2]}"
+		done
 	done
 }
 


### PR DESCRIPTION
Make several attempts to probe for I2C devices if
initial probe fails.