### PR TITLE
DPU related commits

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0040.1010) unstable; urgency=low
+hw-management (1.mlnx.7.0040.1011) unstable; urgency=low
   [ MLNX ] 
 
- -- Yehuda Yehudai <yyehudai@nvidia.com> Thu, 15 Aug 2024 12:10:00 +0300
+ -- Yehuda Yehudai <yyehudai@nvidia.com> Thu, 22 Aug 2024 12:10:00 +0300

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1386,11 +1386,26 @@ else
 			if [ -L $environment_path/"$prefix"_in"$i"_input ]; then
 				unlink $environment_path/"$prefix"_in"$i"_input
 			fi
+			if [ -L $environment_path/"$prefix"_in"$i"_crit ]; then
+				unlink $environment_path/"$prefix"_in"$i"_crit
+			fi
+			if [ -L $environment_path/"$prefix"_in"$i"_lcrit ]; then
+				unlink $environment_path/"$prefix"_in"$i"_lcrit
+			fi
 			if [ -L $environment_path/"$prefix"_curr"$i"_input ]; then
 				unlink $environment_path/"$prefix"_curr"$i"_input
 			fi
 			if [ -L $environment_path/"$prefix"_power"$i"_input ]; then
 				unlink $environment_path/"$prefix"_power"$i"_input
+			fi
+			if [ -L $thermal_path/"$prefix"_temp"$i"_input ]; then
+				unlink $thermal_path/"$prefix"_temp"$i"_input
+			fi
+			if [ -L $thermal_path/"$prefix"_temp"$i"_max ]; then
+				unlink $thermal_path/"$prefix"_temp"$i"_max
+			fi
+			if [ -L $thermal_path/"$prefix"_temp"$i"_crit ]; then
+				unlink $thermal_path/"$prefix"_temp"$i"_crit
 			fi
 			if [ -L $alarm_path/"$prefix"_in"$i"_alarm ]; then
 				unlink $alarm_path/"$prefix"_in"$i"_alarm
@@ -1400,6 +1415,12 @@ else
 			fi
 			if [ -L $alarm_path/"$prefix"_power"$i"_alarm ]; then
 				unlink $alarm_path/"$prefix"_power"$i"_alarm
+			fi
+			if [ -L $alarm_path/"$prefix"_temp"$i"_max_alarm ]; then
+				unlink $alarm_path/"$prefix"_temp"$i"_max_alarm
+			fi
+			if [ -L $alarm_path/"$prefix"_temp"$i"_crit_alarm ]; then
+				unlink $alarm_path/"$prefix"_temp"$i"_crit_alarm
 			fi
 		done
 	fi

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1232,9 +1232,6 @@ if [ "$1" == "add" ]; then
 					mkdir "$hw_management_path/"dpu"$slot_num"/"${dpu_folders[$i]}"
 				fi
 			done
-			if [ -e "$devtree_file" ]; then
-				connect_dynamic_board_devices "dpu_board""$slot_num"
-			fi
 			;;
 		*)
 			;;

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1220,19 +1220,25 @@ if [ "$1" == "add" ]; then
 	fi
 	# Creating dpu folders hierarchy upon dpu udev add event.
 	if [ "$2" == "dpu" ]; then
-		slot_num=$(find_dpu_slot "$3$4")
-		if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
-			mkdir "$hw_management_path"/dpu"$slot_num"
-		fi
-		for i in "${!dpu_folders[@]}"
-		do
-			if [ ! -d "$hw_management_path"/dpu"$slot_num"/"${dpu_folders[$i]}" ]; then
-				mkdir "$hw_management_path/"dpu"$slot_num"/"${dpu_folders[$i]}"
+		case $sku in
+		HI160)
+			slot_num=$(find_dpu_slot "$3$4")
+			if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
+				mkdir "$hw_management_path"/dpu"$slot_num"
 			fi
