### PR TITLE
hw-mgmt: scripts: Add attribute with SED PBA version.

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -120,6 +120,7 @@ chipup_retry_count=3
 fan_speed_tolerance=15
 minimal_unsupported=0
 dummy_psus_supported=0
+sed_pba_guid=0d1d8ac9-9958-4e34-aae6-5236e3232bb5
 
 mctp_bus=""
 mctp_addr=""
@@ -3344,6 +3345,25 @@ map_dummy_psus()
 	done
 }
 
+report_sed_pba_ver()
+{
+    if command -v sedutil-cli &> /dev/null; then
+        if sedutil-cli --query /dev/nvme0 | grep -q "MBREnabled = Y"; then
+            if [ -f /sys/firmware/efi/efivars/SedPbaVer-"$sed_pba_guid" ]; then
+                sed_pba_ver=$(efivar -p -n "$sed_pba_guid"-SedPbaVer | \
+                awk '/Value:/ {found=1; next} found {split($0, a, "|"); split(a[2], b, " "); print b[1]; found=0}')
+            else
+                sed_pba_ver="N/A"
+            fi
+        else
+            sed_pba_ver="N/A"
+        fi
+    else
+        sed_pba_ver="N/A"
+    fi
+    echo "$sed_pba_ver" > "$system_path"/sed_pba_ver
+}
+
 do_start()
 {
 	init_sysfs_monitor_timestamp_files
@@ -3383,6 +3403,7 @@ do_start()
 	if [ -f $config_path/max_tachos ]; then
 		max_tachos=$(<$config_path/max_tachos)
 	fi
+	report_sed_pba_ver
 
 	if [ -v "lm_sensors_config_lc" ] && [ -f $lm_sensors_config_lc ]; then
 		ln -sf $lm_sensors_config_lc $config_path/lm_sensors_config_lc


### PR DESCRIPTION
New SED PBA, versions 83.01.0008 and up, reports version through EFI variable.
If applicable hw-management reads this ERFI variable and report to NOS.

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
