### PR TITLE
hw-mgmt: script: Optimize sync script module update

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -96,43 +96,8 @@ atttrib_list = {
                 },
         },
 
-        {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {  "module1": {"fin": "/sys/module/sx_core/asic0/module0/"},
-                    "module2": {"fin": "/sys/module/sx_core/asic0/module1/"},
-                    "module3": {"fin": "/sys/module/sx_core/asic0/module2/"},
-                    "module4": {"fin": "/sys/module/sx_core/asic0/module3/"},
-                    "module5": {"fin": "/sys/module/sx_core/asic0/module4/"},
-                    "module6": {"fin": "/sys/module/sx_core/asic0/module5/"},
-                    "module7": {"fin": "/sys/module/sx_core/asic0/module6/"},
-                    "module8": {"fin": "/sys/module/sx_core/asic0/module7/"},
-                    "module9": {"fin": "/sys/module/sx_core/asic0/module8/"},
-                    "module10": {"fin": "/sys/module/sx_core/asic0/module9/"},
-                    "module11": {"fin": "/sys/module/sx_core/asic0/module10/"},
-                    "module12": {"fin": "/sys/module/sx_core/asic0/module11/"},
-                    "module13": {"fin": "/sys/module/sx_core/asic0/module12/"},
-                    "module14": {"fin": "/sys/module/sx_core/asic0/module13/"},
-                    "module15": {"fin": "/sys/module/sx_core/asic0/module14/"},
-                    "module16": {"fin": "/sys/module/sx_core/asic0/module15/"},
-                    "module17": {"fin": "/sys/module/sx_core/asic0/module16/"},
-                    "module18": {"fin": "/sys/module/sx_core/asic0/module17/"},
-                    "module19": {"fin": "/sys/module/sx_core/asic0/module18/"},
-                    "module20": {"fin": "/sys/module/sx_core/asic0/module19/"},
-                    "module21": {"fin": "/sys/module/sx_core/asic0/module20/"},
-                    "module22": {"fin": "/sys/module/sx_core/asic0/module21/"},
-                    "module23": {"fin": "/sys/module/sx_core/asic0/module22/"},
-                    "module24": {"fin": "/sys/module/sx_core/asic0/module23/"},
-                    "module25": {"fin": "/sys/module/sx_core/asic0/module24/"},
-                    "module26": {"fin": "/sys/module/sx_core/asic0/module25/"},
-                    "module27": {"fin": "/sys/module/sx_core/asic0/module26/"},
-                    "module28": {"fin": "/sys/module/sx_core/asic0/module27/"},
-                    "module29": {"fin": "/sys/module/sx_core/asic0/module28/"},
-                    "module30": {"fin": "/sys/module/sx_core/asic0/module29/"},
-                    "module31": {"fin": "/sys/module/sx_core/asic0/module30/"},
-                    "module32": {"fin": "/sys/module/sx_core/asic0/module31/"},
-                    "module33": {"fin": "/sys/module/sx_core/asic0/module32/"},
-                    "module34": {"fin": "/sys/module/sx_core/asic0/module33/"},
-                    "module35": {"fin": "/sys/module/sx_core/asic0/module34/"},
-                    "module36": {"fin": "/sys/module/sx_core/asic0/module35/"} }
+        {"fin": None, "fn": "module_temp_populate", "poll": 4, "ts": 0,
+         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 36}
         },
         {"fin": None,
          "fn": "redfish_get_sensor", "arg" : ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
@@ -178,44 +143,8 @@ atttrib_list = {
                     "asic2": {"fin": "/sys/module/sx_core/asic1/"}
                 }
         },
