### PR TITLE
hw-mgmt: patches 6.1: Add patch to fix uninitialized variable

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -714,6 +714,7 @@ Kernel-6.1
 |9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch  |                    | Downstream;skip[sonic,cumulus]           |            |                                                |
 |9005-platform-mellanox-Downstream-Add-dedicated-match-for.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Add dedicated match for QMB8700                |
 |9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream;skip[ALL];take[opt]           |            |                                                |
+|9007-mlxsw-core-Downstream-Fix-uninitialized-variable.patch      |                    | Downstream accepted;skip[sonic]          |            |                                                |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Legend:

--- a/recipes-kernel/linux/linux-6.1/9007-mlxsw-core-Downstream-Fix-uninitialized-variable.patch
+++ b/recipes-kernel/linux/linux-6.1/9007-mlxsw-core-Downstream-Fix-uninitialized-variable.patch
@@ -1,0 +1,47 @@
+From 8a9e2ce4897336d413cc3f6f87065d651080cda6 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 18 Nov 2024 17:57:43 +0200
+Subject: [PATCH hw-mgmt 1/1] mlxsw: core: Downstream: Fix uninitialized
+ variable
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Set variable "status" to zero in function mlxsw_cmd_exec() to prevent
+garbage value to be passed from underling functions.
+
+In case of transaction failure due to some hardware problem,
+uninitialized 'status' may be returned with some garbage value.
+This garbage can be interpreted as some special status, like
+MLXSW_CMD_STATUS_FW_ISSU (0x27) or MLXSW_CMD_STATUS_RUNNING_RESET
+(0x26).
+Such codes are considered by the driver as a special flow, which is
+ended up with driver removing.
+When such code is received - all the next transactions to ASIC are
+blocked.
+
+In case this code is received unintentionally, driver will stop control
+PWM and stop monitor ASIC and receivers’ sensors and system may end up
+with thermal shutdown.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index e2a985ec2c76..352b81f521fa 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -3255,7 +3255,7 @@ int mlxsw_cmd_exec(struct mlxsw_core *mlxsw_core, u16 opcode, u8 opcode_mod,
+ 		   char *in_mbox, size_t in_mbox_size,
+ 		   char *out_mbox, size_t out_mbox_size)
+ {
+-	u8 status;
++	u8 status = 0;
+ 	int err;
+ 
+ 	BUG_ON(in_mbox_size % sizeof(u32) || out_mbox_size % sizeof(u32));
+-- 
+2.44.0
+


### PR DESCRIPTION
mlxsw: core: Downstream: Fix uninitialized variable

Set variable "status" to zero in function mlxsw_cmd_exec() to prevent garbage value to be passed from underling functions.

In case of transaction failure due to some hardware problem, uninitialized 'status' may be returned with some garbage value. This garbage can be interpreted as some special status, like MLXSW_CMD_STATUS_FW_ISSU (0x27) or MLXSW_CMD_STATUS_RUNNING_RESET (0x26).
Such codes are considered by the driver as a special flow, which is ended up with driver removing.
When such code is received - all the next transactions to ASIC are blocked.

In case this code is received unintentionally, driver will stop control PWM and stop monitor ASIC and receivers’ sensors and system may end up with thermal shutdown.