### PR TITLE
hw-mgmgt: thermal: Fix PSU_FAN speed control for FW controlled PSU

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -897,8 +897,21 @@ if [ "$1" == "add" ]; then
 		sleep 1
 		# Set I2C bus for psu
 		echo "$bus" > $config_path/"$psu_name"_i2c_bus
-		# Set default fan speed
-		psu_set_fan_speed "$psu_name" $(< $fan_psu_default)
+
+		# Set default fan speed only if TC will handle it
+		# Otherwise don't touch - let's PSU FW handle it
+		if [ -f $config_path/tc_config.json ]; then
+			# Check if TC have config for PSU fan control
+			fan_pwm_decode=$(cat $config_path/tc_config.json | grep psu_fan_pwm_decode)
+			if [ $? -eq 0 ]; then
+				# TC config for PSU is not disabled
+				echo $fan_pwm_decode | grep "0:100" | grep \\-1
+				if [ $? -ne 0 ]; then
+					psu_set_fan_speed "$psu_name" $(< $fan_psu_default)
+				fi
+			fi
+		fi
+
 		# Add thermal attributes
 		check_n_link "$5""$3"/temp1_input $thermal_path/"$psu_name"_temp1
 		check_n_link "$5""$3"/temp1_max $thermal_path/"$psu_name"_temp1_max

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2752,6 +2752,11 @@ set_config_data()
 	echo $hotplug_linecards > $config_path/hotplug_linecards
 	echo $fan_speed_tolerance > $config_path/fan_speed_tolerance
 	echo $leakage_count > $config_path/leakage_num
+	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
+		cp $thermal_control_config $config_path/tc_config.json
+	else
+		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
+	fi
 }
 
 connect_platform()
@@ -3284,11 +3289,6 @@ do_start()
 		ln -sf $lm_sensors_config $config_path/lm_sensors_config
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
-	fi
-	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
-		cp $thermal_control_config $config_path/tc_config.json
-	else
-		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
 	log_info "Init completed."
 }


### PR DESCRIPTION
If PSU FAN should be controlled by its FW we shouldn't set default PSU
FAN speed on init. PSU FAN default spped will be set only for systems
with TC controllable PSU FANs

Bug: N/A

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
