### PR TITLE
hw-mgmt: service: Define the type sysfs monitor services as oneshot

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -7,6 +7,7 @@ StartLimitIntervalSec=1200
 StartLimitBurst=5
 
 [Service]
+Type=oneshot
 ExecStart=/bin/sh -c "/usr/bin/hw-management-fast-sysfs-monitor.sh start"
 ExecStop=/bin/sh -c "/usr/bin/hw-management-fast-sysfs-monitor.sh stop"
 

--- a/debian/hw-management.hw-management-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-sysfs-monitor.service
@@ -8,6 +8,7 @@ StartLimitIntervalSec=1200
 StartLimitBurst=5
 
 [Service]
+Type=oneshot
 ExecStart=/bin/sh -c "/usr/bin/hw-management-sysfs-monitor.sh start"
 ExecStop=/bin/sh -c "/usr/bin/hw-management-sysfs-monitor.sh stop"
 


### PR DESCRIPTION
Without oneshot definition Sonic service monitor shows the service status as "Down"

Bug: 4389689