### PR TITLE
hw-mgmt: service: Fix dependency of hw-mgmt-fast-sysfs-monitor service

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=HW management Fast Lables Monitor
-Before=hw-management.service
-PartOf=hw-management.service
 
 StartLimitIntervalSec=1200
 StartLimitBurst=5

--- a/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
@@ -61,7 +61,7 @@ do_start_fast_sysfs_monitor()
     log_info "Monitoring ${TOTAL_FILES} files..."
     while (( ELAPSED < FAST_SYSFS_MONITOR_TIMEOUT )); do
     # Check and add missing devices from devtree_file.
-    if [ -e "$devtree_file" ] && [[ ${#DEVICE_ADDED[@]} -lt ${#DEV_FILES[@]} ]]; then
+    if [ -e "$devtree_file" ] && [ -d "$eeprom_path" ] && [[ ${#DEVICE_ADDED[@]} -lt ${#DEV_FILES[@]} ]]; then
         # Read the entire content into an array (space-separated tokens).
         read -ra DEVTREE_ENTRIES < "$devtree_file"
         # Process every 4 tokens as one device entry


### PR DESCRIPTION
Since this service is a 'oneshot' type service,
Remove dependency with hw-management main service. Also add protection in case directory structure
is not ready.

Bug: 4439383