### PR TITLE
hw-mgmt: scripts: Fix vpd parser MAC display issue

### DIFF
--- a/usr/usr/bin/hw-management-vpd-parser.py
+++ b/usr/usr/bin/hw-management-vpd-parser.py
@@ -377,8 +377,7 @@ def mlnx_blk_unpack(data, blk_hdr, size):
                 rec_name = rec_name_fmt.format(idx=idx)
             elif rec_type == "FT_MAC":
                 _data_str = struct.unpack("{}B".format(rec_size), _data)
-                val = int_unpack_be(_data_str)
-                val = ":".join(re.findall("..", "%012x"%val))
+                val = ':'.join(['{:02X}'.format(byte) for byte in _data_str])
                 rec_name = rec_name_fmt.format(idx=idx)
             else:
                 continue


### PR DESCRIPTION
Fix vpd parser MAC display issue. In case if BASE_MAC/BASE_GUID data starting
with 0x0{X} and ends with 0x{X}0 BASE_MAC1 field decoding into 5-byte length
instead of 6-byte.

Was:
BASE_MAC_1:              43:f7:08:9a:5c
BASE_GUID_1:             43:f7:20:30:08:9a:5c

Fixed:
BASE_MAC_1:              04:3f:72:89:a5:c0
BASE_GUID_1:             04:3f:72:03:00:89:a5:c0

Bug: 3825753

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
