### PR TITLE
hw-mgmgt: sensors: Fix missing pwr_conv sensor in SN5600D system

### DIFF
--- a/usr/etc/hw-management-sensors/sn5600d_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600d_sensors.conf
@@ -439,6 +439,18 @@ bus "i2c-4" "i2c-1-mux (chan_id 6)"
 	    label temp2     "PWR_CONV1 Temp2"
 	    ignore temp3
 
+    chip "raa228004-i2c-*-61"
+	    label in1       "PWR_CONV1 VinDC Volt (in)"
+	    ignore in2
+	    label in3       "PWR_CONV1 Vout Volt (out)"
+	    label power1  	"PWR_CONV1 VinDC Pwr (in)"
+	    label power2	"PWR_CONV1 VoutDC Pwr (out)"
+	    label curr1		"PWR_CONV1 Curr Curr (in)"
+	    label curr2     "PWR_CONV1 Curr Curr (out)"
+	    label temp1		"PWR_CONV1 Temp1"
+	    label temp2     "PWR_CONV1 Temp2"
+	    ignore temp3
+
     # PDB temperature sensors
     chip "tmp451-i2c-*-4c"
     	label temp1 "PDB MOS Temp"

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -501,6 +501,7 @@ declare -A bmc_pwr_type3_alternatives=(["pmbus_0"]="pmbus 0x10 18 pwr_conv1" \
 # P*HaHaTjTkEaOdOd
 declare -A pwr_type4_alternatives=( \
 				   ["raa228000_0"]="raa228000 0x61 4 pdb_pwr_conv1" \
+				   ["raa228004_0"]="raa228004 0x61 4 pdb_pwr_conv1" \
 				   ["lm5066_0"]="lm5066i 0x12 4 pdb_hotswap1" \
 				   ["lm5066_1"]="lm5066i 0x14 4 pdb_hotswap2" \
 				   ["tmp451_0"]="tmp451 0x4c 4 pdb_mos_amb" \


### PR DESCRIPTION
Fix missing pwr_conv sensor in SN5600D system.
Add alternative component support: raa228004

Bug: 4354380

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
