### PR TITLE
hw-mgmt: thermal: Fix TC service disable on system start

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -304,15 +304,14 @@ check_simx()
 }
 
 # This function checks if ThermalControl supports current platform
-check_tc_support()
+# Returns 1 if TC is supported, 0 otherwise.
+check_tc_is_supported()
 {
-    sys_sku=$(<$sku_file)
-    if ([ "$sys_sku" = "HI166" ] ||
-        [ "$sys_sku" = "HI167" ]); then
-        return 1
-    else
-        return 0
-    fi
+	if grep -q '"platform_support" : 0' $config_path/tc_config.json; then
+		return 1
+	else
+		return 0
+	fi
 }
 
 # This function create or cleans sysfs monitor helper files.

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -150,7 +150,8 @@ if check_simx; then
 fi
 
 ## Checking if system doesn't require TC
-if ! check_tc_support; then
+check_tc_is_supported
+if [ $? -eq 0 ]; then
 	log_info "Disabe Thermal Control for current platform: $sku"
 	systemctl stop hw-management-tc.service
 	systemctl disable hw-management-tc.service  


### PR DESCRIPTION
By mistake we had "reversed logic" for disabling ThermalControl
on systems without TC support.

Bug: 4466832

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
