### PR TITLE
hw-mgmt: sensor: Correct fan names for MSN4600

### DIFF
--- a/usr/etc/hw-management-sensors/msn4600c_2_sensors.conf
+++ b/usr/etc/hw-management-sensors/msn4600c_2_sensors.conf
@@ -217,11 +217,8 @@ bus "i2c-4" "i2c-1-mux (chan_id 3)"
 # Chassis fans
 chip "mlxreg_fan-isa-*"
     label fan1 "Chassis Fan Drawer-1 Tach 1"
-    label fan2 "Chassis Fan Drawer-1 Tach 2"
-    label fan3 "Chassis Fan Drawer-2 Tach 1"
-    label fan4 "Chassis Fan Drawer-2 Tach 2"
-    label fan5 "Chassis Fan Drawer-3 Tach 1"
-    label fan6 "Chassis Fan Drawer-3 Tach 2"
+    label fan2 "Chassis Fan Drawer-2 Tach 2"
+    label fan3 "Chassis Fan Drawer-3 Tach 3"
 
 # Miscellaneous
 chip "*-virtual-*"


### PR DESCRIPTION
Update the sensor configuration with correct fan
names.

Issue #4124359