### PR TITLE
hw-mgmt: patches: change reset cause of SN2201 in 5.10 backport patch.

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
+++ b/recipes-kernel/linux/linux-5.10/0089-platform-mellanox-Add-support-for-new-SN2201-system.patch
@@ -848,7 +848,7 @@ index 000000000000..51da240ce4f9
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_aux_pwr_or_ref",
++		.label = "reset_aux_pwr_or_fu",
 +		.reg = NVSW_SN2201_RST_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,


### PR DESCRIPTION
Backport kernel 5.10 patch of nvsw-sn2201 contained incorrect reset cause
that didsn't correspond to HW CPLD description and to Linux kernel upstream.
Change reset_aux_pwr_or_ref to reset_aux_pwr_or_fu.

Bug: 4047305
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
