### PR TITLE
hw-mgmt: scripts: Fix the check for usb0 interface configuration

### DIFF
--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -42,7 +42,7 @@ fi
 
 if [ ! -e /sys/class/net/${INTERFACE} ] ||
    [ ! -e /etc/network/interfaces ] ||
-   ! grep -q ${INTERFACE} /etc/network/interfaces; then
+   ! ifquery -l --allow=hotplug | grep -q ${INTERFACE}; then
 	exit 0
 fi
 


### PR DESCRIPTION
The check in hw-management-ifupdown.sh that usb0 configuration is present in /etc/network/interfaces is not robust enough. The NOS may decide to keep usb0 configuration in a different file included by /etc/network/interfaces. In that case usb0 configuration will fail. Use ifquery tool to perform the check, as it covers /etc/network/interfaces and all files it includes.

Bug: 4472264