### PR TITLE
hw-mgmt: scripts: Fix vpd-parser with ONIE MAC decode

### DIFF
--- a/usr/usr/bin/hw-management-vpd-parser.py
+++ b/usr/usr/bin/hw-management-vpd-parser.py
@@ -335,7 +335,10 @@ def format_unpack(_data, item, blk_header, verbose=False):
     item_format = item['format'].format(blk_header['size'])
     val = struct.unpack(item_format, _data)[0]
     if isinstance(val, str):
-        val = val.split('\x00', 1)[0]
+        if blk_header["type"] == ONIE_ID.BASE_MAC:
+            pass
+        else:
+            val = val.split('\x00', 1)[0]
     elif 'I' in item_format:
         val = "{0:#0{1}x}".format(val, 10).upper()
 


### PR DESCRIPTION
In case if onie "Base MAC Address" filed ends with zero byte - vpd-parser
cut last byte in output.
Fixed issue.

Before:
Base MAC Address:        b0cf0e0b5a

After:
Base MAC Address:        b0cf0e0b5a00

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
