### PR TITLE
hw-mgmt: infra: Add supprort for eeprom on FIO board

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1174,8 +1174,12 @@ if [ "$1" == "add" ]; then
 		pdb_eeprom)
 			hw-management-vpd-parser.py -i "$eeprom_path/$eeprom_name" -o "$eeprom_path"/pdb_data
 			;;
-		cable_cartridge_eeprom)
-			hw-management-vpd-parser.py -i "$eeprom_path/$eeprom_name" -o "$eeprom_path"/cable_cartridge_data
+		cable_cartridge*_eeprom)
+			eeprom_vpd_filename=${eeprom_name/"_eeprom"/"_data"}
+			hw-management-vpd-parser.py -i "$eeprom_path/$eeprom_name" -o "$eeprom_path"/$eeprom_vpd_filename
+			;;
+		fio_info)
+			hw-management-vpd-parser.py -i "$eeprom_path/$eeprom_name" -o "$eeprom_path"/fio_data
 			;;
 		*)
 			;;


### PR DESCRIPTION
Add supprort for eeprom on FIO board
Fix cartriddge vpd decode

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
