### PR TITLE
hw-mgmt: services: sysfs monitor and fast boot indication

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.init
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.init
@@ -1,0 +1,50 @@
+#!/bin/bash
+##################################################################################
+# Copyright (c) 2020 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+. /lib/lsb/init-functions
+
+EXECUTABLE=hw-management-fast-sysfs-monitor.sh
+SERVICE=hw-management-fast-sysfs-monitor
+ACTION=$1
+
+__usage="
+Usage: $(basename $0) [Options]
+
+Options:
+    start   Start hw-mngmt-fast-sysfs-monitor.
+    stop    Stop hw-mngmt-fast-sysfs-monitor.
+    restart
+    force-reload	Performs hw-mngmt-fast-sysfs-monitor 'stop' and the 'start.
+"
+
+$EXECUTABLE $ACTION

--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=HW management Fast Lables Monitor
+Before=hw-management.service
+PartOf=hw-management.service
+
+StartLimitIntervalSec=1200
+StartLimitBurst=5
+
+[Service]
+ExecStart=/bin/sh -c "/usr/bin/hw-management-fast-sysfs-monitor.sh start"
+ExecStop=/bin/sh -c "/usr/bin/hw-management-fast-sysfs-monitor.sh stop"
+TimeoutStopSec=1
+
+Restart=on-failure
+RestartSec=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/hw-management.hw-management-sysfs-monitor.init
+++ b/debian/hw-management.hw-management-sysfs-monitor.init
@@ -1,0 +1,50 @@
+#!/bin/bash
+##################################################################################
+# Copyright (c) 2020 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+. /lib/lsb/init-functions
+
+EXECUTABLE=hw-management-sysfs-monitor.sh
+SERVICE=hw-management-sysfs-monitor
+ACTION=$1
+
+__usage="
+Usage: $(basename $0) [Options]
+
+Options:
+    start   Start hw-mngmt-sysfs-monitor.
+    stop    Stop hw-mngmt-sysfs-monitor.
+    restart
+    force-reload	Performs hw-mngmt-sysfs-monitor 'stop' and the 'start.
+"
+
+$EXECUTABLE $ACTION

--- a/debian/hw-management.hw-management-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-sysfs-monitor.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=HW management Lables Monitor
+After=hw-management.service
+Requires=hw-management.service
+PartOf=hw-management.service
+
+StartLimitIntervalSec=1200
+StartLimitBurst=5
+
+[Service]
+ExecStart=/bin/sh -c "/usr/bin/hw-management-sysfs-monitor.sh start"
+ExecStop=/bin/sh -c "/usr/bin/hw-management-sysfs-monitor.sh stop"
+TimeoutStopSec=1
+
+Restart=on-failure
+RestartSec=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/rules
+++ b/debian/rules
@@ -46,21 +46,29 @@ endif
 	cp usr/etc/hw-management-thermal/* debian/$(pname)/etc/hw-management-thermal
 	dh_installdirs -p$(pname) etc/hw-management-virtual
 	cp -a usr/etc/hw-management-virtual/* debian/$(pname)/etc/hw-management-virtual
+	dh_installdirs -p$(pname) etc/hw-management-fast-sysfs-monitor
+	cp -a usr/etc/hw-management-fast-sysfs-monitor/* debian/$(pname)/etc/hw-management-fast-sysfs-monitor
 
 override_dh_installinit:
 	dh_installinit --name=hw-management
 	dh_installinit --name=hw-management-tc
 	dh_installinit --name=hw-management-sync
+	dh_installinit --name=hw-management-sysfs-monitor
+	dh_installinit --name=hw-management-fast-sysfs-monitor
 
 override_dh_systemd_enable:
 	dh_systemd_enable --name=hw-management
 	dh_systemd_enable --name=hw-management-tc
 	dh_systemd_enable --name=hw-management-sync
+	dh_systemd_enable --name=hw-management-sysfs-monitor
+	dh_systemd_enable --name=hw-management-fast-sysfs-monitor
 
 override_dh_systemd_start:
 	dh_systemd_start --name=hw-management
 	dh_systemd_start --name=hw-management-tc
 	dh_systemd_start --name=hw-management-sync
+	dh_systemd_start --name=hw-management-sysfs-monitor
+	dh_systemd_start --name=hw-management-fast-sysfs-monitor
 
 override_dh_strip_nondeterminism:
 

--- a/usr/etc/hw-management-fast-sysfs-monitor/fast_sysfs_labels.json
+++ b/usr/etc/hw-management-fast-sysfs-monitor/fast_sysfs_labels.json
@@ -1,0 +1,3 @@
+[
+    "/var/run/hw-management/eeprom/vpd_info"
+]

--- a/usr/lib/udev/rules.d/49-hw-management-fast-events.rules
+++ b/usr/lib/udev/rules.d/49-hw-management-fast-events.rules
@@ -1,0 +1,45 @@
+
+###########################################################################
+# Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# The below rules contains sysfs attributes, related to Mellanox thermal
+# control. These rules are supposed to catch the following attributes,
+# related to the next components: ASIC and port thermal zone mode, cooling
+# device current state,  statues of hot-pluggable devices, FAN faults, port
+# temperature fault, system ambient temperatures.
+# When trigger is matched, rule related data is to be passed to the event
+# handler.
+# This rules file is meant for highest priority udev events, included in hw-mgmt package.
+
+# EEPROM
+SUBSYSTEM=="i2c", KERNEL=="*-005[0-7]", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add eeprom %S %p"
+SUBSYSTEM=="i2c", KERNEL=="*-005[0-7]", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm eeprom %S %p"

--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -728,10 +728,6 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/MLNXBF49:00/i2c_mlxcpld*/i2c-*/i
 SUBSYSTEM=="iio", KERNEL=="iio:device*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add a2d %S %p %k"
 SUBSYSTEM=="iio", KERNEL=="iio:device*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm a2d %S %p %k"
 
