### PR TITLE
hw-mgmt: patches: Fix dpu attribute mask

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -240,7 +240,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "dpu_id",
 +		.reg = MLXREG_DPU_REG_GP0_RO_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -253,7 +253,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "boot_progress",
 +		.reg = MLXREG_DPU_REG_GP1_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{

--- a/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
+++ b/recipes-kernel/linux/linux-6.1/sonic/0091-platform-mellanox-mlxreg-dpu-Add-initial-support-for.patch
@@ -241,7 +241,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "dpu_id",
 +		.reg = MLXREG_DPU_REG_GP0_RO_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{
@@ -254,7 +254,7 @@ index 000000000..c6cfbee55
 +	{
 +		.label = "boot_progress",
 +		.reg = MLXREG_DPU_REG_GP1_OFFSET,
-+		.mask = GENMASK(3, 0),
++		.bit = GENMASK(3, 0),
 +		.mode = 0444,
 +	},
 +	{


### PR DESCRIPTION
This commit fixes some of the dpu attribute masks.

Bugs: 4378157