### PR TITLE
hw-mgmt: topology: n5110ld: Fix asf driver load.

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2528,6 +2528,7 @@ load_modules()
 	case $sku in
 		HI162)	# JSO
 			modprobe i2c_designware_platform
+			modprobe i2c_asf
 		;;
 		*)
 		;;


### PR DESCRIPTION
Add i2c_asf driver load for n5110_LD system

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