-
-        {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {  "module1": {"fin": "/sys/module/sx_core/asic0/module0/"},
-                    "module2": {"fin": "/sys/module/sx_core/asic0/module1/"},
-                    "module3": {"fin": "/sys/module/sx_core/asic0/module2/"},
-                    "module4": {"fin": "/sys/module/sx_core/asic0/module3/"},
-                    "module5": {"fin": "/sys/module/sx_core/asic0/module4/"},
-                    "module6": {"fin": "/sys/module/sx_core/asic0/module5/"},
-                    "module7": {"fin": "/sys/module/sx_core/asic0/module6/"},
-                    "module8": {"fin": "/sys/module/sx_core/asic0/module7/"},
-                    "module9": {"fin": "/sys/module/sx_core/asic0/module8/"},
-                    "module10": {"fin": "/sys/module/sx_core/asic0/module9/"},
-                    "module11": {"fin": "/sys/module/sx_core/asic0/module10/"},
-                    "module12": {"fin": "/sys/module/sx_core/asic0/module11/"},
-                    "module13": {"fin": "/sys/module/sx_core/asic0/module12/"},
-                    "module14": {"fin": "/sys/module/sx_core/asic0/module13/"},
-                    "module15": {"fin": "/sys/module/sx_core/asic0/module14/"},
-                    "module16": {"fin": "/sys/module/sx_core/asic0/module15/"},
-                    "module17": {"fin": "/sys/module/sx_core/asic0/module16/"},
-                    "module18": {"fin": "/sys/module/sx_core/asic0/module17/"},
-                    "module19": {"fin": "/sys/module/sx_core/asic0/module18/"},
-                    "module20": {"fin": "/sys/module/sx_core/asic0/module19/"},
-                    "module21": {"fin": "/sys/module/sx_core/asic0/module20/"},
-                    "module22": {"fin": "/sys/module/sx_core/asic0/module21/"},
-                    "module23": {"fin": "/sys/module/sx_core/asic0/module22/"},
-                    "module24": {"fin": "/sys/module/sx_core/asic0/module23/"},
-                    "module25": {"fin": "/sys/module/sx_core/asic0/module24/"},
-                    "module26": {"fin": "/sys/module/sx_core/asic0/module25/"},
-                    "module27": {"fin": "/sys/module/sx_core/asic0/module26/"},
-                    "module28": {"fin": "/sys/module/sx_core/asic0/module27/"},
-                    "module29": {"fin": "/sys/module/sx_core/asic0/module28/"},
-                    "module30": {"fin": "/sys/module/sx_core/asic0/module29/"},
-                    "module31": {"fin": "/sys/module/sx_core/asic0/module30/"},
-                    "module32": {"fin": "/sys/module/sx_core/asic0/module31/"},
-                    "module33": {"fin": "/sys/module/sx_core/asic0/module32/"},
-                    "module34": {"fin": "/sys/module/sx_core/asic0/module33/"},
-                    "module35": {"fin": "/sys/module/sx_core/asic0/module34/"},
-                    "module36": {"fin": "/sys/module/sx_core/asic0/module35/"} }
+        {"fin": None, "fn": "module_temp_populate", "poll": 4, "ts": 0,
+         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 36}
         },
         {"fin": None,
          "fn": "redfish_get_sensor", "arg" : ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
@@ -226,77 +155,11 @@ atttrib_list = {
                     "asic1": {"fin": "/sys/module/sx_core/asic0/"}
                 }
         },
-
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {  "module1": {"fin": "/sys/module/sx_core/asic0/module0/"},
-                    "module2": {"fin": "/sys/module/sx_core/asic0/module1/"},
-                    "module3": {"fin": "/sys/module/sx_core/asic0/module2/"},
-                    "module4": {"fin": "/sys/module/sx_core/asic0/module3/"},
-                    "module5": {"fin": "/sys/module/sx_core/asic0/module4/"},
-                    "module6": {"fin": "/sys/module/sx_core/asic0/module5/"},
-                    "module7": {"fin": "/sys/module/sx_core/asic0/module6/"},
-                    "module8": {"fin": "/sys/module/sx_core/asic0/module7/"},
-                    "module9": {"fin": "/sys/module/sx_core/asic0/module8/"},
-                    "module10": {"fin": "/sys/module/sx_core/asic0/module9/"},
-                    "module11": {"fin": "/sys/module/sx_core/asic0/module10/"},
-                    "module12": {"fin": "/sys/module/sx_core/asic0/module11/"},
-                    "module13": {"fin": "/sys/module/sx_core/asic0/module12/"},
-                    "module14": {"fin": "/sys/module/sx_core/asic0/module13/"},
-                    "module15": {"fin": "/sys/module/sx_core/asic0/module14/"},
-                    "module16": {"fin": "/sys/module/sx_core/asic0/module15/"},
-                    "module17": {"fin": "/sys/module/sx_core/asic0/module16/"},
-                    "module18": {"fin": "/sys/module/sx_core/asic0/module17/"},
-                    "module19": {"fin": "/sys/module/sx_core/asic0/module18/"},
-                    "module20": {"fin": "/sys/module/sx_core/asic0/module19/"},
-                    "module21": {"fin": "/sys/module/sx_core/asic0/module20/"},
-                    "module22": {"fin": "/sys/module/sx_core/asic0/module21/"},
-                    "module23": {"fin": "/sys/module/sx_core/asic0/module22/"},
-                    "module24": {"fin": "/sys/module/sx_core/asic0/module23/"},
-                    "module25": {"fin": "/sys/module/sx_core/asic0/module24/"},
-                    "module26": {"fin": "/sys/module/sx_core/asic0/module25/"},
-                    "module27": {"fin": "/sys/module/sx_core/asic0/module26/"},
-                    "module28": {"fin": "/sys/module/sx_core/asic0/module27/"},
-                    "module29": {"fin": "/sys/module/sx_core/asic0/module28/"},
-                    "module30": {"fin": "/sys/module/sx_core/asic0/module29/"},
-                    "module31": {"fin": "/sys/module/sx_core/asic0/module30/"},
-                    "module32": {"fin": "/sys/module/sx_core/asic0/module31/"},
-                    "module33": {"fin": "/sys/module/sx_core/asic0/module32/"},
-                    "module34": {"fin": "/sys/module/sx_core/asic0/module33/"},
-                    "module35": {"fin": "/sys/module/sx_core/asic0/module34/"},
-                    "module36": {"fin": "/sys/module/sx_core/asic0/module35/"},
-                    "module37": {"fin": "/sys/module/sx_core/asic0/module36/"},
-                    "module38": {"fin": "/sys/module/sx_core/asic0/module37/"},
-                    "module39": {"fin": "/sys/module/sx_core/asic0/module38/"},
-                    "module40": {"fin": "/sys/module/sx_core/asic0/module39/"},
-                    "module41": {"fin": "/sys/module/sx_core/asic0/module40/"},
-                    "module42": {"fin": "/sys/module/sx_core/asic0/module41/"},
-                    "module43": {"fin": "/sys/module/sx_core/asic0/module42/"},
-                    "module44": {"fin": "/sys/module/sx_core/asic0/module43/"},
-                    "module45": {"fin": "/sys/module/sx_core/asic0/module44/"},
-                    "module46": {"fin": "/sys/module/sx_core/asic0/module45/"},
-                    "module47": {"fin": "/sys/module/sx_core/asic0/module46/"},
-                    "module48": {"fin": "/sys/module/sx_core/asic0/module47/"},
-                    "module49": {"fin": "/sys/module/sx_core/asic0/module48/"},
-                    "module50": {"fin": "/sys/module/sx_core/asic0/module49/"},
-                    "module51": {"fin": "/sys/module/sx_core/asic0/module50/"},
-                    "module52": {"fin": "/sys/module/sx_core/asic0/module51/"},
-                    "module53": {"fin": "/sys/module/sx_core/asic0/module52/"},
-                    "module54": {"fin": "/sys/module/sx_core/asic0/module53/"},
-                    "module55": {"fin": "/sys/module/sx_core/asic0/module54/"},
-                    "module56": {"fin": "/sys/module/sx_core/asic0/module55/"},
-                    "module57": {"fin": "/sys/module/sx_core/asic0/module56/"},
-                    "module58": {"fin": "/sys/module/sx_core/asic0/module57/"},
-                    "module59": {"fin": "/sys/module/sx_core/asic0/module58/"},
-                    "module60": {"fin": "/sys/module/sx_core/asic0/module59/"},
-                    "module61": {"fin": "/sys/module/sx_core/asic0/module60/"},
-                    "module62": {"fin": "/sys/module/sx_core/asic0/module61/"},
-                    "module63": {"fin": "/sys/module/sx_core/asic0/module62/"},
-                    "module64": {"fin": "/sys/module/sx_core/asic0/module63/"},
-                    "module65": {"fin": "/sys/module/sx_core/asic0/module64/"},
-                    "module66": {"fin": "/sys/module/sx_core/asic0/module65/"} }
-        }
+         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 66}
+        }        
     ],
