### PR TITLE
hw-mgmt: package: Set lm_sensor dependency as selectable parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ sudo apt-get install devscripts build-essential lintian
 - Go into the thermal-control base folder and build the Debian package.
 - Run: `debuild -us -uc -b`
 - To build for ARM64 architecture, run `debuild -us -uc -b -aarm64`
+- To build without lm_sensor dependecy (for Sonic-based OS) run 'debuild --set-envvar=LM_DEPENDS=0 -us -uc -b'
+or 'export LM_DEPENDS=0 && dpkg-buildpackage -us -uc -b'
 - Find in upper folder the builded `.deb` package (for example `hw-management_1.mlnx.18.12.2018_amd64.deb`).
 
 **For converting .deb package to .rpm package:**

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0030.4001) unstable; urgency=low
+hw-management (1.mlnx.7.0030.4002) unstable; urgency=low
   [ MLNX ] 
 
- -- Yehuda Yehudai <yyehudai@nvidia.com> Sun, 05 May 2024 11:10:00 +0300
+ -- Yehuda Yehudai <yyehudai@nvidia.com> Sun, 17 May 2024 10:10:00 +0300

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.nvidia.com
 
 Package:hw-management
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, lsb-base (>= 3.0-6), python2.7 | python3, xxd, lm-sensors, libiio-utils, dmidecode, i2c-tools
+Depends: ${misc:Depends}, ${shlibs:Depends}, ${dist:Depends}, lsb-base (>= 3.0-6), python2.7 | python3, xxd, libiio-utils, dmidecode, i2c-tools
 Description: Thermal control and chassis management for Nvidia systems
  This package supports Nvidia switches family for chassis
  management and thermal control.

--- a/debian/rules
+++ b/debian/rules
@@ -4,8 +4,19 @@ pname:=hw-management
 
 pwd=$(shell pwd)
 
+#debuild -sa -us -uc -eLM_DEPENDS=1
+
+ifeq ($(LM_DEPENDS),0)
+	DEPENDS = -Vdist:Depends=""
+else
+	DEPENDS = -Vdist:Depends="lm-sensors"
+endif
+
 %:
 	dh $@
+
+override_dh_gencontrol:
+	dh_gencontrol -- $(DEPENDS)
 
 override_dh_auto_configure:
 


### PR DESCRIPTION
Set lm_sensor dependency as selectable parameter

To build deb package without lm_sensor dependecy (for Sonic-based OS)
run 'debuild --set-envvar=LM_DEPENDS=0 -us -uc'
or 'export LM_DEPENDS=0 && dpkg-buildpackage -us -uc -b'

Bug: 3895891

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
