### PR TITLE
hw-mgmt: topology: Fix for n51xx COMEX i2c offset init

### DIFF
--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -78,7 +78,7 @@ declare -A comex_bf3_alternatives=(["mp2975_0"]="mp2975 0x6b 15 comex_voltmon1" 
 
 declare -A comex_amd_snw_alternatives=(["mp2855_0"]="mp2855 0x69 15 comex_voltmon1" \
 				   ["mp2975_1"]="mp2975 0x6a 15 comex_voltmon2" \
-				   ["24c128_0"]="24c128 0x50 16 cpu_info"
+				   ["24c128_0"]="24c128 0x50 16 cpu_info" \
 				   ["24c512_0"]="24c512 0x50 16 cpu_info")
 
 declare -A mqm8700_alternatives=(["max11603_0"]="max11603 0x64 5 swb_a2d" \

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2993,7 +2993,7 @@ pre_devtr_init()
 		;;
 	VMOD0021)
 		case $sku in
-		HI162|HI166H|I167)
+		HI162|HI166|HI167)
 			echo 55 > $config_path/cpu_brd_bus_offset
 			;;
 		*)


### PR DESCRIPTION
Fix misprint in COMEX i2c offset init for n51xx

Bug #4004253

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
