### PR TITLE
hw-mgmt: sensors: Remove MDIO PHY from sensors config

### DIFF
--- a/usr/etc/hw-management-sensors/sn4280_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn4280_sensors.conf
@@ -533,5 +533,5 @@ chip "nvme-pci-*"
     ignore temp2
     ignore temp3
 
-chip "00000400400-mdio-*"
-   label temp1 "PHY TEMP"
+chip "*-mdio-*"
+   ignore temp1

--- a/usr/etc/hw-management-sensors/sn5640_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5640_sensors.conf
@@ -490,5 +490,5 @@ chip "nvme-pci-*"
     ignore temp3
 
 # Ethernet PHY temperature sensor
-chip "00000500400-mdio-5"
-   label temp1 "PHY TEMP"
+chip "*-mdio-*"
+   ignore temp1


### PR DESCRIPTION
Set to 'ignore' PHY MDIO on SN4280 and SN5640, since reading of this device is not stable.
And it is not considered for thermal monitoring.

Bug: 4037463