### PR TITLE
hw-mgmt: scripts: Fix invalid dpu entry

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1220,19 +1220,25 @@ if [ "$1" == "add" ]; then
 	fi
 	# Creating dpu folders hierarchy upon dpu udev add event.
 	if [ "$2" == "dpu" ]; then
-		slot_num=$(find_dpu_slot "$3$4")
-		if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
-			mkdir "$hw_management_path"/dpu"$slot_num"
-		fi
-		for i in "${!dpu_folders[@]}"
-		do
-			if [ ! -d "$hw_management_path"/dpu"$slot_num"/"${dpu_folders[$i]}" ]; then
-				mkdir "$hw_management_path/"dpu"$slot_num"/"${dpu_folders[$i]}"
+		case $sku in
+		HI160)
+			slot_num=$(find_dpu_slot "$3$4")
+			if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
+				mkdir "$hw_management_path"/dpu"$slot_num"
 			fi
-		done
-		if [ -e "$devtree_file" ]; then
-			connect_dynamic_board_devices "dpu_board""$slot_num"
-		fi
+			for i in "${!dpu_folders[@]}"
+			do
+				if [ ! -d "$hw_management_path"/dpu"$slot_num"/"${dpu_folders[$i]}" ]; then
+					mkdir "$hw_management_path/"dpu"$slot_num"/"${dpu_folders[$i]}"
+				fi
+			done
+			if [ -e "$devtree_file" ]; then
+				connect_dynamic_board_devices "dpu_board""$slot_num"
+			fi
+			;;
+		*)
+			;;
+		esac
 	fi
 	# Creating lc folders hierarchy upon line card udev add event.
 	if [ "$2" == "linecard" ]; then
@@ -1521,13 +1527,19 @@ else
 	fi
 	# Clear dpu folders upon line card udev rm event.
 	if [ "$2" == "dpu" ]; then
-		slot_num=$(find_dpu_slot "$3$4")
-		if [ -e "$devtree_file" ]; then
-			disconnect_dynamic_board_devices "dpu_board""$slot_num"
-		fi
-		if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
-			rm -rf "$hw_management_path"/dpu"$slot_num"
-		fi
+		case $sku in
+		HI160)
+			slot_num=$(find_dpu_slot "$3$4")
+			if [ -e "$devtree_file" ]; then
+				disconnect_dynamic_board_devices "dpu_board""$slot_num"
+			fi
+			if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
+				rm -rf "$hw_management_path"/dpu"$slot_num"
+			fi
+			;;
+		*)
+			;;
+		esac
 	fi
 	# Clear lc folders upon line card udev rm event.
 	if [ "$2" == "linecard" ]; then


### PR DESCRIPTION
Due to the usage of wildcards in udev rules, the dpu directories were getting created on most of the platforms where DPUs are not present. This patch fixes it by having a check for hw sku, before creating the dpu directories. There by limiting it to only DPU platforms.

The problematic udev rule is with DPU topology creation DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/*-0068"

This one gets triggered for voltage monitors with address 0x68. Having a sku check will prevent it.

Bugs #4001444