### PR TITLE
hw-mgmt: patches: 5.10/6.1: Add kernel new kernel version support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ For detailed information, see the documentation [here](https://github.com/Mellan
 - P4300-A00
 
 ## Supported Kernel versions:
-- 5.10.218
-- 6.1.38
+- 5.10.103, 5.10.140, 5.10.179, 5.10.218, 5.10.226
+- 5.14 all up to 5.14.21
+- 6.1.38, 6.1.90, ,6.1.94, 6.1.119, 6.1.123
 
 ## Sysfs attributes:
 The thermal control operates over sysfs attributes.

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -636,6 +636,7 @@ Kernel-6.1
 |0027-platform-mellanox-mlx-platform-Get-interrupt-line-th.patch  |                    | Feature pending                          |            |                                                |
 |0028-platform-mellanox-Add-initial-support-for-PCIe-based.patch  |                    | Feature pending                          |            |                                                |
 |0029-platform-mellanox-mlxreg-hotplug-Extend-condition-fo.patch  |                    | Feature pending                          |            |                                                |
+|0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch| d56fbfbaf592       | Bugfix accepted                          | v6.1.101   |                                                |
 |0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch  |                    | Feature pending                          |            |                                                |
 |0032-platform_data-mlxreg-Add-field-with-mapped-resource-.patch  | 26917eab144c       | Feature upstream                         |            |                                                |
 |0033-i2c-mlxcpld-Allow-driver-to-run-on-ARM64-architectur.patch  |                    | Feature pending                          |            |                                                |

--- a/recipes-kernel/linux/linux-6.1/0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch
+++ b/recipes-kernel/linux/linux-6.1/0030-1-platform-mellanox-nvsw-sn2201-Add-check-for-platform.patch
@@ -1,0 +1,47 @@
+From d065f198bf6eb0431c124589efbcbf2b54ae0303 Mon Sep 17 00:00:00 2001
+From: Chen Ni <nichen@iscas.ac.cn>
+Date: Wed, 5 Jun 2024 11:27:45 +0800
+Subject: [PATCH] platform/mellanox: nvsw-sn2201: Add check for
+ platform_device_add_resources
+
+[ Upstream commit d56fbfbaf592a115b2e11c1044829afba34069d2 ]
+
+Add check for the return value of platform_device_add_resources() and
+return the error if it fails in order to catch the error.
+
+Signed-off-by: Chen Ni <nichen@iscas.ac.cn>
+Link: https://lore.kernel.org/r/20240605032745.2916183-1-nichen@iscas.ac.cn
+Reviewed-by: Hans de Goede <hdegoede@redhat.com>
+Signed-off-by: Hans de Goede <hdegoede@redhat.com>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+---
+ drivers/platform/mellanox/nvsw-sn2201.c | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
+index 7b9c107..f53baf7 100644
+--- a/drivers/platform/mellanox/nvsw-sn2201.c
++++ b/drivers/platform/mellanox/nvsw-sn2201.c
+@@ -1194,6 +1194,7 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
+ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ {
+ 	struct nvsw_sn2201 *nvsw_sn2201;
++	int ret;
+ 
+ 	nvsw_sn2201 = devm_kzalloc(&pdev->dev, sizeof(*nvsw_sn2201), GFP_KERNEL);
+ 	if (!nvsw_sn2201)
+@@ -1201,8 +1202,10 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ 
+ 	nvsw_sn2201->dev = &pdev->dev;
+ 	platform_set_drvdata(pdev, nvsw_sn2201);
+-	platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
++	ret = platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
+ 				      ARRAY_SIZE(nvsw_sn2201_lpc_io_resources));
++	if (ret)
++		return ret;
+ 
+ 	nvsw_sn2201->main_mux_deferred_nr = NVSW_SN2201_MAIN_MUX_DEFER_NR;
+ 	nvsw_sn2201->main_mux_devs = nvsw_sn2201_main_mux_brdinfo;
+-- 
+2.8.4
+

--- a/recipes-kernel/linux/linux-6.1/0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
+++ b/recipes-kernel/linux/linux-6.1/0030-platform-mellanox-nvsw-sn2201-change-fans-i2c-busses.patch
@@ -1,8 +1,7 @@
-From ddec9cfeb44ed194cadee824f3f49c057bf7a560 Mon Sep 17 00:00:00 2001
+From ac10df67c019b8ee1c80b46390759669cd69862f Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Wed, 12 Jul 2023 14:26:38 +0000
-Subject: [PATH backport v6.1 30/32] platform: mellanox: nvsw-sn2201: change
- fans i2c busses.
+Subject: [PATCH 2/4] platform: mellanox: nvsw-sn2201: change fans i2c busses.
 
 Link: https://www.spinics.net/lists/platform-driver-x86/msg39647.html
 
@@ -18,7 +17,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 8 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 7b9c107c17ce..75b699676ca6 100644
+index f53baf7e7..1a7c45aa4 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -84,6 +84,10 @@

--- a/recipes-kernel/linux/linux-6.1/0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
+++ b/recipes-kernel/linux/linux-6.1/0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch
@@ -1,7 +1,7 @@
-From ab5040e2b99cc3eb57eaa266b90877bcc38c28ed Mon Sep 17 00:00:00 2001
+From 1c43cf584d3fd62823dd3b28018481f15a8836c7 Mon Sep 17 00:00:00 2001
 From: Michael Shych <michaelsh@nvidia.com>
 Date: Wed, 29 Nov 2023 13:12:38 +0000
-Subject: [PATCH v1 1/1] platform: mellanox: indicate deferred I2C bus creation
+Subject: [PATCH 3/4] platform: mellanox: indicate deferred I2C bus creation
  for a hot-plug driver
 
 It fixes timing issue when during initialization hot-plug driver
@@ -15,7 +15,7 @@ Signed-off-by: Michael Shych <michaelsh@nvidia.com>
  1 file changed, 1 insertion(+)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 65b677690..79e4d0619 100644
+index 1a7c45aa4..a3e2bc6d6 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -520,6 +520,7 @@ struct mlxreg_core_hotplug_platform_data nvsw_sn2201_hotplug = {
@@ -27,5 +27,5 @@ index 65b677690..79e4d0619 100644
  
  /* SN2201 static devices. */
 -- 
-2.14.1
+2.20.1
 

--- a/recipes-kernel/linux/linux-6.1/0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
+++ b/recipes-kernel/linux/linux-6.1/0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch
@@ -1,8 +1,8 @@
-From 693ea1c72c6f1b83232c043fdb1b175a450bc172 Mon Sep 17 00:00:00 2001
-From: Vadim Pasternak <vadimp@nvidia.com>
-Date: Wed, 7 Aug 2024 00:09:11 +0000
-Subject: [PATCH backport 6.1 1/1] platform: mellanox: nvsw-sn2200: Add support
- for new system flavour
+From 13e4e0e5b566a116e2107a0a959d2b294b388b42 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 11 Dec 2024 17:49:45 +0200
+Subject: [PATCH 4/4] platform: mellanox: nvsw-sn2200: Add support for new
+ system flavour
 
 Add support for SN2201 system flavour, which is fitting OCP rack
 form-factor and feeded from external power source through the rack
@@ -15,11 +15,11 @@ For new system flavour:
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/nvsw-sn2201.c | 111 +++++++++++++++++++++++-
- 1 file changed, 108 insertions(+), 3 deletions(-)
+ drivers/platform/mellanox/nvsw-sn2201.c | 112 +++++++++++++++++++++++-
+ 1 file changed, 109 insertions(+), 3 deletions(-)
 
 diff --git a/drivers/platform/mellanox/nvsw-sn2201.c b/drivers/platform/mellanox/nvsw-sn2201.c
-index 2612bb5f82a3..d604069e3313 100644
+index a3e2bc6d6..64c705f3b 100644
 --- a/drivers/platform/mellanox/nvsw-sn2201.c
 +++ b/drivers/platform/mellanox/nvsw-sn2201.c
 @@ -6,6 +6,7 @@
@@ -103,7 +103,7 @@ index 2612bb5f82a3..d604069e3313 100644
  };
  
  /* SN2201 default static board info. */
-@@ -608,6 +647,58 @@ static struct mlxreg_hotplug_device nvsw_sn2201_static_brdinfo[] = {
+@@ -608,6 +647,59 @@ static struct mlxreg_hotplug_device nvsw_sn2201_static_brdinfo[] = {
  	},
  };
  
@@ -159,10 +159,11 @@ index 2612bb5f82a3..d604069e3313 100644
 +	},
 +};
 +
