### PR TITLE
hw-mgmt: thermal: add moduleX_status which show same as exposed by the SDK

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -696,7 +696,8 @@ def module_temp_populate(arg_list, _dummy):
             "_temp_fault": temperature_fault,
             "_temp_trip_crit": temperature_trip_crit,
             "_cooling_level_input": cooling_level_input,
-            "_max_cooling_level_input": max_cooling_level_input
+            "_max_cooling_level_input": max_cooling_level_input,
+            "_status": module_present
         }
 
         for suffix, value in file_paths.items():


### PR DESCRIPTION
add moduleX_status which will show module status same as exposed by the
SDK: /sys/module/sx_core/asic0/moduleX/present

FR: 4458339

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
