### PR TITLE
[PoC] Skip downstream BF3 patches and take everything else

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -51,8 +51,8 @@ Kernel-5.10
 |0047-i2c-mlxcpld-Allow-flexible-polling-time-setting-for-.patch  | 712d6617d0a2       | Feature upstream                         |            | (5.16)                                         |
 |0048-hwmon-pmbus-mp2975-Add-missed-POUT-attribute-for-pag.patch  | 2292e2f685cd       | Bugfix upstream                          |  5.10.71   |                                                |
 |0049-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch  |                    | Rejected; take[ALL]                      |            |Need to check patch apply. Can break patch apply|
-|0050-leds-mlxreg-Skip-setting-LED-color-during-initializa.patch  |                    | Downstream                               |            |                                                |
-|0051-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch  |                    | Downstream                               |            | Modular SN4800                                 |
+|0050-leds-mlxreg-Skip-setting-LED-color-during-initializa.patch  |                    | Downstream accepted                      |            |                                                |
+|0051-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch  |                    | Downstream accepted                      |            | Modular SN4800                                 |
 |0052-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch  | e6fab7af6ba1       | Bugfix upstream                          |  5.10.71   |                                                |
 |0053-mlxsw-core-Avoid-creation-virtual-hwmon-objects-by-t.patch  | f8a36880f474       | Feature upstream                         |            |                                                |
 |0054-mlxsw-minimal-Simplify-method-of-modules-number-dete.patch  |                    | Downstream accepted                      |            | must exist in Sonic/CL from 4.9                |
@@ -175,10 +175,10 @@ Kernel-5.10
 |0164-hwmon-jc42-Add-support-for-Seiko-Instruments-S-34TS0.patch  | c7250b5d553c       | Feature upstream                         |            | relevant for CFL systems only                  |
 |0165-platform-mellanox-mlxreg-io-Add-locking-for-io-opera.patch  | 7964f8fc52b1       | Feature upstream                         |            |                                                |
 |0166-DS-leds-leds-mlxreg-Send-udev-event-from-leds-mlxreg.patch  |                    | Downstream accepted                      |            | SN2201                                         |
-|0167-DS-lan743x-Add-support-for-fixed-phy.patch                  |                    | Downstream                               |            | P2317 only                                     |
-|0168-TMP-mlxsw-minimal-Ignore-error-reading-SPAD-register.patch  |                    | Downstream                               |            | MQM8700 only                                   |
+|0167-DS-lan743x-Add-support-for-fixed-phy.patch                  |                    | Downstream accepted                      |            | P2317 only                                     |
+|0168-TMP-mlxsw-minimal-Ignore-error-reading-SPAD-register.patch  |                    | Downstream accepted                      |            | MQM8700 only                                   |
 |0170-i2c-mlxcpld-Fix-register-setting-for-400KHz-frequenc.patch  | e1f77ecc75aa       | Feature upstream                         |            |                                                |
-|0171-platform-mellanox-mlxreg-lc-Fix-cleanup-on-failure-a.patch  | 52e01c0b1d80       | Downstream                               |            | Modular SN4800                                 |
+|0171-platform-mellanox-mlxreg-lc-Fix-cleanup-on-failure-a.patch  | 52e01c0b1d80       | Downstream accepted                      |            | Modular SN4800                                 |
 |0172-DS-platform-mlx-platform-Add-SPI-path-for-rack-switc.patch  |                    | Downstream accepted                      |            | P4697                                          |
 |0173-mlxsw-core-Add-support-for-OSFP-transceiver-modules.patch   | f881c4ab37db       | Feature upstream                         |            |                                                |
 |0174-DS-mlxsw-core_linecards-Skip-devlink-and-provisionin.patch  |                    | Downstream accepted                      |            | SN4800                                         |
@@ -188,7 +188,7 @@ Kernel-5.10
 |0178-platform-mellanox-Introduce-support-for-next-generat.patch  | fcf3790b9b63       | Feature upstream                         |            | SN5600                                         |
 |0179-hwmon-mlxreg-fan-TMP-Do-not-return-negative-value-fo.patch  |                    | Rejected                                 |            | (temporary fix until new TC)                   |
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch  | 525dd5aed67a       | Feature upstream                         |            |                                                |
-|0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch   |                    | Downstream                               |            | disable upstream patch, must exist from 5.10.74|
+|0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch   |                    | Downstream accepted                      |            | disable upstream patch, must exist from 5.10.74|
 |0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
 |0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                       |
 |0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                       |
@@ -302,20 +302,20 @@ Kernel-5.10
 |0303-UBUNTU-SAUCE-Add-BF3-related-ACPI-config-and-Ring-de.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0304-platform-mellanox-mlx-platform-Modify-power-off-call.patch  |                    | Feature pending                          |            |                                                |
 |0305-Extend-driver-to-support-Infineon-Digital-Multi-phas.patch  |                    | Feature pending                          |            |                                                |
-|0306-dt-bindings-trivial-devices-Add-infineon-xdpe1a2g7.patch    |                    | Downstream                               |            |                                                |
-|0307-leds-mlxreg-Add-support-for-new-flavour-of-capabilit.patch  |                    | Downstream                               |            |                                                |
-|0308-leds-mlxreg-Remove-code-for-amber-LED-colour.patch          |                    | Downstream                               |            |                                                |
-|0308-platform_data-mlxreg-Add-capability-bit-and-mask-fie.patch  |                    | Downstream                               |            |                                                |
-|0309-hwmon-mlxreg-fan-Add-support-for-new-flavour-of-capa.patch  |                    | Downstream                               |            |                                                |
-|0310-hwmon-mlxreg-fan-Extend-number-of-supporetd-fans.patch      |                    | Downstream                               |            |                                                |
+|0306-dt-bindings-trivial-devices-Add-infineon-xdpe1a2g7.patch    |                    | Downstream accepted                      |            |                                                |
+|0307-leds-mlxreg-Add-support-for-new-flavour-of-capabilit.patch  |                    | Downstream accepted                      |            |                                                |
+|0308-leds-mlxreg-Remove-code-for-amber-LED-colour.patch          |                    | Downstream accepted                      |            |                                                |
+|0308-platform_data-mlxreg-Add-capability-bit-and-mask-fie.patch  |                    | Downstream accepted                      |            |                                                |
+|0309-hwmon-mlxreg-fan-Add-support-for-new-flavour-of-capa.patch  |                    | Downstream accepted                      |            |                                                |
+|0310-hwmon-mlxreg-fan-Extend-number-of-supporetd-fans.patch      |                    | Downstream accepted                      |            |                                                |
 |0311-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch  |                    | Bugfix pending                           |            | SN2201                                         |
 |0312-platform-mellanox-mlx-platform-Add-reset-callback.patch     |                    | Feature pending                          |            |                                                |
 |0313-platform-mellanox-mlx-platform-Prepare-driver-to-all.patch  |                    | Feature pending                          |            |                                                |
 |0314-platform-mellanox-mlx-platform-Introduce-ACPI-init-f.patch  |                    | Feature pending                          |            |                                                |
 |0315-platform-mellanox-mlx-platform-Get-interrupt-line-th.patch  |                    | Feature pending                          |            |                                                |
 |0316-platform-mellanox-Add-initial-support-for-PCIe-based.patch  |                    | Feature pending                          |            |                                                |
-|0317-platform-mellanox-Introduce-support-for-switches-equ.patch  |                    | Downstream                               |            |                                                |
-|0318-mellanox-Relocate-mlx-platform-driver.patch                 |                    | Downstream                               |            |                                                |
+|0317-platform-mellanox-Introduce-support-for-switches-equ.patch  |                    | Downstream accepted                      |            |                                                |
+|0318-mellanox-Relocate-mlx-platform-driver.patch                 |                    | Downstream accepted                      |            |                                                |
 |0319-UBUNTU-SAUCE-mlxbf-tmfifo-fix-potential-race.patch          |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0320-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-the-Rx-packet-if-no-m.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0321-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-jumbo-frames.patch           |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
