### PR TITLE
hw-management: sysfs systemd services

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -9,7 +9,6 @@ StartLimitBurst=5
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw-management-fast-sysfs-monitor.sh start"
 ExecStop=/bin/sh -c "/usr/bin/hw-management-fast-sysfs-monitor.sh stop"
-TimeoutStopSec=1
 
 Restart=on-failure
 RestartSec=60s

--- a/debian/hw-management.hw-management-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-sysfs-monitor.service
@@ -10,7 +10,6 @@ StartLimitBurst=5
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw-management-sysfs-monitor.sh start"
 ExecStop=/bin/sh -c "/usr/bin/hw-management-sysfs-monitor.sh stop"
-TimeoutStopSec=1
 
 Restart=on-failure
 RestartSec=60s


### PR DESCRIPTION
Remove TimeoutStopSec=1.
Timeout will be handled by systemd default.

Bug: 4406833