### PR TITLE
hw-mgmt: sensors: Add sensorss config rule for 2nd PSU in sn5600/sn5400 systems.

### DIFF
--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -405,6 +405,7 @@ chip "dps460-i2c-*-5a"
     label power2 "PSU-2(R) 54V Rail Pwr (out)"
     label curr1 "PSU-2(R) 220V Rail Curr (in)"
     label curr2 "PSU-2(R) 54V Rail Curr (out)"
+    set power2_cap 0
 
 # Power converters
 chip "pmbus-i2c-*-10"


### PR DESCRIPTION
Add power2_cap setting for 2nd PSU.
By some reason this attribute is reported just on PSU address 0x5a.
It's better add for consistency also for PSU address 0x59.
Related commit: dd733a03cdaff88cbdf1a23f4e3a4eabb550f30c

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