-		done
-		if [ -e "$devtree_file" ]; then
-			connect_dynamic_board_devices "dpu_board""$slot_num"
-		fi
+			for i in "${!dpu_folders[@]}"
+			do
+				if [ ! -d "$hw_management_path"/dpu"$slot_num"/"${dpu_folders[$i]}" ]; then
+					mkdir "$hw_management_path/"dpu"$slot_num"/"${dpu_folders[$i]}"
+				fi
+			done
+			if [ -e "$devtree_file" ]; then
+				connect_dynamic_board_devices "dpu_board""$slot_num"
+			fi
+			;;
+		*)
+			;;
+		esac
 	fi
 	# Creating lc folders hierarchy upon line card udev add event.
 	if [ "$2" == "linecard" ]; then
@@ -1521,13 +1527,19 @@ else
 	fi
 	# Clear dpu folders upon line card udev rm event.
 	if [ "$2" == "dpu" ]; then
-		slot_num=$(find_dpu_slot "$3$4")
-		if [ -e "$devtree_file" ]; then
-			disconnect_dynamic_board_devices "dpu_board""$slot_num"
-		fi
-		if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
-			rm -rf "$hw_management_path"/dpu"$slot_num"
-		fi
+		case $sku in
+		HI160)
+			slot_num=$(find_dpu_slot "$3$4")
+			if [ -e "$devtree_file" ]; then
+				disconnect_dynamic_board_devices "dpu_board""$slot_num"
+			fi
+			if [ ! -d "$hw_management_path"/dpu"$slot_num" ]; then
+				rm -rf "$hw_management_path"/dpu"$slot_num"
+			fi
+			;;
+		*)
+			;;
+		esac
 	fi
 	# Clear lc folders upon line card udev rm event.
 	if [ "$2" == "linecard" ]; then

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -766,3 +766,18 @@ disconnect_dynamic_board_devices()
 		disconnect_device "${board_connect_table[i+1]}" "${board_connect_table[i+2]}"
 	done
 }
+
+load_dpu_sensors()
+{
+	local dpu_num=$1
+	local dpu_ready
+
+	if [ -f $hw_management_path/system/dpu${dpu_num}_ready ]; then
+		dpu_ready=$(< $hw_management_path/system/dpu${dpu_num}_ready)
+		if [ ${dpu_ready} -eq 1 ]; then
+			if [ -e "$devtree_file" ]; then
+				connect_dynamic_board_devices "dpu_board""$dpu_num"
+			fi
+		fi
+	fi
+}

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -1406,4 +1406,20 @@ else
 	if [ "$2" == "sxcore" ]; then
 		/usr/bin/hw-management.sh chipdown 0 "$4/$5"
 	fi
+	if [ "$2" == "dpu" ]; then
+		sku=$(< /sys/devices/virtual/dmi/id/product_sku)
+		case $sku in
+		HI160)
+			# DPU event, replace output folder.
+			input_bus_num=$(echo "$3""$4" | xargs dirname | xargs dirname | xargs basename | cut -d"-" -f1)
+			slot_num=$(find_dpu_slot_from_i2c_bus $input_bus_num)
+			if [ ! -z "$slot_num" ]; then
+				thermal_path="$hw_management_path"/dpu"$slot_num"/thermal
+			fi
+			;;
+		*)
+			;;
+		esac
+		check_n_unlink $thermal_path/"cx_amb"
+	fi
 fi

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -956,6 +956,9 @@ if [ "$1" == "add" ]; then
 				if is_virtual_machine; then
 					if [ -f $vm_vpd_path/psu_vpd ]; then
 						cat $vm_vpd_path/psu_vpd > $eeprom_path/"$psu_name"_vpd
+						# Get PSU FAN direction
+						get_psu_fan_direction $eeprom_path/"$psu_name"_vpd
+						echo $? > "$thermal_path"/"$psu_name"_fan_dir
 					else
 						echo "Failed to read PSU VPD" > $eeprom_path/"$psu_name"_vpd
 					fi

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -683,6 +683,11 @@ if [ "$1" == "add" ]; then
 		init_hotplug_events "$dpu_events_file" "$3$4" 2
 		init_hotplug_events "$dpu_events_file" "$3$4" 3
 		init_hotplug_events "$dpu_events_file" "$3$4" 4
