### PR TITLE
hw-mgmt: patches: Correct mp2891 voltage scaling

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0040.1101) unstable; urgency=low
+hw-management (1.mlnx.7.0040.1102) unstable; urgency=low
   [ MLNX ] 
 
- -- Yehuda Yehudai <yyehudai@nvidia.com> Thu, 25 Jul 2024 17:10:00 +0300
+ -- Yehuda Yehudai <yyehudai@nvidia.com> Tue, 30 Jul 2024 17:10:00 +0300

--- a/recipes-kernel/linux/linux-5.10/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 ++++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 423 +++++++++++++++++++++++++++++++++
- 4 files changed, 561 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
+ 4 files changed, 564 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -164,43 +164,43 @@ index 000000000..c4bda3d7e
 +
 +**temp1_max_alarm**
 diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
-index ee94fcfde..3eba14fac 100644
+index 2303b5b45..8a08b8102 100644
 --- a/drivers/hwmon/pmbus/Kconfig
 +++ b/drivers/hwmon/pmbus/Kconfig
-@@ -220,6 +220,15 @@ config SENSORS_MP2888
+@@ -230,6 +230,15 @@ config SENSORS_MP2888
  	  This driver can also be built as a module. If so, the module will
  	  be called mp2888.
  
 +config SENSORS_MP2891
-+	tristate "MPS MP2891"
-+	help
-+	 If you say yes here you get hardware monitoring support for MPS
-+	 MP2891 Dual Loop Digital Multi-Phase Controller.
++        tristate "MPS MP2891"
++        help
++          If you say yes here you get hardware monitoring support for MPS
++          MP2891 Dual Loop Digital Multi-Phase Controller.
 +
-+	 This driver can also be built as a module. If so, the module will
-+	 be called mp2891.
++          This driver can also be built as a module. If so, the module will
++          be called mp2891.
 +
  config SENSORS_MP2975
  	tristate "MPS MP2975"
  	help
 diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
-index b1b9a3c8b..60151ac03 100644
+index baab12bbf..cc4e09cc4 100644
 --- a/drivers/hwmon/pmbus/Makefile
 +++ b/drivers/hwmon/pmbus/Makefile
-@@ -25,6 +25,7 @@ obj-$(CONFIG_SENSORS_MAX31785)	+= max31785.o
- obj-$(CONFIG_SENSORS_MAX34440)	+= max34440.o
+@@ -26,6 +26,7 @@ obj-$(CONFIG_SENSORS_MAX34440)	+= max34440.o
+ obj-$(CONFIG_SENSORS_DNI_DPS460) += dni_dps460.o
  obj-$(CONFIG_SENSORS_MAX8688)	+= max8688.o
  obj-$(CONFIG_SENSORS_MP2888)	+= mp2888.o
-+obj-$(CONFIG_SENSORS_MP2891)	+= mp2891.o
++obj-$(CONFIG_SENSORS_MP2891)    += mp2891.o
  obj-$(CONFIG_SENSORS_MP2975)	+= mp2975.o
  obj-$(CONFIG_SENSORS_PXE1610)	+= pxe1610.o
  obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
 diff --git a/drivers/hwmon/pmbus/mp2891.c b/drivers/hwmon/pmbus/mp2891.c
 new file mode 100644
-index 000000000..54f019e22
+index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,423 @@
+@@ -0,0 +1,426 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)
@@ -456,7 +456,7 @@ index 000000000..54f019e22
 +	 * bit 13 = 0, the vid_step is defined by bits 15:14:
 +	 * 00b - 6.25mV/LSB, 01b - 5mV/LSB, 10b - 2mV/LSB, 11b - 1mV
 +	 */
-+	if ((ret & MP2891_DAC_2P5MV_MASK) >> MP2891_VID_STEP_POS) {
++	if (ret & MP2891_DAC_2P5MV_MASK) {
 +		data->vid_step[page] = 250;
 +		return mp2891_git_vid_volt_ref(client, data, page);
 +	}
@@ -467,6 +467,9 @@ index 000000000..54f019e22
 +			break;
 +	case 2:
 +		data->vid_step[page] = 200;
++		break;
++	case 3:
++		data->vid_step[page] = 100;
 +		break;
 +	default:
 +		data->vid_step[page] = 250;
@@ -625,5 +628,5 @@ index 000000000..54f019e22
 +MODULE_DESCRIPTION("PMBus driver for MPS MP2891 device");
 +MODULE_LICENSE("GPL");
 -- 
-2.20.1
+2.44.0
 

--- a/recipes-kernel/linux/linux-5.10/dvs/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/dvs/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 423 +++++++++++++++++++++++++++++++++
- 4 files changed, 561 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
+ 4 files changed, 564 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -197,10 +197,10 @@ index b1b9a3c8b..60151ac03 100644
  obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
 diff --git a/drivers/hwmon/pmbus/mp2891.c b/drivers/hwmon/pmbus/mp2891.c
 new file mode 100644
-index 000000000..38b5365f9
+index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,423 @@
+@@ -0,0 +1,426 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)
@@ -456,7 +456,7 @@ index 000000000..38b5365f9
 +	 * bit 13 = 0, the vid_step is defined by bits 15:14:
 +	 * 00b - 6.25mV/LSB, 01b - 5mV/LSB, 10b - 2mV/LSB, 11b - 1mV
 +	 */