@@ -323,17 +323,17 @@ Kernel-5.10
 |0323-mlxbf_gige-add-set_link_ksettings-ethtool-callback.patch    |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0324-mlxbf_gige-fix-white-space-in-mlxbf_gige_eth_ioctl.patch    |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0325-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
-|0326-platform-mellanox-mlxreg-hotplug-Add-support-for-new.patch  |                    | Downstream                               |            |                                                |
-|0327-platform-mellanox-mlx-platform-Change-register-name.patch   |                    | Downstream                               |            |                                                |
-|0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch  |                    | Downstream                               |            |                                                |
+|0326-platform-mellanox-mlxreg-hotplug-Add-support-for-new.patch  |                    | Downstream accepted                      |            |                                                |
+|0327-platform-mellanox-mlx-platform-Change-register-name.patch   |                    | Downstream accepted                      |            |                                                |
+|0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch  |                    | Downstream accepted                      |            |                                                |
 |0329-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0330-mlxsw-i2c-Downstream-Add-retry-mechanism-for-failed-.patch  |                    | Downstream accepted                      |            |                                                |
 |0331-mlxsw-i2c-DBG-Add-debug-output-for-failed-transactio.patch  |                    | Downstream accepted                      |            |                                                |
 |0332-platform-mellanox-indicate-deferred-I2C-bus-creation.patch  |                    | Bugfix pending                           |            | SN2201                                         |
 |9000-DS-OPT-iio-pressure-icp20100-add-driver-for-InvenSense-.patch|                   | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-DS-OPT-e1000e-skip-NVM-checksum.patch                       |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
-|9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream                               |            |                                                |
-|9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch  |                    | Downstream                               |            | P4300                                          |
+|9002-TMP-fix-for-fan-minimum-speed.patch                         |                    | Downstream accepted                      |            |                                                |
+|9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch  |                    | Downstream accepted                      |            | P4300                                          |
 |9004-DS-OPT-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch|                 | Downstream accepted                      |            |                                                |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -289,7 +289,7 @@ Kernel-5.10
 |0288-UBUNTU-SAUCE-gpio-mmio-handle-ngpios-properly-in-bgp.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0289-UBUNTU-SAUCE-gpio-mlxbf3-Add-gpio-driver-support.patch      |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0291-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch  |                    | Downstream accepted                      |            | SN3750SX                                       |
-|0292-mlxsw-i2c-Limit-single-transaction-buffer-size.patch        |                    | Downstream accepted;skip[sonic]          |            | BF3-COME                                       |
+|0292-mlxsw-i2c-Limit-single-transaction-buffer-size.patch        |                    | Downstream accepted                      |            | BF3-COME                                       |
 |0293-mlxsw-reg-Limit-MTBR-register-records-buffer-by-one-.patch  |                    | Downstream accepted                      |            |                                                |
 |0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch  |                    | Feature pending; os[sonic,opt]           |            |                                                |
 |0295-dt-bindings-trivial-devices-Add-mps-mp2891.patch            |                    | Feature pending                          |            |                                                |

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -315,7 +315,7 @@ Kernel-5.10
 |0315-platform-mellanox-mlx-platform-Get-interrupt-line-th.patch  |                    | Feature pending                          |            |                                                |
 |0316-platform-mellanox-Add-initial-support-for-PCIe-based.patch  |                    | Feature pending                          |            |                                                |
 |0317-platform-mellanox-Introduce-support-for-switches-equ.patch  |                    | Downstream accepted                      |            |                                                |
-|0318-mellanox-Relocate-mlx-platform-driver.patch                 |                    | Downstream accepted                      |            |                                                |
+|0318-mellanox-Relocate-mlx-platform-driver.patch                 |                    | Downstream accepted; os[sonic]           |            |                                                |
 |0319-UBUNTU-SAUCE-mlxbf-tmfifo-fix-potential-race.patch          |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0320-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-the-Rx-packet-if-no-m.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0321-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-jumbo-frames.patch           |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -99,12 +99,12 @@ Kernel-5.10
 |0095-hwmon-mlxreg-fan-Fix-out-of-bounds-read-on-array-fan.patch  | 000cc5bc49aa       | Feature upstream                         |            |                                                |
 |0096-hwmon-mlxreg-fan-Modify-PWM-connectivity-validation.patch   | b1c24237341f       | Feature upstream                         |            |                                                |
 |0097-hwmon-mlxreg-fan-Support-distinctive-names-per-diffe.patch  | b2be2422c0c9       | Feature upstream                         |            |                                                |
-|0097-1-mlxsw-Use-u16-for-local_port-field.patch                  |                    | Downstream                               |            |                                                |
-|0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch                    |                    | Downstream                               |            |                                                |
-|0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch          |                    | Downstream                               |            |                                                |
-|0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch           |                    | Downstream                               |            |                                                |
-|0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch             |                    | Downstream                               |            |                                                |
-|0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch   |                    | Downstream                               |            |                                                |
+|0097-1-mlxsw-Use-u16-for-local_port-field.patch                  |                    | Downstream;skip[sonic]                   |            |                                                |
+|0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch                    |                    | Downstream;skip[sonic]                   |            |                                                |
+|0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch          |                    | Downstream;skip[sonic]                   |            |                                                |
+|0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch           |                    | Downstream;skip[sonic]                   |            |                                                |
+|0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch             |                    | Downstream;skip[sonic]                   |            |                                                |
+|0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch   |                    | Downstream;skip[sonic]                   |            |                                                |
 |0098-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | IB Disable FW update                           |
 |0099-mlxsw-core_hwmon-Fix-variable-names-for-hwmon-attrib.patch  | bed8f4197cb2       | Downstream accepted                      |            | Modular SN4800                                 |
 |0100-mlxsw-core_thermal-Rename-labels-according-to-naming.patch  | 009da9fad567       | Downstream accepted                      |            | Modular SN4800                                 |

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -190,19 +190,19 @@ Kernel-5.10
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch  | 525dd5aed67a       | Feature upstream                         |            |                                                |
 |0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch   |                    | Downstream                               |            | disable upstream patch, must exist from 5.10.74|
 |0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
-|0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
-|0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                       |
+|0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                       |
 |0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Feature upstream                         |            |                                                |
 |0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch  | 26e118ea98cf       | Feature upstream                         |            |                                                |
-|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
-|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
-|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
-|0190-i2c-mlxcpld-Support-PCIe-mapped-register-space.patch        |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
-|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch  |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
-|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc7815660      | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
-|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357e      | Feature upstream;skip[sonic]             |            | BF3-COME                                       |
-|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch  |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
-|0195-platform-x86-MLX_PLATFORM-select-REGMAP-instead-of-d.patch  |                    | Bugfix upstream;skip[sonic]             | 5.10.175   | BF3-COME accepted in 6.1                       |
+|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Feature upstream                         |            | BF3-COME                                       |
+|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Feature pending                          |            | BF3-COME                                       |
+|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0190-i2c-mlxcpld-Support-PCIe-mapped-register-space.patch        |                    | Feature pending                          |            | BF3-COME                                       |
+|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc7815660      | Feature upstream                         |            | BF3-COME                                       |
+|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357e      | Feature upstream                         |            | BF3-COME                                       |
+|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch  |                    | Feature pending                          |            | BF3-COME                                       |
+|0195-platform-x86-MLX_PLATFORM-select-REGMAP-instead-of-d.patch  |                    | Bugfix upstream                          | 5.10.175   | BF3-COME accepted in 6.1                       |
 |0196-platform-mellanox-Cosmetic-changes.patch                    |                    | Feature pending                          |            |                                                |
 |0197-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            |                                                |
 |0198-platform-mellanox-Add-new-attributes.patch                  |                    | Feature pending                          |            |                                                |
