### PR TITLE
hw-mgmt: patches: Fix dpu boot_progress attribute

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0040.2205) unstable; urgency=low
+hw-management (1.mlnx.7.0040.2206) unstable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Tue, 21 Mar 2025 11:49:00 +0300
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Wed, 26 Mar 2025 11:49:00 +0300

--- a/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -68,7 +68,7 @@ index d7f4d940c..7d11503dd 100644
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
 diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
 new file mode 100644
-index 000000000..b7685012d
+index 000000000..c6cfbee55
 --- /dev/null
 +++ b/drivers/platform/mellanox/mlxreg-dpu.c
 @@ -0,0 +1,626 @@
@@ -252,7 +252,7 @@ index 000000000..b7685012d
 +	},
 +	{
 +		.label = "boot_progress",
-+		.reg = MLXREG_DPU_REG_GP0_OFFSET,
++		.reg = MLXREG_DPU_REG_GP1_OFFSET,
 +		.mask = GENMASK(3, 0),
 +		.mode = 0444,
 +	},

--- a/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -68,7 +68,7 @@ index ba56485cbe8c..e86723b44c2e 100644
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
 diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
 new file mode 100644
-index 000000000..b7685012d
+index 000000000..c6cfbee55
 --- /dev/null
 +++ b/drivers/platform/mellanox/mlxreg-dpu.c
 @@ -0,0 +1,626 @@
@@ -252,7 +252,7 @@ index 000000000..b7685012d
 +	},
 +	{
 +		.label = "boot_progress",
-+		.reg = MLXREG_DPU_REG_GP0_OFFSET,
++		.reg = MLXREG_DPU_REG_GP1_OFFSET,
 +		.mask = GENMASK(3, 0),
 +		.mode = 0444,
 +	},


### PR DESCRIPTION
Recent rebase has caused an issue with dpu boot_progress register name change. This patch corrects it.
    
Bugs: 4378157
    
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>