### PR TITLE
hw-mgmt: thermal: Fix code syntax issue in TC

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -3739,7 +3739,7 @@ class ThermalManagement(hw_management_file_op):
                 module_name = "module{}".format(idx)
                 if self.check_file("thermal/{}_temp_input".format(module_name)):
                     # check if module is TEC-cooled
-                    if TEC_SUPPORT_ENABLED
+                    if TEC_SUPPORT_ENABLED:
                         if self.check_file("thermal/{}_cooling_level".format(module_name)):
                             self._sensor_add_config("thermal_module_tec_sensor", module_name + "_tec", {"base_file_name": module_name})
                             module_name = module_name + "_tec"


### PR DESCRIPTION
Fix code syntax issue in TC. Missing ':' symbol

Bug: 4474282

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