@@ -346,12 +346,12 @@ Kernel-6.1
 |0003-platform-mellanox-Cosmetic-changes-rename-to-more-co.patch  | acc6ea304590       | Feature upstream                         |            |                                                |
 |0004-platform-mellanox-Introduce-support-for-next-generat.patch  | fcf3790b9b63       | Feature upstream                         |            | SN5600                                         |
 |0005-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
-|0006-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
-|0007-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0006-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                        |
+|0007-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                        |
 |0008-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Feature upstream                         |            |                                                |
-|0009-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc781566       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
-|0010-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
-|0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0009-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc781566       | Feature upstream                         |            | BF3-COME                                        |
+|0010-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357       | Feature upstream                         |            | BF3-COME                                        |
+|0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream                         |            | BF3-COME                                        |
 |0012-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            | Accepted for 6.4                               |
 |0013-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            | Accepted for 6.4                               |
 |0014-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Bugfix pending                           |            | Accepted for 6.4                               |
@@ -401,27 +401,27 @@ Kernel-6.1
 |0062-pinctrl-mlxbf3-Add-pinctrl-driver-support.patch             | d11f932808dc       | Feature upstream                         |            | BF3                                            |
 |0063-gpio-mlxbf3-Add-gpio-driver-support.patch                   | cd33f216d241       | Feature upstream                         |            | BF3                                            |
 |0064-pinctrl-mlxbf3-set-varaiable-mlxbf3_pmx_funcs-storag.patch  | 743d3336029f       | Feature upstream                         |            | BF3                                            |
-|0066-UBUNTU-SAUCE-sdhci-of-dwcmshc-Enable-host-V4-support.patch  | 95921151e043       | Downstream                               |            | BF3                                            |
-|0067-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch  | cfd4ea4815d1       | Downstream                               |            | BF3                                            |
-|0068-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-Add-runtime-PM-ope.patch  |                    | Downstream                               |            | BF3                                            |
-|0069-UBUNTU-SAUCE-mlxbf_gige-add-ethtool-mlxbf_gige_set_r.patch  |                    | Downstream                               |            | BF3                                            |
-|0070-UBUNTU-SAUCE-Fix-OOB-handling-RX-packets-in-heavy-tr.patch  |                    | Downstream                               |            | BF3                                            |
-|0071-UBUNTU-SAUCE-mlxbf-gige-Fix-intermittent-no-ip-issue.patch  |                    | Downstream                               |            | BF3                                            |
-|0072-mlxbf_gige-add-MDIO-support-for-BlueField-3.patch           | 2321d69f92aa       | Downstream                               |            | BF3                                            |
-|0073-mlxbf_gige-support-10M-100M-1G-speeds-on-BlueField-3.patch  | 20d03d4d9437       | Downstream                               |            | BF3                                            |
-|0074-mlxbf_gige-add-set_link_ksettings-ethtool-callback.patch    |                    | Downstream                               |            | BF3                                            |
-|0075-UBUNTU-SAUCE-mlxbf-gige-Fix-kernel-panic-at-shutdown.patch  |                    | Downstream                               |            | BF3                                            |
-|0076-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-boot.patch  |                    | Downstream                               |            | BF3                                            |
-|0077-UBUNTU-SAUCE-mlx-bootctl-support-icm-carveout-eeprom.patch  |                    | Downstream                               |            | BF3                                            |
-|0078-UBUNTU-SAUCE-mlxbf-bootctl-support-SMC-call-for-sett.patch  |                    | Downstream                               |            | BF3                                            |
-|0079-UBUNTU-SAUCE-mlxbf-ptm-power-and-thermal-management-.patch  |                    | Downstream                               |            | BF3                                            |
-|0080-UBUNTU-SAUCE-mlxbf-ptm-update-license.patch                 |                    | Downstream                               |            | BF3                                            |
-|0081-UBUNTU-SAUCE-mlxbf-ptm-use-0444-instead-of-S_IRUGO.patch    |                    | Downstream                               |            | BF3                                            |
-|0082-UBUNTU-SAUCE-mlxbf-ptm-add-atx-debugfs-nodes.patch          |                    | Downstream                               |            | BF3                                            |
-|0083-UBUNTU-SAUCE-mlxbf-ptm-update-module-version.patch          |                    | Downstream                               |            | BF3                                            |
-|0084-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Downstream                               |            | BF3                                            |
+|0066-UBUNTU-SAUCE-sdhci-of-dwcmshc-Enable-host-V4-support.patch  | 95921151e043       | Downstream;skip[sonic]                   |            | BF3                                            |
+|0067-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch  | cfd4ea4815d1       | Downstream;skip[sonic]                   |            | BF3                                            |
+|0068-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-Add-runtime-PM-ope.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0069-UBUNTU-SAUCE-mlxbf_gige-add-ethtool-mlxbf_gige_set_r.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0070-UBUNTU-SAUCE-Fix-OOB-handling-RX-packets-in-heavy-tr.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0071-UBUNTU-SAUCE-mlxbf-gige-Fix-intermittent-no-ip-issue.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0072-mlxbf_gige-add-MDIO-support-for-BlueField-3.patch           | 2321d69f92aa       | Downstream;skip[sonic]                   |            | BF3                                            |
+|0073-mlxbf_gige-support-10M-100M-1G-speeds-on-BlueField-3.patch  | 20d03d4d9437       | Downstream;skip[sonic]                   |            | BF3                                            |
+|0074-mlxbf_gige-add-set_link_ksettings-ethtool-callback.patch    |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0075-UBUNTU-SAUCE-mlxbf-gige-Fix-kernel-panic-at-shutdown.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0076-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-boot.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0077-UBUNTU-SAUCE-mlx-bootctl-support-icm-carveout-eeprom.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0078-UBUNTU-SAUCE-mlxbf-bootctl-support-SMC-call-for-sett.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0079-UBUNTU-SAUCE-mlxbf-ptm-power-and-thermal-management-.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0080-UBUNTU-SAUCE-mlxbf-ptm-update-license.patch                 |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0081-UBUNTU-SAUCE-mlxbf-ptm-use-0444-instead-of-S_IRUGO.patch    |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0082-UBUNTU-SAUCE-mlxbf-ptm-add-atx-debugfs-nodes.patch          |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0083-UBUNTU-SAUCE-mlxbf-ptm-update-module-version.patch          |                    | Downstream;skip[sonic]                   |            | BF3                                            |
+|0084-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Downstream;skip[sonic]                   |            | BF3                                            |
 |0085-hwmon-mlxreg-fan-Separate-methods-of-fan-setting-com.patch  |                    | Bugfix pending                           |            |                                                |
-|0086-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream                               |            | BF3                                            |
+|0086-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream;skip[sonic]                   |            | BF3                                            |
 |0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch  |                    | Bugfix pending                           |            | SN2201                                         |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream                               |            | Disable FW update                              |
 |8001-platform-mellanox-Downstream-Add-dedicated-match-for.patch  |                    | Downstream                               |            | Add dedicated match for QMB8700                |

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -346,12 +346,12 @@ Kernel-6.1
 |0003-platform-mellanox-Cosmetic-changes-rename-to-more-co.patch  | acc6ea304590       | Feature upstream                         |            |                                                |
 |0004-platform-mellanox-Introduce-support-for-next-generat.patch  | fcf3790b9b63       | Feature upstream                         |            | SN5600                                         |
 |0005-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
-|0006-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                        |
-|0007-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                        |
+|0006-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                       |
+|0007-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                       |
 |0008-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Feature upstream                         |            |                                                |
