### PR TITLE
hw-mgmt: sensor: Fix for unexpected negative vout_min on lm5066i

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -967,6 +967,17 @@ if [ "$1" == "add" ]; then
 			done
 			;;
 		esac
+		# WA for fix negative vout_min value in lm5066i sensor
+		dev_name=$(cat "$3""$4"/name)
+		if  [ "$dev_name" == "lm5066i" ]; then
+			if [ -f $environment_path/"$prefix"_in2_min ]; then
+				val=$(cat $environment_path/"$prefix"_in2_min)
+				# check if Vout min is negative and fix it
+				if  [[ $val == -* ]]; then
+					echo 0 > $environment_path/"$prefix"_in2_min
+				fi
+			fi
+		fi
 	fi
 	if [ "$2" == "led" ]; then
 		# Detect if it belongs to line card or to main board.


### PR DESCRIPTION
By default in lm5066i VOUT_UV_WARN_LIMIT registrer == 0. Because of issue in
driver calculation formula it trasnsforms to -0.11V instead of 0, which is
not reasonable.
It can be fixed by writing 0 to *_in2_min sysfs attribute.

Bug: 4264364

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
