### PR TITLE
w-mgmt: thermal: fixed of sporadically FAN fail issue on msn3410

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn3420.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn3420.json
@@ -31,18 +31,18 @@
 	"psu_fan_pwm_decode" : {"0:10": 10, "11:21": 20, "21:30": 30, "31:40": 40, "41:50": 50, "51:60": 60,  "61:70": 60, "71:80": 60, "81:90": 60, "91:100": 60},
 	"fan_trend" : {
 		"C2P": {
-			"0" : {"rpm_min":5400, "rpm_max":23000, "slope": 221, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
-			"1" : {"rpm_min":4800, "rpm_max":20500, "slope": 195, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}},
+			"0" : {"rpm_min":5400, "rpm_max":23000, "slope": 221, "pwm_min" : 25, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
+			"1" : {"rpm_min":4800, "rpm_max":20500, "slope": 195, "pwm_min" : 25, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}},
 		"P2C": {
-			"0" : {"rpm_min":5400, "rpm_max":23000, "slope": 221, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
-			"1" : {"rpm_min":4800, "rpm_max":20500, "slope": 195, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}
+			"0" : {"rpm_min":5400, "rpm_max":23000, "slope": 221, "pwm_min" : 25, "pwm_max_reduction" : 10, "rpm_tolerance" : 30},
+			"1" : {"rpm_min":4800, "rpm_max":20500, "slope": 195, "pwm_min" : 25, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}
 		}
 	},
 	"dev_parameters" : {
 		"asic":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 20, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3},
 		"module\\d+":     {"pwm_min": 20, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
-		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
+		"sensor_amb":     {"pwm_min": 25, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},


### PR DESCRIPTION
On FANs which have HW degradation and minimal PWM set (20%) - FAN rotation
speed can be lower than minimual. It can cause fan_fail sataus.

This commit fixed issue by set minmal PWM to 25%.

Bug:

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