-|0009-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc781566       | Feature upstream                         |            | BF3-COME                                        |
-|0010-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357       | Feature upstream                         |            | BF3-COME                                        |
-|0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream                         |            | BF3-COME                                        |
+|0009-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc781566       | Feature upstream                         |            | BF3-COME                                       |
+|0010-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357       | Feature upstream                         |            | BF3-COME                                       |
+|0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream                         |            | BF3-COME                                       |
 |0012-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            | Accepted for 6.4                               |
 |0013-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            | Accepted for 6.4                               |
 |0014-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Bugfix pending                           |            | Accepted for 6.4                               |

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -50,7 +50,7 @@ Kernel-5.10
 |0046-i2c-mlxcpld-Reduce-polling-time-for-performance-impr.patch  | 669b2e4aa1a8       | Feature upstream                         |            | (5.16)                                         |
 |0047-i2c-mlxcpld-Allow-flexible-polling-time-setting-for-.patch  | 712d6617d0a2       | Feature upstream                         |            | (5.16)                                         |
 |0048-hwmon-pmbus-mp2975-Add-missed-POUT-attribute-for-pag.patch  | 2292e2f685cd       | Bugfix upstream                          |  5.10.71   |                                                |
-|0049-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch  |                    | Rejected; take[ALL]                      |            |Need to check patch apply. Can break patch apply|
+|0049-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch  |                    | Downstream accepted; take[ALL]           |            |Need to check patch apply. Can break patch apply|
 |0050-leds-mlxreg-Skip-setting-LED-color-during-initializa.patch  |                    | Downstream accepted                      |            |                                                |
 |0051-leds-mlxreg-Allow-multi-instantiation-of-same-name-L.patch  |                    | Downstream accepted                      |            | Modular SN4800                                 |
 |0052-hwmon-mlxreg-fan-Return-non-zero-value-when-fan-curr.patch  | e6fab7af6ba1       | Bugfix upstream                          |  5.10.71   |                                                |

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -99,12 +99,12 @@ Kernel-5.10
 |0095-hwmon-mlxreg-fan-Fix-out-of-bounds-read-on-array-fan.patch  | 000cc5bc49aa       | Feature upstream                         |            |                                                |
 |0096-hwmon-mlxreg-fan-Modify-PWM-connectivity-validation.patch   | b1c24237341f       | Feature upstream                         |            |                                                |
 |0097-hwmon-mlxreg-fan-Support-distinctive-names-per-diffe.patch  | b2be2422c0c9       | Feature upstream                         |            |                                                |
-|0097-1-mlxsw-Use-u16-for-local_port-field.patch                  |                    | Feature pending                          |            |                                                |
-|0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch                    |                    | Feature pending                          |            |                                                |
-|0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch          |                    | Feature pending                          |            |                                                |
-|0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch           |                    | Downstream accepted                      |            |                                                |
-|0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch             |                    | Downstream accepted                      |            |                                                |
-|0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch   |                    | Downstream accepted                      |            |                                                |
+|0097-1-mlxsw-Use-u16-for-local_port-field.patch                  |                    | Downstream                               |            |                                                |
+|0097-2-mlxsw-i2c-Fix-chunk-size-setting.patch                    |                    | Downstream                               |            |                                                |
+|0097-3-mlxsw-core_hwmon-Adjust-module-label-names.patch          |                    | Downstream                               |            |                                                |
+|0098-1-Revert-mlxsw-Use-u16-for-local_port-field.patch           |                    | Downstream                               |            |                                                |
+|0098-2-Revert-mlxsw-i2c-Fix-chunk-size-setting.patch             |                    | Downstream                               |            |                                                |
+|0098-3-Revert-mlxsw-core_hwmon-Adjust-module-label-names.patch   |                    | Downstream                               |            |                                                |
 |0098-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | IB Disable FW update                           |
 |0099-mlxsw-core_hwmon-Fix-variable-names-for-hwmon-attrib.patch  | bed8f4197cb2       | Downstream accepted                      |            | Modular SN4800                                 |
 |0100-mlxsw-core_thermal-Rename-labels-according-to-naming.patch  | 009da9fad567       | Downstream accepted                      |            | Modular SN4800                                 |
@@ -190,87 +190,87 @@ Kernel-5.10
 |0180-hwmon-pmbus-Fix-sensors-readouts-for-MPS-Multi-phase.patch  | 525dd5aed67a       | Feature upstream                         |            |                                                |
 |0181-Revert-Fix-out-of-bounds-memory-accesses-in-thermal.patch   |                    | Downstream                               |            | disable upstream patch, must exist from 5.10.74|
 |0182-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
-|0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                       |
-|0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                       |
+|0183-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0184-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
 |0185-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Feature upstream                         |            |                                                |
 |0186-platform-mellanox-mlxreg-hotplug-Allow-more-flexible.patch  | 26e118ea98cf       | Feature upstream                         |            |                                                |
-|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Feature upstream                         |            | BF3-COME                                       |
-|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Feature pending                          |            | BF3-COME                                       |
-|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0190-i2c-mlxcpld-Support-PCIe-mapped-register-space.patch        |                    | Feature pending                          |            | BF3-COME                                       |
-|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc7815660      | Feature upstream                         |            | BF3-COME                                       |
-|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357e      | Feature upstream                         |            | BF3-COME                                       |
-|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch  |                    | Feature pending                          |            | BF3-COME                                       |
-|0195-platform-x86-MLX_PLATFORM-select-REGMAP-instead-of-d.patch  |                    | Bugfix upstream                          | 5.10.175   | BF3-COME accepted in 6.1                       |
+|0187-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0188-i2c-mux-Add-register-map-based-mux-driver.patch             |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
+|0189-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
+|0190-i2c-mlxcpld-Support-PCIe-mapped-register-space.patch        |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
+|0192-i2c-mlxcpld-Add-support-for-extended-transaction-len.patch  |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
+|0193-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc7815660      | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0194-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357e      | Feature upstream;skip[sonic]             |            | BF3-COME                                       |
+|0195-platform-mellanox-Add-support-for-dynamic-I2C-channe.patch  |                    | Feature pending;skip[sonic]              |            | BF3-COME                                       |
+|0195-platform-x86-MLX_PLATFORM-select-REGMAP-instead-of-d.patch  |                    | Bugfix upstream;skip[sonic]             | 5.10.175   | BF3-COME accepted in 6.1                       |
 |0196-platform-mellanox-Cosmetic-changes.patch                    |                    | Feature pending                          |            |                                                |
 |0197-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            |                                                |
 |0198-platform-mellanox-Add-new-attributes.patch                  |                    | Feature pending                          |            |                                                |
 |0199-platform-mellanox-Change-register-offset-addresses.patch    |                    | Bugfix pending                           |            | P4262                                          |
-|0200-dt-bindings-i2c-mellanox-i2c-mlxbf-convert-txt-to-YA.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0200-dt-bindings-i2c-mellanox-i2c-mlxbf-convert-txt-to-YA.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0201-i2c-mlxbf-incorrect-base-address-passed-during-io-wr.patch  | 2a5be6d1340c       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
 |0202-i2c-mlxbf-prevent-stack-overflow-in-mlxbf_i2c_smbus_.patch  | de24aceb07d4       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
-|0203-i2c-mlxbf-remove-IRQF_ONESHOT.patch                         | 92be2c122e49       | Downstream                               |            | BF3-COME                                       |
+|0203-i2c-mlxbf-remove-IRQF_ONESHOT.patch                         | 92be2c122e49       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0204-i2c-mlxbf-Fix-frequency-calculation.patch                   | 37f071ec327b       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
 |0205-i2c-mlxbf-support-lock-mechanism.patch                      | 86067ccfa142       | Bugfix upstream                          |  5.10.162  | BF3-COME                                       |
