### PR TITLE
hw-mgmt: patches: Improve dpu interrupt handling

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -712,6 +712,7 @@ Kernel-6.1
 |0100-platform-mellanox-mlxreg-io-Extend-number-of-hwmon-a.patch  |                    | Downstream accepted					  |            |                                          |
 |0101-platform_data-mlxreg-Add-fields-for-interrupt-storm-.patch  |                    | Downstream accepted					  |            |                                                |
 |0102-platform-mellanox-mlxreg-hotplug-Add-support-for-han.patch  |                    | Downstream accepted					  |            |                                                |
+|0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch  |                    | Downstream accepted                      |            | SN4280                                         |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |

--- a/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -1,4 +1,4 @@
-From ccd3dacb0e6400941032a6b6fdc0dc7ccb087dcd Mon Sep 17 00:00:00 2001
+From 972719eb05ea348b12759e7c12596ca9d60ce644 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 4 Dec 2023 07:12:52 +0000
 Subject: platform/mellanox: mlxreg-dpu: Add initial support for Nvidia DPU
@@ -27,12 +27,12 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
  drivers/platform/mellanox/Kconfig      |  12 +
  drivers/platform/mellanox/Makefile     |   1 +
- drivers/platform/mellanox/mlxreg-dpu.c | 625 +++++++++++++++++++++++++++++++++
- 3 files changed, 638 insertions(+)
+ drivers/platform/mellanox/mlxreg-dpu.c | 626 +++++++++++++++++++++++++
+ 3 files changed, 639 insertions(+)
  create mode 100644 drivers/platform/mellanox/mlxreg-dpu.c
 
 diff --git a/drivers/platform/mellanox/Kconfig b/drivers/platform/mellanox/Kconfig
-index 75efd345b22e..9c86385e70a3 100644
+index 018ce2833..14c14c9c2 100644
 --- a/drivers/platform/mellanox/Kconfig
 +++ b/drivers/platform/mellanox/Kconfig
 @@ -26,6 +26,18 @@ config MLX_PLATFORM
@@ -55,7 +55,7 @@ index 75efd345b22e..9c86385e70a3 100644
  	tristate "Mellanox platform hotplug driver support"
  	depends on HWMON
 diff --git a/drivers/platform/mellanox/Makefile b/drivers/platform/mellanox/Makefile
-index d7f4d940c505..7d11503dde9b 100644
+index d7f4d940c..7d11503dd 100644
 --- a/drivers/platform/mellanox/Makefile
 +++ b/drivers/platform/mellanox/Makefile
 @@ -8,6 +8,7 @@ obj-$(CONFIG_MLXBF_BOOTCTL)	+= mlxbf-bootctl.o
@@ -68,18 +68,19 @@ index d7f4d940c505..7d11503dde9b 100644
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
 diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
 new file mode 100644
-index 000000000000..a61c13647bdc
+index 000000000..c6cfbee55
 --- /dev/null
 +++ b/drivers/platform/mellanox/mlxreg-dpu.c
-@@ -0,0 +1,625 @@
+@@ -0,0 +1,626 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia Data Processor Unit platform driver
 + *
-+ * Copyright (C) 2024 Nvidia Technologies Ltd.
++ * Copyright (C) 2025 Nvidia Technologies Ltd.
 + */
 +
 +#include <linux/device.h>
++#include <linux/dev_printk.h>
 +#include <linux/i2c.h>
 +#include <linux/module.h>
 +#include <linux/platform_data/mlxcpld.h>
