### PR TITLE
hw-mgmt: attributes: Fix module temp input name in sync script

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -545,6 +545,10 @@ def module_temp_populate(arg_list, arg):
     """
     @summary: Update module attributes
     """
+    f_name = "/var/run/hw-management/thermal/{}_temp_input".format(arg_list[0])
+    if os.path.islink(f_name):
+        return
+
     try:
         arg = int(arg)
         if arg >= 0:
@@ -561,8 +565,7 @@ def module_temp_populate(arg_list, arg):
         temp_emergency = ""
         temp_fault = ""
         temp_trip_crit = ""
-        
-    f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
+
     with open(f_name, 'w', encoding="utf-8") as f:
         f.write(str(val)+"\n")
 


### PR DESCRIPTION
Change moduleX temperature input attribute name:

moduleXX -> module XX_temp_input

Bug: 4198371

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
