### PR TITLE
hw-mgmt: Increase wait time for testing hwmon object existence for ASIC

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -687,6 +687,9 @@ function restore_i2c_bus_frequency_default()
 			chipup_test_time=5
 		fi
 		;;
+	VMOD0014)
+			chipup_test_time=5
+		;;
 	*)
 		chipup_test_time=2
 		;;


### PR DESCRIPTION
Increase wait time from 2 to 5 seconds for VMOD0014 systems to align it with others SPC1 systems.

Bug: #4368754