### PR TITLE
hw-mgmt: scripts: fix init errors of GPIOs for JTAG on AMD based systems.

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -820,7 +820,7 @@ set_jtag_gpio()
 		fi
 	fi
 
-	if [ "$board_type" == "VMOD0021" ]; then
+	if [ "$cpu_type" == "$AMD_SNW_CPU" ]; then
 		return 0
 	fi
 


### PR DESCRIPTION
CPLD update on AMD-based systems is done through the LPC CPLD interface.
So, GPIOs for JTAG are not relevant and shouldn't be initialised.

Bug: 4116810
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
