### PR TITLE
hw-mgmt: sensors: Adjust fan labels for MSN2010, MSN2100 and MSN2410 …

### DIFF
--- a/usr/etc/hw-management-sensors/msn2010_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2010_sensors.conf
@@ -25,10 +25,10 @@ chip "tps53679-*"
     label iout2 "TPS iout2"
 
 chip "mlxsw-*"
-    label fan3 "fan1"
-    label fan4 "fan2"
-    label fan1 "fan3"
-    label fan2 "fan4"
+    label fan3 "Chassis Fan Drawer-1 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 1"
+    label fan1 "Chassis Fan Drawer-3 Tach 1"
+    label fan2 "Chassis Fan Drawer-4 Tach 1"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/etc/hw-management-sensors/msn2100_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2100_sensors.conf
@@ -27,10 +27,10 @@ chip "lm75-i2c-17-49"
     label temp1 "Ambient Board Temp"
 
 chip "mlxsw-*"
-    label fan3 "fan1"
-    label fan4 "fan2"
-    label fan1 "fan3"
-    label fan2 "fan4"
+    label fan3 "Chassis Fan Drawer-1 Tach 1"
+    label fan4 "Chassis Fan Drawer-2 Tach 1"
+    label fan1 "Chassis Fan Drawer-3 Tach 1"
+    label fan2 "Chassis Fan Drawer-4 Tach 1"
     ignore temp2
     ignore temp3
     ignore temp4

--- a/usr/etc/hw-management-sensors/msn2410_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn2410_sensors.conf
@@ -27,14 +27,14 @@ chip "lm75-i2c-17-49"
     label temp1 "Ambient Board Temp"
 
 chip "mlxsw-*"
-    label fan7 "fan1"
-    label fan8 "fan2"
-    label fan5 "fan3"
-    label fan6 "fan4"
-    label fan3 "fan5"
-    label fan4 "fan6"
-    label fan1 "fan7"
-    label fan2 "fan8"
+    label fan7 "Chassis Fan Drawer-1 Tach 1"
+    label fan8 "Chassis Fan Drawer-1 Tach 2"
+    label fan5 "Chassis Fan Drawer-2 Tach 1"
+    label fan6 "Chassis Fan Drawer-2 Tach 2"
+    label fan3 "Chassis Fan Drawer-3 Tach 1"
+    label fan4 "Chassis Fan Drawer-3 Tach 2"
+    label fan1 "Chassis Fan Drawer-4 Tach 1"
+    label fan2 "Chassis Fan Drawer-4 Tach 2"
     ignore temp2
     ignore temp3
     ignore temp4


### PR DESCRIPTION
…systems

Adjust chassis fan labels for MSN2010, MSN2100 and MSN2410 systems to match fan labels for other systems.

Fixes: #3733632