### PR TITLE
hw-mgmt: topology: Fix missing endline character in ./asic1

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -509,24 +509,24 @@ def asic_temp_populate(arg_list, arg):
         val = 0xffff + arg + 1
     f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
     with open(f_name, 'w', encoding="utf-8") as f:
-        f.write(str(val))
+        f.write(str(val)+"\n")
 
     f_name = "/var/run/hw-management/thermal/{}_temp_trip_crit".format(arg_list[0])
     if not os.path.isfile(f_name):
         with open(f_name, 'w', encoding="utf-8") as f:
-            f.write("105000")
+            f.write("105000\n")
 
         f_name = "/var/run/hw-management/thermal/{}_temp_emergency".format(arg_list[0])
         with open(f_name, 'w', encoding="utf-8") as f:
-            f.write("120000")
+            f.write("120000\n")
 
         f_name = "/var/run/hw-management/thermal/{}_temp_crit".format(arg_list[0])
         with open(f_name, 'w', encoding="utf-8") as f:
-            f.write("85000")
+            f.write("85000\n")
 
         f_name = "/var/run/hw-management/thermal/{}_temp_norm".format(arg_list[0])
         with open(f_name, 'w', encoding="utf-8") as f:
-            f.write("75000")
+            f.write("75000\n")
 
 # ----------------------------------------------------------------------
 def module_temp_populate(arg_list, arg):
@@ -539,10 +539,10 @@ def module_temp_populate(arg_list, arg):
             val = arg * 125
         else:
             val = 0xffff + arg + 1
-        temp_crit = "70000"
-        temp_emergency = "75000"
-        temp_fault = "0"
-        temp_trip_crit = "120000"
+        temp_crit = "70000\n"
+        temp_emergency = "75000\n"
+        temp_fault = "0\n"
+        temp_trip_crit = "120000\n"
     except:
         val = ""
         temp_crit = ""
@@ -552,7 +552,7 @@ def module_temp_populate(arg_list, arg):
         
     f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
     with open(f_name, 'w', encoding="utf-8") as f:
-        f.write(str(val))
+        f.write(str(val)+"\n")
 
     f_name = "/var/run/hw-management/thermal/{}_temp_crit".format(arg_list[0])
     with open(f_name, 'w', encoding="utf-8") as f:


### PR DESCRIPTION
Fix missing endline character in ./thermal/asic1.
Added '\n' at end of file

Bug SW #4172888

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
