### PR TITLE
hw-mgmt: thermal: TC fix "sensor missing error" display name. To be consistant with thermal table data, changed "sensor missing error" displayed name.

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -185,7 +185,7 @@ class CONST(object):
     RUNNING = "RUNNING"
 
     # error types
-    SENSOR_READ_ERR = "sensor_read_err"
+    SENSOR_READ_ERR = "sensor_read_error"
     FAN_ERR = "fan_err"
     PSU_ERR = "psu_err"
     TACHO = "tacho"


### PR DESCRIPTION
sensor_read_err => sensor_read_error

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
