### PR TITLE
hw-mgmt: patches: Re-add downstream minimal driver patch for kernel 6.1

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -452,6 +452,7 @@ Kernel-6.1
 |9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch  |                    | Downstream;skip[sonic]                   |            | P4300                                          |
 |9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch  |                    | Downstream;skip[sonic]                   |            |                                                |
 |9005-platform-mellanox-Downstream-Add-dedicated-match-for.patch  |                    | Downstream;skip[sonic]                   |            | Add dedicated match for QMB8700                |
+|9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream;skip[ALL];take[opt]           |            |                                                |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Legend:


### PR DESCRIPTION
Commit 2ec3e6ec633d792449bfb7044fccbf7d40dd43f3 accidentally removed a patch from 6.1 patch table that makes minimal driver work correctly on Q3200 systems with latest ASIC FW. This commit re-adds the missing patch.

Fixes: #3900159, #3900138