### PR TITLE
hw-mgmt: patches: kernel 5.10/6.1: N51xx fix for power button reset cause

### DIFF
--- a/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -651,7 +651,7 @@ index ad1e421fe..71ab11400 100644
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_leak_con",
++		.label = "reset_pwr_button_or_leak_con",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
 +		.mode = 0444,

--- a/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -668,7 +668,7 @@ index bfa2588782bd..09390c38723a 100644
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_swb_dc_dc_pwr_fail",
++		.label = "reset_pwr_button_or_leak_con",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0444,


### PR DESCRIPTION
Fix for power button reset cause – reset cause should be
“reset_pwr_button_or_leak_con”.

Required fix in CPU - renaming:
“reset_leak_con” -> “reset_pwr_button_or_leak_con”.

Until we don’t have this fix, reset cause will be exposed as “reset_leak_con”.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