-# EEPROM
-SUBSYSTEM=="i2c", KERNEL=="*-005[0-7]", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add eeprom %S %p"
-SUBSYSTEM=="i2c", KERNEL=="*-005[0-7]", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm eeprom %S %p"
-
 # WATCHDOG
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add watchdog %S %p"
 SUBSYSTEM=="watchdog", KERNEL=="watchdog*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm watchdog %S %p"

--- a/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+##################################################################################
+# Copyright (c) 2020 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+source hw-management-helpers.sh
+
+log_info "hw-mngmt-fast-sysfs-monitor started."
+
+FAST_SYSFS_MONITOR_ACTION=$1
+
+__usage="
+Usage: $(basename "$0") [Options]
+
+Options:
+    start   Start hw-mngmt-fast-sysfs-monitor.
+	stop	Stop hw-mngmt-fast-sysfs-monitor.
+    restart
+    force-reload	Performs hw-mngmt-fast-sysfs-monitor 'stop' and the 'start.
+"
+
+do_start_fast_sysfs_monitor()
+{
+    log_info "Starting hw-mngmt-fast-sysfs-monitor logic."
+    # Extract file paths from JSON manually (removes brackets, quotes, and spaces)
+    FILES=($(grep -o '"[^"]*"' "$FAST_SYSFS_MONITOR_LABELS_JSON" | tr -d '"' ))
+    # Get the total number of files to check.
+    TOTAL_FILES=${#FILES[@]}
+    declare -A FOUND_FILES
+    ELAPSED=0
+    log_info "Monitoring ${TOTAL_FILES} files..."
+    # Loop until all files exist or timeout is reached.
+    while (( $(echo "$ELAPSED < $FAST_SYSFS_MONITOR_TIMEOUT" | bc -l) )); do
+        for FILE in "${FILES[@]}"; do
+            if [[ -f "$FILE" ]]; then
+                FOUND_FILES["$FILE"]=1
+            fi
+        done
+        # Check if all files are found.
+        if [[ ${#FOUND_FILES[@]} -eq $TOTAL_FILES ]]; then
+            log_info "All fast sysfs lables exist. Done."
+            # Get the current time with milliseconds.
+            local current_time=$(awk '{print int($1 * 1000)}' /proc/uptime)
+            # Write the current time into the fast sysfs ready file.
+            echo "$current_time" > "$FAST_SYSFS_MONITOR_RDY_FILE"
+            exit 0
+        fi
+        # Wait and increment elapsed time
+        sleep "$FAST_SYSFS_MONITOR_INTERVAL"
+        ELAPSED=$(echo "$ELAPSED + $FAST_SYSFS_MONITOR_INTERVAL" | bc)
+    done
+    
+    log_info "Timeout reached. Not all files were found."
+    exit 1
+}
+
+do_stop_fast_sysfs_monitor()
+{
+    # Remove older WD process if it exists.
+    if [ -f "$FAST_SYSFS_MONITOR_PID_FILE" ]; then
+        local FAST_MONITOR_PID
+        FAST_MONITOR_PID=$(cat "$FAST_SYSFS_MONITOR_PID_FILE")
+        if kill -0 "$FAST_MONITOR_PID" 2>/dev/null; then
+            if kill "$FAST_MONITOR_PID"; then
+                log_info "HW Mangement old fast sysfs monitor process killed succesfully."
+                rm -f "$FAST_SYSFS_MONITOR_PID_FILE"
+            else
+                log_info "HW Mangement failed to kill old fast sysfs monitor process."
+                exit 1
+            fi
+        else
+            log_info "HW Mangement old fast sysfs monitor process $FAST_MONITOR_PID already dead, remove the pid file."
+            rm -f "$FAST_SYSFS_MONITOR_PID_FILE"
+        fi
+    fi
+}
+
+case $FAST_SYSFS_MONITOR_ACTION in
+    start)
+        # Save the PID of the Fast Sysfs Monitor process.
+        touch "$FAST_SYSFS_MONITOR_PID_FILE"
+        echo $! > "$FAST_SYSFS_MONITOR_PID_FILE"
+        log_info "HW Mangement Fast Sysfs Monitor process created."
+        do_start_fast_sysfs_monitor
+    ;;
+    stop)
+        do_stop_fast_sysfs_monitor
+    ;;
+    restart|force-reload)
+        do_stop_fast_sysfs_monitor
+        sleep 5
+        do_start_fast_sysfs_monitor
+    ;;
+    *)
+        echo "$__usage"
+        exit 1
+    ;;
+esac
+exit 0

