### PR TITLE
hw-mgmgt: script: Fix hw-mgmt-sync failed issue on Juliet

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -728,7 +728,7 @@ def main():
     sys_attr = atttrib_list["def"]
     for key, val in atttrib_list.items():
         if re.match(key, product_sku):
-            sys_attr.update(val)
+            sys_attr.extend(val)
             break
 
     for attr in sys_attr:


### PR DESCRIPTION
Fix hw-mgmgt sync scripyt crash.

Bug: 4248850

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
