### PR TITLE
hw-mgmgt: script: Fix asic temp sync

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -549,10 +549,6 @@ def asic_temp_populate(arg_list, arg):
         if os.path.islink(f_dst_name):
             continue
 
-        # If independent mode - skip temperature reading
-        if is_module_host_management_mode(os.path.join(f_asic_src_path, "module0")):
-            continue
-
         # Default temperature values
         try:
             f_src_input = os.path.join(f_asic_src_path, "temperature/input")


### PR DESCRIPTION
Fix asic temp sync for systems with minimal disabled.
ASIC temperature sync should be updated independent of SDK mode.

Bug: 4463009

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
