### PR TITLE
hw-mgmt: scripts: Add ASIC state check on temperature reading

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -534,18 +534,26 @@ def asic_temp_populate(arg_list, arg):
     """
     @summary: Update asic attributes
     """
+    f_asic_ready = "/var/run/hw-management/config/{}_ready".format(arg_list[0])
     try:
-        val = sdk_temp2degree(int(arg))
-        temp_norm = "75000\n"
-        temp_crit = "85000\n"
-        temp_emergency = "105000\n"
-        temp_fault = "120000\n"
-    except:
-        val = ""
-        temp_crit = ""
-        temp_emergency = ""
-        temp_fault = ""
-        temp_norm = ""
+        with open(f_asic_reay, 'r') as f:
+            asic_ready = int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        asic_ready = 1
+
+    if asic_ready:
+        try:
+            val = sdk_temp2degree(int(arg))
+            temp_norm = "75000\n"
+            temp_crit = "85000\n"
+            temp_emergency = "105000\n"
+            temp_fault = "120000\n"
+        except:
+            val = "0"
+            temp_crit = ""
+            temp_emergency = ""
+            temp_fault = ""
+            temp_norm = ""
 
     f_name = "/var/run/hw-management/thermal/{}".format(arg_list[0])
     with open(f_name, 'w', encoding="utf-8") as f:


### PR DESCRIPTION
When the ASIC SX driver is not available due to the ISSU state,
temperature reading is not available. This commit adds a check for the
asic{}_ready flag to determine if temperature reading is available:

/var/run/hw-management/config/asic{}_ready

1 - ASIC sx driver ready to temperature read
0 - ASIC driver not loaded of temperature is not avalible

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