-     "def": [
+    "def": [
          {"fin": "/var/run/hw-management/config/thermal_enforced_full_spped",
          "fn": "run_cmd",
          "arg": ["if [[ -f /var/run/hw-management/config/thermal_enforced_full_spped && "
@@ -601,14 +464,16 @@ def asic_temp_populate(arg_list, arg):
 # ----------------------------------------------------------------------
 def module_temp_populate(arg_list, _dummy):
     ''
-    total_module_count = 0
-    for module_name, module_attr in arg_list.items():
-        total_module_count += 1
-        f_dst_name = "/var/run/hw-management/thermal/{}_temp_input".format(module_name)
+    fin = arg_list["fin"]
+    module_count = arg_list["module_count"]
+    offset = arg_list["fout_idx_offset"]
+    host_management_mode = None
+    for idx in range(module_count):
+        f_dst_name = "/var/run/hw-management/thermal/module{}_temp_input".format(idx+offset)
         if os.path.islink(f_dst_name):
             continue
 
-        f_src_path = module_attr["fin"]
+        f_src_path = fin.format(idx)
         module_present = 0
 
         # Check if module is present
@@ -628,7 +493,10 @@ def module_temp_populate(arg_list, _dummy):
 
         if module_present:
             # If control mode is FW, skip temperature reading (independent mode)
-            if is_module_host_management_mode(f_src_path):
+            if host_management_mode is None:
+                host_management_mode = is_module_host_management_mode(f_src_path)
+
+            if host_management_mode:
                 continue
 
             f_src_input = os.path.join(f_src_path, "temperature/input")
@@ -672,7 +540,7 @@ def module_temp_populate(arg_list, _dummy):
                 f.write("{}\n".format(value))
 
     with open("/var/run/hw-management/config/module_counter", 'w+', encoding="utf-8") as f:
-        f.write("{}\n".format(total_module_count))
+        f.write("{}\n".format(module_count))
     return
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Optimize sync script module update.

1. Change in system configuration. Define total module count instead
   of per module definition.
2. Check SDK SW/FW reading mode by reading just one module config.
   No need to check each module config because modules can't be initialized
   in the "mixed" mode.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
