### PR TITLE
hw-mgmt: thermal: Add "hotswap" and "bmc" TC sensor support

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_jso.json
+++ b/usr/etc/hw-management-thermal/tc_config_jso.json
@@ -1,0 +1,42 @@
+ {
+	"name": "jso",
+	"dmin" : {
+		"C2P": {
+			"fan_err": {
+				"tacho": {"-127:120": 30},
+				"direction": {"-127:120": 30},
+				"present": {"-127:120": 30}
+			},
+			"psu_err":  {
+				"present": {"-127:120": 30},
+				"direction": {"-127:120": 30}
+			},
+			"sensor_read_error" : {"-127:120": 70}
+		}
+	},
+	"psu_fan_pwm_decode" : {"0:100": -1},
+	"fan_trend" : {
+        "C2P": {
+			"0" : {"rpm_min":6879, "rpm_max":33000, "slope": 213.2, "pwm_min" : 30, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
+			"1" : {"rpm_min":5650, "rpm_max":30000, "slope": 200.4, "pwm_min" : 30, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}
+			}
+	}, 
+	"dev_parameters" : {
+		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3},
+		"module\\d+":     {"pwm_min": 30, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
+		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30, "base_file_name": {"C2P": "fan_amb"},
+		"swb\\d+_voltmon\\d+_temp":{"pwm_min": 30, "pwm_max" : 100, "val_min": "!85000", "val_max": "!125000", "poll_time": 60},
+		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time":  60},
+		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
+		"ibc\\d+":        {"pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "!100000", "poll_time": 30},
+		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
+		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
+	},
+	"sensor_list" : ["cpu", 
+					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
+					"sodimm1",
+					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6",
+					"ibc1", "ibc2", "ibc3", "ibc4",
+					"hotswap1", "bmc"
+					]
+}

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -274,6 +274,13 @@ SENSOR_DEF_CONFIG = {
                          "pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "!105000", "poll_time": 3,
                          "input_suffix": "_input"
                         },
+    r'hotswap\d+_temp': {"type": "thermal_sensor",
+                         "pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 30,
+                         "input_suffix": "_input"
+                        },
+    r'bmc\d+_temp':     {"type": "thermal_sensor",
+                         "pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 30,
+                        },
     r'dpu\\d+_module':  {"type": "dpu_module",
                          "pwm_min": 20, "pwm_max": 30, "val_min": "!70000", "val_max": "!95000", "poll_time": 5, "child_sensors_list" : []
                         },
@@ -2387,6 +2394,8 @@ class ThermalManagement(hw_managemet_file_op):
                           r'drivetemp':"add_drivetemp_sensor",
                           r'ibc\d*':"add_ibc_sensor",
                           r'ctx_amb\d*':"add_connectx_sensor",
+                          r'hotswap\d+':"add_hotswap_sensor",
+                          r'bmc\d+':"add_bmc_sensor",
                           r'dpu\d*_cpu':"add_DPU_cpu_sensor",
                           r'dpu\d*_sodimm\d+':"add_DPU_sodimm_sensor",
                           r'dpu\d*_drivetemp':"add_DPU_drivetemp_sensor",
@@ -3086,6 +3095,18 @@ class ThermalManagement(hw_managemet_file_op):
     # ----------------------------------------------------------------------
     def add_connectx_sensor(self, name):
         self._sensor_add_config("thermal_sensor", name, {"base_file_name": "thermal/{}".format(name)})
+
+    # ----------------------------------------------------------------------
+    def add_hotswap_sensor(self, name):
+        in_file = "thermal/pdb_{}_temp1".format(name)
+        sensor_name = "{}_temp".format(name)
+        self._sensor_add_config("thermal_sensor", sensor_name, {"base_file_name": in_file})
+
+    # ----------------------------------------------------------------------
+    def add_bmc_sensor(self, name):
+        in_file = "thermal/bmc{}_temp".format(name)
+        sensor_name = "{}_temp".format(name)
+        self._sensor_add_config("thermal_sensor", sensor_name, {"base_file_name": in_file})
 
     # ----------------------------------------------------------------------
     def add_DPU_cpu_sensor(self, name):


### PR DESCRIPTION
1. Add "hotswap" and "bmc" TC sensor support

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
