### PR TITLE
hw-mgmgt: scripts: Fix FAN debounce function error

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -472,6 +472,7 @@ function set_fan_direction()
 			return
 		fi
 		fan_debounce_counter=0
+		fan_dir_old=2
 		fan_debounce_timer=$fan_debounce_timeout_ms
 		# debounce timeout for FAN dir. 2 times in a row read same value or delay > fan_debounce_timer.
 		while (("$fan_debounce_timer" > 0)) && (("$fan_debounce_counter" < 2))


### PR DESCRIPTION
Error on run hw-management-chassis-events.sh hotplug-event FAN1 0

/usr/bin/hw-management-chassis-events.sh: line 480: [: 63: unary
operator expected

These error belong to FAN debounce function. It happens because
fan_dir_old variable was not initialized.

Fix: initialize fan_dir_old variable

Bug: 4486154

Signed-off-byr Oleksandr Shamray <oleksandrs@nvidia.com>