-|0206-i2c-mlxbf-add-multi-slave-functionality.patch               | bdc4af281b70       | Downstream                               |            | BF3-COME                                       |
-|0207-i2c-mlxbf-support-BlueField-3-SoC.patch                     | 19e13e1330c6       | Downstream                               |            | BF3-COME                                       |
-|0208-i2c-mlxbf-remove-device-tree-support.patch                  | be18c5ede25d       | Downstream                               |            | BF3-COME                                       |
-|0209-UBUNTU-SAUCE-i2c-mlxbf.c-Add-driver-version.patch           |                    | Downstream                               |            | BF3-COME                                       |
-|0210-platform-mellanox-Typo-fix-in-the-file-mlxbf-bootctl.patch  | 04cdaf6d8f52       | Downstream                               |            | BF3-COME                                       |
-|0211-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-boot.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0212-platform-mellanox-mlxbf-pmc-Add-Mellanox-BlueField-P.patch  | 1a218d312e65       | Downstream                               |            | BF3-COME                                       |
-|0213-platform-mellanox-mlxbf-pmc-fix-kernel-doc-notation.patch   | 0c59e612c0b6       | Downstream                               |            | BF3-COME                                       |
-|0214-platform-mellanox-mlxbf-pmc-Fix-an-IS_ERR-vs-NULL-bu.patch  | 804034c4ffc5       | Downstream                               |            | BF3-COME                                       |
-|0215-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-pmc.patch   |                    | Downstream                               |            | BF3-COME                                       |
-|0216-UBUNTU-SAUCE-mlxbf_pmc-Fix-references-to-sprintf.patch      |                    | Downstream                               |            | BF3-COME                                       |
-|0217-UBUNTU-SAUCE-mlxbf-pmc-Fix-error-when-reading-unprog.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0218-UBUNTU-SAUCE-platform-mellanox-Add-mlx-trio-driver.patch    |                    | Downstream                               |            | BF3-COME                                       |
-|0219-UBUNTU-SAUCE-platform-mellanox-mlxbf-tmfifo-Add-Blue.patch  | bc05ea63b394       | Downstream                               |            | BF3-COME                                       |
-|0220-UBUNTU-SAUCE-pka-Add-pka-driver.patch                       |                    | Downstream                               |            | BF3-COME                                       |
-|0221-UBUNTU-SAUCE-platform-mellanox-Add-mlxbf-livefish-dr.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0222-workqueue-Add-resource-managed-version-of-delayed-wo.patch  | 0341ce544394       | Downstream                               |            | BF3-COME                                       |
-|0223-devm-helpers-Fix-devm_delayed_work_autocancel-kernel.patch  | a943d76352db       | Downstream                               |            | BF3-COME                                       |
-|0224-devm-helpers-Add-resource-managed-version-of-work-in.patch  | 7a2c4cc537fa       | Downstream                               |            | BF3-COME                                       |
-|0225-UBUNTU-SAUCE-Add-support-to-pwr-mlxbf.c-driver.patch        |                    | Downstream                               |            | BF3-COME                                       |
-|0226-Add-Mellanox-BlueField-Gigabit-Ethernet-driver.patch        | f92e1869d74e       | Downstream                               |            | BF3-COME                                       |
-|0227-mlxbf_gige-clear-valid_polarity-upon-open.patch             | ee8a9600b539       | Downstream                               |            | BF3-COME                                       |
-|0228-net-mellanox-mlxbf_gige-Replace-non-standard-interru.patch  | 6c2a6ddca763       | Downstream                               |            | BF3-COME                                       |
-|0229-mlxbf_gige-increase-MDIO-polling-rate-to-5us.patch          | 0a02e282bad4       | Downstream                               |            | BF3-COME                                       |
-|0230-mlxbf_gige-remove-driver-managed-interrupt-counts.patch     | f4826443f4d6       | Downstream                               |            | BF3-COME                                       |
-|0231-mlxbf_gige-remove-own-module-name-define-and-use-KBU.patch  | cfbc80e34e3a       | Downstream                               |            | BF3-COME                                       |
-|0232-UBUNTU-SAUCE-mlxbf_gige-add-ethtool-mlxbf_gige_set_r.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0233-UBUNTU-SAUCE-Fix-OOB-handling-RX-packets-in-heavy-tr.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0236-UBUNTU-SAUCE-mlxbf_gige-clear-MDIO-gateway-lock-afte.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0237-mlxbf_gige-compute-MDIO-period-based-on-i1clk.patch         | 3a1a274e933f       | Downstream                               |            | BF3-COME                                       |
-|0238-net-mlxbf_gige-Fix-an-IS_ERR-vs-NULL-bug-in-mlxbf_gi.patch  | 4774db8dfc6a       | Downstream                               |            | BF3-COME                                       |
-|0239-UBUNTU-SAUCE-mlxbf_gige-add-MDIO-support-for-BlueFie.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0240-UBUNTU-SAUCE-mlxbf_gige-support-10M-100M-1G-speeds-o.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0243-UBUNTU-SAUCE-bluefield_edac-Add-SMC-support.patch           |                    | Downstream                               |            | BF3-COME                                       |
-|0244-UBUNTU-SAUCE-bluefield_edac-Update-license-and-copyr.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0245-gpio-mlxbf2-Convert-to-device-PM-ops.patch                  | dabe57c3a32d       | Downstream                               |            | BF3-COME                                       |
-|0246-gpio-mlxbf2-Drop-wrong-use-of-ACPI_PTR.patch                | 603607e70e36       | Downstream                               |            | BF3-COME                                       |
-|0247-gpio-mlxbf2-Use-devm_platform_ioremap_resource.patch        | 4e6864f8563d       | Downstream                               |            | BF3-COME                                       |
-|0248-gpio-mlxbf2-Use-DEFINE_RES_MEM_NAMED-helper-macro.patch     | d0ef631d40ba       | Downstream                               |            | BF3-COME                                       |
-|0249-gpio-mlxbf2-Introduce-IRQ-support.patch                     |                    | Downstream                               |            | BF3-COME                                       |
-|0250-UBUNTU-SAUCE-gpio-mlxbf2.c-support-driver-version.patch     |                    | Downstream                               |            | BF3-COME                                       |
-|0251-mmc-sdhci-of-dwcmshc-add-rockchip-platform-support.patch    | 08f3dff799d4       | Downstream                               |            | BF3-COME                                       |
-|0252-mmc-sdhci-of-dwcmshc-add-ACPI-support-for-BlueField-.patch  | eb81ed518079       | Downstream                               |            | BF3-COME                                       |
-|0253-mmc-sdhci-of-dwcmshc-fix-error-return-code-in-dwcmsh.patch  | 34884c4f6483       | Downstream                               |            | BF3-COME                                       |
-|0254-mmc-sdhci-of-dwcmshc-set-MMC_CAP_WAIT_WHILE_BUSY.patch      | 57ac3084f598       | Downstream                               |            | BF3-COME                                       |
-|0255-mmc-sdhci-of-dwcmshc-Re-enable-support-for-the-BlueF.patch  | a0753ef66c34       | Downstream                               |            | BF3-COME                                       |
-|0256-UBUNTU-SAUCE-Support-BlueField-3-GPIO-driver.patch          |                    | Downstream                               |            | BF3-COME                                       |
-|0257-regmap-debugfs-Enable-writing-to-the-regmap-debugfs-.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0258-UBUNTU-SAUCE-mlx-bootctl-support-icm-carveout-eeprom.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0259-mmc-sdhci-of-dwcmshc-Enable-host-V4-support-for-Blue.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0260-UBUNTU-SAUCE-mlxbf-pka-Fix-kernel-crash-with-pka-TRN.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0261-mlxbf-ptm-power-and-thermal-management-debugfs-drive.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0262-UBUNTU-SAUCE-mlxbf-pmc-Fix-event-string-typo.patch          | b0b698b80c56       | Downstream                               |            | BF3-COME                                       |
-|0263-UBUNTU-SAUCE-mlxbf-pmc-Support-for-BlueField-3-perfo.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0264-UBUNTU-SAUCE-platform-mellanox-Add-ctrl-message-and-.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0206-i2c-mlxbf-add-multi-slave-functionality.patch               | bdc4af281b70       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0207-i2c-mlxbf-support-BlueField-3-SoC.patch                     | 19e13e1330c6       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0208-i2c-mlxbf-remove-device-tree-support.patch                  | be18c5ede25d       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0209-UBUNTU-SAUCE-i2c-mlxbf.c-Add-driver-version.patch           |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0210-platform-mellanox-Typo-fix-in-the-file-mlxbf-bootctl.patch  | 04cdaf6d8f52       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0211-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-boot.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0212-platform-mellanox-mlxbf-pmc-Add-Mellanox-BlueField-P.patch  | 1a218d312e65       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0213-platform-mellanox-mlxbf-pmc-fix-kernel-doc-notation.patch   | 0c59e612c0b6       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0214-platform-mellanox-mlxbf-pmc-Fix-an-IS_ERR-vs-NULL-bu.patch  | 804034c4ffc5       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0215-UBUNTU-SAUCE-platform-mellanox-Updates-to-mlxbf-pmc.patch   |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0216-UBUNTU-SAUCE-mlxbf_pmc-Fix-references-to-sprintf.patch      |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0217-UBUNTU-SAUCE-mlxbf-pmc-Fix-error-when-reading-unprog.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0218-UBUNTU-SAUCE-platform-mellanox-Add-mlx-trio-driver.patch    |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0219-UBUNTU-SAUCE-platform-mellanox-mlxbf-tmfifo-Add-Blue.patch  | bc05ea63b394       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0220-UBUNTU-SAUCE-pka-Add-pka-driver.patch                       |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0221-UBUNTU-SAUCE-platform-mellanox-Add-mlxbf-livefish-dr.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0222-workqueue-Add-resource-managed-version-of-delayed-wo.patch  | 0341ce544394       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0223-devm-helpers-Fix-devm_delayed_work_autocancel-kernel.patch  | a943d76352db       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0224-devm-helpers-Add-resource-managed-version-of-work-in.patch  | 7a2c4cc537fa       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0225-UBUNTU-SAUCE-Add-support-to-pwr-mlxbf.c-driver.patch        |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0226-Add-Mellanox-BlueField-Gigabit-Ethernet-driver.patch        | f92e1869d74e       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0227-mlxbf_gige-clear-valid_polarity-upon-open.patch             | ee8a9600b539       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0228-net-mellanox-mlxbf_gige-Replace-non-standard-interru.patch  | 6c2a6ddca763       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0229-mlxbf_gige-increase-MDIO-polling-rate-to-5us.patch          | 0a02e282bad4       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0230-mlxbf_gige-remove-driver-managed-interrupt-counts.patch     | f4826443f4d6       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0231-mlxbf_gige-remove-own-module-name-define-and-use-KBU.patch  | cfbc80e34e3a       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0232-UBUNTU-SAUCE-mlxbf_gige-add-ethtool-mlxbf_gige_set_r.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0233-UBUNTU-SAUCE-Fix-OOB-handling-RX-packets-in-heavy-tr.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0236-UBUNTU-SAUCE-mlxbf_gige-clear-MDIO-gateway-lock-afte.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0237-mlxbf_gige-compute-MDIO-period-based-on-i1clk.patch         | 3a1a274e933f       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0238-net-mlxbf_gige-Fix-an-IS_ERR-vs-NULL-bug-in-mlxbf_gi.patch  | 4774db8dfc6a       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0239-UBUNTU-SAUCE-mlxbf_gige-add-MDIO-support-for-BlueFie.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0240-UBUNTU-SAUCE-mlxbf_gige-support-10M-100M-1G-speeds-o.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0243-UBUNTU-SAUCE-bluefield_edac-Add-SMC-support.patch           |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0244-UBUNTU-SAUCE-bluefield_edac-Update-license-and-copyr.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0245-gpio-mlxbf2-Convert-to-device-PM-ops.patch                  | dabe57c3a32d       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0246-gpio-mlxbf2-Drop-wrong-use-of-ACPI_PTR.patch                | 603607e70e36       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0247-gpio-mlxbf2-Use-devm_platform_ioremap_resource.patch        | 4e6864f8563d       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0248-gpio-mlxbf2-Use-DEFINE_RES_MEM_NAMED-helper-macro.patch     | d0ef631d40ba       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0249-gpio-mlxbf2-Introduce-IRQ-support.patch                     |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0250-UBUNTU-SAUCE-gpio-mlxbf2.c-support-driver-version.patch     |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0251-mmc-sdhci-of-dwcmshc-add-rockchip-platform-support.patch    | 08f3dff799d4       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0252-mmc-sdhci-of-dwcmshc-add-ACPI-support-for-BlueField-.patch  | eb81ed518079       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0253-mmc-sdhci-of-dwcmshc-fix-error-return-code-in-dwcmsh.patch  | 34884c4f6483       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0254-mmc-sdhci-of-dwcmshc-set-MMC_CAP_WAIT_WHILE_BUSY.patch      | 57ac3084f598       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0255-mmc-sdhci-of-dwcmshc-Re-enable-support-for-the-BlueF.patch  | a0753ef66c34       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0256-UBUNTU-SAUCE-Support-BlueField-3-GPIO-driver.patch          |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0257-regmap-debugfs-Enable-writing-to-the-regmap-debugfs-.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0258-UBUNTU-SAUCE-mlx-bootctl-support-icm-carveout-eeprom.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0259-mmc-sdhci-of-dwcmshc-Enable-host-V4-support-for-Blue.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0260-UBUNTU-SAUCE-mlxbf-pka-Fix-kernel-crash-with-pka-TRN.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0261-mlxbf-ptm-power-and-thermal-management-debugfs-drive.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0262-UBUNTU-SAUCE-mlxbf-pmc-Fix-event-string-typo.patch          | b0b698b80c56       | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0263-UBUNTU-SAUCE-mlxbf-pmc-Support-for-BlueField-3-perfo.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0264-UBUNTU-SAUCE-platform-mellanox-Add-ctrl-message-and-.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0265-hwmon-mlxreg-fan-Return-zero-speed-for-broken-fan.patch     |                    | Bugfix upstream                          | 5.10.173   |                                                |
-|0266-UBUNTU-SAUCE-mlxbf-pmc-Bug-fix-for-BlueField-3-count.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0267-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0266-UBUNTU-SAUCE-mlxbf-pmc-Bug-fix-for-BlueField-3-count.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0267-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-add-the-missing-de.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0268-DS-mlxsw-core_linecards-Disable-firmware-bundling-ma.patch  |                    | Downstream accepted                      |            |                                                |
 |0269-platform-mellanox-Add-field-upgrade-capability-regis.patch  |                    | Feature pending                          |            | P4262                                          |
 |0270-platform-mellanox-Modify-reset-causes-description.patch     |                    | Feature pending                          |            |                                                |
