### PR TITLE
hw-mgmt: thermal: TC Fix log for PSU pwm update

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -1680,10 +1680,10 @@ class psu_fan_sensor(system_device):
         @summary: Set PWM level for PSU FAN
         @param pwm: PWM level value <= 100%
         """
-        self.log.info("Write {} PWM {}".format(self.name, pwm))
         try:
             present = self.thermal_read_file_int("{0}_pwr_status".format(self.base_file_name))
             if present == 1:
+                self.log.info("Write {} PWM {}".format(self.name, pwm))
                 psu_pwm, _, _ = g_get_range_val(self.pwm_decode, pwm)
                 if not psu_pwm:
                     self.log.info("{} Can't much PWM {} to PSU. PWM value not be change".format(self.name, pwm))


### PR DESCRIPTION
Fix log message "Write PSU1 PWM 80". Add log only in case PSU is
present. Prevously it was printed even if PSU is out.
This issue related only to TC logging system.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
