### PR TITLE
hw-mgmt: scripts: Cleanup dpu sensor attributes

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1386,11 +1386,26 @@ else
 			if [ -L $environment_path/"$prefix"_in"$i"_input ]; then
 				unlink $environment_path/"$prefix"_in"$i"_input
 			fi
+			if [ -L $environment_path/"$prefix"_in"$i"_crit ]; then
+				unlink $environment_path/"$prefix"_in"$i"_crit
+			fi
+			if [ -L $environment_path/"$prefix"_in"$i"_lcrit ]; then
+				unlink $environment_path/"$prefix"_in"$i"_lcrit
+			fi
 			if [ -L $environment_path/"$prefix"_curr"$i"_input ]; then
 				unlink $environment_path/"$prefix"_curr"$i"_input
 			fi
 			if [ -L $environment_path/"$prefix"_power"$i"_input ]; then
 				unlink $environment_path/"$prefix"_power"$i"_input
+			fi
+			if [ -L $thermal_path/"$prefix"_temp"$i"_input ]; then
+				unlink $thermal_path/"$prefix"_temp"$i"_input
+			fi
+			if [ -L $thermal_path/"$prefix"_temp"$i"_max ]; then
+				unlink $thermal_path/"$prefix"_temp"$i"_max
+			fi
+			if [ -L $thermal_path/"$prefix"_temp"$i"_crit ]; then
+				unlink $thermal_path/"$prefix"_temp"$i"_crit
 			fi
 			if [ -L $alarm_path/"$prefix"_in"$i"_alarm ]; then
 				unlink $alarm_path/"$prefix"_in"$i"_alarm
@@ -1400,6 +1415,12 @@ else
 			fi
 			if [ -L $alarm_path/"$prefix"_power"$i"_alarm ]; then
 				unlink $alarm_path/"$prefix"_power"$i"_alarm
+			fi
+			if [ -L $alarm_path/"$prefix"_temp"$i"_max_alarm ]; then
+				unlink $alarm_path/"$prefix"_temp"$i"_max_alarm
+			fi
+			if [ -L $alarm_path/"$prefix"_temp"$i"_crit_alarm ]; then
+				unlink $alarm_path/"$prefix"_temp"$i"_crit_alarm
 			fi
 		done
 	fi

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -958,6 +958,9 @@ if [ "$1" == "add" ]; then
 				if is_virtual_machine; then
 					if [ -f $vm_vpd_path/psu_vpd ]; then
 						cat $vm_vpd_path/psu_vpd > $eeprom_path/"$psu_name"_vpd
+						# Get PSU FAN direction
+						get_psu_fan_direction $eeprom_path/"$psu_name"_vpd
+						echo $? > "$thermal_path"/"$psu_name"_fan_dir
 					else
 						echo "Failed to read PSU VPD" > $eeprom_path/"$psu_name"_vpd
 					fi

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -1410,4 +1410,20 @@ else
 	if [ "$2" == "sxcore" ]; then
 		/usr/bin/hw-management.sh chipdown 0 "$4/$5"
 	fi
+	if [ "$2" == "dpu" ]; then
+		sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+		case $sku in
+		HI160)
+			# DPU event, replace output folder.
+			input_bus_num=$(echo "$3""$4" | xargs dirname | xargs dirname | xargs basename | cut -d"-" -f1)
+			slot_num=$(find_dpu_slot_from_i2c_bus $input_bus_num)
+			if [ ! -z "$slot_num" ]; then
+				thermal_path="$hw_management_path"/dpu"$slot_num"/thermal
+			fi
+			;;
+		*)
+			;;
+		esac
+		check_n_unlink $thermal_path/"cx_amb"
+	fi
 fi


### PR DESCRIPTION
This PR has two commits:

1)  hw-mgmt: scripts: Cleanup dpu sensor attributes
    
    In the event of dpu[1-4]_shtdn_ready signal, dpu
    sensor attributes under /var/run/hw-management/dpu[1-4]
    directories in the folders alarm, thermal, environemnt
    were not removed. This commit remove these stale entries.
    
    Bugs #3995269

2) hw-mgmt: scripts: Fix psu fan dir for virtual environment

    Psu fan direction attribute was missing from virtual
    platforms. This commit adds this support.
    
    Bugs #3851470
    
 
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>