--- a/usr/usr/bin/hw-management-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-sysfs-monitor.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+##################################################################################
+# Copyright (c) 2020 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+source hw-management-helpers.sh
+
+log_info "hw-mngmt-sysfs-monitor started."
+
+SYSFS_MONITOR_ACTION=$1
+
+__usage="
+Usage: $(basename "$0") [Options]
+
+Options:
+    start   Start hw-mngmt-sysfs-monitor.
+	stop	Stop hw-mngmt-sysfs-monitor.
+    restart
+    force-reload	Performs hw-mngmt-sysfs-monitor 'stop' and the 'start.
+"
+
+do_start_sysfs_monitor()
+{
+    log_info "Starting hw-mngmt-sysfs-monitor logic."
+    while true; do
+        # Get the current time with milliseconds.
+        local current_time=$(awk '{print int($1 * 1000)}' /proc/uptime)
+        # Read the last update time from both reset files.
+        local last_reset_time_A=$(cat "$SYSFS_MONITOR_RESET_FILE_A" 2>/dev/null || echo 0)
+        local last_reset_time_B=$(cat "$SYSFS_MONITOR_RESET_FILE_B" 2>/dev/null || echo 0)
+        # Ensure both variables are valid integers, defaulting to 0 if empty or invalid.
+        last_reset_time_A=${last_reset_time_A:-0}
+        last_reset_time_B=${last_reset_time_B:-0}
+        # Determine which file has the most recent reset time.
+        if [ "$last_reset_time_A" -gt "$last_reset_time_B" ]; then
+            last_reset_time="$last_reset_time_A"
+        else
+            last_reset_time="$last_reset_time_B"
+        fi
+        # Calculate the time difference in milliseconds.
+        local time_diff=$((current_time - last_reset_time))
+        # Check if the time difference exceeds the timeout in milliseconds.
+        if [ "$time_diff" -ge $((SYSFS_MONITOR_TIMEOUT * 1000)) ]; then
+            # Update syslog.
+            log_info "current_time $current_time"
+            log_info "last_reset_time $last_reset_time"
+            log_info "sysfs monitor time diff = $time_diff"
+            log_info "sysfs monitor done!"
+            # Write the current time into the sysfs ready file.
+            echo "$current_time" > "$SYSFS_MONITOR_RDY_FILE"
+            # Exit the sysfs monitor.
+            exit 0
+        fi
+        # Sleep for the specified delay period in seconds.
+        sleep "$SYSFS_MONITOR_DELAY"
+    done
+}
+
+do_stop_sysfs_monitor()
+{
+    # Remove older WD process if it exists.
+    if [ -f "$SYSFS_MONITOR_PID_FILE" ]; then
+        local MONITOR_PID
+        MONITOR_PID=$(cat "$SYSFS_MONITOR_PID_FILE")
+        if kill -0 "$MONITOR_PID" 2>/dev/null; then
+            if kill "$MONITOR_PID"; then
+                log_info "HW Mangement old sysfs monitor process killed succesfully."
+                rm -f "$SYSFS_MONITOR_PID_FILE"
+            else
+                log_info "HW Mangement failed to kill old sysfs monitor process."
+                exit 1
+            fi
+        else
+            log_info "HW Mangement old sysfs monitor process $MONITOR_PID already dead, remove the pid file."
+            rm -f "$SYSFS_MONITOR_PID_FILE"
+        fi
+    fi
+}
+
+case $SYSFS_MONITOR_ACTION in
+    start)
+        # Save the PID of the sysfs monitor process.
+        touch "$SYSFS_MONITOR_PID_FILE"
+        echo $! > "$SYSFS_MONITOR_PID_FILE"
+        log_info "HW Mangement Sysfs Monitor process created."
+        do_start_sysfs_monitor
+    ;;
+    stop)
+        do_stop_sysfs_monitor
+    ;;
+    restart|force-reload)
+        do_stop_sysfs_monitor
+        sleep 5
+        do_start_sysfs_monitor
+    ;;
+    *)
+        echo "$__usage"
+        exit 1
+    ;;
+esac
+exit 0

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3192,6 +3192,7 @@ map_asic_pci_to_i2c_bus()
 
 do_start()
 {
+	init_sysfs_monitor_timestamp_files
 	create_symbolic_links
 	check_cpu_type
 	pre_devtr_init


### PR DESCRIPTION
Added support for:
1. Provide trigger event to signal all sysfs attributes are ready.
2. Provide fast boot indication for specific sysfs attributes.
3. Provide fast boot optimizations for specific devices.