### PR TITLE
hw-mgmt: udev rules: Add OFFLINE rule for SDK

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -884,6 +884,8 @@ SUBSYSTEM=="i2c", DEVPATH=="/devices/platform/MLNXBF49:00/i2c_mlxcpld*/i2c-*/i2c
 # SDK
 SUBSYSTEM=="pci", DRIVERS=="sx_core", ENV{SX_CORE_EVENT}=="1", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sxcore add %S %p"
 SUBSYSTEM=="pci", DRIVERS=="sx_core", ENV{SX_CORE_EVENT}=="1", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove %S %p"
+SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="online", RUN+="/usr/bin/hw-management-thermal-events.sh add sxcore add %S %p"
+SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="offline", RUN+="/usr/bin/hw-management-thermal-events.sh rm sxcore remove %S %p"
 
 # DPU
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-001f/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add dpu %S %p"


### PR DESCRIPTION
SDK raises KOBJ_OFFLINE prior entering ISSU.
Add this event to UDEV rules for removing minimal driver before ISSU is activated.

sxd_kernel: sending UDEV event from sx-core driver [bus=0000:07:00.0, action=5 (KOBJ_OFFLINE), origin='ISSU notification'] kernel: [ 3930.396462] sxd_kernel: ISSU FW DONE.
kernel: [ 3930.397867] mlxsw_minimal 2-0048:
HW semaphore is not released -> after ISSU FW DONE kernel: [ 3930.404402] mlxsw_minimal 2-0048:
Cmd exec failed
(opcode=40(ACCESS_REG),opcode_mod=0,in_mod=0,status=27(*UNKNOWN*))

Fixes: https://redmine.mellanox.com/issues/4063285