-+	if ((ret & MP2891_DAC_2P5MV_MASK) >> MP2891_VID_STEP_POS) {
++	if (ret & MP2891_DAC_2P5MV_MASK) {
 +		data->vid_step[page] = 250;
 +		return mp2891_git_vid_volt_ref(client, data, page);
 +	}
@@ -467,6 +467,9 @@ index 000000000..38b5365f9
 +			break;
 +	case 2:
 +		data->vid_step[page] = 200;
++		break;
++	case 3:
++		data->vid_step[page] = 100;
 +		break;
 +	default:
 +		data->vid_step[page] = 250;

--- a/recipes-kernel/linux/linux-5.10/nvos/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/nvos/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 423 +++++++++++++++++++++++++++++++++
- 4 files changed, 561 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
+ 4 files changed, 564 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -197,10 +197,10 @@ index b1b9a3c8b..60151ac03 100644
  obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
 diff --git a/drivers/hwmon/pmbus/mp2891.c b/drivers/hwmon/pmbus/mp2891.c
 new file mode 100644
-index 000000000..38b5365f9
+index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,423 @@
+@@ -0,0 +1,426 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)
@@ -456,7 +456,7 @@ index 000000000..38b5365f9
 +	 * bit 13 = 0, the vid_step is defined by bits 15:14:
 +	 * 00b - 6.25mV/LSB, 01b - 5mV/LSB, 10b - 2mV/LSB, 11b - 1mV
 +	 */
-+	if ((ret & MP2891_DAC_2P5MV_MASK) >> MP2891_VID_STEP_POS) {
++	if (ret & MP2891_DAC_2P5MV_MASK) {
 +		data->vid_step[page] = 250;
 +		return mp2891_git_vid_volt_ref(client, data, page);
 +	}
@@ -467,6 +467,9 @@ index 000000000..38b5365f9
 +			break;
 +	case 2:
 +		data->vid_step[page] = 200;
++		break;
++	case 3:
++		data->vid_step[page] = 100;
 +		break;
 +	default:
 +		data->vid_step[page] = 250;

--- a/recipes-kernel/linux/linux-5.10/opt/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/opt/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 423 +++++++++++++++++++++++++++++++++
- 4 files changed, 561 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
+ 4 files changed, 564 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -197,10 +197,10 @@ index b1b9a3c8b..60151ac03 100644
  obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
 diff --git a/drivers/hwmon/pmbus/mp2891.c b/drivers/hwmon/pmbus/mp2891.c
 new file mode 100644
-index 000000000..38b5365f9
+index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,423 @@
+@@ -0,0 +1,426 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)
@@ -456,7 +456,7 @@ index 000000000..38b5365f9
 +	 * bit 13 = 0, the vid_step is defined by bits 15:14:
 +	 * 00b - 6.25mV/LSB, 01b - 5mV/LSB, 10b - 2mV/LSB, 11b - 1mV
 +	 */
-+	if ((ret & MP2891_DAC_2P5MV_MASK) >> MP2891_VID_STEP_POS) {
++	if (ret & MP2891_DAC_2P5MV_MASK) {
 +		data->vid_step[page] = 250;
 +		return mp2891_git_vid_volt_ref(client, data, page);
 +	}
@@ -467,6 +467,9 @@ index 000000000..38b5365f9
 +			break;
 +	case 2:
 +		data->vid_step[page] = 200;
++		break;
++	case 3:
++		data->vid_step[page] = 100;
 +		break;
 +	default:
 +		data->vid_step[page] = 250;

--- a/recipes-kernel/linux/linux-5.10/sonic/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/sonic/0294-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 423 +++++++++++++++++++++++++++++++++
- 4 files changed, 561 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
+ 4 files changed, 564 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -197,10 +197,10 @@ index b1b9a3c8b..60151ac03 100644
  obj-$(CONFIG_SENSORS_TPS40422)	+= tps40422.o
 diff --git a/drivers/hwmon/pmbus/mp2891.c b/drivers/hwmon/pmbus/mp2891.c
 new file mode 100644
-index 000000000..38b5365f9
+index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,423 @@
+@@ -0,0 +1,426 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)
@@ -456,7 +456,7 @@ index 000000000..38b5365f9
 +	 * bit 13 = 0, the vid_step is defined by bits 15:14:
 +	 * 00b - 6.25mV/LSB, 01b - 5mV/LSB, 10b - 2mV/LSB, 11b - 1mV
 +	 */