++
  /* LED default data. */
  static struct mlxreg_core_data nvsw_sn2201_led_data[] = {
  	{
-@@ -982,7 +1073,10 @@ static int nvsw_sn2201_config_init(struct nvsw_sn2201 *nvsw_sn2201, void *regmap
+@@ -982,7 +1074,10 @@ static int nvsw_sn2201_config_init(struct nvsw_sn2201 *nvsw_sn2201, void *regmap
  	nvsw_sn2201->io_data = &nvsw_sn2201_regs_io;
  	nvsw_sn2201->led_data = &nvsw_sn2201_led;
  	nvsw_sn2201->wd_data = &nvsw_sn2201_wd;
@@ -174,11 +175,12 @@ index 2612bb5f82a3..d604069e3313 100644
  
  	/* Register IO access driver. */
  	if (nvsw_sn2201->io_data) {
-@@ -1199,11 +1293,17 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
+@@ -1199,12 +1294,18 @@ static int nvsw_sn2201_config_pre_init(struct nvsw_sn2201 *nvsw_sn2201)
  static int nvsw_sn2201_probe(struct platform_device *pdev)
  {
  	struct nvsw_sn2201 *nvsw_sn2201;
 +	const char *sku;
+ 	int ret;
  
  	nvsw_sn2201 = devm_kzalloc(&pdev->dev, sizeof(*nvsw_sn2201), GFP_KERNEL);
  	if (!nvsw_sn2201)
@@ -191,8 +193,8 @@ index 2612bb5f82a3..d604069e3313 100644
 +
  	nvsw_sn2201->dev = &pdev->dev;
  	platform_set_drvdata(pdev, nvsw_sn2201);
- 	platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
-@@ -1212,8 +1312,13 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
+ 	ret = platform_device_add_resources(pdev, nvsw_sn2201_lpc_io_resources,
+@@ -1215,8 +1316,13 @@ static int nvsw_sn2201_probe(struct platform_device *pdev)
  	nvsw_sn2201->main_mux_deferred_nr = NVSW_SN2201_MAIN_MUX_DEFER_NR;
  	nvsw_sn2201->main_mux_devs = nvsw_sn2201_main_mux_brdinfo;
  	nvsw_sn2201->cpld_devs = nvsw_sn2201_cpld_brdinfo;
@@ -209,5 +211,5 @@ index 2612bb5f82a3..d604069e3313 100644
  	return nvsw_sn2201_config_pre_init(nvsw_sn2201);
  }
 -- 
-2.44.0
+2.20.1
 


### PR DESCRIPTION
Add kernel 5.10.226/6.1.123 support

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
