### PR TITLE
hw-mgmt: scripts: Fix SODIMM naming on SN5610 and SN5640

### DIFF
--- a/usr/etc/hw-management-sensors/sn5640_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5640_sensors.conf
@@ -462,17 +462,8 @@ chip "mp2975-i2c-*-6a"
     label power2 "PMIC-13 COMEX VDD_MEM OUTPUT POWER"
 
 # AMD Comex SODIMM temperature sensors
-chip "jc42-i2c-*-1a"
-    label temp1 "SODIMM1 Temp"
-
 chip "jc42-i2c-*-1b"
-    label temp1 "SODIMM2 Temp"
-
-chip "jc42-i2c-*-1e"
-    label temp1 "SODIMM3 Temp"
-
-chip "jc42-i2c-*-1f"
-    label temp1 "SODIMM4 Temp"
+    label temp1 "SODIMM1 Temp"
 
 # AMD Comex CPU temperature sensor
 chip "k10temp-pci-*"

--- a/usr/etc/hw-management-thermal/tc_config_sn5610.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5610.json
@@ -41,7 +41,7 @@
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60},
 		"drivetemp":      {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!100000", "poll_time": 60}
 	},
-	"sensor_list" : ["asic1", "cpu", "drivetemp", "sodimm2",
+	"sensor_list" : ["asic1", "cpu", "drivetemp", "sodimm1",
 					 "drwr1", "drwr2", "drwr3", "drwr4", "drwr5",
 					 "psu1", "psu2", "psu3", "psu4",
 					 "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5",

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -814,10 +814,14 @@ if [ "$1" == "add" ]; then
 				sodimm2_addr='001a'
 			;;
 			$AMD_SNW_CPU)
-				sodimm1_addr='001a'
-				sodimm2_addr='001b'
-				sodimm3_addr='001e'
-				sodimm4_addr='001f'
+				if [[ $sku == "HI171" ]] || [[ $sku == "HI172" ]]; then
+					sodimm1_addr='001b'
+				else
+					sodimm1_addr='001a'
+					sodimm2_addr='001b'
+					sodimm3_addr='001e'
+					sodimm4_addr='001f'
+				fi
 			;;
 			*)
 				exit 0


### PR DESCRIPTION
There is only one SODIMM module on SN5610 and SN5640 systems at I2C address 0x1b. Name it SODIMM1 and adjust all relevant files.