### PR TITLE
hw-mgmgt: scripts: Add cpld registers dump on system start

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -175,6 +175,20 @@ trace_udev_events()
 	return 0
 }
 
+show_hw_info()
+{
+	arch=$(uname -m)
+	if [ "$arch" = "aarch64" ]; then
+		CPLD_IOREG_RANGE=512
+	else
+		CPLD_IOREG_RANGE=256
+	fi
+
+	log_info "== cpld reg dump start =="
+    iorw -b 0x2500 -r -l $CPLD_IOREG_RANGE | expand | logger
+	log_info "== cpld reg dump end =="
+}
+
 check_cpu_type()
 {
 	if [ ! -f $config_path/cpu_type ]; then

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3346,6 +3346,7 @@ map_dummy_psus()
 
 do_start()
 {
+	show_hw_info
 	init_sysfs_monitor_timestamp_files
 	create_symbolic_links
 	check_cpu_type


### PR DESCRIPTION
Add cpld registers dump on system start. Dump will be
saved in the system 'syslog' logfile.

FR: 4458180

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
