### PR TITLE
hw-mgmt: events: Add event handler for switch board  eeprom

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1230,8 +1230,17 @@ if [ "$1" == "add" ]; then
 			;;
 		mgmt_fru*_info)
 			eeprom_vpd_filename=${eeprom_name/"_info"/"_data"}
-			hw-management-vpd-parser.py -i "$eeprom_path/$eeprom_name" -o "$eeprom_path"/$eeprom_vpd_filename
+			if command -v ipmi-fru 2>&1 >/dev/null; then
+				ipmi-fru --fru-file="$eeprom_path"/"$eeprom_name" > "$eeprom_path"/"$eeprom_vpd_filename"
+			fi
 			;;
+		swb_info)
+			if [ "$board_type" == "VMOD0021" ]; then
+				if command -v ipmi-fru 2>&1 >/dev/null; then
+					ipmi-fru --fru-file="$eeprom_path"/"$eeprom_name" > "$eeprom_path"/swb_data
+				fi
+			fi
+			;;			
 		*)
 			;;
 		esac

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2313,7 +2313,7 @@ n51xxld_specific()
 			echo 4 > $config_path/cartridge_num
 			;;
 		HI177)	# Kyber
-			echo 4 > $config_path/cartridge_num
+			echo 0 > $config_path/cartridge_num
 			;;
 		*)	# According Juliet SO.
 			add_i2c_dynamic_bus_dev_connection_table "${so_cartridge_eeprom_connect_table[@]}"


### PR DESCRIPTION
Add event for "swb_info" event.
Set number of cartridges for GB200HD to zero.

Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
