### PR TITLE
hw-mgmt: patches: Fixing mp2891 driver loading

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 ++++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
- 4 files changed, 564 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 430 +++++++++++++++++++++++++++++++++
+ 4 files changed, 568 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -200,7 +200,7 @@ new file mode 100644
 index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,430 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)

--- a/recipes-kernel/linux/linux-5.10/dvs/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/dvs/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
- 4 files changed, 564 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 430 +++++++++++++++++++++++++++++++++
+ 4 files changed, 568 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -200,7 +200,7 @@ new file mode 100644
 index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,430 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)

--- a/recipes-kernel/linux/linux-5.10/nvos/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/nvos/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
- 4 files changed, 564 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 430 +++++++++++++++++++++++++++++++++
+ 4 files changed, 568 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -200,7 +200,7 @@ new file mode 100644
 index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,430 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)

--- a/recipes-kernel/linux/linux-5.10/opt/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/opt/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
- 4 files changed, 564 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 430 +++++++++++++++++++++++++++++++++
+ 4 files changed, 568 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -200,7 +200,7 @@ new file mode 100644
 index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,430 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)

--- a/recipes-kernel/linux/linux-5.10/sonic/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/sonic/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -24,8 +24,8 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  Documentation/hwmon/mp2891.rst | 128 +++++++++
  drivers/hwmon/pmbus/Kconfig    |   9 +
  drivers/hwmon/pmbus/Makefile   |   1 +
- drivers/hwmon/pmbus/mp2891.c   | 426 +++++++++++++++++++++++++++++++++
- 4 files changed, 564 insertions(+)
+ drivers/hwmon/pmbus/mp2891.c   | 430 +++++++++++++++++++++++++++++++++
+ 4 files changed, 568 insertions(+)
  create mode 100644 Documentation/hwmon/mp2891.rst
  create mode 100644 drivers/hwmon/pmbus/mp2891.c
 
@@ -200,7 +200,7 @@ new file mode 100644
 index 000000000..8e551b9c5
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp2891.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,430 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Hardware monitoring driver for MPS Multi-phase Digital VR Controllers(MP2891)


### PR DESCRIPTION
In 5.10 kernel, mp2891 driver was not initialized. It was due to a corrupted patch. Fixing the patch.

Bugs #4048801 #4082431