### PR TITLE
hw-mgmt: topology: n51xx: Fix fan_amb sensor name

### DIFF
--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -261,7 +261,7 @@ declare -A sn4280_alternatives=(["max11603_0"]="max11603 0x6d 5 swb_a2d" \
 
 # V0-K*G0EgEgJa-S*RgRgRgTcTcFcEiRgRgRgSaSaGeGb-L*GbFdEiTcFdSaXbXc-P*OaOaOaOaHaEi-C*GeGdFdRiRaEg
 # for JSO
-declare -A n5110ld_platform_alternatives=(["adt75_0"]="adt75 0x49 6 fan_amb",
+declare -A n5110ld_platform_alternatives=(["adt75_0"]="adt75 0x49 6 fan_amb" \
 								["emc1412_0"]="emc1403 0x4C 6 fpga")
 
 declare -A n5110ld_swb_alternatives=(["mp2891_0"]="mp2891 0x66 5 voltmon1" \


### PR DESCRIPTION
Fix fan_amb sensor name. Remove redundant ","
fan_amb, -> fan_amb

Bug: 3988849

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
