### PR TITLE
w-mgmt: scripts: Add fanX_speed_tolerance attribute

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -373,6 +373,7 @@ if [ "$1" == "add" ]; then
 						check_n_link "$3""$4"/fan"$i"_fault "$tpath"/fan"$j"_fault
 						check_n_link "$cpath"/fan_min_speed "$tpath"/fan"$j"_min
 						check_n_link "$cpath"/fan_max_speed "$tpath"/fan"$j"_max
+						check_n_link "$cpath"/fan_speed_tolerance "$tpath"/fan"$j"_speed_tolerance
 						# Save max_tachos to config
 						echo $i > "$cpath"/max_tachos
 					fi
@@ -479,6 +480,7 @@ if [ "$1" == "add" ]; then
 				check_n_link "$3""$4"/fan"$i"_fault $thermal_path/fan"$j"_fault
 				check_n_link $config_path/fan_min_speed $thermal_path/fan"$j"_min
 				check_n_link $config_path/fan_max_speed $thermal_path/fan"$j"_max
+				check_n_link $config_path/fan_speed_tolerance $thermal_path/fan"$j"_speed_tolerance
 				# Save max_tachos to config.
 				echo $i > $config_path/max_tachos
 			fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -116,6 +116,7 @@ chipup_log_size=4096
 reset_dflt_attr_num=18
 smart_switch_reset_attr_num=17
 chipup_retry_count=3
+fan_speed_tolerance=15
 
 mctp_bus=""
 mctp_addr=""
@@ -2576,6 +2577,7 @@ set_config_data()
 	echo $hotplug_pwrs > $config_path/hotplug_pwrs
 	echo $hotplug_fans > $config_path/hotplug_fans
 	echo $hotplug_linecards > $config_path/hotplug_linecards
+	echo $fan_speed_tolerance > $config_path/fan_speed_tolerance
 }
 
 connect_platform()


### PR DESCRIPTION
The fanX_speed_tolerance attribute is defining how mutch FAN RPM can be different
from expected max/min. Value defined in percent.
Example:

fan1_max = 10000
fan1_speed_tolerance = 15

In this case, range 8500..12000 is considered as normal.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
