### PR TITLE
hw-mgmt: init: Blacklist cdc_subset network driver

### DIFF
--- a/usr/etc/modprobe.d/hw-management.conf
+++ b/usr/etc/modprobe.d/hw-management.conf
@@ -15,3 +15,4 @@ blacklist pcspkr
 blacklist i2c_piix4
 blacklist i2c_asf
 blacklist cfg80211
+blacklist cdc_subset


### PR DESCRIPTION
Initialization of usb network interface on BMC enabled systems occasionally results in the following error messages:

cdc_subset: probe of 1-2.1:1.0 failed with error -22
cdc_ether: probe of 1-2.1:1.0 failed with error -16

Since both cdc_subset and cdc_ether drivers can handle usb network interface between host CPU and BMC, blacklist the cdc_subset driver to make sure that only cdc_ether driver is loaded. This fixes the error messages above.

Bug: 4260024