### PR TITLE
hw-mgmt: scripts: Fix power coretamp module load on SimX

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2530,7 +2530,9 @@ load_modules()
 			# coretemp driver supported only on Intel chips
 			;;
 		*)
-			modprobe coretemp
+			if ! check_simx; then
+				modprobe coretemp
+			fi
 			;;
 	esac
 


### PR DESCRIPTION
Since SimX doesn't support CPU core temp emulation - disables 'coretemp'
module load in case of running on SimX

Bug: 4093394

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
