### PR TITLE
hw-mgmt: scripts: Delete psuN_i2c_bus files when PSUs are plugged out

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -1419,6 +1419,9 @@ else
 			rm -f "$config_path"/"$psu_name"_power_slope
 			rm -f "$config_path"/"$psu_name"_power_capacity
 		fi
+		if [ -e "$config_path"/"$psu_name"_i2c_bus ]; then
+			rm -f "$config_path"/"$psu_name"_i2c_bus
+		fi
 	fi
 	if [ "$2" == "sxcore" ]; then
 		/usr/bin/hw-management.sh chipdown 0 "$4/$5"


### PR DESCRIPTION
These files are generated when PSUs are detected on I2C bus. However they are not removed when PSUs are plugged out. This makes it difficult to differentiate between real and dummy PSUs since dummy PSUs are not visible on I2C.