### PR TITLE
hw-mgmt: scripts: Fix dpu_shtdn action script

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -594,7 +594,7 @@ function handle_hotplug_event()
 	fan*)
 		handle_hotplug_fan_event "$attribute" "$event"
 		;;
-	dpu*_ready)
+	dpu[1-8]_ready)
 		# Connect dynamic devices.
 		if [ -e "$devtree_file" ]; then
 			if [ -e "$config_path"/dpu_board_type ]; then
@@ -612,7 +612,7 @@ function handle_hotplug_event()
 			connect_underlying_devices "$bus"
 		fi
 		;;
-	dpu*_shtdn_ready)
+	dpu[1-8]_shtdn_ready)
 		# Disconnect dynamic devices.
 		if [ -e "$devtree_file" ]; then
 			if [ -e "$config_path"/dpu_board_type ]; then


### PR DESCRIPTION
The pattern dpu*_ready in hotplug action script was causing both dpu[1-8]_ready and dpu[1-8]_shtdn_ready events to execute the dynamic sensor loading function. The problem was that the wild card character '*' was redirecting dpu*_shtdn_ready events to dpu*_ready case, because it ends with '_ready'. This patch fixes this problem by having the dpu slot numbers in the pattern checking, there by avoiding the '*' wild card character.