### PR TITLE
hw-mgmt: thermal: TC fix for sensor min/max limits calculation

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -1318,16 +1318,15 @@ class system_device(hw_managemet_file_op):
         @return: int min/max value
         """
         default_val = self.sensors_config.get(trh_type, CONST.TEMP_MIN_MAX[trh_type])
-        if str(default_val)[0] == "!":
-            # Use config value instead of device parameter reading
-            default_val = default_val[1:]
-            val = default_val
-        else:
-            val = self.get_file_val(filename, default_val)
         try:
-            val = int(val) / scale
+            if str(default_val)[0] == "!":
+                # Use config value instead of device parameter reading
+                default_val = default_val[1:]
+                val = int(default_val) / CONST.TEMP_SENSOR_SCALE
+            else:
+                val = self.get_file_val(filename, int(default_val) / CONST.TEMP_SENSOR_SCALE, scale)
         except:
-            pass
+            val = None 
         self.log.debug("Set {} {} : {}".format(self.name, trh_type, val))
         return val
 


### PR DESCRIPTION
For systems that use sensor value scale factor != 1000 this
value should be applied to min/max sensor threshold.
This commit fix bug with min/max calculation for sensors with
value divider differents than default (1000)

Bug: 4284991

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
