### PR TITLE
V.7.0040.1000 BR

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -110,8 +110,8 @@ SUBSYSTEM=="hwmon", DRIVERS=="k10temp", DEVPATH=="/devices/pci0000:00/0000:00:18
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/virtual/thermal/thermal_zone*/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add pch_temp %S %p"
 
 # SODIMM temp
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sodimm_temp %p %k %S %n"
+SUBSYSTEM=="hwmon", DRIVERS=="jc42", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
+SUBSYSTEM=="hwmon", DRIVERS=="jc42", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sodimm_temp %p %k %S %n"
 
 # QEMU SODIMM temp
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"

--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -102,6 +102,9 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-
 # CPU temperature
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/coretemp.0/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add cputemp %S %p"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/coretemp.0/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm cputemp %S %p"
+# CPU temperature of main die AMD Epyc3000
+SUBSYSTEM=="hwmon", DRIVERS=="k10temp", DEVPATH=="/devices/pci0000:00/0000:00:18.3/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add cputemp_amd %S %p"
+SUBSYSTEM=="hwmon", DRIVERS=="k10temp", DEVPATH=="/devices/pci0000:00/0000:00:18.3/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh add cputemp_amd %S %p"
 
 # PCH temp
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/virtual/thermal/thermal_zone*/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add pch_temp %S %p"

--- a/usr/usr/bin/hw-management-devtree-check.sh
+++ b/usr/usr/bin/hw-management-devtree-check.sh
@@ -171,6 +171,9 @@ devtr_sim_environment_vars()
 			BF3_CPU)
 				cpu_type="${BF3_CPU}"
 				;;
+			AMD_SNW_CPU)
+				cpu_type="${AMD_SNW_CPU}"
+				;;
 			*)
 				cpu_type=$(<"$config_path"/cpu_type)
 				;;

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -76,8 +76,9 @@ declare -A comex_cfl_alternatives=(["mp2975_0"]="mp2975 0x6b 15 comex_voltmon1" 
 declare -A comex_bf3_alternatives=(["mp2975_0"]="mp2975 0x6b 15 comex_voltmon1" \
 				   ["24c512_0"]="24c512 0x50 16 cpu_info")
 
-declare -A comex_amd_snw_alternatives=(["mp2855_0"]="mp2855 0x29 15 comex_voltmon1" \
+declare -A comex_amd_snw_alternatives=(["mp2855_0"]="mp2855 0x69 15 comex_voltmon1" \
 				   ["mp2975_1"]="mp2975 0x6a 15 comex_voltmon2" \
+				   ["24c128_0"]="24c128 0x50 16 cpu_info"
 				   ["24c512_0"]="24c512 0x50 16 cpu_info")
 
 declare -A mqm8700_alternatives=(["max11603_0"]="max11603 0x64 5 swb_a2d" \

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -76,8 +76,8 @@ declare -A comex_cfl_alternatives=(["mp2975_0"]="mp2975 0x6b 15 comex_voltmon1" 
 declare -A comex_bf3_alternatives=(["mp2975_0"]="mp2975 0x6b 15 comex_voltmon1" \
 				   ["24c512_0"]="24c512 0x50 16 cpu_info")
 
-declare -A comex_amd_snw_alternatives=(["mp2855_0"]="mp2855 0x69 15 comex_voltmon1" \
-				   ["mp2855_1"]="mp2855 0x6a 15 comex_voltmon2" \
+declare -A comex_amd_snw_alternatives=(["mp2855_0"]="mp2855 0x29 15 comex_voltmon1" \
+				   ["mp2975_1"]="mp2975 0x6a 15 comex_voltmon2" \
 				   ["24c512_0"]="24c512 0x50 16 cpu_info")
 
 declare -A mqm8700_alternatives=(["max11603_0"]="max11603 0x64 5 swb_a2d" \

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -146,6 +146,7 @@ CFL_CPU=0x69E
 DNV_CPU=0x65F
 BF3_CPU=0xD42
 AMD_SNW_CPU=0x171
+amd_snw_i2c_sodimm_dev=/sys/devices/platform/AMDI0010:02
 n5110_mctp_bus="0"
 n5110_mctp_addr="100a"
 

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -57,6 +57,9 @@ fan_drwr_num=0
 fan_direction_exhaust=46
 fan_direction_intake=52
 pwm_min_level=51
+# AMD Epyc3000 CPU temperatures (C) in scale 1000
+AMD_SNW_TEMP_CRIT=100000
+AMD_SNW_TEMP_MAX=95000
 
 FAN_MAP_DEF=(1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20)
 
@@ -741,6 +744,25 @@ if [ "$1" == "add" ]; then
 				check_n_link "$3""$4"/temp"$i"_crit $thermal_path/cpu_"$name"_crit
 				check_n_link "$3""$4"/temp"$i"_max $thermal_path/cpu_"$name"_max
 				check_n_link "$3""$4"/temp"$i"_crit_alarm $alarm_path/cpu_"$name"_crit_alarm
+			fi
+		done
+	fi
+	# AMD CPU provides Temp control input for every die and real die temperature input
+	# just for main die 0. Real die temp isn't reported on low-end AMD Epyc3151.
+	# Thus, use 1st Tctl which exist for all AMD Epyc 3000 CPUs. Find and process it as Intel CPU pack.
+	# Put constants to crit and max as AMD k10temp driver doesn't provide these inputs.
+	if [ "$2" == "cputemp_amd" ]; then
+		for file in "$3""$4"/*; do
+			if ls "$file" | grep -q "label" ; then
+				label_name=$(cat "$file")
+				if [ "$label_name" == "Tctl" ]; then
+					fname="${file##*/}"
+					idx=${fname:4:1}
+					check_n_link "$3""$4"/temp"$idx"_input $thermal_path/cpu_pack
+					echo "$AMD_SNW_TEMP_MAX" > $thermal_path/cpu_pack_max
+					echo "$AMD_SNW_TEMP_CRIT" > $thermal_path/cpu_pack_crit
+					break
+				fi
 			fi
 		done
 	fi

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -797,6 +797,10 @@ if [ "$1" == "add" ]; then
 				sodimm2_addr='001a'
 			;;
 			$AMD_SNW_CPU)
+				sodimm1_addr='001a'
+				sodimm2_addr='001b'
+				sodimm3_addr='001e'
+				sodimm4_addr='001f'
 			;;
 			*)
 				exit 0
@@ -810,6 +814,12 @@ if [ "$1" == "add" ]; then
 			;;
 			$sodimm2_addr)
 				sodimm_name=sodimm2_temp
+			;;
+			$sodimm3_addr)
+				sodimm_name=sodimm3_temp
+			;;
+			$sodimm4_addr)
+				sodimm_name=sodimm4_temp
 			;;
 			*)
 				exit 0

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -787,6 +787,10 @@ set_jtag_gpio()
 			jtag_tms=88
 			jtag_tdo=89
 			;;