@@ -283,23 +283,23 @@ Kernel-5.10
 |0281-platform-mellanox-mlx-platform-Modify-health-and-pow.patch  |                    | Feature pending                          |            | P4262                                          |
 |0282-platform-mellanox-mlx-platform-Add-reset-cause-attri.patch  |                    | Feature pending                          |            |                                                |
 |0284-platform-mellanox-mlx-platform-add-support-for-addit.patch  |                    | Feature pending                          |            |                                                |
-|0285-UBUNTU-SAUCE-mlxbf-gige-Fix-intermittent-no-ip-issue.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0286-pinctrl-Introduce-struct-pinfunction-and-PINCTRL_PIN.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0287-pinctrl-mlxbf3-Add-pinctrl-driver-support.patch             |                    | Downstream                               |            | BF3-COME                                       |
-|0288-UBUNTU-SAUCE-gpio-mmio-handle-ngpios-properly-in-bgp.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0289-UBUNTU-SAUCE-gpio-mlxbf3-Add-gpio-driver-support.patch      |                    | Downstream                               |            | BF3-COME                                       |
+|0285-UBUNTU-SAUCE-mlxbf-gige-Fix-intermittent-no-ip-issue.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0286-pinctrl-Introduce-struct-pinfunction-and-PINCTRL_PIN.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0287-pinctrl-mlxbf3-Add-pinctrl-driver-support.patch             |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0288-UBUNTU-SAUCE-gpio-mmio-handle-ngpios-properly-in-bgp.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0289-UBUNTU-SAUCE-gpio-mlxbf3-Add-gpio-driver-support.patch      |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0291-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch  |                    | Downstream accepted                      |            | SN3750SX                                       |
-|0292-mlxsw-i2c-Limit-single-transaction-buffer-size.patch        |                    | Downstream accepted                      |            | BF3-COME                                       |
+|0292-mlxsw-i2c-Limit-single-transaction-buffer-size.patch        |                    | Downstream accepted;skip[sonic]          |            | BF3-COME                                       |
 |0293-mlxsw-reg-Limit-MTBR-register-records-buffer-by-one-.patch  |                    | Downstream accepted                      |            |                                                |
 |0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch  |                    | Feature pending; os[sonic,opt]           |            |                                                |
 |0295-dt-bindings-trivial-devices-Add-mps-mp2891.patch            |                    | Feature pending                          |            |                                                |
