### PR TITLE
hw-mgmt: scripts: Fix gpio export/unexport. Fix pdb_eeprom name

### DIFF
--- a/usr/usr/bin/hw-management-devtree-check.sh
+++ b/usr/usr/bin/hw-management-devtree-check.sh
@@ -131,7 +131,7 @@ devtr_2_csv_convert()
 # DT_SYS_SKU - system SKU
 # DT_PATH -full path of devtree file for use. Default is /var/run/hw-management/config
 # DT_CPU_TYPE - simulate other CPU. Currently Broadwell, Coffelake and BF3 CPUs are supported
-# 	BDW_CPU, CFL_CPU, BF3_CPU e.g. export DT_CPU_TYPE=BDW_CPU
+# 	BDW_CPU, CFL_CPU, BF3_CPU, AMD_CPU e.g. export DT_CPU_TYPE=BDW_CPU
 devtr_sim_environment_vars()
 {
 	if [[ -z "${DT_BOARD_TYPE}" ]]; then

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -333,7 +333,7 @@ declare -A pwr_type3_alternatives=(["pmbus_0"]="pmbus 0x10 4 pwr_conv1" \
 				   	["pmbus_2"]="pmbus 0x13 4 pwr_conv3" \
 				   	["pmbus_3"]="pmbus 0x15 4 pwr_conv4" \
 				   	["lm5066_0"]="lm5066 0x16 4 pdb_hotwap1" \
-				   	["24c512_0"]="24c512 0x51 4 pdb_info")
+				   	["24c512_0"]="24c512 0x51 4 pdb_eeprom")
 
 declare -A platform_type0_alternatives=(["max11603_0"]="max11603 0x6d 15 carrier_a2d" \
 					["lm75_0"]="lm75 0x49 17 fan_amb" \

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -918,7 +918,7 @@ set_gpios()
 
 	for ((i=0; i<${#gpio_idx[@]}; i+=1)); do
 		gpionum=$((gpiobase+${gpio_idx[$i]}))
-		echo $gpionum > /sys/class/gpio/export
+		echo $gpionum > /sys/class/gpio/$export_unexport
 		if [ "$export_unexport" == "export" ]; then
 			check_n_link /sys/class/gpio/gpio$gpionum/value $system_path/"${gpio_names[$i]}"
 		fi


### PR DESCRIPTION
1. Fix pdb_eeprom name on N5110 to be aligned with name on other systems pdb_info => pdb_eeprom
2. Fix gpio export/unexport on hw-mgmt stop.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
