### PR TITLE
hw-mgmgt: thermal: TC fix bmc sensor init for N5xxx systems

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -310,6 +310,7 @@ Kernel-5.10
 |0300-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2855-c.patch  |                    | Feature pending; os[sonic,opt,nvos,dvs]  |            |                                                |
 |0301-crypto-ccp-Reject-SEV-commands-with-mismatching-comm.patch  | d5760dee127b       | Bugfix upstream                          | 5.1.184    |                                                |
 |0302-crypto-ccp-Play-nice-with-vmalloc-d-memory-for-SEV-c.patch  | 8347b99473a3       | Bugfix upstream                          | 5.1.184    |                                                |
+|0303-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch  |                    | Downstream accepted                      |            |                                                |
 |7001-mctp-Add-MCTP-base.patch                                    |                    | Downstream                               |            | MCTP                                           |
 |7002-mctp-Add-base-socket-protocol-definitions.patch             |                    | Downstream                               |            | MCTP                                           |
 |7003-mctp-Add-base-packet-definitions.patch                      |                    | Downstream                               |            | MCTP                                           |
@@ -702,6 +703,7 @@ Kernel-6.1
 |0095-platform-mellanox-nvsw-sn2201-Add-support-for-new-sy.patch  |                    | Downstream accepted                      |            |                                                |
 |0096-platform-mellanox-Downstream-Add-dedicated-match-for.patch  |                    | Downstream accepted;skip[sonic,cumulus]  |            | Add dedicated match for QMB8700                |
 |0097-platform-mellanox-mlx-platform-Add-support-for-new-N.patch  |                    | Downstream accepted					  |            | SN5640                                         |
+|0098-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch  |                    | Downstream accepted					  |            |                                          |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |

--- a/recipes-kernel/linux/linux-5.10/0303-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
+++ b/recipes-kernel/linux/linux-5.10/0303-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
@@ -1,0 +1,31 @@
+From 47139cf7689304ea32467fd61647380b42599578 Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Tue, 4 Feb 2025 14:12:42 +0200
+Subject: [PATCH] platform/mellanox: mlxreg-io: Extend number of hwmon
+ attributes
+
+Extend maximum number of the attributes, exposed to 'sysfs' to support
+new systems having more attributes.
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index ddc08ab..881182c 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -18,7 +18,7 @@
+ 
+ /* Attribute parameters. */
+ #define MLXREG_IO_ATT_SIZE	10
+-#define MLXREG_IO_ATT_NUM	96
++#define MLXREG_IO_ATT_NUM	128
+ 
+ /**
+  * struct mlxreg_io_priv_data - driver's private data:
+-- 
+2.8.4
+

--- a/recipes-kernel/linux/linux-6.1/0098-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
+++ b/recipes-kernel/linux/linux-6.1/0098-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch
@@ -1,0 +1,33 @@
+From 41b6df4fb187cd6a4bbf501017090821825d3bef Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Wed, 5 Feb 2025 14:45:21 +0200
+Subject: [PATCH] platform/mellanox: mlxreg-io: Extend number of hwmon
+ attributes
+
+Extend maximum number of the attributes, exposed to 'sysfs' to support
+new systems having more attributes.
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-io.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-io.c b/drivers/platform/mellanox/mlxreg-io.c
+index ddc08ab..881182c 100644
+--- a/drivers/platform/mellanox/mlxreg-io.c
++++ b/drivers/platform/mellanox/mlxreg-io.c
+@@ -18,7 +18,7 @@
+ 
+ /* Attribute parameters. */
+ #define MLXREG_IO_ATT_SIZE	10
+-#define MLXREG_IO_ATT_NUM	96
++#define MLXREG_IO_ATT_NUM	128
+ 
+ /**
+  * struct mlxreg_io_priv_data - driver's private data:
+-- 
+2.8.4
+


### PR DESCRIPTION
Add BMC thermal sensor to TC sensor list. Fix BMC thermal sensor name
in N5xxx thermal config

Bug: 4288149

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
