### PR TITLE
hw-management: fast sysfs monitor

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1249,8 +1249,10 @@ if [ "$1" == "add" ]; then
 		fi
 		drv_name=$(< "$busdir"/name)
 		if [[ $drv_name == *"24c"* ]]; then
-			ln -sf "$3""$4"/eeprom $eeprom_path/$eeprom_name 2>/dev/null
-			chmod 400 $eeprom_path/$eeprom_name 2>/dev/null
+			if [ ! -L "$eeprom_path/$eeprom_name" ]; then
+				check_n_link "$3""$4"/eeprom $eeprom_path/$eeprom_name 2>/dev/null
+				chmod 400 $eeprom_path/$eeprom_name 2>/dev/null
+			fi
 		else
 			return
 		fi

--- a/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
@@ -72,10 +72,12 @@ do_start_fast_sysfs_monitor()
             file_name=${DEVTREE_ENTRIES[i+3]}
             # Check if file_name is in monitored devices and also hasn't been added yet.
             if [[ " ${DEV_FILES[@]} " =~ " $file_name " && -z "${DEVICE_ADDED[$file_name]}" ]]; then
-                log_info "Adding device: $driver_name $address $bus $file_name"
-                echo "$driver_name $address" > "/sys/bus/i2c/devices/i2c-$bus/new_device"
-                sleep 1 # Let the filesystem relax.
-                DEVICE_ADDED[$file_name]=1
+                if [ ! -d /sys/bus/i2c/devices/$bus-00"${address#0x}" ] && [ ! -d /sys/bus/i2c/devices/$bus-000"${address#0x}" ]; then
+                    log_info "Adding device: $driver_name $address $bus $file_name"
+                    echo "$driver_name $address" > "/sys/bus/i2c/devices/i2c-$bus/new_device"
+                    sleep 1 # Let the filesystem relax.
+                    DEVICE_ADDED[$file_name]=1
+                fi
             fi
         done
     fi


### PR DESCRIPTION
Add protection in case race condition between
hw-management service and fast-sysfs service.

Bug: 4406920