### PR TITLE
hw-mgmgt: thermal: Fix FAN min/max speed settings

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -405,12 +405,13 @@ if [ "$1" == "add" ]; then
 						check_n_link "$3""$4"/fan"$i"_input "$tpath"/fan"$j"_speed_get
 						check_n_link "$3""$4"/pwm1 "$tpath"/fan"$j"_speed_set
 						check_n_link "$3""$4"/fan"$i"_fault "$tpath"/fan"$j"_fault
-						check_n_link "$cpath"/fan_min_speed "$tpath"/fan"$j"_min
-						check_n_link "$cpath"/fan_max_speed "$tpath"/fan"$j"_max
 						ln -sf "$cpath"/fan_speed_tolerance "$tpath"/fan"$j"_speed_tolerance
 						# Save max_tachos to config
 						echo $i > "$cpath"/max_tachos
 					fi
+				done
+				for ((i=1; i<=$(<$config_path/max_tachos); i+=1)); do
+					set_fan_speed_limits fan"$i"
 				done
 			fi
 
@@ -512,12 +513,13 @@ if [ "$1" == "add" ]; then
 				check_n_link "$3""$4"/fan"$i"_input $thermal_path/fan"$j"_speed_get
 				check_n_link "$3""$4"/pwm1 $thermal_path/fan"$j"_speed_set
 				check_n_link "$3""$4"/fan"$i"_fault $thermal_path/fan"$j"_fault
-				check_n_link $config_path/fan_min_speed $thermal_path/fan"$j"_min
-				check_n_link $config_path/fan_max_speed $thermal_path/fan"$j"_max
 				check_n_link $config_path/fan_speed_tolerance $thermal_path/fan"$j"_speed_tolerance
 				# Save max_tachos to config.
 				echo $i > $config_path/max_tachos
 			fi
+		done
+		for ((i=1; i<=$(<$config_path/max_tachos); i+=1)); do
+			set_fan_speed_limits fan"$i"
 		done
 	fi
 	if [ "$2" == "thermal_zone" ]; then

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1264,8 +1264,10 @@ msn27xx_msb_msx_specific()
 		*)
 			max_tachos=8
 			hotplug_fans=4
-			echo 25000 > $config_path/fan_max_speed
-			echo 1500 > $config_path/fan_min_speed
+			echo 21000 > $config_path/fan_front_max_speed
+			echo 6300 > $config_path/fan_front_min_speed
+			echo 18000 > $config_path/fan_rear_max_speed
+			echo 5400 > $config_path/fan_rear_min_speed
 			echo 18000 > $config_path/psu_fan_max
 			echo 2000 > $config_path/psu_fan_min
 			echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
@@ -1379,8 +1381,10 @@ mqmxxx_msn37x_msn34x_specific()
 	add_cpu_board_to_connection_table
 
 	max_tachos=12
-	echo 25000 > $config_path/fan_max_speed
-	echo 4500 > $config_path/fan_min_speed
+	echo 23000 > $config_path/fan_front_max_speed
+	echo 5400 > $config_path/fan_front_min_speed
+	echo 20500 > $config_path/fan_rear_max_speed
+	echo 4800 > $config_path/fan_rear_min_speed
 	echo 25000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num


### PR DESCRIPTION
For system FANs we have attributes fanX_min/fanX_max which show FAN
max/min speed. But for systems with 2 FANs in drawer speeds are differ
for front/rear fan.

Curent limits didn't take this specific into account and values are
the same for rear/front fans. It cause issue when FAN real
maximum and fanX_max in attribute have > 10% diff.

To fix it should be used separate configuration for for Front/Rear fan

Bug: 4468363

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
