### PR TITLE
hw-mgmt: patches: Add downstream mlxsw minimal driver patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
 
-hw-management (1.mlnx.7.0040.0006) unstable; urgency=low
+hw-management (1.mlnx.7.0040.0007) unstable; urgency=low
   [ MLNX ] 
 
- -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 09 Apr 2024 11:35:00 +0300
+ -- MellanoxBSP <system-sw-low-level@mellanox.com> Mon, 18 Apr 2024 10:15:00 +0300

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -339,6 +339,7 @@ Kernel-5.10
 |9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch  |                    | Downstream                               |            | P4300                                          |
 |9004-DS-OPT-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch|                 | Downstream                               |            |                                                |
 |9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch  |                    | Downstream                               |            |                                                |
+|9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream                               |            |                                                |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Kernel-6.1
@@ -451,6 +452,7 @@ Kernel-6.1
 |9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch  |                    | Downstream                               |            | P4300                                          |
 |9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch  |                    | Downstream                               |            |                                                |
 |9005-platform-mellanox-Downstream-Add-dedicated-match-for.patch  |                    | Downstream                               |            | Add dedicated match for QMB8700                |
+|9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream                               |            |                                                |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Legend:

--- a/recipes-kernel/linux/linux-5.10/9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch
+++ b/recipes-kernel/linux/linux-5.10/9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch
@@ -1,0 +1,100 @@
+From dc3765b8a93bb663b6fb709658bebadb6d69c9e4 Mon Sep 17 00:00:00 2001
+From: Felix Radensky <fradensky@nvidia.com>
+Date: Wed, 17 Apr 2024 08:45:00 +0000
+Subject: [PATCH] mlxsw: core_hwmon: Fix module sensor number for QM3200
+
+This patch hardcodes the number of modules per ASICs on QM3200 systems
+instead of reading the actual number of modules from the MGPIR register.
+This is a WA for recent FW versions that incorrectly report the number
+of modules per ASIC.
+
+On QM3200 systems ASIC1 and ASIC2 control 18 and 19 modules respectively.
+ASICs are identified by thir i2c bus number, with ASIC1 using i2c bus 2.
+
+Signed-off-by: Felix Radensky <fradensky@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c | 33 ++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index f80050cec..ef42c8a1d 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -8,6 +8,7 @@
+ #include <linux/hwmon.h>
+ #include <linux/err.h>
+ #include <linux/sfp.h>
++#include <linux/dmi.h>
+ 
+ #include "core.h"
+ #include "core_env.h"
+@@ -26,6 +27,8 @@
+ 				MLXSW_HWMON_GEARBOXES_MAX_COUNT * MLXSW_HWMON_ATTR_PER_GEARBOX + \
+ 				MLXSW_MFCR_TACHOS_MAX + MLXSW_MFCR_PWMS_MAX)
+ 
++#define MLXSW_HWMON_HI157_MODULE_NUM 18
++
+ struct mlxsw_hwmon_attr {
+ 	struct device_attribute dev_attr;
+ 	struct mlxsw_hwmon_dev *mlxsw_hwmon_dev;
+@@ -33,6 +36,8 @@ struct mlxsw_hwmon_attr {
+ 	char name[32];
+ };
+ 
++static int mlxsw_hwmon_module_num = 0;
++
+ static int
+ mlxsw_hwmon_get_attr_index(int index, int count, u16 *gearbox_sensor_map)
+ {
+@@ -714,6 +719,13 @@ static int mlxsw_hwmon_module_init(struct mlxsw_hwmon_dev *mlxsw_hwmon_dev)
+ 	mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
+ 			       &module_sensor_max, NULL);
+ 
++	if (mlxsw_hwmon_module_num) {
++		if (!strcmp(dev_name(mlxsw_hwmon->bus_info->dev), "2-0048"))
++			module_sensor_max = mlxsw_hwmon_module_num;
++		else
++			module_sensor_max = mlxsw_hwmon_module_num + 1;
++	}
++
+ 	/* Add extra attributes for module temperature. Sensor index is
+ 	 * assigned to sensor_count value, while all indexed before
+ 	 * sensor_count are already utilized by the sensors connected through
+@@ -950,6 +962,25 @@ static void mlxsw_hwmon_linecards_unregister(struct mlxsw_hwmon *hwmon)
+ 	kfree(hwmon->linecards);
+ }
+ 
++static int mlxsw_dmi_hi157_matched(const struct dmi_system_id *dmi)
++{
++	mlxsw_hwmon_module_num = MLXSW_HWMON_HI157_MODULE_NUM;
++
++	return 1;
++}
++
++static const struct dmi_system_id mlxsw_hwmon_dmi_table[]  = {
++	{
++		.callback = mlxsw_dmi_hi157_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0018"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI157"),
++		},
++	},
++	{ }
++};
++MODULE_DEVICE_TABLE(dmi, mlxsw_hwmon_dmi_table);
++
+ int mlxsw_hwmon_init(struct mlxsw_core *mlxsw_core,
+ 		     const struct mlxsw_bus_info *mlxsw_bus_info,
+ 		     struct mlxsw_hwmon **p_hwmon)
+@@ -959,6 +990,8 @@ int mlxsw_hwmon_init(struct mlxsw_core *mlxsw_core,
+ 	u8 gbox_num;
+ 	int err;
+ 
++	dmi_check_system(mlxsw_hwmon_dmi_table);
++
+ 	mlxsw_hwmon = kzalloc(sizeof(*mlxsw_hwmon), GFP_KERNEL);
+ 	if (!mlxsw_hwmon)
+ 		return -ENOMEM;
+-- 
+2.14.1
+

--- a/recipes-kernel/linux/linux-6.1/9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch
+++ b/recipes-kernel/linux/linux-6.1/9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch
@@ -1,0 +1,100 @@
+From 370387a12367612af4de85edce10abf8e8d20ddb Mon Sep 17 00:00:00 2001
+From: Felix Radensky <fradensky@nvidia.com>
+Date: Wed, 17 Apr 2024 12:50:11 +0000
+Subject: [PATCH] mlxsw: core_hwmon: Fix module sensor number for QM3200
+
+This patch hardcodes the number of modules per ASICs on QM3200 systems
+instead of reading the actual number of modules from the MGPIR register.
+This is a WA for recent FW versions that incorrectly report the number
+of modules per ASIC.
+
+On QM3200 systems ASIC1 and ASIC2 control 18 and 19 modules respectively.
+ASICs are identified by thir i2c bus number, with ASIC1 using i2c bus 2.
+
+Signed-off-by: Felix Radensky <fradensky@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c | 33 ++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index 9c12e1feb..8d38df80a 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -8,6 +8,7 @@
+ #include <linux/hwmon.h>
+ #include <linux/err.h>
+ #include <linux/sfp.h>
++#include <linux/dmi.h>
+ 
+ #include "core.h"
+ #include "core_env.h"
+@@ -26,6 +27,8 @@
+ 				MLXSW_HWMON_GEARBOXES_MAX_COUNT * MLXSW_HWMON_ATTR_PER_GEARBOX + \
+ 				MLXSW_MFCR_TACHOS_MAX + MLXSW_MFCR_PWMS_MAX)
+ 
++#define MLXSW_HWMON_HI157_MODULE_NUM 18
++
+ struct mlxsw_hwmon_attr {
+ 	struct device_attribute dev_attr;
+ 	struct mlxsw_hwmon_dev *mlxsw_hwmon_dev;
+@@ -33,6 +36,8 @@ struct mlxsw_hwmon_attr {
+ 	char name[32];
+ };
+ 
++static int mlxsw_hwmon_module_num = 0;
++
+ static int mlxsw_hwmon_get_attr_index(int index, int count)
+ {
+ 	if (index >= count)
+@@ -698,6 +703,13 @@ static int mlxsw_hwmon_module_init(struct mlxsw_hwmon_dev *mlxsw_hwmon_dev)
+ 	mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
+ 			       &module_sensor_max, NULL);
+ 
++	if (mlxsw_hwmon_module_num) {
++		if (!strcmp(dev_name(mlxsw_hwmon->bus_info->dev), "2-0048"))
++			module_sensor_max = mlxsw_hwmon_module_num;
++		else
++			module_sensor_max = mlxsw_hwmon_module_num + 1;
++	}
++
+ 	/* Add extra attributes for module temperature. Sensor index is
+ 	 * assigned to sensor_count value, while all indexed before
+ 	 * sensor_count are already utilized by the sensors connected through
+@@ -853,6 +865,25 @@ static struct mlxsw_linecards_event_ops mlxsw_hwmon_event_ops = {
+ 	.got_inactive = mlxsw_hwmon_got_inactive,
+ };
+ 
++static int mlxsw_dmi_hi157_matched(const struct dmi_system_id *dmi)
++{
++	mlxsw_hwmon_module_num = MLXSW_HWMON_HI157_MODULE_NUM;
++
++	return 1;
++}
++
++static const struct dmi_system_id mlxsw_hwmon_dmi_table[]  = {
++	{
++		.callback = mlxsw_dmi_hi157_matched,
++		.matches = {
++			DMI_MATCH(DMI_BOARD_NAME, "VMOD0018"),
++			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI157"),
++		},
++	},
++	{ }
++};
++MODULE_DEVICE_TABLE(dmi, mlxsw_hwmon_dmi_table);
++
+ int mlxsw_hwmon_init(struct mlxsw_core *mlxsw_core,
+ 		     const struct mlxsw_bus_info *mlxsw_bus_info,
+ 		     struct mlxsw_hwmon **p_hwmon)
+@@ -863,6 +894,8 @@ int mlxsw_hwmon_init(struct mlxsw_core *mlxsw_core,
+ 	u8 num_of_slots;
+ 	int err;
+ 
++	dmi_check_system(mlxsw_hwmon_dmi_table);
++
+ 	mlxsw_reg_mgpir_pack(mgpir_pl, 0);
+ 	err = mlxsw_reg_query(mlxsw_core, MLXSW_REG(mgpir), mgpir_pl);
+ 	if (err)
+-- 
+2.14.1
+


### PR DESCRIPTION
Add downsteam mlxsw minimal driver patch to hardcode the number of modules per ASICs on QM3200 systems instead of reading the actual number of modules from the MGPIR register. This is a WA for recent FW versions that incorrectly report the number of modules per ASIC.