### PR TITLE
hw-mgmt: scripts: Enable Juliet platform emulation

### DIFF
--- a/usr/etc/hw-management-virtual/HI166/environment
+++ b/usr/etc/hw-management-virtual/HI166/environment
@@ -1,0 +1,32 @@
+comex_voltmon1_curr2_input 750
+comex_voltmon1_curr3_input 6500
+comex_voltmon1_in1_input 13437
+comex_voltmon1_in2_crit 1281
+comex_voltmon1_in2_input 1081
+comex_voltmon1_in2_lcrit 656
+comex_voltmon1_in3_crit 1168
+comex_voltmon1_in3_input 968
+comex_voltmon1_in3_lcrit 543
+
+comex_voltmon2_curr1_input 0
+comex_voltmon2_curr2_input 1000
+comex_voltmon2_in1_crit 17000
+comex_voltmon2_in1_input 13250
+comex_voltmon2_in2_crit 1290
+comex_voltmon2_in2_input 1201
+comex_voltmon2_in2_lcrit 900
+comex_voltmon2_power1_input 0
+comex_voltmon2_power2_input 1000000
+
+pdb_hotswap1_curr1_input 2467
+pdb_hotswap1_curr1_max 27195
+pdb_hotswap1_in1_crit 88724
+pdb_hotswap1_in1_input 54307
+pdb_hotswap1_in1_lcrit 30
+pdb_hotswap1_in1_max 88724
+pdb_hotswap1_in1_min 30
+pdb_hotswap1_in2_input 54324
+pdb_hotswap1_in2_lcrit 0
+pdb_hotswap1_in2_min 0
+pdb_hotswap1_power1_input 135802469
+pdb_hotswap1_power1_max 2409758965

--- a/usr/etc/hw-management-virtual/HI166/thermal
+++ b/usr/etc/hw-management-virtual/HI166/thermal
@@ -1,0 +1,23 @@
+sodimm1_temp_crit 95000
+sodimm1_temp_crit_alarm 0
+sodimm1_temp_crit_hyst 89000
+sodimm1_temp_input 32000
+sodimm1_temp_max 85000
+sodimm1_temp_max_alarm 0
+sodimm1_temp_max_hyst 79000
+sodimm1_temp_min 0
+sodimm1_temp_min_alarm 0
+
+pdb_hotswap1_temp1_crit 255937
+pdb_hotswap1_temp1_input 30000
+pdb_hotswap1_temp1_max 255937
+
+comex_voltmon1_temp1_crit 120000
+comex_voltmon1_temp1_input 42000
+comex_voltmon2_temp1_crit 115000
+comex_voltmon2_temp1_input 43000
+comex_voltmon2_temp1_max 105000
+
+cpu_pack 42625
+cpu_pack_crit 100000
+cpu_pack_max 95000

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -258,7 +258,7 @@ check_labels_enabled()
 check_if_simx_supported_platform()
 {
 	case $vm_sku in
-		HI130|HI122|HI144|HI147|HI157|HI112|MSN2700-CS2FO|MSN2410-CB2F|MSN2100|HI160|HI158)
+		HI130|HI122|HI144|HI147|HI157|HI112|MSN2700-CS2FO|MSN2410-CB2F|MSN2100|HI160|HI158|HI166)
 			return 0
 			;;
 
@@ -276,6 +276,21 @@ check_simx()
 	else
 		return 1
 	fi
+}
+
+# Create the missed out links due to lack of emulation
+process_simx_links()
+{
+	local dir_list
+
+	# Create the attributes in thermal and environment directories of hw-management.
+        dir_list="thermal environment"
+        for i in $dir_list; do
+                while IFS=' ' read -r filename value; do
+                        [ -z "$filename" ] && continue
+                        echo "$value" > "$hw_management_path"/"$i"/"$filename"
+                done < "$vm_vpd_path"/"$i"
+        done
 }
 
 # Check if file exists and create soft link

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -72,6 +72,20 @@ if [ ! -f /var/run/hw-management/system/cpld_base ]; then
 	timeout 5 bash -c 'until [ -f /var/run/hw-management/system/cpld_base ]; do sleep 0.2; done'
 fi
 
+# Create the links for the sensors which doesn't have emulation drivers
+if check_simx; then
+        if check_if_simx_supported_platform; then
+                case $sku in
+                        HI166)
+                                process_simx_links
+                                ;;
+                        *)
+                                ;;
+                esac
+
+        fi
+fi
+
 ## Check SKU and run the below only for relevant.
 case $sku in
 	HI130|HI151|HI157|HI158|HI162|HI166|HI167|HI169|HI170)

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -592,6 +592,7 @@ ariel_cartridge_eeprom_connect_table=( 24c02 0x50 47 cable_cartridge1_eeprom \
 	24c02 0x50 50 cable_cartridge2_eeprom)
 
 n5110ld_vpd_connect_table=(24c512 0x51 2 vpd_info)
+n5110ld_virtual_vpd_connect_table=(24c512 0x51 10 vpd_info)
 
 # I2C busses naming.
 cfl_come_named_busses=( come-vr 15 come-amb 15 come-fru 16 )
@@ -2241,6 +2242,9 @@ n51xxld_specific()
 		esac
 		# Add VPD explicitly.
 		echo ${n5110ld_vpd_connect_table[0]} ${n5110ld_vpd_connect_table[1]} > /sys/bus/i2c/devices/i2c-${n5110ld_vpd_connect_table[2]}/new_device
+		if check_simx; then
+			echo ${n5110ld_virtual_vpd_connect_table[0]} ${n5110ld_virtual_vpd_connect_table[1]} > /sys/bus/i2c/devices/i2c-${n5110ld_virtual_vpd_connect_table[2]}/new_device
+		fi
 	fi
 	asic_i2c_buses=(11 21)
 	echo 1 > $config_path/global_wp_wait_step
@@ -2303,6 +2307,10 @@ n51xxld_specific_cleanup()
 	unlink /dev/i2c-8
 	# Remove VPD explicitly.
 	echo ${n5110ld_vpd_connect_table[1]} > /sys/bus/i2c/devices/i2c-${n5110ld_vpd_connect_table[2]}/delete_device
+	if check_simx; then
+		echo ${n5110ld_virtual_vpd_connect_table[1]} > /sys/bus/i2c/devices/i2c-${n5110ld_virtual_vpd_connect_table[2]}/delete_device
+	fi
+
 
 }
 
@@ -2940,6 +2948,11 @@ set_sodimms()
 
 	i2c_dir=$(ls -1d "$amd_snw_i2c_sodimm_dev"/i2c-*)
 	i2c_bus="${i2c_dir##*-}"
+	if check_simx; then
+		# i2c-designware emulattion is not available. For the virtual
+		# platforms that used AMD comex, sodimm sensor is defined at i2c-10
+		i2c_bus=10
+	fi
 	if [ -z "$i2c_bus" ]; then
 		log_err "Error: I2C bus of SODIMMs TS isn't found."
 		return 1


### PR DESCRIPTION
Bug: N/A

This patch set adds the support for
 - Enabling platform emulation for Juliet
 - Sensor attributes for which the sensor emulation driver is not available.
 - Workaround for sodimm sensor availability in AMD based virtual platforms