### PR TITLE
hw-mgmt: service: Fix dependencies of hw-mgmt fast sysfs monitor service

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=HW management Fast Lables Monitor
-Before=hw-management.service
+After=hw-management.service
+Requires=hw-management.service
 PartOf=hw-management.service
 
 StartLimitIntervalSec=1200


### PR DESCRIPTION
The service depends of directory structure created by hw-mgmt service and should start running after hw-mgmt service.

Bug: 4439383