@@ -239,7 +240,7 @@ index 000000000000..a61c13647bdc
 +	{
 +		.label = "dpu_id",
 +		.reg = MLXREG_DPU_REG_GP0_RO_OFFSET,
-+		.bit = GENMASK(3, 0),
++		.mask = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -252,7 +253,7 @@ index 000000000000..a61c13647bdc
 +	{
 +		.label = "boot_progress",
 +		.reg = MLXREG_DPU_REG_GP1_OFFSET,
-+		.bit = GENMASK(3, 0),
++		.mask = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -388,13 +389,14 @@ index 000000000000..a61c13647bdc
 +	.mask = MLXREG_DPU_AGGR_MASK,
 +};
 +
-+/* mlxreg_dpu - device private data
-+ * @dev: platform device;
-+ * @data: pltaform core data;
-+ * @io_data: register access platform data;
-+ * @io_regs: register access device;
-+ * @hotplug_data: hotplug platform data;
-+ * @hotplug: hotplug device;
++/**
++ * struct mlxreg_dpu - device private data
++ * @dev: platform device
++ * @data: platform core data
++ * @io_data: register access platform data
++ * @io_regs: register access device
++ * @hotplug_data: hotplug platform data
++ * @hotplug: hotplug device
 + */
 +struct mlxreg_dpu {
 +	struct device *dev;
@@ -477,6 +479,11 @@ index 000000000000..a61c13647bdc
 +	return false;
 +}
 +
++static const struct reg_default mlxreg_dpu_regmap_default[] = {
++        { MLXREG_DPU_REG_PG_EVENT_OFFSET, 0x00 },
++        { MLXREG_DPU_REG_HEALTH_EVENT_OFFSET, 0x00 },
++};
++
 +/* Configuration for the register map of a device with 2 bytes address space. */
 +static const struct regmap_config mlxreg_dpu_regmap_conf = {
 +	.reg_bits = 16,
@@ -486,10 +493,13 @@ index 000000000000..a61c13647bdc
 +	.writeable_reg = mlxreg_dpu_writeable_reg,
 +	.readable_reg = mlxreg_dpu_readable_reg,
 +	.volatile_reg = mlxreg_dpu_volatile_reg,
++	.reg_defaults = mlxreg_dpu_regmap_default,
++	.num_reg_defaults = ARRAY_SIZE(mlxreg_dpu_regmap_default),
 +};
 +
-+static int mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
-+					struct mlxreg_core_hotplug_platform_data *hotplug_data)
++static int
++mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
++			     const struct mlxreg_core_hotplug_platform_data *hotplug_data)
 +{
 +	struct mlxreg_core_item *item;
 +	int i;
@@ -501,18 +511,15 @@ index 000000000000..a61c13647bdc
 +
 +	mlxreg_dpu->hotplug_data->items = devm_kmemdup(dev, hotplug_data->items,
 +						       mlxreg_dpu->hotplug_data->counter *
-+						       sizeof(*hotplug_data->items),
++						       sizeof(*mlxreg_dpu->hotplug_data->items),
 +						       GFP_KERNEL);
 +	if (!mlxreg_dpu->hotplug_data->items)
 +		return -ENOMEM;
 +
 +	item = mlxreg_dpu->hotplug_data->items;
-+	for (i = 0; i < mlxreg_dpu->hotplug_data->counter; i++, item++) {
-+		item = devm_kmemdup(dev, &hotplug_data->items[i], sizeof(*item), GFP_KERNEL);
-+		if (!item)
-+			return -ENOMEM;
++	for (i = 0; i < hotplug_data->counter; i++, item++) {
 +		item->data = devm_kmemdup(dev, hotplug_data->items[i].data,
-+					  hotplug_data->items[i].count * sizeof(item->data),
++					  hotplug_data->items[i].count * sizeof(*item->data),
 +					  GFP_KERNEL);
 +		if (!item->data)
 +			return -ENOMEM;
@@ -532,6 +539,7 @@ index 000000000000..a61c13647bdc
 +	err = regmap_read(regmap, MLXREG_DPU_REG_CONFIG3_OFFSET, &regval);
 +	if (err)
 +		return err;
++
 +	switch (regval) {
 +	case MLXREG_DPU_BF3:
 +		/* Copy platform specific hotplug data. */
@@ -551,15 +559,15 @@ index 000000000000..a61c13647bdc
 +	if (mlxreg_dpu->io_data) {
 +		mlxreg_dpu->io_data->regmap = regmap;
 +		mlxreg_dpu->io_regs =
-+		platform_device_register_resndata(dev, "mlxreg-io", data->slot, NULL, 0,
-+						  mlxreg_dpu->io_data,
-+						  sizeof(*mlxreg_dpu->io_data));
++			platform_device_register_resndata(dev, "mlxreg-io",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->io_data,
++							  sizeof(*mlxreg_dpu->io_data));
 +		if (IS_ERR(mlxreg_dpu->io_regs)) {
 +			dev_err(dev, "Failed to create regio for client %s at bus %d at addr 0x%02x\n",
 +				data->hpdev.brdinfo->type, data->hpdev.nr,
 +				data->hpdev.brdinfo->addr);
-+			err = PTR_ERR(mlxreg_dpu->io_regs);
-+			goto fail_register_io;
++			return PTR_ERR(mlxreg_dpu->io_regs);
 +		}
 +	}
 +
@@ -568,9 +576,10 @@ index 000000000000..a61c13647bdc
 +		mlxreg_dpu->hotplug_data->regmap = regmap;
 +		mlxreg_dpu->hotplug_data->irq = irq;
 +		mlxreg_dpu->hotplug =
-+		platform_device_register_resndata(dev, "mlxreg-hotplug", data->slot, NULL, 0,
-+						  mlxreg_dpu->hotplug_data,
-+						  sizeof(*mlxreg_dpu->hotplug_data));
++			platform_device_register_resndata(dev, "mlxreg-hotplug",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->hotplug_data,
++							  sizeof(*mlxreg_dpu->hotplug_data));
 +		if (IS_ERR(mlxreg_dpu->hotplug)) {
 +			err = PTR_ERR(mlxreg_dpu->hotplug);
 +			goto fail_register_hotplug;
@@ -581,16 +590,13 @@ index 000000000000..a61c13647bdc
 +
 +fail_register_hotplug:
 +	platform_device_unregister(mlxreg_dpu->io_regs);
-+fail_register_io:
 +
 +	return err;
 +}
 +
 +static void mlxreg_dpu_config_exit(struct mlxreg_dpu *mlxreg_dpu)
 +{
-+	/* Unregister hotplug driver. */
 +	platform_device_unregister(mlxreg_dpu->hotplug);
-+	/* Unregister IO access driver. */
 +	platform_device_unregister(mlxreg_dpu->io_regs);
 +}
 +
@@ -605,13 +611,13 @@ index 000000000000..a61c13647bdc
 +	if (!data || !data->hpdev.brdinfo)
 +		return -EINVAL;
 +
-+	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
-+	if (!mlxreg_dpu)
-+		return -ENOMEM;
-+
 +	data->hpdev.adapter = i2c_get_adapter(data->hpdev.nr);
 +	if (!data->hpdev.adapter)
 +		return -EPROBE_DEFER;
++
++	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
++	if (!mlxreg_dpu)
++		return -ENOMEM;
 +
 +	/* Create device at the top of DPU I2C tree.*/
 +	data->hpdev.client = i2c_new_client_device(data->hpdev.adapter,
@@ -623,8 +629,7 @@ index 000000000000..a61c13647bdc
 +		goto i2c_new_device_fail;
 +	}
 +
-+	regmap = devm_regmap_init_i2c(data->hpdev.client,
-+				      &mlxreg_dpu_regmap_conf);
++	regmap = devm_regmap_init_i2c(data->hpdev.client, &mlxreg_dpu_regmap_conf);
 +	if (IS_ERR(regmap)) {
 +		dev_err(&pdev->dev, "Failed to create regmap for client %s at bus %d at addr 0x%02x\n",
 +			data->hpdev.brdinfo->type, data->hpdev.nr, data->hpdev.brdinfo->addr);
@@ -646,12 +651,9 @@ index 000000000000..a61c13647bdc
 +	mlxreg_dpu->dev = &pdev->dev;
 +	platform_set_drvdata(pdev, mlxreg_dpu);
 +
-+	/* Configure DPU. */
 +	err = mlxreg_dpu_config_init(mlxreg_dpu, regmap, data, data->hpdev.brdinfo->irq);
 +	if (err)
 +		goto mlxreg_dpu_config_init_fail;
-+
-+	return err;
 +
 +mlxreg_dpu_config_init_fail:
 +regcache_sync_fail:
@@ -696,7 +698,6 @@ index 000000000000..a61c13647bdc
 +MODULE_DESCRIPTION("Nvidia Data Processor Unit platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:mlxreg-dpu");
-+
 -- 
-2.14.1
+2.44.0
 

--- a/recipes-kernel/linux/linux-6.1/0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
+++ b/recipes-kernel/linux/linux-6.1/0103-platform-mellanox-mlx-dpu-improve-interrupt-handling.patch
@@ -1,0 +1,155 @@
+From edf1951c7f5e87a9b6c2ad82bd97866012f552a6 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Tue, 25 Mar 2025 11:20:04 +0200
+Subject: [PATCH 01/22] From 4b17e10a22771fcd2dbb4754c43200af2fc69425 Mon Sep
+ 17 00:00:00 2001 From: Ciju Rajan K <crajank@nvidia.com> Date: Tue, 18 Mar
+ 2025 21:15:00 +0200 Subject: platform/mellanox: mlxreg-dpu: Introduce
+ completion callback
+
+DPU auxiliary powering can cause interrupt flooding because
+DPU interrupt handlers are not configured yet, while middle
+interrupt aggregation register is unmasked by default during
+initialization. Thus, interrupts are getting through, while
+handlers are still not fully initialized. Do not unmask
+aggregation interrupt register at initialization for all
+DPUs. Instead do it per DPU, when its initialization is done.
+
+This patch also adds the change to clear the DPU event
+registers.
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 28 +++++++++++++++++++++---
+ drivers/platform/mellanox/mlxreg-dpu.c   |  8 +++++++
+ include/linux/platform_data/mlxreg.h     |  4 ++++
+ 3 files changed, 37 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index b1713d805..d2dfdac34 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -2198,6 +2198,8 @@ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+ 	},
+ };
+ 
++#define MLXPLAT_SMART_SWITCH_SLOT_TO_MASK(s)   (GENMASK((s) * 2 - 1, (s) * 2 - 2))
++
+ 
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_lc_act = {
+@@ -3334,6 +3336,23 @@ static struct mlxreg_core_item mlxplat_mlxcpld_smart_switch_items[] = {
+ 	},
+ };
+ 
++static int mlxplat_dpu_completion_notify(void *handle, int id)
++{
++       u32 regval, mask;
++       int err;
++
++       if (id <= 0 || id > 4)
++               return -EINVAL;
++
++       err = regmap_read(handle, MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET, &regval);
++       if (err)
++               return err;
++
++       mask = MLXPLAT_SMART_SWITCH_SLOT_TO_MASK(id);
++
++       return regmap_write(handle, MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET, regval | mask);
++}
++
+ static
+ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_smart_switch_data = {
+ 	.items = mlxplat_mlxcpld_smart_switch_items,
+@@ -3371,24 +3390,28 @@ static struct mlxreg_core_data mlxplat_mlxcpld_smart_switch_dpu_data[] = {
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[0],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE,
+ 		.slot = 1,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu2",
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[1],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 1,
+ 		.slot = 2,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu3",
+ 		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[2],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 2,
+ 		.slot = 3,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ 	{
+ 		.label = "dpu4",
+-		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[2],
++		.hpdev.brdinfo = &mlxplat_mlxcpld_smart_switch_dpu_devs[3],
+ 		.hpdev.nr = MLXPLAT_CPLD_NR_DPU_BASE + 3,
+ 		.slot = 4,
++		.completion_notify = mlxplat_dpu_completion_notify,
+ 	},
+ };
+ 
+@@ -8018,8 +8041,6 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_WD1_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD2_ACT_OFFSET, 0x00 },
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
+-	{ MLXPLAT_CPLD_LPC_REG_AGGRCX_MASK_OFFSET,
+-	  MLXPLAT_CPLD_LPC_SM_SW_MASK },
+ };
+ 
+ struct mlxplat_mlxcpld_regmap_context {
+@@ -9333,6 +9354,7 @@ static int mlxplat_post_init(struct mlxplat_priv *priv)
+ 	/* Add DPU drivers. */
+ 	for (j = 0; j < MLXPLAT_CPLD_DPU_MAX_DEVS; j++) {
+ 		if (mlxplat_dpu_data[j]) {
++			mlxplat_dpu_data[j]->handle = priv->regmap;
+ 			priv->pdev_dpu[j] =
+ 				platform_device_register_resndata(&mlxplat_dev->dev, "mlxreg-dpu",
+ 								  j, NULL, 0, mlxplat_dpu_data[j],
+diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
+index b7685012d..aa8923c49 100644
+--- a/drivers/platform/mellanox/mlxreg-dpu.c
++++ b/drivers/platform/mellanox/mlxreg-dpu.c
+@@ -581,6 +581,14 @@ static int mlxreg_dpu_probe(struct platform_device *pdev)
+ 	if (err)
+ 		goto mlxreg_dpu_config_init_fail;
+ 
++	err = data->completion_notify(data->handle, data->slot);
++	if (err)
++		goto mlxreg_dpu_completion_notify_fail;
++
++	return err;
++
++mlxreg_dpu_completion_notify_fail:
++	mlxreg_dpu_config_exit(mlxreg_dpu);
+ mlxreg_dpu_config_init_fail:
+ regcache_sync_fail:
+ devm_regmap_init_i2c_fail:
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index 67dddacfa..e8f2032b3 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -136,6 +136,8 @@ struct mlxreg_hotplug_device {
+  * @wmark_low_cntr: interrupt storm counter;
+  * @wmark_low_ts: interrupt storm low bound timestamp;
+  * @wmark_high_ts: interrupt storm high bound timestamp;
++ * @handle: parent handle;
++ * @completion_notify: callback to notify when platform driver probing is done;
+  */
+ struct mlxreg_core_data {
+ 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
+@@ -161,6 +163,8 @@ struct mlxreg_core_data {
+ 	unsigned int wmark_low_cntr;
+ 	unsigned long wmark_low_ts;
+ 	unsigned long wmark_high_ts;
++	void *handle;
++	int (*completion_notify)(void *handle, int id);
+ };
+ 
+ /**
+-- 
+2.44.0
+

--- a/recipes-kernel/linux/linux-6.1/8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch
+++ b/recipes-kernel/linux/linux-6.1/8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch
@@ -1,4 +1,4 @@
-From bebcb59ddbedc8eb9fe5274453a2188b3f52f24c Mon Sep 17 00:00:00 2001
+From 3c81b9ab64bfbf723877bfb5561b42d30d074343 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Wed, 2 Aug 2023 07:58:51 +0000
 Subject: [PATCH v6.1 03/16] platform: mlx-platform: Downstream: Add SPI path
@@ -13,7 +13,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  2 files changed, 18 insertions(+)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 2c893410bd4d..bb2a683788cb 100644
+index d2dfdac34..dacb42492 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -19,6 +19,7 @@
@@ -24,7 +24,7 @@ index 2c893410bd4d..bb2a683788cb 100644
  
  #define MLX_PLAT_DEVICE_NAME		"mlxplat"
  
-@@ -3324,6 +3325,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_switch_data = {
+@@ -3570,6 +3571,16 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT,
  };
  
@@ -41,7 +41,7 @@ index 2c893410bd4d..bb2a683788cb 100644
  /* Platform led default data */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_led_data[] = {
  	{
-@@ -7474,6 +7485,7 @@ static struct mlxreg_core_platform_data
+@@ -8286,6 +8297,7 @@ static struct mlxreg_core_platform_data
  	*mlxplat_wd_data[MLXPLAT_CPLD_WD_MAX_DEVS];
  static struct mlxreg_core_data *mlxplat_dpu_data[MLXPLAT_CPLD_DPU_MAX_DEVS];
  static const struct regmap_config *mlxplat_regmap_config;
@@ -49,7 +49,7 @@ index 2c893410bd4d..bb2a683788cb 100644
  static struct pci_dev *lpc_bridge;
  static struct pci_dev *i2c_bridge;
  static struct pci_dev *jtag_bridge;
-@@ -7796,6 +7808,7 @@ static int __init mlxplat_dmi_rack_switch_matched(const struct dmi_system_id *dm
+@@ -8660,6 +8672,7 @@ static int __init mlxplat_dmi_rack_switch_matched(const struct dmi_system_id *dm
  		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
  	mlxplat_i2c = &mlxplat_mlxcpld_i2c_ng_data;
  	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_rack_switch;
@@ -57,7 +57,7 @@ index 2c893410bd4d..bb2a683788cb 100644
  
  	return mlxplat_register_platform_device();
  }
-@@ -7840,6 +7853,7 @@ static int __init mlxplat_dmi_l1_switch_matched(const struct dmi_system_id *dmi)
+@@ -8725,6 +8738,7 @@ static int __init mlxplat_dmi_l1_switch_matched(const struct dmi_system_id *dmi)
  	mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config_rack_switch;
  	pm_power_off = mlxplat_poweroff;
  	mlxplat_reboot_nb = &mlxplat_reboot_default_nb;
@@ -65,7 +65,7 @@ index 2c893410bd4d..bb2a683788cb 100644
  
  	return mlxplat_register_platform_device();
  }
-@@ -8390,6 +8404,9 @@ static int mlxplat_post_init(struct mlxplat_priv *priv)
+@@ -9333,6 +9347,9 @@ static int mlxplat_post_init(struct mlxplat_priv *priv)
  		}
  	}
  
@@ -76,10 +76,10 @@ index 2c893410bd4d..bb2a683788cb 100644
  	err = mlxplat_mlxcpld_check_wd_capability(priv->regmap);
  	if (err)
 diff --git a/drivers/spi/spi.c b/drivers/spi/spi.c
-index 5f9aedd1f0b6..fd22406b701d 100644
+index df774fb14..c2d55f09d 100644
 --- a/drivers/spi/spi.c
 +++ b/drivers/spi/spi.c
-@@ -867,6 +867,7 @@ int spi_register_board_info(struct spi_board_info const *info, unsigned n)
+@@ -889,6 +889,7 @@ int spi_register_board_info(struct spi_board_info const *info, unsigned n)
  
  	return 0;
  }
@@ -88,5 +88,5 @@ index 5f9aedd1f0b6..fd22406b701d 100644
  /*-------------------------------------------------------------------------*/
  
 -- 
-2.20.1
+2.44.0
 

--- a/recipes-kernel/linux/linux-6.1/9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch
+++ b/recipes-kernel/linux/linux-6.1/9003-platform-mellanox-Introduce-support-of-Nvidia-L1-tra.patch
@@ -1,4 +1,4 @@
-From 862d26a9e9abfc37daf2bbdecf8068e2386e3d0f Mon Sep 17 00:00:00 2001
+From eac1c07fc7de496ce02ce2e84bb32dd7db7449d0 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 14 Jan 2024 14:21:57 +0000
 Subject: [PATCH 2/3] platform: mellanox: Introduce support of Nvidia L1 tray
@@ -24,10 +24,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 206 insertions(+)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 5796e4695a2a..144ee24c11fd 100644
+index dacb42492..ab7951511 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
-@@ -3059,6 +3059,25 @@ static struct mlxreg_core_data mlxplat_mlxcpld_erot_error_items_data[] = {
+@@ -3129,6 +3129,25 @@ static struct mlxreg_core_data mlxplat_mlxcpld_erot_error_items_data[] = {
  	},
  };
  
@@ -53,7 +53,7 @@ index 5796e4695a2a..144ee24c11fd 100644
  static struct mlxreg_core_item mlxplat_mlxcpld_rack_switch_items[] = {
  	{
  		.data = mlxplat_mlxcpld_ext_psu_items_data,
-@@ -3480,6 +3499,82 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_switch_data = {
+@@ -3571,6 +3590,82 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT,
  };
  
@@ -136,7 +136,7 @@ index 5796e4695a2a..144ee24c11fd 100644
  static struct spi_board_info rack_switch_switch_spi_board_info[] = {
  	{
  		.modalias       = "spidev",
-@@ -4245,6 +4340,86 @@ static struct mlxreg_core_platform_data mlxplat_l1_switch_led_data = {
+@@ -4336,6 +4431,86 @@ static struct mlxreg_core_platform_data mlxplat_l1_switch_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_l1_switch_led_data),
  };
  
@@ -223,7 +223,7 @@ index 5796e4695a2a..144ee24c11fd 100644
  /* Platform led data for XDR systems */
  static struct mlxreg_core_data mlxplat_mlxcpld_xdr_led_data[] = {
  	{
-@@ -8252,6 +8427,30 @@ static int __init mlxplat_dmi_l1_switch_matched(const struct dmi_system_id *dmi)
+@@ -8743,6 +8918,30 @@ static int __init mlxplat_dmi_l1_switch_matched(const struct dmi_system_id *dmi)
  	return mlxplat_register_platform_device();
  }
  
@@ -254,7 +254,7 @@ index 5796e4695a2a..144ee24c11fd 100644
  static int __init mlxplat_dmi_bf3_comex_default_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -8456,6 +8655,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -8961,6 +9160,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0017"),
  		},
  	},
@@ -269,5 +269,5 @@ index 5796e4695a2a..144ee24c11fd 100644
  		.callback = mlxplat_dmi_xdr_matched,
  		.matches = {
 -- 
-2.20.1
+2.44.0
 

--- a/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -1,4 +1,4 @@
-From 73e37aabcd33e8a1c6a3d1297c86841f51d53df4 Mon Sep 17 00:00:00 2001
+From 02fbaa3ca309b3a319a7e5d40195aec257e74e56 Mon Sep 17 00:00:00 2001
 From: Oleksandr Shamray <oleksandrs@nvidia.com>
 Date: Fri, 11 Oct 2024 11:16:01 +0300
 Subject: [PATCH 3/5] platform: mellanox: Downstream: Introduce support of
@@ -17,11 +17,11 @@ of the all required platform driver.
 Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
 Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 1125 +++++++++++++++++++++++++++---
+ drivers/platform/mellanox/mlx-platform.c | 1125 ++++++++++++++++++++--
  1 file changed, 1038 insertions(+), 87 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index f2af30f..5e67d33 100644
+index ab7951511..0a0d4805a 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -53,6 +53,7 @@
@@ -147,7 +147,7 @@ index f2af30f..5e67d33 100644
  /* Platform hotplug devices */
  static struct i2c_board_info mlxplat_mlxcpld_pwr[] = {
  	{
-@@ -3643,6 +3697,34 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_g3_switch_data = {
+@@ -3666,6 +3720,34 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_g3_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT,
  };
  
@@ -182,7 +182,7 @@ index f2af30f..5e67d33 100644
  static struct spi_board_info rack_switch_switch_spi_board_info[] = {
  	{
  		.modalias       = "spidev",
-@@ -4662,6 +4744,87 @@ static struct mlxreg_core_platform_data mlxplat_xdr_led_data = {
+@@ -4685,6 +4767,87 @@ static struct mlxreg_core_platform_data mlxplat_xdr_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_xdr_led_data),
  };
  
@@ -270,7 +270,7 @@ index f2af30f..5e67d33 100644
  /* Platform register access default */
  static struct mlxreg_core_data mlxplat_mlxcpld_default_regs_io_data[] = {
  	{
-@@ -5079,6 +5242,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -5102,6 +5265,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0644,
  		.secured = 1,
  	},
@@ -283,7 +283,7 @@ index f2af30f..5e67d33 100644
  	{
  		.label = "erot1_recovery",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-@@ -7021,120 +7190,650 @@ static struct mlxreg_core_platform_data mlxplat_smart_switch_regs_io_data = {
+@@ -7044,120 +7213,650 @@ static struct mlxreg_core_platform_data mlxplat_smart_switch_regs_io_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_smart_switch_regs_io_data),
  };
  
@@ -1017,7 +1017,7 @@ index f2af30f..5e67d33 100644
  	},
  	{
  		.label = "tacho13",
-@@ -7442,6 +8141,124 @@ static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
+@@ -7465,6 +8164,124 @@ static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
  		.version = 1,
  };
  
@@ -1142,7 +1142,7 @@ index f2af30f..5e67d33 100644
  /* Watchdog type1: hardware implementation version1
   * (MSN2700, MSN2410, MSN2740, MSN2100 and MSN2140 systems).
   */
-@@ -7677,6 +8494,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7700,6 +8517,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1150,7 +1150,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -7741,6 +8559,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7764,6 +8582,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1159,7 +1159,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
-@@ -7762,6 +8582,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7785,6 +8605,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
@@ -1168,7 +1168,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -7804,6 +8626,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7827,6 +8649,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1176,7 +1176,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -7896,6 +8719,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7919,6 +8742,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1186,7 +1186,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
-@@ -7955,6 +8781,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7978,6 +8804,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
@@ -1196,7 +1196,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -7997,6 +8826,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8020,6 +8849,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1204,7 +1204,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -8087,6 +8917,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8110,6 +8940,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1214,7 +1214,7 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
-@@ -8140,6 +8973,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8163,6 +8996,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
@@ -1224,8 +1224,8 @@ index f2af30f..5e67d33 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -8208,6 +9044,17 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
- 	  MLXPLAT_CPLD_LPC_SM_SW_MASK },
+@@ -8229,6 +9065,17 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
+ 	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
  };
  
 +
@@ -1242,7 +1242,7 @@ index f2af30f..5e67d33 100644
  struct mlxplat_mlxcpld_regmap_context {
  	void __iomem *base;
  };
-@@ -8330,6 +9177,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_smart_switch = {
+@@ -8351,6 +9198,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_smart_switch = {
  	.reg_write = mlxplat_mlxcpld_reg_write,
  };
  
@@ -1263,7 +1263,7 @@ index f2af30f..5e67d33 100644
  /* Wait completion routine for indirect access for register map */
  static int mlxplat_fpga_completion_wait(struct mlxplat_mlxcpld_regmap_context *ctx)
  {
-@@ -8455,6 +9316,8 @@ static struct spi_board_info *mlxplat_spi;
+@@ -8476,6 +9337,8 @@ static struct spi_board_info *mlxplat_spi;
  static struct pci_dev *lpc_bridge;
  static struct pci_dev *i2c_bridge;
  static struct pci_dev *jtag_bridge;
@@ -1272,7 +1272,7 @@ index f2af30f..5e67d33 100644
  
  /* Platform default reset function */
  static int mlxplat_reboot_notifier(struct notifier_block *nb, unsigned long action, void *unused)
-@@ -8487,6 +9350,26 @@ static void mlxplat_poweroff(void)
+@@ -8508,6 +9371,26 @@ static void mlxplat_poweroff(void)
  	kernel_halt();
  }
  
@@ -1299,7 +1299,7 @@ index f2af30f..5e67d33 100644
  static int __init mlxplat_register_platform_device(void)
  {
  	mlxplat_dev = platform_device_register_simple(MLX_PLAT_DEVICE_NAME, -1,
-@@ -8997,6 +9880,40 @@ static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *d
+@@ -9018,6 +9901,40 @@ static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *d
  	return mlxplat_register_platform_device();
  }
  
@@ -1340,10 +1340,11 @@ index f2af30f..5e67d33 100644
  static int __init mlxplat_dmi_ng400_hi171_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -9159,6 +10076,40 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -9179,6 +10096,40 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0019"),
  		},
  	},
- 	{
++	{
 +		.callback = mlxplat_dmi_l1_scale_out_switch_matched,
 +		.matches = {
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0021"),
@@ -1377,11 +1378,10 @@ index f2af30f..5e67d33 100644
 +			DMI_MATCH(DMI_BOARD_NAME, "VMOD0021"),
 +		},
 +	},
-+	{
+ 	{
  		.callback = mlxplat_dmi_ng400_hi171_matched,
  		.matches = {
- 			DMI_MATCH(DMI_BOARD_NAME, "VMOD0022"),
-@@ -9260,8 +10211,8 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9281,8 +10232,8 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  	int i, shift = 0;
  
  	/* Scan adapters from expected id to verify it is free. */
@@ -1392,7 +1392,7 @@ index f2af30f..5e67d33 100644
  	     mlxplat_max_adap_num; i++) {
  		search_adap = i2c_get_adapter(i);
  		if (search_adap) {
-@@ -9270,7 +10221,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9291,7 +10242,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  		}
  
  		/* Return if expected parent adapter is free. */
@@ -1401,7 +1401,7 @@ index f2af30f..5e67d33 100644
  			return 0;
  		break;
  	}
-@@ -9292,7 +10243,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9313,7 +10264,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  	}
  
  	/* Shift bus only if mux provided by 'mlxplat_mux_data'. */
@@ -1411,5 +1411,5 @@ index f2af30f..5e67d33 100644
  
  	return 0;
 -- 
-2.8.4
+2.44.0
 

--- a/recipes-kernel/linux/linux-6.1/9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch
+++ b/recipes-kernel/linux/linux-6.1/9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch
@@ -1,4 +1,4 @@
-From 7ded72c51767be0494ac744b01a8f2ab429bf332 Mon Sep 17 00:00:00 2001
+From 8520e22fbf192a2ae7351b98eab037b684eeb70d Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 13 Jan 2025 12:49:33 +0200
 Subject: platform: mellanox: mlx-platform: Change register 0x28 name
@@ -13,7 +13,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 67fefeb56..e5b3c41b8 100644
+index 0a0d4805a..67d626e10 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -53,7 +53,7 @@
@@ -25,7 +25,7 @@ index 67fefeb56..e5b3c41b8 100644
  #define MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION	0x2a
  #define MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET	0x2b
  #define MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET	0x2d
-@@ -8100,7 +8100,6 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -8517,7 +8517,6 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -33,7 +33,7 @@ index 67fefeb56..e5b3c41b8 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -8232,7 +8231,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8649,7 +8648,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -42,7 +42,7 @@ index 67fefeb56..e5b3c41b8 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -8432,7 +8431,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8849,7 +8848,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:

--- a/recipes-kernel/linux/linux-6.1/9009-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch
+++ b/recipes-kernel/linux/linux-6.1/9009-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch
@@ -1,4 +1,4 @@
-From c5bab86c637b19085a5554710d5a058bc52c61a4 Mon Sep 17 00:00:00 2001
+From 0cfea65c3af019ebe8b5a8e25f6f59f31b9458de Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 13 Jan 2025 17:02:32 +0200
 Subject: platform: mellanox: mlx-platform: Add support for Q3450-LD Nvidia XDR switch
@@ -23,7 +23,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 294 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index a723f9297..ca3376a38 100644
+index 67d626e10..dea0c873a 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -38,6 +38,7 @@
@@ -192,7 +192,7 @@ index a723f9297..ca3376a38 100644
  static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
  	{
  		.label = "pwr1",
-@@ -3697,34 +3828,6 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_g3_switch_data = {
+@@ -3720,34 +3851,6 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_l1_g3_switch_data = {
  	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_LOW | MLXPLAT_CPLD_LOW_AGGR_MASK_PWR_BUT,
  };
  
@@ -227,7 +227,7 @@ index a723f9297..ca3376a38 100644
  static struct spi_board_info rack_switch_switch_spi_board_info[] = {
  	{
  		.modalias       = "spidev",
-@@ -4744,6 +4847,68 @@ static struct mlxreg_core_platform_data mlxplat_xdr_led_data = {
+@@ -4767,6 +4870,68 @@ static struct mlxreg_core_platform_data mlxplat_xdr_led_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_xdr_led_data),
  };
  
@@ -296,7 +296,7 @@ index a723f9297..ca3376a38 100644
  /* Platform led data for L1 scale out switch systems */
  static struct mlxreg_core_data mlxplat_mlxcpld_l1_scale_out_led_data[] = {
  	{
-@@ -5127,6 +5292,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -5150,6 +5315,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -309,7 +309,7 @@ index a723f9297..ca3376a38 100644
  	{
  		.label = "cpld1_pn",
  		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
-@@ -5169,6 +5340,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -5192,6 +5363,13 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0444,
  		.regnum = 2,
  	},
@@ -323,7 +323,7 @@ index a723f9297..ca3376a38 100644
  	{
  		.label = "cpld1_version_min",
  		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
-@@ -5205,6 +5383,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -5228,6 +5406,12 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.bit = GENMASK(7, 0),
  		.mode = 0444,
  	},
@@ -336,7 +336,7 @@ index a723f9297..ca3376a38 100644
  	{
  		.label = "asic_reset",
  		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
-@@ -5242,6 +5426,54 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
+@@ -5265,6 +5449,54 @@ static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
  		.mode = 0644,
  		.secured = 1,
  	},
@@ -391,7 +391,7 @@ index a723f9297..ca3376a38 100644
      {
  		.label = "leakage_status_clear",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-@@ -8598,6 +8830,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8621,6 +8853,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET:
@@ -399,7 +399,7 @@ index a723f9297..ca3376a38 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -8610,6 +8843,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8633,6 +8866,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN1_OFFSET:
@@ -407,7 +407,7 @@ index a723f9297..ca3376a38 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP3_OFFSET:
-@@ -8744,6 +8978,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8767,6 +9001,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
@@ -415,7 +415,7 @@ index a723f9297..ca3376a38 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -8798,6 +9033,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8821,6 +9056,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET:
@@ -423,7 +423,7 @@ index a723f9297..ca3376a38 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -8810,6 +9046,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8833,6 +9069,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN1_OFFSET:
@@ -431,7 +431,7 @@ index a723f9297..ca3376a38 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP3_OFFSET:
-@@ -8936,6 +9173,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8959,6 +9196,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
@@ -439,7 +439,7 @@ index a723f9297..ca3376a38 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -9856,6 +10094,27 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
+@@ -9877,6 +10115,27 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
  	return mlxplat_register_platform_device();
  }
  
@@ -467,7 +467,7 @@ index a723f9297..ca3376a38 100644
  static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -10062,6 +10321,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -10083,6 +10342,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI159"),
  		},
  	},

--- a/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -69,18 +69,19 @@ index ba56485cbe8c..e86723b44c2e 100644
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
 diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
 new file mode 100644
-index 000000000000..f831d6dd5ece
+index 000000000..c6cfbee55
 --- /dev/null
 +++ b/drivers/platform/mellanox/mlxreg-dpu.c
-@@ -0,0 +1,625 @@
+@@ -0,0 +1,626 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia Data Processor Unit platform driver
 + *
-+ * Copyright (C) 2024 Nvidia Technologies Ltd.
++ * Copyright (C) 2025 Nvidia Technologies Ltd.
 + */
 +
 +#include <linux/device.h>
++#include <linux/dev_printk.h>
 +#include <linux/i2c.h>
 +#include <linux/module.h>
 +#include <linux/platform_data/mlxcpld.h>
@@ -240,7 +241,7 @@ index 000000000000..f831d6dd5ece
 +	{
 +		.label = "dpu_id",
 +		.reg = MLXREG_DPU_REG_GP0_RO_OFFSET,
-+		.bit = GENMASK(3, 0),
++		.mask = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -253,7 +254,7 @@ index 000000000000..f831d6dd5ece
 +	{
 +		.label = "boot_progress",
 +		.reg = MLXREG_DPU_REG_GP1_OFFSET,
-+		.bit = GENMASK(3, 0),
++		.mask = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -389,13 +390,14 @@ index 000000000000..f831d6dd5ece
 +	.mask = MLXREG_DPU_AGGR_MASK,
 +};
 +
-+/* mlxreg_dpu - device private data
-+ * @dev: platform device;
-+ * @data: pltaform core data;
-+ * @io_data: register access platform data;
-+ * @io_regs: register access device;
-+ * @hotplug_data: hotplug platform data;
-+ * @hotplug: hotplug device;
++/**
++ * struct mlxreg_dpu - device private data
++ * @dev: platform device
++ * @data: platform core data
++ * @io_data: register access platform data
++ * @io_regs: register access device
++ * @hotplug_data: hotplug platform data
++ * @hotplug: hotplug device
 + */
 +struct mlxreg_dpu {
 +	struct device *dev;
@@ -478,6 +480,11 @@ index 000000000000..f831d6dd5ece
 +	return false;
 +}
 +
++static const struct reg_default mlxreg_dpu_regmap_default[] = {
++        { MLXREG_DPU_REG_PG_EVENT_OFFSET, 0x00 },
++        { MLXREG_DPU_REG_HEALTH_EVENT_OFFSET, 0x00 },
++};
++
 +/* Configuration for the register map of a device with 2 bytes address space. */
 +static const struct regmap_config mlxreg_dpu_regmap_conf = {
 +	.reg_bits = 16,
@@ -487,10 +494,13 @@ index 000000000000..f831d6dd5ece
 +	.writeable_reg = mlxreg_dpu_writeable_reg,
 +	.readable_reg = mlxreg_dpu_readable_reg,
 +	.volatile_reg = mlxreg_dpu_volatile_reg,
++	.reg_defaults = mlxreg_dpu_regmap_default,
++	.num_reg_defaults = ARRAY_SIZE(mlxreg_dpu_regmap_default),
 +};
 +
-+static int mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
-+					struct mlxreg_core_hotplug_platform_data *hotplug_data)
++static int
++mlxreg_dpu_copy_hotplug_data(struct device *dev, struct mlxreg_dpu *mlxreg_dpu,
++			     const struct mlxreg_core_hotplug_platform_data *hotplug_data)
 +{
 +	struct mlxreg_core_item *item;
 +	int i;
@@ -502,18 +512,15 @@ index 000000000000..f831d6dd5ece
 +
 +	mlxreg_dpu->hotplug_data->items = devm_kmemdup(dev, hotplug_data->items,
 +						       mlxreg_dpu->hotplug_data->counter *
-+						       sizeof(*hotplug_data->items),
++						       sizeof(*mlxreg_dpu->hotplug_data->items),
 +						       GFP_KERNEL);
 +	if (!mlxreg_dpu->hotplug_data->items)
 +		return -ENOMEM;
 +
 +	item = mlxreg_dpu->hotplug_data->items;
-+	for (i = 0; i < mlxreg_dpu->hotplug_data->counter; i++, item++) {
-+		item = devm_kmemdup(dev, &hotplug_data->items[i], sizeof(*item), GFP_KERNEL);
-+		if (!item)
-+			return -ENOMEM;
++	for (i = 0; i < hotplug_data->counter; i++, item++) {
 +		item->data = devm_kmemdup(dev, hotplug_data->items[i].data,
-+					  hotplug_data->items[i].count * sizeof(item->data),
++					  hotplug_data->items[i].count * sizeof(*item->data),
 +					  GFP_KERNEL);
 +		if (!item->data)
 +			return -ENOMEM;
@@ -533,6 +540,7 @@ index 000000000000..f831d6dd5ece
 +	err = regmap_read(regmap, MLXREG_DPU_REG_CONFIG3_OFFSET, &regval);
 +	if (err)
 +		return err;
++
 +	switch (regval) {
 +	case MLXREG_DPU_BF3:
 +		/* Copy platform specific hotplug data. */
@@ -552,15 +560,15 @@ index 000000000000..f831d6dd5ece
 +	if (mlxreg_dpu->io_data) {
 +		mlxreg_dpu->io_data->regmap = regmap;
 +		mlxreg_dpu->io_regs =
-+		platform_device_register_resndata(dev, "mlxreg-io", data->slot, NULL, 0,
-+						  mlxreg_dpu->io_data,
-+						  sizeof(*mlxreg_dpu->io_data));
++			platform_device_register_resndata(dev, "mlxreg-io",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->io_data,
++							  sizeof(*mlxreg_dpu->io_data));
 +		if (IS_ERR(mlxreg_dpu->io_regs)) {
 +			dev_err(dev, "Failed to create regio for client %s at bus %d at addr 0x%02x\n",
 +				data->hpdev.brdinfo->type, data->hpdev.nr,
 +				data->hpdev.brdinfo->addr);
-+			err = PTR_ERR(mlxreg_dpu->io_regs);
-+			goto fail_register_io;
++			return PTR_ERR(mlxreg_dpu->io_regs);
 +		}
 +	}
 +
@@ -569,9 +577,10 @@ index 000000000000..f831d6dd5ece
 +		mlxreg_dpu->hotplug_data->regmap = regmap;
 +		mlxreg_dpu->hotplug_data->irq = irq;
 +		mlxreg_dpu->hotplug =
-+		platform_device_register_resndata(dev, "mlxreg-hotplug", data->slot, NULL, 0,
-+						  mlxreg_dpu->hotplug_data,
-+						  sizeof(*mlxreg_dpu->hotplug_data));
++			platform_device_register_resndata(dev, "mlxreg-hotplug",
++							  data->slot, NULL, 0,
++							  mlxreg_dpu->hotplug_data,
++							  sizeof(*mlxreg_dpu->hotplug_data));
 +		if (IS_ERR(mlxreg_dpu->hotplug)) {
 +			err = PTR_ERR(mlxreg_dpu->hotplug);
 +			goto fail_register_hotplug;
@@ -582,16 +591,13 @@ index 000000000000..f831d6dd5ece
 +
 +fail_register_hotplug:
 +	platform_device_unregister(mlxreg_dpu->io_regs);
-+fail_register_io:
 +
 +	return err;
 +}
 +
 +static void mlxreg_dpu_config_exit(struct mlxreg_dpu *mlxreg_dpu)
 +{
-+	/* Unregister hotplug driver. */
 +	platform_device_unregister(mlxreg_dpu->hotplug);
-+	/* Unregister IO access driver. */
 +	platform_device_unregister(mlxreg_dpu->io_regs);
 +}
 +
@@ -606,13 +612,13 @@ index 000000000000..f831d6dd5ece
 +	if (!data || !data->hpdev.brdinfo)
 +		return -EINVAL;
 +
-+	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
-+	if (!mlxreg_dpu)
-+		return -ENOMEM;
-+
 +	data->hpdev.adapter = i2c_get_adapter(data->hpdev.nr);
 +	if (!data->hpdev.adapter)
 +		return -EPROBE_DEFER;
++
++	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
++	if (!mlxreg_dpu)
++		return -ENOMEM;
 +
 +	/* Create device at the top of DPU I2C tree.*/
 +	data->hpdev.client = i2c_new_client_device(data->hpdev.adapter,
@@ -624,8 +630,7 @@ index 000000000000..f831d6dd5ece
 +		goto i2c_new_device_fail;
 +	}
 +
-+	regmap = devm_regmap_init_i2c(data->hpdev.client,
-+				      &mlxreg_dpu_regmap_conf);
++	regmap = devm_regmap_init_i2c(data->hpdev.client, &mlxreg_dpu_regmap_conf);
 +	if (IS_ERR(regmap)) {
 +		dev_err(&pdev->dev, "Failed to create regmap for client %s at bus %d at addr 0x%02x\n",
 +			data->hpdev.brdinfo->type, data->hpdev.nr, data->hpdev.brdinfo->addr);
@@ -647,12 +652,9 @@ index 000000000000..f831d6dd5ece
 +	mlxreg_dpu->dev = &pdev->dev;
 +	platform_set_drvdata(pdev, mlxreg_dpu);
 +
-+	/* Configure DPU. */
 +	err = mlxreg_dpu_config_init(mlxreg_dpu, regmap, data, data->hpdev.brdinfo->irq);
 +	if (err)
 +		goto mlxreg_dpu_config_init_fail;
-+
-+	return err;
 +
 +mlxreg_dpu_config_init_fail:
 +regcache_sync_fail:
@@ -697,7 +699,6 @@ index 000000000000..f831d6dd5ece
 +MODULE_DESCRIPTION("Nvidia Data Processor Unit platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
 +MODULE_ALIAS("platform:mlxreg-dpu");
-+
 -- 
-2.34.1
+2.44.0
 


### PR DESCRIPTION
DPU auxiliary powering can cause interrupt flooding because DPU interrupt handlers are not configured yet, while middle interrupt aggregation register is unmasked by default during initialization. Thus, interrupts are getting through, while handlers are still not fully initialized. Do not unmask aggregation interrupt register at initialization for all DPUs. Instead do it per DPU, when its initialization is done.

This patch also adds the change to clear the DPU event registers.

This commit also does the following:
 - There are patches on mlx-platform.c which are not taken by certain NOSs. This commit rebases the patches and update the patch_status table to avoid build failures.
- Patch rebase to avoid conflicts in mlx-platform.c

Bugs: 4338675