### PR TITLE
hw-mgmt: thermal: Fix "blacklist is malfunction issue"

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -3297,6 +3297,8 @@ class ThermalManagement(hw_managemet_file_op):
 
             for dev_obj in self.dev_obj_list:
                 if dev_obj.enable:
+                    if dev_obj.state != CONST.RUNNING:
+                        continue
                     fault_list = dev_obj.get_fault_list_static_filtered()
                     if not fault_list:
                         continue


### PR DESCRIPTION
Fix issue when TC counts errors even it was paused by black list.

Bug: 3885405, 3883147

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
