### PR TITLE
hw-mgmt: thermal: Remove non existent sensor

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn27002.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn27002.json
@@ -47,7 +47,7 @@
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
 	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
-	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2", "voltmon6"]
+	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb", "voltmon1", "voltmon2"]
 }
 
  


### PR DESCRIPTION
Remving voltmon6 entry from thermal profile for MSN27002. This will fix the error "ERROR - voltmon6_temp: read file thermal/voltmon6_temp1_input errors count 7'.

Bug #3726901