### PR TITLE
hw-mgmt: patches: Fix r/w attributes for bmc_to_cpu_ctrl (N5110_LD)

### DIFF
--- a/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -473,7 +473,7 @@ index ece3eaf72..42c7512a3 100644
 +		.label = "bmc_to_cpu_ctrl",
 +		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
-+		.mode = 0200,
++		.mode = 0644,
 +	},
 +	{
 +		.label = "uart_sel",

--- a/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -467,7 +467,7 @@ index 19a98f4..cd429e5 100644
 +		.label = "bmc_to_cpu_ctrl",
 +		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
-+		.mode = 0200,
++		.mode = 0644,
 +	},
 +	{
 +		.label = "uart_sel",


### PR DESCRIPTION
Fix r/w attributes for bmc_to_cpu_ctrl (N5110_LD).
0200 => 0644

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
