### PR TITLE
hw-mgmt: kernel: Fix platform patch for SN5610/SN5640

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2411,7 +2411,7 @@ sn5640_specific()
 		HI172)	# Gaur
 			thermal_control_config="$thermal_control_configs_path/tc_config_sn5610.json"
 		;;
-		HI671)	# Bison
+		HI171)	# Bison
 			thermal_control_config="$thermal_control_configs_path/tc_config_sn5640.json"
 		;;
 		*)
@@ -2420,7 +2420,6 @@ sn5640_specific()
 	esac
 
 	lm_sensors_labels="$lm_sensors_configs_path/sn5640_sensors_labels.json"
-	thermal_control_config="$thermal_control_configs_path/tc_config_sn5640.json"
 	named_busses+=(${sn5640_named_busses[@]})
 	add_come_named_busses $ng800_cpu_bus_offset
 	echo -n "${named_busses[@]}" > $config_path/named_busses


### PR DESCRIPTION
Fix kernel crash on PSU DC power down:

[  348.667680] rcu: INFO: rcu_preempt detected stalls on CPUs/tasks:
[  348.673858] rcu: 	3-...!: (0 ticks this GP) idle=1090/0/0x0
softirq=7221/7221 fqs=0 (false positive?)
[  348.683658] 	(detected by 5, t=6505 jiffies, g=25049, q=1086
ncpus=16)
[  348.690268] Sending NMI from CPU 5 to CPUs 3:
[  348.694697] NMI backtrace for cpu 3 skipped: idling at
native_safe_halt+0xb/0x10
[  348.695700] rcu: rcu_preempt kthread timer wakeup didn't happen for
6508 jiffies! g25049 f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402
[  348.713700] rcu: 	Possible timer handling issue on cpu=5
timer-softirq=919
[  348.720654] rcu: rcu_preempt kthread starved for 6515 jiffies! g25049
f0x0 RCU_GP_WAIT_FQS(5) ->state=0x402 ->cpu=5
[  348.731203] rcu: 	Unless rcu_preempt kthread gets sufficient CPU
time, OOM is now expected behavior.
[  348.740436] rcu: RCU grace-period kthread stack dump:
[  348.745552] task:rcu_preempt     state:I stack:0     pid:16    ppid:2
flags:0x00004000
[  348.754004] Call Trace:
[  348.756492]  <TASK>
[  348.758643]  __schedule+0x7b2/0x1660
[  348.762295]  ? io_schedule_timeout+0xb0/0xb0
[  348.766627]  ? check_chain_key+0x202/0x2b0
[  348.770812]  schedule+0x8e/0x140
[  348.774098]  schedule_timeout+0x13e/0x290
[  348.778172]  ? usleep_range_state+0x120/0x120
[  348.782590]  ? mark_held_locks+0x23/0x90
[  348.786576]  ? __bpf_trace_tick_stop+0xf0/0xf0
[  348.791104]  ? prepare_to_swait_event+0xb0/0x220
[  348.795802]  rcu_gp_fqs_loop+0x1d5/0x7b0
[  348.799792]  ? force_qs_rnp+0x480/0x480
[  348.803700]  ? rcu_gp_init+0x795/0xc80
[  348.807527]  ? rcu_gp_fqs_loop+0x7b0/0x7b0
[  348.811690]  ? lockdep_hardirqs_on_prepare+0x145/0x220
[  348.816897]  ? _raw_spin_unlock_irqrestore+0x56/0x70
[  348.821937]  ? rcu_gp_fqs_loop+0x7b0/0x7b0
[  348.826094]  rcu_gp_kthread+0x1b9/0x290
[  348.829989]  ? rcu_gp_fqs_loop+0x7b0/0x7b0
[  348.834144]  ? lockdep_hardirqs_on_prepare+0x145/0x220
[  348.839367]  ? __kthread_parkme+0xce/0xf0
[  348.843447]  ? rcu_gp_fqs_loop+0x7b0/0x7b0
[  348.847602]  kthread+0x17b/0x1b0
[  348.850882]  ? kthread+0xcf/0x1b0
[  348.854250]  ? kthread_complete_and_exit+0x20/0x20
[  348.859116]  ret_from_fork+0x1f/0x30
[  348.862784]  </TASK>

Fixed in platform patch for SN5610/SN5640

Bug:4279508

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
