### PR TITLE
hw-mgmt: kernel modules: Blacklist WIFI core driver

### DIFF
--- a/usr/etc/modprobe.d/hw-management-arm64.conf
+++ b/usr/etc/modprobe.d/hw-management-arm64.conf
@@ -12,3 +12,4 @@ blacklist nvidia_drm
 blacklist pcspkr
 blacklist i2c_piix4
 blacklist mlxbf_tmfifo
+blacklist cfg80211

--- a/usr/etc/modprobe.d/hw-management.conf
+++ b/usr/etc/modprobe.d/hw-management.conf
@@ -14,3 +14,4 @@ blacklist nvidia_drm
 blacklist pcspkr
 blacklist i2c_piix4
 blacklist i2c_asf
+blacklist cfg80211


### PR DESCRIPTION
Prevents systemd-networkd from loading WIFI core driver and causing a bunch of errors showing up in the logs.