-+	if ((ret & MP2891_DAC_2P5MV_MASK) >> MP2891_VID_STEP_POS) {
++	if (ret & MP2891_DAC_2P5MV_MASK) {
 +		data->vid_step[page] = 250;
 +		return mp2891_git_vid_volt_ref(client, data, page);
 +	}
@@ -467,6 +467,9 @@ index 000000000..38b5365f9
 +			break;
 +	case 2:
 +		data->vid_step[page] = 200;
++		break;
++	case 3:
++		data->vid_step[page] = 100;
 +		break;
 +	default:
 +		data->vid_step[page] = 250;

--- a/recipes-kernel/linux/linux-6.1/0048-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-6.1/0048-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,14 +24,14 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 ++++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 424 +++++++++++++++++++++++++++++++++
- 4 files changed, 562 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 427 +++++++++++++++++++++++++++++++++
+ 4 files changed, 565 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
 diff --git a/Documentation/hwmon/mp2891.rst b/Documentation/hwmon/mp2891.rst
 new file mode 100644
-index 000000000000..c4bda3d7ee8a
+index 000000000..c4bda3d7e
 --- /dev/null
 +++ b/Documentation/hwmon/mp2891.rst
 @@ -0,0 +1,128 @@
@@ -164,7 +164,7 @@ index 000000000000..c4bda3d7ee8a
 +
 +**temp1_max_alarm**
 diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
-index 89668af67206..77d67344cee4 100644
+index 89668af67..77d67344c 100644
 --- a/drivers/hwmon/pmbus/Kconfig
 +++ b/drivers/hwmon/pmbus/Kconfig
 @@ -299,6 +299,15 @@ config SENSORS_MP2888
@@ -184,7 +184,7 @@ index 89668af67206..77d67344cee4 100644
  	tristate "MPS MP2975"
  	help
 diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
-index 0002dbe22d52..8e767d7b8c5b 100644
+index 0002dbe22..8e767d7b8 100644
 --- a/drivers/hwmon/pmbus/Makefile
 +++ b/drivers/hwmon/pmbus/Makefile
 @@ -32,6 +32,7 @@ obj-$(CONFIG_SENSORS_MAX31785)	+= max31785.o
@@ -197,10 +197,10 @@ index 0002dbe22d52..8e767d7b8c5b 100644
  obj-$(CONFIG_SENSORS_PLI1209BC)	+= pli1209bc.o
 diff --git a/drivers/hwmon/pmbus/mp2891.c b/drivers/hwmon/pmbus/mp2891.c
 new file mode 100644
-index 000000000000..1547625fea7e
+index 000000000..a4386e8e9
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,424 @@
+@@ -0,0 +1,427 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)
@@ -456,7 +456,7 @@ index 000000000000..1547625fea7e
 +	 * bit 13 = 0, the vid_step is defined by bits 15:14:
 +	 * 00b - 6.25mV/LSB, 01b - 5mV/LSB, 10b - 2mV/LSB, 11b - 1mV
 +	 */
-+	if ((ret & MP2891_DAC_2P5MV_MASK) >> MP2891_VID_STEP_POS) {
++	if (ret & MP2891_DAC_2P5MV_MASK) {
 +		data->vid_step[page] = 250;
 +		return mp2891_git_vid_volt_ref(client, data, page);
 +	}
@@ -467,6 +467,9 @@ index 000000000000..1547625fea7e
 +			break;
 +	case 2:
 +		data->vid_step[page] = 200;
++		break;
++	case 3:
++		data->vid_step[page] = 100;
 +		break;
 +	default:
 +		data->vid_step[page] = 250;
@@ -626,5 +629,5 @@ index 000000000000..1547625fea7e
 +MODULE_LICENSE("GPL");
 +MODULE_IMPORT_NS(PMBUS);
 -- 
-2.20.1
+2.44.0
 


### PR DESCRIPTION
This patch fixes the issue while shifting the bits in pmbus register 0xBD. A right shift of 14 bits
would make the value as 0 and the check for BIT(13) will always fail. This was causing the wrong scale value of 5mv to be used (instead of 2.5mv) for vou2.

Bug #3962952