### PR TITLE
hw-mgmgt: thermal: TC fix bmc sensor init for N5xxx systems

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_n5100ld.json
+++ b/usr/etc/hw-management-thermal/tc_config_n5100ld.json
@@ -30,10 +30,10 @@
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
 		"ibc\\d+":        {"pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "!100000", "poll_time": 30},
 		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
-		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
+		"bmc_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
 	},
 	"error_mask" : {"psu_err" : ["direction", "present"], "fan_err" : ["direction"]},
-	"sensor_list" : ["cpu",
+	"sensor_list" : ["cpu", "bmc",
 					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
 					"sodimm1",
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4",

--- a/usr/etc/hw-management-thermal/tc_config_n5110ld.json
+++ b/usr/etc/hw-management-thermal/tc_config_n5110ld.json
@@ -30,10 +30,10 @@
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
 		"ibc\\d+":        {"pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "!100000", "poll_time": 30},
 		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
-		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
+		"bmc_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
 	},
 	"error_mask" : {"psu_err" : ["direction", "present"], "fan_err" : ["direction"]},
-	"sensor_list" : ["cpu",
+	"sensor_list" : ["cpu", "bmc",
 					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
 					"sodimm1",
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4",

--- a/usr/etc/hw-management-thermal/tc_config_n5110ld_ttm.json
+++ b/usr/etc/hw-management-thermal/tc_config_n5110ld_ttm.json
@@ -30,10 +30,10 @@
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
 		"ibc\\d+":        {"pwm_min": 30, "pwm_max": 100, "val_min": "!70000", "val_max": "!100000", "poll_time": 30},
 		"hotswap\\d+_temp": {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!150000", "poll_time": 30},
-		"bmc\\d+_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
+		"bmc_temp":   {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!125000", "poll_time": 30}
 	},
 	"error_mask" : {"psu_err" : ["direction", "present"], "fan_err" : ["direction"]},
-	"sensor_list" : ["cpu",
+	"sensor_list" : ["cpu", "bmc",
 					"swb_voltmon1", "swb_voltmon2", "swb_voltmon3", "swb_voltmon4", "swb_voltmon5", "swb_voltmon6",
 					"sodimm1",
 					"drivetemp", "drwr1", "drwr2", "drwr3", "drwr4",

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -295,7 +295,7 @@ SENSOR_DEF_CONFIG = {
                          "val_lcrit": -10000, "val_hcrit": 150000, "poll_time": 30, 
                          "input_suffix": "_input"
                         },
-    r'bmc\d+_temp':     {"type": "thermal_sensor",
+    r'bmc_temp':     {"type": "thermal_sensor",
                          "pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000",
                          "val_lcrit": 0, "val_hcrit": 150000, "poll_time": 30,
                         },
@@ -2587,7 +2587,7 @@ class ThermalManagement(hw_managemet_file_op):
                           r'pdb_pwr\d*':"add_pdb_pwr_sensor",
                           r'ctx_amb\d*':"add_connectx_sensor",
                           r'hotswap\d+':"add_hotswap_sensor",
-                          r'bmc\d+':"add_bmc_sensor",
+                          r'bmc':"add_bmc_sensor",
                           r'dpu\d*_cpu':"add_DPU_cpu_sensor",
                           r'dpu\d*_sodimm\d+':"add_DPU_sodimm_sensor",
                           r'dpu\d*_drivetemp':"add_DPU_drivetemp_sensor",
@@ -3383,7 +3383,7 @@ class ThermalManagement(hw_managemet_file_op):
 
     # ----------------------------------------------------------------------
     def add_bmc_sensor(self, name):
-        in_file = "thermal/bmc{}_temp".format(name)
+        in_file = "thermal/{}".format(name)
         sensor_name = "{}_temp".format(name)
         self._sensor_add_config("thermal_sensor", sensor_name, {"base_file_name": in_file})
 


### PR DESCRIPTION
Add BMC thermal sensor to TC sensor list. Fix BMC thermal sensor name
in N5xxx thermal config

Bug: 4288149

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
