### PR TITLE
hw-mgmt: scripts: Fix coretemp module insert  on AMD systems

### DIFF
--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -6,7 +6,6 @@ i2c-dev
 pmbus
 tps53679
 max1363
-coretemp
 lm75
 tmp102
 ledtrig-timer

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2516,6 +2516,15 @@ load_modules()
 			modprobe drivetemp
 		fi
 	fi
+	case $cpu_type in
+		$AMD_SNW_CPU)
+			# coretemp driver supported only on Intel chips
+			;;
+		*)
+			modprobe coretemp
+			;;
+	esac
+
 	case $sku in
 		HI162|HI166|HI167)	# Juliet
 			modprobe i2c_asf


### PR DESCRIPTION
Fix issue "Failed to insert module 'coretemp': No such device".
Module 'coretemp' doesn't support AND CPU.

Bug: 4042338

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
