### PR TITLE
hw-mgmt: sensors: Fix temperature sensor descriptions for SN5600

### DIFF
--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -1,5 +1,5 @@
 ##################################################################################
-# Copyright (c) 2019 - 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN5600
 ##################################################################################
@@ -12,17 +12,17 @@ chip "mlxsw-i2c-*-48"
     label temp1 "Ambient ASIC Temp"
 
 chip "tmp102-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air intake)"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
 chip "adt75-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air intake)"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
 chip "stts751-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air intake)"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
 chip "tmp102-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air exhaust)"
+    label temp1 "Ambient Port Side Temp (air intake)"
 chip "adt75-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air exhaust)"
+    label temp1 "Ambient Port Side Temp (air intake)"
 chip "stts751-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air exhaust)"
+    label temp1 "Ambient Port Side Temp (air intake)"
 
 # Power controllers
 chip "mp2975-i2c-*-62"


### PR DESCRIPTION
SN5600 uses reverse (C2P) fans, so fan side temperature sensor is at air exhaust side and port side sensor is at air intake side.