### PR TITLE
hw-mgmt: scripts: Add wait for udev to complete device initialization

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2800,6 +2800,7 @@ do_start()
 	depmod -a 2>/dev/null
 	set_config_data
 	udevadm trigger --action=add
+	udevadm settle
 	set_sodimm_temp_limits
 	set_jtag_gpio "export"
 	create_event_files


### PR DESCRIPTION
Run "udevadm settle" after "udev trigger" to make sure that all udev events are handled before proceding with hw-management initialization. This fixes device initialization issues on XDR and BF3 platforms.