+		# Based on the DPU ready signal, connect the DPU sensors
+		load_dpu_sensors 1
+		load_dpu_sensors 2
+		load_dpu_sensors 3
+		load_dpu_sensors 4
 		# BF3 debugfs temperature sensors linkage
 		if [ -f /sys/kernel/debug/mlxbf-ptm/monitors/status/core_temp ]; then
 			ln -sf /sys/kernel/debug/mlxbf-ptm/monitors/status/core_temp $thermal_path/cpu_pack

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3084,7 +3084,6 @@ do_start()
 	devtr_check_smbios_device_description
 	check_system
 	set_asic_pci_id
-	set_dpu_pci_id
 	set_sodimms
 
 	asic_control=$(< $config_path/asic_control) 


### PR DESCRIPTION
This PR takes the following commits to V.7.0040.1000_BR

1)
commit 84e39de609eb3b2a77f39990e1c912e47321c67b
Author: Ciju Rajan K <crajank@nvidia.com>
Date:   Thu Aug 22 09:00:23 2024 +0300

    Update changelog to V.7.0040.1011
    
    Signed-off-by: Ciju Rajan K <crajank@nvidia.com>

2)
commit 4ecc77278ca169c9fa983df8422420fa1f20a93c
Author: Ciju Rajan K <crajank@nvidia.com>
Date:   Wed Aug 21 09:29:02 2024 +0300

    hw-mgmt: scripts: Support for DPU dark mode
    
    This commit does the following:
     - Connect the DPU sensors only if DPUs are powered on
     - Remove the 'dpu_detected_num' config variable
     - Remove the pci addresses of DPUs from config folder
    
    Bugs #4037464
    
    Signed-off-by: Ciju Rajan K <crajank@nvidia.com>

3)
commit e465cc3d87545d55eef91bb01d477cdc2fab5f02
Author: Ciju Rajan K <crajank@nvidia.com>
Date:   Tue Aug 20 10:19:21 2024 +0300

    hw-mgmt: scripts: Cleanup dpu sensor attributes
    
    In the event of dpu[1-4]_shtdn_ready signal, dpu
    sensor attributes under /var/run/hw-management/dpu[1-4]
    directories in the folders alarm, thermal, environemnt
    were not removed. This commit remove these stale entries.
    
    Bugs #3995269
    
    Signed-off-by: Ciju Rajan K <crajank@nvidia.com>

4)
commit 876342ac738b978a94e72dcbe8ae20d66496124f
Author: Ciju Rajan K <crajank@nvidia.com>
Date:   Tue Aug 20 08:05:39 2024 +0300

    hw-mgmt: scripts: Fix psu fan dir for virtual environment
    
    Psu fan direction attribute was missing from virtual
    platforms. This commit adds this support.
    
    Bugs #3851470
    
    Signed-off-by: Ciju Rajan K <crajank@nvidia.com>

5)
commit 256b8d80eb47849e67b7ae388be65c41273e0cc6
Author: Ciju Rajan K <crajank@nvidia.com>
Date:   Fri Jul 26 07:38:16 2024 +0300

    hw-mgmt: scripts: Fix invalid dpu entry
    
    Due to the usage of wildcards in udev rules, the dpu
    directories were getting created on most of the platforms
    where DPUs are not present. This patch fixes it by
    having a check for hw sku, before creating the dpu
    directories. There by limiting it to only DPU platforms.
    
    The problematic udev rule is with DPU topology creation
    DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld.*/i2c-*/i2c-*/*-0068"
    
    This one gets triggered for voltage monitors with address 0x68.
    Having a sku check will prevent it.
    
    Bugs #4001444
    
    Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
