### PR TITLE
hw-mgmt: thermal: Set PSU fan dir to "Unknown" if PSU FRU is broken

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -962,6 +962,8 @@ if [ "$1" == "add" ]; then
 					exit 0
 				fi
 				echo "Failed to read PSU VPD" > $eeprom_path/"$psu_name"_vpd
+				# Set "Unknown fan dir in case failed to read PSU VPD.
+				echo 2 > "$thermal_path"/"$psu_name"_fan_dir
 				exit 0
 			else
 				# Add PSU FAN speed info.


### PR DESCRIPTION
Set PSU fan dir value to "Unknown" (value 2) if PSU FRU is broken

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
