### PR TITLE
hw-mggmt: thermal: Fix thermal amb sensor link for multi asic systems

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -289,8 +289,6 @@ if [ "$1" == "add" ]; then
 		find_i2c_bus
 		i2c_comex_mon_bus_default=$(< $i2c_comex_mon_bus_default_file)
 		comex_bus=$((i2c_comex_mon_bus_default+i2c_bus_offset))
-		# Verify if this is ASIC sensor
-		asic_bus=$((i2c_asic_bus_default+i2c_bus_offset))
 		if [ -f $config_path/cx_default_i2c_bus ]; then
 			cx_i2c_bus=$(< $config_path/cx_default_i2c_bus)
 			cx_i2c_bus=$((cx_i2c_bus+i2c_bus_offset))
@@ -298,14 +296,26 @@ if [ "$1" == "add" ]; then
 		busdir=$(echo "$3""$4" |xargs dirname |xargs dirname)
 		busfolder=$(basename "$busdir")
 		bus="${busfolder:0:${#busfolder}-5}"
+		# Verify if this is ASIC sensor
+		if [ ! -f "$config_path/asic_num" ]; then
+			asic_num=1
+		else
+			asic_num=$(< $config_path/asic_num)
+		fi
+		for ((i=1; i<=asic_num; i+=1)); do
+			asic_i2c_bus_id=$(< $config_path/asic"$i"_i2c_bus_id)
+			asic_bus=$((asic_i2c_bus_id+i2c_bus_offset))
+			if [ "$bus" == "$asic_bus" ]; then
+				exit 0
+			fi
+		done
+
 		if [ "$bus" == "$comex_bus" ]; then
 			if [ $2 == cx_amb ]; then
 				check_n_link "$3""$4"/temp2_input $thermal_path/cx_amb
 			else
 				check_n_link "$3""$4"/temp1_input $thermal_path/comex_amb
 			fi
-		elif [ "$bus" == "$asic_bus" ]; then
-			exit 0
 		elif [ $bus -eq $cx_i2c_bus ]; then
 			check_n_link "$3""$4"/temp2_input $thermal_path/cx_amb
 		else


### PR DESCRIPTION
Fix thermal sensor link create for multi asic systems. For multi ASIC
systems hw-mgmt should check if i2c device doesn't belong to any ASIC
bus.

Bug: 4327177

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