-|0296-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-Add-runtime-PM-ope.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0298-UBUNTU-SAUCE-mlxbf-ptm-use-0444-instead-of-S_IRUGO.patch    |                    | Downstream                               |            | BF3-COME                                       |
-|0299-UBUNTU-SAUCE-mlxbf-ptm-add-atx-debugfs-nodes.patch          |                    | Downstream                               |            | BF3-COME                                       |
-|0300-UBUNTU-SAUCE-mlxbf-ptm-update-module-version.patch          |                    | Downstream                               |            | BF3-COME                                       |
-|0301-UBUNTU-SAUCE-mlxbf-gige-Fix-kernel-panic-at-shutdown.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0302-UBUNTU-SAUCE-mlxbf-bootctl-support-SMC-call-for-sett.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0303-UBUNTU-SAUCE-Add-BF3-related-ACPI-config-and-Ring-de.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0296-UBUNTU-SAUCE-mmc-sdhci-of-dwcmshc-Add-runtime-PM-ope.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0298-UBUNTU-SAUCE-mlxbf-ptm-use-0444-instead-of-S_IRUGO.patch    |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0299-UBUNTU-SAUCE-mlxbf-ptm-add-atx-debugfs-nodes.patch          |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0300-UBUNTU-SAUCE-mlxbf-ptm-update-module-version.patch          |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0301-UBUNTU-SAUCE-mlxbf-gige-Fix-kernel-panic-at-shutdown.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0302-UBUNTU-SAUCE-mlxbf-bootctl-support-SMC-call-for-sett.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0303-UBUNTU-SAUCE-Add-BF3-related-ACPI-config-and-Ring-de.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0304-platform-mellanox-mlx-platform-Modify-power-off-call.patch  |                    | Feature pending                          |            |                                                |
 |0305-Extend-driver-to-support-Infineon-Digital-Multi-phas.patch  |                    | Feature pending                          |            |                                                |
 |0306-dt-bindings-trivial-devices-Add-infineon-xdpe1a2g7.patch    |                    | Downstream                               |            |                                                |
@@ -316,17 +316,17 @@ Kernel-5.10
 |0316-platform-mellanox-Add-initial-support-for-PCIe-based.patch  |                    | Feature pending                          |            |                                                |
 |0317-platform-mellanox-Introduce-support-for-switches-equ.patch  |                    | Downstream                               |            |                                                |
 |0318-mellanox-Relocate-mlx-platform-driver.patch                 |                    | Downstream                               |            |                                                |
-|0319-UBUNTU-SAUCE-mlxbf-tmfifo-fix-potential-race.patch          |                    | Downstream                               |            | BF3-COME                                       |
-|0320-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-the-Rx-packet-if-no-m.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0321-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-jumbo-frames.patch           |                    | Downstream                               |            | BF3-COME                                       |
-|0322-UBUNTU-SAUCE-mlxbf-tmfifo.c-Amend-previous-tmfifo-pa.patch  |                    | Downstream                               |            | BF3-COME                                       |
-|0323-mlxbf_gige-add-set_link_ksettings-ethtool-callback.patch    |                    | Downstream                               |            | BF3-COME                                       |
-|0324-mlxbf_gige-fix-white-space-in-mlxbf_gige_eth_ioctl.patch    |                    | Downstream                               |            | BF3-COME                                       |
-|0325-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Downstream                               |            | BF3-COME                                       |
+|0319-UBUNTU-SAUCE-mlxbf-tmfifo-fix-potential-race.patch          |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0320-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-the-Rx-packet-if-no-m.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0321-UBUNTU-SAUCE-mlxbf-tmfifo-Drop-jumbo-frames.patch           |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0322-UBUNTU-SAUCE-mlxbf-tmfifo.c-Amend-previous-tmfifo-pa.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0323-mlxbf_gige-add-set_link_ksettings-ethtool-callback.patch    |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0324-mlxbf_gige-fix-white-space-in-mlxbf_gige_eth_ioctl.patch    |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
+|0325-UBUNTU-SAUCE-mlxbf-bootctl-Fix-kernel-panic-due-to-b.patch  |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0326-platform-mellanox-mlxreg-hotplug-Add-support-for-new.patch  |                    | Downstream                               |            |                                                |
 |0327-platform-mellanox-mlx-platform-Change-register-name.patch   |                    | Downstream                               |            |                                                |
 |0328-platform-mellanox-mlx-platform-Add-support-for-new-X.patch  |                    | Downstream                               |            |                                                |
-|0329-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream                               |            | BF3-COME                                       |
+|0329-gpio-mlxbf3-Fix-error-message.patch                         |                    | Downstream;skip[sonic]                   |            | BF3-COME                                       |
 |0330-mlxsw-i2c-Downstream-Add-retry-mechanism-for-failed-.patch  |                    | Downstream accepted                      |            |                                                |
 |0331-mlxsw-i2c-DBG-Add-debug-output-for-failed-transactio.patch  |                    | Downstream accepted                      |            |                                                |
 |0332-platform-mellanox-indicate-deferred-I2C-bus-creation.patch  |                    | Bugfix pending                           |            | SN2201                                         |
@@ -346,12 +346,12 @@ Kernel-6.1
 |0003-platform-mellanox-Cosmetic-changes-rename-to-more-co.patch  | acc6ea304590       | Feature upstream                         |            |                                                |
 |0004-platform-mellanox-Introduce-support-for-next-generat.patch  | fcf3790b9b63       | Feature upstream                         |            | SN5600                                         |
 |0005-platform-mellanox-Introduce-support-of-new-Nvidia-L1.patch  | dd635e33b5c9       | Feature upstream                         |            | P4262                                          |
-|0006-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream                         |            | BF3-COME                                       |
-|0007-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream                         |            | BF3-COME                                       |
+|0006-platform-mellanox-Split-initialization-procedure.patch      | 0170f616f496       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0007-platform-mellanox-Split-logic-in-init-and-exit-flow.patch   | 158cd8320776       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
 |0008-platform-mellanox-Extend-all-systems-with-I2C-notifi.patch  | 233fd7e44cd7       | Feature upstream                         |            |                                                |
-|0009-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc781566       | Feature upstream                         |            | BF3-COME                                       |
-|0010-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357       | Feature upstream                         |            | BF3-COME                                       |
-|0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream                         |            | BF3-COME                                       |
+|0009-platform-mellanox-mlx-platform-Add-mux-selection-reg.patch  | cefdbc781566       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0010-platform-mellanox-mlx-platform-Move-bus-shift-assign.patch  | 50b823fdd357       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
+|0011-platform-mellanox-mlx-platform-Initialize-shift-vari.patch  | 1a0009abfa78       | Feature upstream;skip[sonic]             |            | BF3-COME                                        |
 |0012-platform-mellanox-Fix-order-in-exit-flow.patch              |                    | Bugfix pending                           |            | Accepted for 6.4                               |
 |0013-platform-mellanox-mlx-platform-Fix-signals-polarity-.patch  |                    | Bugfix pending                           |            | Accepted for 6.4                               |
 |0014-platform-mellanox-mlx-platform-Modify-graceful-shutd.patch  |                    | Bugfix pending                           |            | Accepted for 6.4                               |

