### PR TITLE
hw-mgmt: sensors: Fix MP2891 current labels for SN5610/SN5640

### DIFF
--- a/usr/etc/hw-management-sensors/sn5640_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5640_sensors.conf
@@ -357,8 +357,8 @@ chip "mp2891-i2c-*-6e"
     label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    label curr2    "PMIC-11 DVDD_M Rail Curr (out1)"
+    label curr3    "PMIC-11 VDDSCC Rail Curr (out2)"
     ignore curr4
     ignore curr5
     ignore curr6
@@ -372,8 +372,8 @@ chip "xdpe1a2g7-i2c-*-6e"
     label power2   "PMIC-11 VDDSCC Rail Pwr (out1)"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
-    label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    label curr2    "PMIC-11 DVDD_M Rail Curr (out1)"
+    label curr3    "PMIC-11 VDDSCC Rail Curr (out2)"
     ignore curr4
     ignore curr5
     ignore curr6


### PR DESCRIPTION
The current labels for MP2891 VR at I2C address 0x6E are swapped between VDDSCC and DVDD_M rails, which results in incorrect current reporting.

Bug: 4404746