### PR TITLE
hw-mgmt: scripts Fix FAN dir attribute for PN in none-MLNX format

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1160,6 +1160,8 @@ if [ "$1" == "add" ]; then
 					echo 0 > $thermal_path/"${fan_prefix}"_dir
 					;;
 				*)
+					# Unknown FAN dir
+					echo 2 > $thermal_path/"${fan_prefix}"_dir
 					;;
 				esac
 			fi


### PR DESCRIPTION
For the systems, with FANs equiped with FRU EEPRM fan_direction attr
value can be extracted from FRU PN field. If PN is not in MLNX
format (MTEF-FANR-A) or broken - not possible to get fan_direction
and fanX_dir attribute not crating.

With this fix added fan direction value == 2, which means "FAN
direction can't be extracted"

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
