### PR TITLE
hw-mgmt: infra: Optimize PSU init time

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -818,7 +818,8 @@ if [ "$1" == "add" ]; then
 			exit 0
 		fi
 		# Allow PS controller to stabilize
-		sleep 2
+		retry_helper "ls" 0.2 20 "$2 takes too long to init" "$5""$3"/in1_input
+		sleep 1
 		# Set I2C bus for psu
 		echo "$bus" > $config_path/"$psu_name"_i2c_bus
 		# Set default fan speed


### PR DESCRIPTION
For PSU on udev event we have a delay 2 sec which is needed to
allow PSU controller to stabilize. This delay of 2 sec can be too much.

In this change, we replaced constant delay to PSU attribute polling,
which can help us to get the exact time when PSU is ready and reduce
wait time for PSU attributes init.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
