### PR TITLE
hw-mgmt: rules: Explicitly set the name of USB network interface

### DIFF
--- a/usr/lib/udev/rules.d/76-hw-management-bmc.rules
+++ b/usr/lib/udev/rules.d/76-hw-management-bmc.rules
@@ -33,7 +33,7 @@
 # These rules handle USB net up/down events.
 
 # Bring up the USB network interface when it is plugged in.
-SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", RUN+="/usr/bin/hw-management-ifupdown.sh usb0 up"
+SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", NAME="usb0", RUN+="/usr/bin/hw-management-ifupdown.sh usb0 up"
 
 # Bring down the USB network interface when it is unplugged.
 SUBSYSTEM=="net", ACTION=="remove", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", RUN+="/usr/bin/hw-management-ifupdown.sh usb0 down"


### PR DESCRIPTION
In kernel version 6.1.123 the name of USB network interface has changed from usb0 to eth2. This breaks IP address assignement of this interface as our network configuration files assume usb0 as interface name. Fix udev rule to explicitcly set the name of this interface as usb0.