### PR TITLE
hw-mgmt: thermal: TC add voltmon swb* support

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_qm3000.json
+++ b/usr/etc/hw-management-thermal/tc_config_qm3000.json
@@ -26,7 +26,7 @@
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3},
 		"module\\d+":     {"pwm_min": 30, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
-		"voltmon\\d+_temp":{"pwm_min": 30, "pwm_max" : 100, "val_min": "!85000", "val_max": "!125000", "poll_time": 60},
+		"swb\\d+_voltmon\\d+_temp":{"pwm_min": 30, "pwm_max" : 100, "val_min": "!85000", "val_max": "!125000", "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time":  60},
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"connectx8" :{"pwm_min": 30, "pwm_max" : 100, "val_min": "70000", "val_max": 105000, "poll_time": 3}
@@ -35,6 +35,7 @@
 	"sensor_list" : ["asic1", "asic2", "asic4", "asic4", "ctx_amb", "cpu", 
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "drwr8", "drwr9", "drwr10",
 					"psu1", "psu2", "psu3", "psu4", "psu5", "psu6", "psu7", "psu8", "sodimm1",
-					"voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11", "voltmon12"
+					"swb1_voltmon1", "swb1_voltmon2", "swb1_voltmon3", "swb1_voltmon4", "swb1_voltmon5", "swb1_voltmon6", 
+					"swb2_voltmon1", "swb2_voltmon2", "swb2_voltmon3", "swb2_voltmon4", "swb2_voltmon5", "swb2_voltmon6"
 					]
 }

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2380,6 +2380,7 @@ class ThermalManagement(hw_managemet_file_op):
                           r'module\d*':"add_module_sensor",
                           r'cpu':"add_cpu_sensor",
                           r'voltmon\d+':"add_voltmon_sensor",
+                          r'swb\d+_voltmon\d+': "add_swb_voltmon_sensor",
                           r'asic\d+':"add_asic_sensor",
                           r'sodimm\d+':"add_sodimm_sensor",
                           r'sensor_amb':"add_amb_sensor",
@@ -3045,6 +3046,12 @@ class ThermalManagement(hw_managemet_file_op):
         in_file = "thermal/{}_temp1".format(name)
         sensor_name = "{}_temp".format(name)
         self._sensor_add_config("thermal_sensor", sensor_name, {"base_file_name": in_file})
+
+    # ----------------------------------------------------------------------
+    def add_swb_voltmon_sensor(self, name):
+        in_file = "thermal/{}_temp1".format(name)
+        sensor_name = "{}_temp".format(name)
+        self._sensor_add_config("thermal_sensor", sensor_name, {"type": "thermal_sensor", "base_file_name": in_file, "input_suffix": "_input"})
 
     # ----------------------------------------------------------------------
     def add_asic_sensor(self, name):


### PR DESCRIPTION
Add support for voltmon thermal sensors located on swb*.
New names for sensors: swb*_voltmon

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
