### PR TITLE
hw-mgmt: sensors: Fix some misnamed PSU labels

### DIFF
--- a/usr/etc/hw-management-sensors/mqm9520_sensors.conf
+++ b/usr/etc/hw-management-sensors/mqm9520_sensors.conf
@@ -122,7 +122,7 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
         label in1 "PSU-2(L) 220V Rail (in)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
-        label fan1 "PSU-1(L) Fan 1"
+        label fan1 "PSU-2(L) Fan 1"
         ignore fan2
         ignore fan3
         label temp1 "PSU-2(L) Temp 1"

--- a/usr/etc/hw-management-sensors/msn4700_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4700_sensors.conf
@@ -181,7 +181,7 @@ bus "i2c-15" "i2c-1-mux (chan_id 6)"
 # Power supplies
 bus "i2c-4" "i2c-1-mux (chan_id 3)"
     chip "dps460-i2c-*-58"
-        label in1 "PSU-1(L) 220V Rail (in)"
+        label in1 "PSU-2(L) 220V Rail (in)"
         ignore in2
         label in3 "PSU-2(L) 12V Rail (out)"
         label fan1 "PSU-2(L) Fan 1"


### PR DESCRIPTION
Some some PSU1 labels for MSN4700 and MQM9520 are
incorrectly marked as PSU2.