+		$AMD_SNW_CPU)
+			echo 0x2094 > $config_path/jtag_rw_reg
+			echo 0x2095 > $config_path/jtag_ro_reg
+			;;
 		*)
 			return 0
 			;;
@@ -888,6 +892,7 @@ set_gpios()
 			return 1
 			;;
 		$AMD_SNW_CPU)
+			set_jtag_gpio $1
 			# TBD Remove "boot_completed","nvme_present"/4,42 GPIOs after AMD BU
 			gpiolabel="AMDI0030:00"
 			gpio_idx=(5 6 4 42)

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2883,6 +2883,39 @@ set_dpu_pci_id()
 	return
 }
 
+# DIMM Temp sensor driver jc42 doesn't probe/find sodimm_ts on AMD platform
+# Check and add availab
+set_sodimms()
+{
+	local i2c_dir
+	local i2c_bus
+	amd_snw_sodimm_ts_addr=(0x1a 0x1b 0x1e 0x1f)
+
+	if [ "$cpu_type" != "$AMD_SNW_CPU" ]; then
+		return 0
+	fi
+
+	if ! lsmod | grep -q i2c_designware_platform; then
+		modprobe i2c_designware_platform
+		sleep 0.5
+	fi
+
+	i2c_dir=$(ls -1d "$amd_snw_i2c_sodimm_dev"/i2c-*)
+	i2c_bus="${i2c_dir##*-}"
+	if [ -z "$i2c_bus" ]; then
+		log_err "Error: I2C bus of SODIMMs TS isn't found."
+		return 1
+	fi
+
+	for ((i=0; i<${#amd_snw_sodimm_ts_addr[@]}; i+=1)); do
+		j=$(echo ${amd_snw_sodimm_ts_addr[$i]} | cut -b 3-)
+		i2cdetect -y -a -r 0 ${amd_snw_sodimm_ts_addr[$i]} ${amd_snw_sodimm_ts_addr[$i]} | grep -qi $j
+		if [ $? -eq 0 ]; then
+			echo "jc42" "${amd_snw_sodimm_ts_addr[$i]}" > /sys/bus/i2c/devices/i2c-$i2c_bus/new_device
+		fi
+	done
+}
+
 pre_devtr_init()
 {
 	case $board_type in
@@ -2985,6 +3018,7 @@ do_start()
 	check_system
 	set_asic_pci_id
 	set_dpu_pci_id
+	set_sodimms
 
 	asic_control=$(< $config_path/asic_control) 
 	if [[ $asic_control -ne 0 ]]; then

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2909,7 +2909,7 @@ set_sodimms()
 
 	for ((i=0; i<${#amd_snw_sodimm_ts_addr[@]}; i+=1)); do
 		j=$(echo ${amd_snw_sodimm_ts_addr[$i]} | cut -b 3-)
-		i2cdetect -y -a -r 0 ${amd_snw_sodimm_ts_addr[$i]} ${amd_snw_sodimm_ts_addr[$i]} | grep -qi $j
+		i2cdetect -y -a -r $i2c_bus ${amd_snw_sodimm_ts_addr[$i]} ${amd_snw_sodimm_ts_addr[$i]} | grep -qi $j
 		if [ $? -eq 0 ]; then
 			echo "jc42" "${amd_snw_sodimm_ts_addr[$i]}" > /sys/bus/i2c/devices/i2c-$i2c_bus/new_device
 		fi


### PR DESCRIPTION
- hw-mgmt: scripts & udev: Add handling of AMD Epyc3000 CPU temperature.
- hw-mgmt: udev: Change trigger rules for SODIMMs temp sensors.
- hw-mgmt: scripts: fix devtree voltmon description on AMD comex.
- hw-mgmt: scripts: Add process SODIMM temp sensors events on AMD Epyc3000 CPU.
- hw-mgmt: scripts: add jtag configs for AMD CPU based systems.
- hw-mgmt: scripts: tempory code for testing AMD Comex on old systems. Should be reverted later.
- hw-mgmt: scripts: Add SODIMM temp sensors init on AMD Epyc3000 CPU.
