### PR TITLE
hw-mgmt: sysvinit files

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.init
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.init
@@ -31,6 +31,20 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+### BEGIN INIT INFO
+# Provides: hw-management-fast-sysfs-monitor
+# Required-Start: $local_fs $remote_fs $syslog
+# Required-Stop: $local_fs $remote_fs $syslog
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: <HW management Fast Lables Monitor>
+# Description: <Monitors Fast hardware label changes in sysfs>
+### END INIT INFO
+# Available options:
+# start	- start monitoring fast sysfs lables creation.
+# stop	- stop monitoring fast sysfs lables creation.
+#
+
 . /lib/lsb/init-functions
 
 EXECUTABLE=hw-management-fast-sysfs-monitor.sh

--- a/debian/hw-management.hw-management-sysfs-monitor.init
+++ b/debian/hw-management.hw-management-sysfs-monitor.init
@@ -31,6 +31,20 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+### BEGIN INIT INFO
+# Provides: hw-management-sysfs-monitor
+# Required-Start: hw-management
+# Required-Stop: hw-management
+# Default-Start: 2 3 4 5
+# Default-Stop: 0 1 6
+# Short-Description: <HW management Lables Monitor>
+# Description: <Monitors hardware label changes in sysfs>
+### END INIT INFO
+# Available options:
+# start	- start monitoring sysfs lables creation.
+# stop	- stop monitoring sysfs lables creation.
+#
+
 . /lib/lsb/init-functions
 
 EXECUTABLE=hw-management-sysfs-monitor.sh

--- a/debian/hw-management.hw-management.init
+++ b/debian/hw-management.hw-management.init
@@ -33,8 +33,8 @@
 
 ### BEGIN INIT INFO
 # Provides: hw-management
-# Required-Start: $local_fs $remote_fs $syslog
-# Required-Stop: $local_fs $remote_fs $syslog
+# Required-Start: $local_fs $remote_fs $syslog hw-management-fast-sysfs-monitor
+# Required-Stop: $local_fs $remote_fs $syslog hw-management-fast-sysfs-monitor
 # Default-Start: 2 3 4 5
 # Default-Stop:  0 1 6
 # Short-Description: <Chassis Hardware management of Mellanox systems>


### PR DESCRIPTION
Added lsb block header for older systems with sysvinit support, in sysfs monitor init files.