### PR TITLE
hw-mgmt: thermal: Fix q3200_ra/q3400_ra name in thermal config

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_q3200.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3200.json
@@ -1,5 +1,5 @@
  {
-	"name": "q3200",
+	"name": "q3200/q3200_ra",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {

--- a/usr/etc/hw-management-thermal/tc_config_q3400.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3400.json
@@ -1,5 +1,5 @@
  {
-	"name": "q3400",
+	"name": "q3400/q3400_ra",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {


### PR DESCRIPTION
Fix q3200_ra/q3400_ra name in thermal config.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