--- a/recipes-kernel/linux/deploy_kernel_patches.py
+++ b/recipes-kernel/linux/deploy_kernel_patches.py
@@ -269,7 +269,7 @@ def copy_to_candidate_ver_filter(patch, accepted_folder, candidate_folder, kver)
 
 # ----------------------------------------------------------------------
 def skip_patch_filter(patch, accepted_folder, candidate_folder, kver):
-    patch[CONST.PATCH_DST] = CONST.PATCH_CANDIDATE
+    patch[CONST.PATCH_DST] = CONST.PATCH_ACCEPTED
     return None
 
 # ----------------------------------------------------------------------

--- a/recipes-kernel/linux/deploy_kernel_patches.py
+++ b/recipes-kernel/linux/deploy_kernel_patches.py
@@ -269,7 +269,7 @@ def copy_to_candidate_ver_filter(patch, accepted_folder, candidate_folder, kver)
 
 # ----------------------------------------------------------------------
 def skip_patch_filter(patch, accepted_folder, candidate_folder, kver):
-    patch[CONST.PATCH_DST] = CONST.PATCH_ACCEPTED
+    patch[CONST.PATCH_DST] = CONST.PATCH_CANDIDATE
     return None
 
 # ----------------------------------------------------------------------

--- a/recipes-kernel/linux/linux-5.10/sonic/0318-mellanox-Relocate-mlx-platform-driver.patch
+++ b/recipes-kernel/linux/linux-5.10/sonic/0318-mellanox-Relocate-mlx-platform-driver.patch
@@ -1,0 +1,93 @@
+From 322be1d4efce0d11fd32ecc1bb0b08e85839a043 Mon Sep 17 00:00:00 2001
+From: Vivek Reddy <vkarri@nvidia.com>
+Date: Thu, 14 Mar 2024 22:45:41 +0000
+Subject: [PATCH] mellanox: Relocate mlx-platform driver
+
+Signed-off-by: Vivek Reddy <vkarri@nvidia.com>
+---
+ drivers/platform/mellanox/Kconfig                 | 12 ++++++++++++
+ drivers/platform/mellanox/Makefile                |  1 +
+ drivers/platform/{x86 => mellanox}/mlx-platform.c |  0
+ drivers/platform/x86/Kconfig                      | 13 -------------
+ drivers/platform/x86/Makefile                     |  1 -
+ 5 files changed, 13 insertions(+), 14 deletions(-)
+ rename drivers/platform/{x86 => mellanox}/mlx-platform.c (100%)
+
+diff --git a/drivers/platform/mellanox/Kconfig b/drivers/platform/mellanox/Kconfig
+index 75e2bee17..ff8267329 100644
+--- a/drivers/platform/mellanox/Kconfig
++++ b/drivers/platform/mellanox/Kconfig
+@@ -14,6 +14,18 @@ menuconfig MELLANOX_PLATFORM
+ 
+ if MELLANOX_PLATFORM
+ 
++config MLX_PLATFORM
++	tristate "Mellanox Technologies platform support"
++	depends on I2C && REGMAP
++	help
++	  This option enables system support for the Mellanox Technologies
++	  platform. The Mellanox systems provide data center networking
++	  solutions based on Virtual Protocol Interconnect (VPI) technology
++	  enable seamless connectivity to 56/100Gb/s InfiniBand or 10/40/56GbE
++	  connection.
++
++	  If you have a Mellanox system, say Y or M here.
++
+ config MLXREG_HOTPLUG
+ 	tristate "Mellanox platform hotplug driver support"
+ 	depends on REGMAP
+diff --git a/drivers/platform/mellanox/Makefile b/drivers/platform/mellanox/Makefile
+index 6af37ee88..23919e56a 100644
+--- a/drivers/platform/mellanox/Makefile
++++ b/drivers/platform/mellanox/Makefile
+@@ -3,6 +3,7 @@
+ # Makefile for linux/drivers/platform/mellanox
+ # Mellanox Platform-Specific Drivers
+ #
++obj-$(CONFIG_MLX_PLATFORM)	+= mlx-platform.o
+ obj-$(CONFIG_MLXBF_BOOTCTL)	+= mlxbf-bootctl.o
+ obj-$(CONFIG_MLXBF_TMFIFO)	+= mlxbf-tmfifo.o
+ obj-$(CONFIG_MLXREG_HOTPLUG)	+= mlxreg-hotplug.o
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+similarity index 100%
+rename from drivers/platform/x86/mlx-platform.c
+rename to drivers/platform/mellanox/mlx-platform.c
+diff --git a/drivers/platform/x86/Kconfig b/drivers/platform/x86/Kconfig
+index 84c5b922f..4270d4c17 100644
+--- a/drivers/platform/x86/Kconfig
++++ b/drivers/platform/x86/Kconfig
+@@ -1193,19 +1193,6 @@ config I2C_MULTI_INSTANTIATE
+ 	  To compile this driver as a module, choose M here: the module
+ 	  will be called i2c-multi-instantiate.
+ 
+-config MLX_PLATFORM
+-	tristate "Mellanox Technologies platform support"
+-	depends on I2C
+-	select REGMAP
+-	help
+-	  This option enables system support for the Mellanox Technologies
+-	  platform. The Mellanox systems provide data center networking
+-	  solutions based on Virtual Protocol Interconnect (VPI) technology
+-	  enable seamless connectivity to 56/100Gb/s InfiniBand or 10/40/56GbE
+-	  connection.
+-
+-	  If you have a Mellanox system, say Y or M here.
+-
+ config TOUCHSCREEN_DMI
+ 	bool "DMI based touchscreen configuration info"
+ 	depends on ACPI && DMI && I2C=y && TOUCHSCREEN_SILEAD
+diff --git a/drivers/platform/x86/Makefile b/drivers/platform/x86/Makefile
+index 5f823f7ef..1db86675f 100644
+--- a/drivers/platform/x86/Makefile
++++ b/drivers/platform/x86/Makefile
+@@ -122,7 +122,6 @@ obj-$(CONFIG_TOPSTAR_LAPTOP)	+= topstar-laptop.o
+ 
+ # Platform drivers
+ obj-$(CONFIG_I2C_MULTI_INSTANTIATE)	+= i2c-multi-instantiate.o
+-obj-$(CONFIG_MLX_PLATFORM)		+= mlx-platform.o
+ obj-$(CONFIG_TOUCHSCREEN_DMI)		+= touchscreen_dmi.o
+ 
+ # Intel uncore drivers
+-- 
+2.17.1
+


### PR DESCRIPTION
**DA -> Downstream Accepted**

**Expectation:**
Will need all the patches except Downstream BF3 in the SONiC Canonical build. (Tried changing Feature upstream/pending/fixes to skip but seems other patches have dependencies on them so didn't try fixing it) 

**Changes Made:** 
1) Moved all the downstream BF3 patches to skip[sonic].

2) Patches 0098-1/2/3 were added to revert 0097-1/2/3 to work for canonical build. But since we are going to build canonical with Downstream patches from now on, i assumed all the patches 0097/0098-1/2/3 can be skipped for SONiC.

3) Kernel compiled fine with points 1-2, i.e. changes until commit 38c9e89f388eeb0d5b7d18e8637b6d88e70dd854

4) After changes specified in points 1 & 2, the following patches are still downstream:
0050, 0051, 0167, 0168, 0171, 018, 0306-0310, 0317, 0318, 0326, 0327, 0328, 9002, 9003

5) 0049 is rejected. Which means this is moved to candidate folder and not accepted. Not sure how to fix this, so marked it DA. But we will need this patch.
 
6) When i moved all of them to DA , the patch 0318-platform-mellanox-Introduce-support-for-switches-equ.patch did not apply properly. Following line is a remnant from one of the BF3 patches, so this patch must be updated. Thus fixed and added a new patch for SONiC. This change resulted in a successful compilation of canonical build
```
obj-$(CONFIG_MLXBF_PMC)         += mlxbf-pmc.o
```

7) This is tested only on 5.10

8) Runtime implication not known
