### PR TITLE
hw-mgmt: thermal: Update system profile for QM3000

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_qm3000.json
+++ b/usr/etc/hw-management-thermal/tc_config_qm3000.json
@@ -28,13 +28,12 @@
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
 		"swb\\d+_voltmon\\d+_temp":{"pwm_min": 30, "pwm_max" : 100, "val_min": "!85000", "val_max": "!125000", "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time":  60},
-		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
-		"connectx8" :{"pwm_min": 30, "pwm_max" : 100, "val_min": "70000", "val_max": 105000, "poll_time": 3}
+		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
 	"error_mask" : {"psu" : ["direction", "present"]},
-	"sensor_list" : ["asic1", "asic2", "asic4", "asic4", "ctx_amb", "cpu", 
+	"sensor_list" : ["asic1", "asic2", "asic3", "asic4", "cpu",
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "drwr8", "drwr9", "drwr10",
-					"psu1", "psu2", "psu3", "psu4", "psu5", "psu6", "psu7", "psu8", "sodimm1",
+					"psu1", "psu2", "psu3", "psu4", "psu5", "psu6", "psu7", "psu8", "sodimm1", "sodimm2",
 					"swb1_voltmon1", "swb1_voltmon2", "swb1_voltmon3", "swb1_voltmon4", "swb1_voltmon5", "swb1_voltmon6", 
 					"swb2_voltmon1", "swb2_voltmon2", "swb2_voltmon3", "swb2_voltmon4", "swb2_voltmon5", "swb2_voltmon6"
 					]


### PR DESCRIPTION
This commit makes the following changes:
 1. Removes non existent ctx_amb ConnectX-8 sensor
 2. Adds missing SODIMM2 sensor
 3. Fixes typo in ASIC3 sensor name