### PR TITLE
hw-mgmt: service: Add start/stop for sync service when hw-mgmt start/stop

### DIFF
--- a/debian/hw-management.hw-management.service
+++ b/debian/hw-management.hw-management.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Chassis HW management service of Mellanox systems
 Documentation=man:hw-management.service(8)
+Wants=hw-management-sync.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Add to hw-management service start/stop synchronisation with hw-mgmt-sync.service

hw-mgmt stop -> hw-mgmt-sync stop
hw-mgmt stuart -> hw-mgmt-sync start

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
