### PR TITLE
hw-mgmt: attributes: Fix PSU attributes

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -923,8 +923,10 @@ if [ "$1" == "add" ]; then
 		fi
 		psu_connect_power_sensor "$5""$3"/power1 "$psu_name"_power_in
 		psu_connect_power_sensor "$5""$3"/power2 "$psu_name"_power
+		psu_connect_power_sensor "$5""$3"/power2 "$psu_name"_power_out
 		psu_connect_power_sensor "$5""$3"/curr1 "$psu_name"_curr_in
 		psu_connect_power_sensor "$5""$3"/curr2 "$psu_name"_curr
+		psu_connect_power_sensor "$5""$3"/curr2 "$psu_name"_curr_out
 
 		# Allow modification for some PSU thresholds through 'sensors'
 		# utilities 'sets instruction.


### PR DESCRIPTION
Fix psu curr/power out attributes names. Add more conventional names
psuX_power_out and psuX_curr_out attributes in additional to existing
psuX_power and psuX_curr.

Attributes psu1_volt_in/out psu1_curr_in/out psu1_power_in/out will be
available for all platforms (if PSU supported).

Bug: 4150586

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
