### PR TITLE
hw-mgmt: service: Fix deadlock for hw-gmgt <-> TC sevice start on SIMX

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -303,6 +303,18 @@ check_simx()
 	fi
 }
 
+# This function checks if ThermalControl supports current platform
+check_tc_support()
+{
+    sys_sku=$(<$sku_file)
+    if ([ "$sys_sku" = "HI166" ] ||
+        [ "$sys_sku" = "HI167" ]); then
+        return 1
+    else
+        return 0
+    fi
+}
+
 # This function create or cleans sysfs monitor helper files.
 init_sysfs_monitor_timestamp_files()
 {

--- a/usr/usr/bin/hw-management-ready.sh
+++ b/usr/usr/bin/hw-management-ready.sh
@@ -53,27 +53,6 @@ if [ -d /var/run/hw-management ]; then
 	rm -fr /var/run/hw-management
 fi
 
-# If the BSP emulation is not available for the platforms that run in the SimX
-# environment, TC need to be stopped. Otherwise enabling TC.
-if check_simx; then
-    if ! check_if_simx_supported_platform; then
-	    if systemctl is-enabled --quiet hw-management-tc; then
-		    echo "Stopping and disabling hw-management-tc on SimX"
-		    systemctl stop hw-management-tc
-		    systemctl disable hw-management-tc
-	    fi
-	    echo "Start Chassis HW management service."
-	    logger -t hw-management -p daemon.notice "Start Chassis HW management service."
-	    exit 0
-    else
-	    if ! systemctl is-enabled --quiet hw-management-tc; then
-		    echo "Enabling and starting hw-management-tc"
-		    systemctl enable hw-management-tc
-		    systemctl start hw-management-tc
-	    fi
-    fi
-fi
-
 case $board_type in
 VMOD0014)
 	if [ ! -d /sys/devices/pci0000:00/0000:00:1f.0/NVSN2201:00/mlxreg-hotplug/hwmon ]; then

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -126,15 +126,33 @@ if [ -f $service_file_path ]; then
 	fi
 fi
 
+# If the BSP emulation is not available for the platforms that run in the SimX
+# environment, TC need to be stopped. Otherwise enabling TC.
+if check_simx; then
+    if ! check_if_simx_supported_platform; then
+	    if systemctl is-enabled --quiet hw-management-tc; then
+		    echo "Stopping and disabling hw-management-tc on SimX"
+		    systemctl stop hw-management-tc
+		    systemctl disable hw-management-tc
+	    fi
+	    echo "Start Chassis HW management service."
+	    logger -t hw-management -p daemon.notice "Start Chassis HW management service."
+	    exit 0
+    else
+	    if ! systemctl is-enabled --quiet hw-management-tc; then
+		    echo "Enabling and starting hw-management-tc"
+		    if check_tc_support; then
+			    systemctl enable hw-management-tc
+			    nohup systemctl start hw-management-tc &
+			fi
+	    fi
+    fi
+fi
+
 ## Checking if system doesn't require TC
-case $sku in
-	HI176|HI177)
-		# disable TC
-		log_info "Disabe Thermal Control for this system: $sku"
-		systemctl stop hw-management-tc.service
-		systemctl disable hw-management-tc.service  
-		;;
-	*)
-		# Do nothing
-esac
+if ! check_tc_support; then
+	log_info "Disabe Thermal Control for current platform: $sku"
+	systemctl stop hw-management-tc.service
+	systemctl disable hw-management-tc.service  
+fi
 


### PR DESCRIPTION
On SIMX, hw-mgmt tries to start the TC service during initialization. However, the TC service has a strong dependency:
Requires=hw-management.service. This means the TC service cannot start before hw-mgmt starts. But hw-mgmt attempts to start TC earlier. In this case, neither hw-mgmt nor TC will complete initialization.

This commit resolves this deadlock by postponing the start of the TC service.

Bug: 4427090