### PR TITLE
hwmgmt: scripts: Skip asic/module sensor value update

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -645,12 +645,16 @@ def asic_temp_populate(arg_list, arg):
     """
     @summary: Update asic attributes
     """
+    f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
+    if os.path.islink(f_name):
+        return
+
     arg = int(arg)
     if arg >= 0:
         val = arg * 125
     else:
         val = 0xffff + arg + 1
-    f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
+
     with open(f_name, 'w', encoding="utf-8") as f:
         f.write(str(val))
 
@@ -676,6 +680,10 @@ def module_temp_populate(arg_list, arg):
     """
     @summary: Update module attributes
     """
+    f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
+    if os.path.islink(f_name):
+        return
+
     try:
         arg = int(arg)
         if arg >= 0:
@@ -693,7 +701,7 @@ def module_temp_populate(arg_list, arg):
         temp_fault = ""
         temp_trip_crit = ""
         
-    f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
+
     with open(f_name, 'w', encoding="utf-8") as f:
         f.write(str(val))
 


### PR DESCRIPTION
If asic/module sensor files already created and it's a soft link - skip
updating it

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
