### PR TITLE
hw-mgmt: sensors: fix labels for sensors output on SN5600/SN5400 systems.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.3931) unstable; urgency=low
+hw-management (1.mlnx.7.0030.3932) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Sun, 29 Jan 2024 11:10:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Tue, 30 Jan 2024 11:10:00 +0300

--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -379,7 +379,7 @@ chip "xdpe15284-i2c-*-6e"
 chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
-    label in3 "PSU-1(L) 12V Rail (out)"
+    label in3 "PSU-1(L) 54V Rail (out)"
     ignore fan2
     ignore fan3
     label fan1 "PSU-1(L) Fan 1"
@@ -387,14 +387,14 @@ chip "dps460-i2c-*-59"
     label temp2 "PSU-1(L) Temp 2"
     label temp3 "PSU-1(L) Temp 3"
     label power1 "PSU-1(L) 220V Rail Pwr (in)"
-    label power2 "PSU-1(L) 12V Rail Pwr (out)"
+    label power2 "PSU-1(L) 54V Rail Pwr (out)"
     label curr1 "PSU-1(L) 220V Rail Curr (in)"
-    label curr2 "PSU-1(L) 12V Rail Curr (out)"
+    label curr2 "PSU-1(L) 54V Rail Curr (out)"
     set power2_cap 0
 chip "dps460-i2c-*-5a"
     label in1 "PSU-2(R) 220V Rail (in)"
     ignore in2
-    label in3 "PSU-2(R) 12V Rail (out)"
+    label in3 "PSU-2(R) 54V Rail (out)"
     ignore fan2
     ignore fan3
     label fan1 "PSU-2(R) Fan 1"
@@ -402,35 +402,35 @@ chip "dps460-i2c-*-5a"
     label temp2 "PSU-2(R) Temp 2"
     label temp3 "PSU-2(R) Temp 3"
     label power1 "PSU-2(R) 220V Rail Pwr (in)"
-    label power2 "PSU-2(R) 12V Rail Pwr (out)"
+    label power2 "PSU-2(R) 54V Rail Pwr (out)"
     label curr1 "PSU-2(R) 220V Rail Curr (in)"
-    label curr2 "PSU-2(R) 12V Rail Curr (out)"
+    label curr2 "PSU-2(R) 54V Rail Curr (out)"
 
 # Power converters
 chip "pmbus-i2c-*-10"
     label in1      	"IBC-1 PWR CONV 54V Rail (in1)"
-    ignore in2
+    label in2		"IBC-1 13V5 Rail (out)"
     ignore in3
     label temp1    	"IBC-1 Temp 1"
     ignore curr1
     label curr2 	"IBC-1 13V5 Rail Curr (out)"
 chip "pmbus-i2c-*-11"
     label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
-    ignore in2
+    label in2		"IBC-2 13V5 Rail (out)"
     ignore in3
     label temp1    	"IBC-2 Temp 1"
     label curr1 	"IBC-2 13V5 Rail Curr (out)"
     ignore curr2
 chip "pmbus-i2c-*-13"
     label in1      	"IBC-3 PWR CONV 54V Rail (in1)"
-    ignore in2
+    label in2		"IBC-3 13V5 Rail (out)"
     ignore in3
     label temp1    	"IBC-3 Temp 1"
     label curr1 	"IBC-3 13V5 Rail Curr (out)"
     ignore curr2
 chip "pmbus-i2c-*-15"
     label in1      	"IBC-4 PWR CONV 54V Rail (in1)"
-    ignore in2
+    label in2		"IBC-4 13V5 Rail (out)"
     ignore in3
     label temp1    	"IBC-4 Temp 1"
     label curr1 	"IBC-4 13V5 Rail Curr (out)"
@@ -438,19 +438,19 @@ chip "pmbus-i2c-*-15"
 
 #COMEX CFL
 chip "mp2975-i2c-39-6b"
-    label in1 "PMIC-6 PSU 12V Rail (vin)"
-    label in2 "PMIC-6 COMEX VCORE (out1)"
-    label in3 "PMIC-6 COMEX VCCSA (out2)"
-    label temp1 "PMIC-6 Temp"
-    label power1 "PMIC-6 COMEX Pwr (pin)"
-    label power2 "PMIC-6 COMEX VCORE Pwr (pout1)"
-    label power3 "PMIC-6 COMEX VCCSA Pwr (pout2)"
-    label curr1 "PMIC-6 COMEX Curr (iin)"
-    label curr2 "PMIC-6 COMEX VCORE Rail Curr (out1)"
+    label in1 "PMIC-12 PSU 13V5 Rail (vin)"
+    label in2 "PMIC-12 COMEX VCORE (out1)"
+    label in3 "PMIC-12 COMEX VCCSA (out2)"
+    label temp1 "PMIC-12 Temp"
+    label power1 "PMIC-12 COMEX Pwr (pin)"
+    label power2 "PMIC-12 COMEX VCORE Pwr (pout1)"
+    label power3 "PMIC-12 COMEX VCCSA Pwr (pout2)"
+    label curr1 "PMIC-12 COMEX Curr (iin)"
+    label curr2 "PMIC-12 COMEX VCORE Rail Curr (out1)"
     ignore curr3
     ignore curr4
     ignore curr5
-    label curr6 "PMIC-6 COMEX VCCSA Rail Curr (out2)"
+    label curr6 "PMIC-12 COMEX VCCSA Rail Curr (out2)"
     ignore curr7
 
 # Chassis fans


### PR DESCRIPTION
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
