### PR TITLE
hw-mgmt: scripts: Update platform emulation sensor values for Juliet

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0040.3940) unstable; urgency=low
+hw-management (1.mlnx.7.0040.3941) unstable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Tue, 18 Mar 2025 12:38:00 +030
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Thu, 20 Mar 2025 11:20:00 +030

--- a/usr/etc/hw-management-virtual/HI166/environment
+++ b/usr/etc/hw-management-virtual/HI166/environment
@@ -30,3 +30,71 @@ pdb_hotswap1_in2_lcrit 0
 pdb_hotswap1_in2_min 0
 pdb_hotswap1_power1_input 135802469
 pdb_hotswap1_power1_max 2409758965
+
+pwr_conv1_in1_crit 64000
+pwr_conv1_in1_input 53750
+pwr_conv1_in1_lcrit 35562
+pwr_conv1_in2_crit 16000
+pwr_conv1_in2_input 13457
+pwr_conv1_in2_lcrit 8199
+
+pwr_conv2_in1_crit 64000
+pwr_conv2_in1_input 53750
+pwr_conv2_in1_lcrit 35562
+pwr_conv2_in2_crit 16000
+pwr_conv2_in2_input 13437
+pwr_conv2_in2_lcrit 8199
+
+voltmon1_in1_crit 16000
+voltmon1_in1_input 13500
+voltmon1_in1_lcrit 26
+voltmon1_in2_crit 833
+voltmon1_in2_input 747
+voltmon1_in2_lcrit 615
+
+voltmon2_in1_crit 16000
+voltmon2_in1_input 13438
+voltmon2_in1_lcrit 256
+voltmon2_in3_crit 908
+voltmon2_in3_input 760
+voltmon2_in3_lcrit 670
+voltmon2_in2_crit 1300
+voltmon2_in2_input 1200
+voltmon2_in2_lcrit 1100
+
+voltmon3_in1_crit 16000
+voltmon3_in1_input 13438
+voltmon3_in1_lcrit 256
+voltmon3_in3_lcrit 670
+voltmon3_in3_crit 908
+voltmon3_in3_input 760
+voltmon3_in2_lcrit 1100
+voltmon3_in2_input 1200
+voltmon3_in2_crit 1300
+
+voltmon4_in1_crit 16000
+voltmon4_in1_input 13438
+voltmon4_in1_lcrit 26
+voltmon4_in2_crit 833
+voltmon4_in2_input 747
+voltmon4_in2_lcrit 615
+
+voltmon5_in1_crit 16000
+voltmon5_in1_input 13438
+voltmon5_in1_lcrit 256
+voltmon5_in3_crit 908
+voltmon5_in3_input 757
+voltmon5_in3_lcrit 670
+voltmon5_in2_input 1200
+voltmon5_in2_crit 1300
+voltmon5_in2_lcrit 1100
+
+voltmon6_in1_crit 16000
+voltmon6_in1_input 13406
+voltmon6_in1_lcrit 256
+voltmon6_in3_input 760
+voltmon6_in3_crit 908
+voltmon6_in3_lcrit 670
+voltmon6_in2_crit 1300
+voltmon6_in2_lcrit 1100
+voltmon6_in2_input 1200

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -374,6 +374,7 @@ process_simx_links()
         for i in $dir_list; do
                 while IFS=' ' read -r filename value; do
                         [ -z "$filename" ] && continue
+                        [ -L "$hw_management_path"/"$i"/"$filename" ] && check_n_unlink "$hw_management_path"/"$i"/"$filename"
                         echo "$value" > "$hw_management_path"/"$i"/"$filename"
                 done < "$vm_vpd_path"/"$i"
         done


### PR DESCRIPTION
This patch updates values and adds missing values to voltage sensor data on Juliet Qemu emulation.

Bugs: 4363327