### PR TITLE
hw-mgmt: scripts: Fix init error fox SimX paltform

### DIFF
--- a/usr/usr/bin/hw-management-ready.sh
+++ b/usr/usr/bin/hw-management-ready.sh
@@ -40,8 +40,8 @@
 #              Report start of hw-management service to console and logger.
 
 source hw-management-helpers.sh
-board_type=`cat /sys/devices/virtual/dmi/id/board_name`
-product_sku=`cat /sys/devices/virtual/dmi/id/product_sku`
+[ -f "$board_type_file" ] && board_type=$(< $board_type_file) || board_type="Unknown"
+[ -f "$sku_file" ] && product_sku=$(< $sku_file) || product_sku="Unknown"
 
 if systemctl is-active --quiet hw-management; then
         echo "Error: HW management service is already active."

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -58,8 +58,8 @@
 #
 
 source hw-management-helpers.sh
-board_type=$(< $board_type_file)
-sku=$(< $sku_file)
+[ -f "$board_type_file" ] && board_type=$(< $board_type_file) || board_type="Unknown"
+[ -f "$sku_file" ] && sku=$(< $sku_file) || sku="Unknown"
 source hw-management-devtree.sh
 # Local constants and variables
 
@@ -2486,7 +2486,7 @@ create_event_files()
 	if [ $pwr_events_count -ne 0 ]; then
 		if [ -f "$power_events_file" ]; then
 			declare -a power_events="($(< power_events_file))"
-			for ((i=0; i<=pwr_events_count; i+=1)); do
+			for ((i=0; i<pwr_events_count; i+=1)); do
 				check_n_init $events_path/${power_events[$i]} 0
 			done
 		else


### PR DESCRIPTION
Fix SKU/platform reading if it's not exists. This can be when running on
SimX platform.

log messages example before fix:

/usr/bin/hw-management.sh: line 61: /sys/devices/virtual/dmi/id/board_name: No such file or directory
/usr/bin/hw-management.sh: line 62: /sys/devices/virtual/dmi/id/product_sku: No such file or directory
/usr/bin/hw-management-helpers.sh: line 325: /var/run/hw-management/events/: Is a directory

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
