### PR TITLE
hw-mgmt: thermal: Fix tc config files

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn5400.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn5400.json
@@ -46,7 +46,7 @@
 		"drivetemp":      {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
 		"ibc\\d+":         {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!110000", "poll_time": 60}
 	},
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "cpu", "drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "ibc1", "ibc2", "ibc3", "ibc4", "psu1", "psu2", 
 	"sensor_amb", "sodimm1", "sodimm2", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"]
 }

--- a/usr/etc/hw-management-thermal/tc_config_n5100ld.json
+++ b/usr/etc/hw-management-thermal/tc_config_n5100ld.json
@@ -32,7 +32,7 @@
 		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
 		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
 	},
-	"error_mask" : {"psu" : ["direction", "present"], "fan" : ["direction"]},
+	"error_mask" : {"psu_err" : ["direction", "present"], "fan_err" : ["direction"]},
 	"sensor_list" : ["cpu",
 					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
 					"sodimm1",

--- a/usr/etc/hw-management-thermal/tc_config_n5110ld.json
+++ b/usr/etc/hw-management-thermal/tc_config_n5110ld.json
@@ -32,7 +32,7 @@
 		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
 		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
 	},
-	"error_mask" : {"psu" : ["direction", "present"], "fan" : ["direction"]},
+	"error_mask" : {"psu_err" : ["direction", "present"], "fan_err" : ["direction"]},
 	"sensor_list" : ["cpu",
 					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
 					"sodimm1",

--- a/usr/etc/hw-management-thermal/tc_config_n5110ld_ttm.json
+++ b/usr/etc/hw-management-thermal/tc_config_n5110ld_ttm.json
@@ -32,7 +32,7 @@
 		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
 		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
 	},
-	"error_mask" : {"psu" : ["direction", "present"], "fan" : ["direction"]},
+	"error_mask" : {"psu_err" : ["direction", "present"], "fan_err" : ["direction"]},
 	"sensor_list" : ["cpu",
 					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
 					"sodimm1",

--- a/usr/etc/hw-management-thermal/tc_config_q3200.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3200.json
@@ -30,7 +30,7 @@
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time":  60},
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "asic2", "cpu",
 	"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5",
 	"psu1", "psu2",  "psu3", "psu4", "sensor_amb", "sodimm1",

--- a/usr/etc/hw-management-thermal/tc_config_q3400.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3400.json
@@ -30,7 +30,7 @@
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time":  60},
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 95000, "poll_time": 60}
 	},
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "asic2", "asic3", "asic4", "cpu",
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "drwr8", "drwr9", "drwr10",
 					"psu1", "psu2", "psu3", "psu4", "psu5", "psu6", "psu7", "psu8", "sodimm1", "sodimm2",

--- a/usr/etc/hw-management-thermal/tc_config_sn4280.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn4280.json
@@ -50,7 +50,7 @@
    		"dpu\\d+_drivetemp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!55000", "val_max": "!70000", "poll_time": 60},
     	"dpu\\d+_voltmon\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60}
 	},
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "psu1", "psu2", "sensor_amb",
 					"voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5",
 					"dpu1_module", "dpu2_module", "dpu3_module", "dpu4_module"]

--- a/usr/etc/hw-management-thermal/tc_config_sn5610.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5610.json
@@ -46,6 +46,6 @@
 					 "psu1", "psu2", "psu3", "psu4",
 					 "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5",
 					 "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"],
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"redundancy" : {"fan_err" : {"min_err_cnt" : "2" }}
 }

--- a/usr/etc/hw-management-thermal/tc_config_sn5640.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5640.json
@@ -46,6 +46,6 @@
 					 "psu1", "psu2", "psu3", "psu4",
 					 "sensor_amb", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5",
 					 "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"],
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"redundancy" : {"fan_err" : {"min_err_cnt" : "2" }}
 }


### PR DESCRIPTION
Fix tc_config files. Rename error_mask type:

psu -> psu_err
fan -> fan_err

Affected systems: msn5400, n5110ld, q3200, q3400, sn4280, sn5610, sn5640
Condition: if error happens on masked sensor - mask will be ignored.
Epecting pwm change even if error was masked.

Bug: 4248463

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
