### PR TITLE
hw-mgmt: patches: Update mp2891 threshold limits

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -342,13 +342,13 @@ index 000000000..8e551b9c5
 +		ret = pmbus_read_word_data(client, page, phase, MP2891_PMBUS_VOUT_MIN);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 105;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_VOUT_OV_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, PMBUS_VOUT_MAX);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 95;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_IOUT_UC_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, reg);

--- a/recipes-kernel/linux/linux-5.10/dvs/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/dvs/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -342,13 +342,13 @@ index 000000000..8e551b9c5
 +		ret = pmbus_read_word_data(client, page, phase, MP2891_PMBUS_VOUT_MIN);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 105;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_VOUT_OV_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, PMBUS_VOUT_MAX);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 95;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_IOUT_UC_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, reg);

--- a/recipes-kernel/linux/linux-5.10/nvos/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/nvos/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -342,13 +342,13 @@ index 000000000..8e551b9c5
 +		ret = pmbus_read_word_data(client, page, phase, MP2891_PMBUS_VOUT_MIN);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 105;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_VOUT_OV_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, PMBUS_VOUT_MAX);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 95;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_IOUT_UC_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, reg);

--- a/recipes-kernel/linux/linux-5.10/opt/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/opt/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -342,13 +342,13 @@ index 000000000..8e551b9c5
 +		ret = pmbus_read_word_data(client, page, phase, MP2891_PMBUS_VOUT_MIN);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 105;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_VOUT_OV_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, PMBUS_VOUT_MAX);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 95;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_IOUT_UC_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, reg);

--- a/recipes-kernel/linux/linux-5.10/sonic/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-5.10/sonic/0261-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -342,13 +342,13 @@ index 000000000..8e551b9c5
 +		ret = pmbus_read_word_data(client, page, phase, MP2891_PMBUS_VOUT_MIN);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 105;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_VOUT_OV_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, PMBUS_VOUT_MAX);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 95;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_IOUT_UC_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, reg);

--- a/recipes-kernel/linux/linux-6.1/0048-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
+++ b/recipes-kernel/linux/linux-6.1/0048-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2891-c.patch
@@ -342,13 +342,13 @@ index 000000000..522c0bb5f
 +		ret = pmbus_read_word_data(client, page, phase, MP2891_PMBUS_VOUT_MIN);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 105;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_VOUT_OV_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, PMBUS_VOUT_MAX);
 +		if (ret <= 0)
 +			return ret;
-+		ret = (ret & GENMASK(10, 0)) * data->vid_step[page] * 95;
++		ret = (ret & GENMASK(10, 0)) * data->vid_step[page];
 +		return DIV_ROUND_CLOSEST(ret, 10000);
 +	case PMBUS_IOUT_UC_FAULT_LIMIT:
 +		ret = pmbus_read_word_data(client, page, phase, reg);


### PR DESCRIPTION
Fixing the wrong calculation in mp 2891 for VOUT thresholds. Remove
thresholds scaling by 1.05/0.95.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
