### PR TITLE
hw-mgmt: patches: Fix dpu attribute mask

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-hw-management (1.mlnx.7.0040.2206) unstable; urgency=low
+hw-management (1.mlnx.7.0040.2207) unstable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Wed, 26 Mar 2025 11:49:00 +0300
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Fri, 27 Mar 2025 11:49:00 +0300

--- a/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -240,7 +240,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "dpu_id",
 +		.reg = MLXREG_DPU_REG_GP0_RO_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -253,7 +253,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "boot_progress",
 +		.reg = MLXREG_DPU_REG_GP1_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{

--- a/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -240,7 +240,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "dpu_id",
 +		.reg = MLXREG_DPU_REG_GP0_RO_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -253,7 +253,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "boot_progress",
 +		.reg = MLXREG_DPU_REG_GP1_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{


### PR DESCRIPTION
This commit fixes some of the dpu attribute masks.
    
Bugs: 4378157
    
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>