### PR TITLE
hw-mgmt: scripts: fix missing psu config attributes on SN5400

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.3000) unstable; urgency=low
+hw-management (1.mlnx.7.0030.3032) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 1 Jan 2024 13:44:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Sun, 21 Jan 2024 13:44:00 +0300

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -970,7 +970,7 @@ if [ "$1" == "add" ]; then
 					fw_primary_ver=$(echo $fw_ver_all | cut -d. -f1)
 					fw_ver=$(echo $fw_ver_all | cut -d. -f2)
 				fi
-				if [[ "$cap" == "3000" &&  $sku == "HI144" ]]; then
+				if [[ "$cap" == "3000" && ( $sku == "HI144" || $sku == "HI147" ) ]]; then
 					if [ ! -e "$config_path"/amb_tmp_warn_limit ]; then
 						echo 38000 > "$config_path"/amb_tmp_warn_limit
 					fi


### PR DESCRIPTION
Fix bug #3747683

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
