### PR TITLE
hw-mgmt: thermal: Update system profile for QM3400

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_qm3400.json
+++ b/usr/etc/hw-management-thermal/tc_config_qm3400.json
@@ -28,11 +28,10 @@
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
 		"voltmon\\d+_temp":{"pwm_min": 30, "pwm_max" : 100, "val_min": "!85000", "val_max": "!125000", "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time":  60},
-		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
-		"ctx_amb" :{"pwm_min": 30, "pwm_max" : 100, "val_min": "70000", "val_max": 105000, "poll_time": 3}
+		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
 	"error_mask" : {"psu" : ["direction", "present"]},
-	"sensor_list" : ["asic1", "asic2", "ctx_amb", "cpu", 
+	"sensor_list" : ["asic1", "asic2", "cpu",
 	"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5",
 	"psu1", "psu2",  "psu3", "psu4", "sensor_amb", "sodimm1",
 	"voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6"]


### PR DESCRIPTION
This commit removes the non existent ctx_amb ConnectX thermal sensor from the TC configuration.

Bug #3847931