### PR TITLE
hw-mgmt: patches: Fix Sonic build by ignoring all Q3450 patches

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -398,7 +398,7 @@ Kernel-5.10
 |9004-DS-OPT-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch|                 | Downstream accepted                      |            |                                                |
 |9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch  |                    | Downstream;skip[sonic]                   |            |                                                |
 |9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream;skip[ALL];take[opt]           |            |                                                |
-|9007-platform-mellanox-mlx-platform-Change-register-0x28-.patch  |                    | Downstream accepted                      |            |                                                |
+|9007-platform-mellanox-mlx-platform-Change-register-0x28-.patch  |                    | Downstream;skip[sonic,cumulus]           |            |                                                |
 |9008-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Q3450                                          |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -731,7 +731,7 @@ Kernel-6.1
 |9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch  |                    | Downstream;skip[sonic,cumulus]           |            |                                                |
 |9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9007-mlxsw-core-Downstream-Fix-uninitialized-variable.patch      |                    | Downstream accepted;skip[sonic]          |            |                                                |
-|9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch  |                    | Downstream accepted                      |            |                                                |
+|9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch  |                    | Downstream;skip[sonic,cumulus]           |            |                                                |
 |9009-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Q3450                                          |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
The patch 900X-platform-mellanox-mlx-platform-Change-register-0x28-.patch relies on patch 9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch that is skipped by Sonic build, thus causing build failure. Fix this by ignoring 900X-platform-mellanox-mlx-platform-Change-register-0x28-.patch as well for Sonic build.