### PR TITLE
hw-mgmt: thermal: TC fix timer for while loops based on current system time

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -393,7 +393,7 @@ def current_milli_time():
         get current time in milliseconds
     @return: int value time in milliseconds
     """
-    return round(time.time() * 1000)
+    return round(time.clock_gettime(1) * 1000)
 
 
 # ----------------------------------------------------------------------
@@ -2494,6 +2494,7 @@ class ThermalManagement(hw_managemet_file_op):
 
         if self.check_file("config/thermal_delay"):
             thermal_delay = int(self.read_file("config/thermal_delay"))
+            self.log.notice("Additional delay defined in ./config/thermal_delay ({} sec).".format(thermal_delay), 1)
             timeout = current_milli_time() + 1000 * thermal_delay
             while timeout > current_milli_time():
                 if not self.write_pwm(self.pwm_target):


### PR DESCRIPTION
In while loops like:

  end = current_milli_time() + delay
  while end > current_milli_time():
    do_somthing()

We potentially can get incorrect delay in case if during loop system
time will be changed. It happens because current_milli_time() based on system time
and this time can be forwarded or rewinded.  To fix this issue - it needs to
change current_milli_time to time which can't be changed, like: system uptime,
application uptime etc.

This fix changing current_milli_time() to read CLOCK_PROCESS_CPUTIME_ID
(High-resolution per-process timer from the CPU) timer as reference.

Bug #4042294

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
