### PR TITLE
hw-mgmt: scripts: Support for DPU dark mode

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1232,9 +1232,6 @@ if [ "$1" == "add" ]; then
 					mkdir "$hw_management_path/"dpu"$slot_num"/"${dpu_folders[$i]}"
 				fi
 			done
-			if [ -e "$devtree_file" ]; then
-				connect_dynamic_board_devices "dpu_board""$slot_num"
-			fi
 			;;
 		*)
 			;;

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -748,3 +748,18 @@ disconnect_dynamic_board_devices()
 		disconnect_device "${board_connect_table[i+1]}" "${board_connect_table[i+2]}"
 	done
 }
+
+load_dpu_sensors()
+{
+	local dpu_num=$1
+	local dpu_ready
+
+	if [ -f $hw_management_path/system/dpu${dpu_num}_ready ]; then
+		dpu_ready=$(< $hw_management_path/system/dpu${dpu_num}_ready)
+		if [ ${dpu_ready} -eq 1 ]; then
+			if [ -e "$devtree_file" ]; then
+				connect_dynamic_board_devices "dpu_board""$dpu_num"
+			fi
+		fi
+	fi
+}

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -685,6 +685,11 @@ if [ "$1" == "add" ]; then
 		init_hotplug_events "$dpu_events_file" "$3$4" 2
 		init_hotplug_events "$dpu_events_file" "$3$4" 3
 		init_hotplug_events "$dpu_events_file" "$3$4" 4
+		# Based on the DPU ready signal, connect the DPU sensors
+		load_dpu_sensors 1
+		load_dpu_sensors 2
+		load_dpu_sensors 3
+		load_dpu_sensors 4
 		# BF3 debugfs temperature sensors linkage
 		if [ -f /sys/kernel/debug/mlxbf-ptm/monitors/status/core_temp ]; then
 			ln -sf /sys/kernel/debug/mlxbf-ptm/monitors/status/core_temp $thermal_path/cpu_pack

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3014,7 +3014,6 @@ do_start()
 	devtr_check_smbios_device_description
 	check_system
 	set_asic_pci_id
-	set_dpu_pci_id
 	set_sodimms
 
 	asic_control=$(< $config_path/asic_control) 


### PR DESCRIPTION
This commit does the following:
 - Connect the DPU sensors only if DPUs are powered on
 - Remove the 'dpu_detected_num' config variable
 - Remove the pci addresses of DPUs from config folder

Bugs #4037464