### PR TITLE
hw-mgmt: attributes: Fix max and crit values for ASIC temperatures

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -510,8 +510,8 @@ def asic_temp_populate(arg_list, arg):
             val = 0xffff + arg + 1
         temp_norm = "75000\n"
         temp_crit = "85000\n"
-        temp_fault = "105000\n"
-        temp_emergency = "120000\n"
+        temp_emergency = "105000\n"
+        temp_fault = "120000\n"
     except:
         val = ""
         temp_crit = ""


### PR DESCRIPTION
Fix in hw-mgmt sunc script max and crit values for ASIC temperatures

Bug: 4173495

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
