### PR TITLE
hw-mgmt: attributes: Fix PDB HSC/thermal sensor type

### DIFF
--- a/usr/etc/hw-management-sensors/n51xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n51xxld_sensors.conf
@@ -195,10 +195,17 @@ bus "i2c-29" "i2c-9-mux (chan_id 20)"
 	    label curr3    "PMIC-6 ASIC2_HVDD_PL1 Curr (out1)"
 	    label curr4    "PMIC-6 ASIC2_DVDD_PL1Curr (out2)"
 
-
-bus "i2c-12" "i2c-9-mux (chan_id 3)"
+bus "i2c-11" "i2c-9-mux (chan_id 3)"
 	# Hot-swap
 	chip "lm5066-i2c-*-16"
+	    label in1       "HSC VinDC Volt (in)"
+	    label in3       "HSC Vout Volt (out)"
+	    ignore in2
+	    label power1    "HSC VinDC Pwr (in)"
+	    label curr1     "HSC VinDC Curr (in)"
+	    label temp1     "HSC Temp"
+	    
+	chip "lm5066i-i2c-*-16"
 	    label in1       "HSC VinDC Volt (in)"
 	    label in3       "HSC Vout Volt (out)"
 	    ignore in2

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -39,7 +39,7 @@ declare -A board_arr=(["C"]="cpu_board" ["S"]="switch_board" ["F"]="fan_board" [
 
 declare -A category_arr=(["T"]="thermal" ["R"]="regulator" ["A"]="a2d" ["P"]="pressure" ["E"]="eeprom" ["O"]="powerconv" ["H"]="hotswap" ["G"]="gpio" ["N"]="network" ["J"]="jitter" ["X"]="osc" ["F"]="fpga", ["S"]="erot", ["C"]="rtc")
 
-declare -A thermal_arr=(["0"]="dummy" ["a"]="lm75" ["b"]="tmp102" ["c"]="adt75" ["d"]="stts751" ["e"]="tmp75" ["f"]="tmp421" ["g"]="emc1412" ["h"]="lm90" ["i"]="tmp411")
+declare -A thermal_arr=(["0"]="dummy" ["a"]="lm75" ["b"]="tmp102" ["c"]="adt75" ["d"]="stts751" ["e"]="tmp75" ["f"]="tmp421" ["g"]="lm90" ["h"]="emc1412" ["i"]="tmp411" ["j"]="tmp1075" ["k"]="tmp451")
 
 declare -A regulator_arr=(["0"]="dummy" ["a"]="mp2975" ["b"]="mp2888" ["c"]="tps53679" ["d"]="xdpe12284" ["e"]="152x4" ["f"]="pmbus" ["g"]="mp2891" ["h"]="xdpe1a2g7" ["i"]="mp2855")
 


### PR DESCRIPTION
1. Fix i2c 14-4c sensor type in devtree lm90 -> emc1412
2. Fix HSC sensor type lm5066 -> lm5066i

Bug: N/A

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
