### PR TITLE
hw-mgmt: Increase fast sysfs T.O (#1661)

### DIFF
--- a/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
@@ -100,7 +100,7 @@ do_start_fast_sysfs_monitor()
     (( ELAPSED += FAST_SYSFS_MONITOR_INTERVAL ))
     done
     log_info "Timeout reached. Not all files were found."
-    exit 1
+    exit 0
 }
 
 do_stop_fast_sysfs_monitor()

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -154,7 +154,7 @@ SYSFS_MONITOR_PID_FILE="/tmp/sysfs_monitor.pid"
 
 # hw-mngmt-fast-sysfs-monitor GLOBALS
 FAST_SYSFS_MONITOR_INTERVAL=1  # 1 seconds
-FAST_SYSFS_MONITOR_TIMEOUT=120   # 2 minutes
+FAST_SYSFS_MONITOR_TIMEOUT=300   # 5 minutes
 FAST_SYSFS_MONITOR_LABELS_JSON="/etc/hw-management-fast-sysfs-monitor/fast_sysfs_labels.json"
 FAST_SYSFS_MONITOR_PID_FILE="/tmp/fast_sysfs_monitor.pid"
 FAST_SYSFS_MONITOR_RDY_FILE=$hw_management_path/fast_sysfs_labels_rdy


### PR DESCRIPTION
Increase fast sysfs T.O for supporting lower end systems. Exit with warning in case of T.O