### PR TITLE
hw-mgmt: thermal: Update thermal data for smart switch

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_sn4280.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn4280.json
@@ -43,7 +43,7 @@
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 30, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!65000", "val_max": "!85000", "poll_time": 60},
-		"dpu\\d+_module" :{"child_sensors_list" : ["voltmon1", "voltmon2", "cx_amb", "sodimm1","drivetemp"], "poll_time": 3},
+		"dpu\\d+_module" :{"child_sensors_list" : ["cx_amb", "sodimm1", "drivetemp"], "poll_time": 3},
 		"dpu\\d+_cx_amb": {"pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "!105000", "poll_time": 30},
     	"dpu\\d+_cpu":    { "pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "105000", "poll_time": 3},
     	"dpu\\d+_sodimm\\d+": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_crit": 95000, "poll_time": 60},


### PR DESCRIPTION
Update thermal data for smart switch: removed DPS voltmon from TC monitoring

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
