### PR TITLE
hw-mgmgt: debug: Add debug dump handler for PWM enforce event

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -312,6 +312,14 @@ atttrib_list = {
 #        {"fin": None,
 #         "fn": "asic_state_poll", "arg" : ["/sys/module/sx_core/asic0/", None], "poll": 10, "ts": 0}
 #    ],
+     "def": [
+         {"fin": "/var/run/hw-management/config/thermal_enforced_full_spped",
+         "fn": "run_cmd",
+         "arg": ["if [[ -f /var/run/hw-management/config/thermal_enforced_full_spped && "
+                 "$(</var/run/hw-management/config/thermal_enforced_full_spped) == \"1\" ]]; then "
+                 "/usr/bin/hw-management-user-dump; fi"],
+         "poll": 5, "ts": 0},
+    ],
     "test": [
          {"fin": "/tmp/power_button_clr",
          "fn": "run_power_button_event",
@@ -717,16 +725,11 @@ def main():
         product_sku = sys.argv[1]
     product_sku = product_sku.strip()
     
-    sys_attr = None
+    sys_attr = atttrib_list["def"]
     for key, val in atttrib_list.items():
         if re.match(key, product_sku):
-            sys_attr = val
+            sys_attr.update(val)
             break
-
-    if not sys_attr:
-        print("Not supported product SKU: {}".format(product_sku))
-        while True:
-            time.sleep(10)
 
     for attr in sys_attr:
         init_attr(attr)


### PR DESCRIPTION
In case of PWM enforce event hApens (because of TC issued it) debug dump
handler will be called.

Flag:
/var/run/hw-management/config/thermal_enforced_full_spped
will set in case of FAN full speed set in abnormal situations, like
ASIC not accesible.

When it happens, hw-management will call /usr/bin/hw-managemrnt-user-dump, which is user callback. OS on init can create symbolic link:
/usr/bin/hw-managemrnt-user-dump -> /usr/cumulus/bin/cl-support.
OS can set their callback, if needed or not set at all.

Bug: 4221324, 4221324

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
