### PR TITLE
hw-mgmt: services: fix fast sysfs monitor service

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.init
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.init
@@ -44,7 +44,7 @@ Options:
     start   Start hw-mngmt-fast-sysfs-monitor.
     stop    Stop hw-mngmt-fast-sysfs-monitor.
     restart
-    force-reload	Performs hw-mngmt-fast-sysfs-monitor 'stop' and the 'start.
+    force-reload    Performs hw-mngmt-fast-sysfs-monitor 'stop' and the 'start.
 "
 
 $EXECUTABLE $ACTION

--- a/debian/hw-management.hw-management-sysfs-monitor.init
+++ b/debian/hw-management.hw-management-sysfs-monitor.init
@@ -44,7 +44,7 @@ Options:
     start   Start hw-mngmt-sysfs-monitor.
     stop    Stop hw-mngmt-sysfs-monitor.
     restart
-    force-reload	Performs hw-mngmt-sysfs-monitor 'stop' and the 'start.
+    force-reload    Performs hw-mngmt-sysfs-monitor 'stop' and the 'start.
 "
 
 $EXECUTABLE $ACTION

--- a/usr/lib/udev/rules.d/49-hw-management-fast-events.rules
+++ b/usr/lib/udev/rules.d/49-hw-management-fast-events.rules
@@ -1,6 +1,6 @@
 
 ###########################################################################
-# Copyright (c) 2018-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -150,7 +150,7 @@ SYSFS_MONITOR_RESET_FILE_B="/tmp/sysfs_monitor_time_b"
 SYSFS_MONITOR_PID_FILE="/tmp/sysfs_monitor.pid"
 
 # hw-mngmt-fast-sysfs-monitor GLOBALS
-FAST_SYSFS_MONITOR_INTERVAL=0.5  # 500 milliseconds
+FAST_SYSFS_MONITOR_INTERVAL=1  # 1 seconds
 FAST_SYSFS_MONITOR_TIMEOUT=120   # 2 minutes
 FAST_SYSFS_MONITOR_LABELS_JSON="/etc/hw-management-fast-sysfs-monitor/fast_sysfs_labels.json"
 FAST_SYSFS_MONITOR_PID_FILE="/tmp/fast_sysfs_monitor.pid"

--- a/usr/usr/bin/hw-management-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-sysfs-monitor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##################################################################################
-# Copyright (c) 2020 - 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -41,9 +41,9 @@ Usage: $(basename "$0") [Options]
 
 Options:
     start   Start hw-mngmt-sysfs-monitor.
-	stop	Stop hw-mngmt-sysfs-monitor.
+    stop    Stop hw-mngmt-sysfs-monitor.
     restart
-    force-reload	Performs hw-mngmt-sysfs-monitor 'stop' and the 'start.
+    force-reload    Performs hw-mngmt-sysfs-monitor 'stop' and the 'start.
 "
 
 do_start_sysfs_monitor()
@@ -85,7 +85,7 @@ do_start_sysfs_monitor()
 
 do_stop_sysfs_monitor()
 {
-    # Remove older WD process if it exists.
+    # Remove older sysfs-monitor process if it exists.
     if [ -f "$SYSFS_MONITOR_PID_FILE" ]; then
         local MONITOR_PID
         MONITOR_PID=$(cat "$SYSFS_MONITOR_PID_FILE")


### PR DESCRIPTION
1. Removed 'bc' tool usage which is missing from Sonic.
2. Added further optimization for fast boot.