### PR TITLE
hw-mgmt: thermal: TC fixed issue "dictionary changed size"

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -3168,7 +3168,8 @@ class ThermalManagement(hw_managemet_file_op):
 
         while self.obj_init_continue:
             self.obj_init_continue = False
-            for key, _ in self.sys_config[CONST.SYS_CONF_SENSORS_CONF].items():
+            sys_config = dict(self.sys_config[CONST.SYS_CONF_SENSORS_CONF])
+            for key, _ in sys_config.items():
                 dev_obj = self._add_dev_obj(key)
                 if not dev_obj:
                     self.log.error("{} create failed".format(key))


### PR DESCRIPTION
TC during init combined devices like "dpu_sensor" returned error:

  File "/tmp/./hw_management_thermal_control.py", line 3467, in <module>
    thermal_management.init()
  File "/tmp/./hw_management_thermal_control.py", line 3171, in init
    for key, _ in self.sys_config[CONST.SYS_CONF_SENSORS_CONF].items():
  RuntimeError: dictionary changed size during iteration

This commit fixing such issue.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
