### PR TITLE
hw-mgmt: thermal: TC: disable auto add asic sensors to monitoring

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_default.json
+++ b/usr/etc/hw-management-thermal/tc_config_default.json
@@ -48,7 +48,8 @@
 		"gearbox\\d+":    {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 6},
 		"pch":            {"pwm_min": 20, "pwm_max" : 100, "val_min": 50000, "val_max": 85000, "poll_time": 10, "enable" : 0},
 		"comex_amb":      {"pwm_min": 20, "pwm_max" : 100, "val_min": 45000, "val_max": 85000, "poll_time": 10, "enable" : 0}
-	}
+	},
+	"sensor_list" : ["asic1", "cpu", "sensor_amb"]
 }
 
  

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2531,8 +2531,6 @@ class ThermalManagement(hw_managemet_file_op):
         # Collect asic sensors
         try:
             self.asic_counter = int(self.read_file("config/asic_num"))
-            for asic_idx in range(1, self.asic_counter + 1):
-                sensor_list.append("asic{}".format(asic_idx))
         except BaseException:
             self.log.error("Missing ASIC num config.", 1)
             sys.exit(1)


### PR DESCRIPTION
Disable auto add asic sensors to monitoring. Add ASIC thermal sensors only
if it defined in TC thermal data .json

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
