### PR TITLE
hw-mgmt: scripts: Fix module temperature sync conflict in SW mode

### DIFF
--- a/unittest/hw_mgmgt_sync/module_populate/README_tests.md
+++ b/unittest/hw_mgmgt_sync/module_populate/README_tests.md
@@ -1,0 +1,120 @@
+# Unit Tests for module_temp_populate Function
+
+This directory contains comprehensive unit tests for the `module_temp_populate` function from `hw_management_sync.py`.
+
+## Features
+
+- **Path-agnostic**: Tests can be run from any directory
+- **Randomized testing**: Each test run uses random module configurations (present/mode states)
+- **Comprehensive coverage**: Tests all scenarios:
+  - SDK_SW_CONTROL mode (should skip processing)
+  - SDK_FW_CONTROL mode with present modules (should write actual values)
+  - SDK_FW_CONTROL mode with absent modules (should write zeros)
+- **Mock file system**: Uses temporary directories to avoid affecting real system files
+- **Detailed verification**: Checks file creation, content, and proper temperature calculations
+
+## Test Scenarios
+
+### Module Configuration Parameters
+- **module_count**: 5 modules (as requested)
+- **present**: Randomly set to 0 (absent) or 1 (present) for each module
+- **mode**: Randomly set to:
+  - `CONST.SDK_FW_CONTROL` (0) - Firmware control mode
+  - `CONST.SDK_SW_CONTROL` (1) - Software control mode
+
+### Expected Behavior Testing
+
+1. **SDK_SW_CONTROL mode**: 
+   - No files should be created in `/var/run/hw-management/thermal/`
+   - Function should skip processing these modules
+
+2. **SDK_FW_CONTROL mode + present=0**:
+   - Files should be created with zero values:
+     - `module{X}_temp_input` = "0"
+     - `module{X}_temp_crit` = "0"
+     - `module{X}_temp_emergency` = "0"
+     - `module{X}_temp_fault` = "0"
+     - `module{X}_temp_trip_crit` = "0"
+
+3. **SDK_FW_CONTROL mode + present=1**:
+   - Files should be created with actual temperature values:
+     - `module{X}_temp_input` = calculated temperature using `sdk_temp2degree()`
+     - `module{X}_temp_crit` = calculated critical temperature
+     - `module{X}_temp_emergency` = critical + 10000 (EMERGENCY_OFFSET)
+     - `module{X}_temp_fault` = "0"
+     - `module{X}_temp_trip_crit` = "120000" (CONST.MODULE_TEMP_CRIT_DEF)
+
+## Usage
+
+### Method 1: Using the shell script (Recommended)
+```bash
+./run_tests.sh <path_to_hw_management_sync.py> [--verbose]
+```
+
+**Examples:**
+```bash
+# Run tests with relative path
+./run_tests.sh ./hw_management_sync.py
+
+# Run tests with absolute path and verbose output
+./run_tests.sh /full/path/to/hw_management_sync.py --verbose
+
+# From any directory
+/path/to/tests/run_tests.sh /path/to/hw_management_sync.py
+```
+
+### Method 2: Direct Python execution
+```bash
+python3 test_module_temp_populate.py <path_to_hw_management_sync.py> [--verbose]
+```
+
+## Test Output
+
+The tests will show:
+- Random module configurations generated for each test run
+- Verification of file creation/non-creation based on module modes
+- Verification of file contents (zeros vs actual values)
+- Temperature calculation verification
+- Module counter file verification
+
+### Sample Output
+```
+Testing hw_management_sync.py from: /path/to/hw_management_sync.py
+======================================================================
+Module 1: present=1, mode=0, temp=25, threshold=70
+Module 2: present=0, mode=0, temp=30, threshold=75
+Module 3: present=1, mode=1, temp=35, threshold=80
+Module 4: present=0, mode=1, temp=40, threshold=85
+Module 5: present=1, mode=0, temp=45, threshold=90
+======================================================================
+✓ Module module1: FW control, present - actual values (temp=3125, crit=8750)
+✓ Module module2: FW control, not present - zero values
+✓ Module module3: SW control mode - no files created
+✓ Module module4: SW control mode - no files created
+✓ Module module5: FW control, present - actual values (temp=5625, crit=11250)
+✓ Module counter file verified
+.
+----------------------------------------------------------------------
+Ran 1 test in 0.XXXs
+
+OK
+```
+
+## Files
+
+- `test_module_temp_populate.py`: Main test file with comprehensive test cases
+- `run_tests.sh`: Shell script wrapper for easy test execution
+- `README_tests.md`: This documentation file
+
+## Requirements
+
+- Python 3.x
+- Standard Python libraries (unittest, tempfile, random, etc.)
+- The `hw_management_sync.py` file being tested
+
+## Notes
+
+- Tests use mocking to avoid requiring actual hardware or system files
+- Each test run generates different random configurations for thorough testing
+- Temporary directories are automatically cleaned up after tests
+- Tests are designed to be completely isolated from the real file system 

--- a/unittest/hw_mgmgt_sync/module_populate/run_all_tests.py
+++ b/unittest/hw_mgmgt_sync/module_populate/run_all_tests.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test runner for module_temp_populate function
+Works without unittest dependencies - compatible with Python 3.6+
+"""
+
+import sys
+import os
+import tempfile
+import shutil
+import random
+import argparse
+
+def setup_import_path(hw_mgmt_path=None):
+    """Setup import path for hw_management_sync module"""
+    if hw_mgmt_path:
+        if os.path.isfile(hw_mgmt_path):
+            hw_mgmt_dir = os.path.dirname(os.path.abspath(hw_mgmt_path))
+        else:
+            hw_mgmt_dir = os.path.abspath(hw_mgmt_path)
+    else:
+        # Auto-detect
+        if os.path.exists('./hw_management_sync.py'):
+            hw_mgmt_dir = '.'
+        elif os.path.exists('./bin/hw_management_sync.py'):
+            hw_mgmt_dir = './bin'
+        else:
+            raise FileNotFoundError("Cannot find hw_management_sync.py")
+    
+    hw_mgmt_dir = os.path.abspath(hw_mgmt_dir)
+    if hw_mgmt_dir not in sys.path:
+        sys.path.insert(0, hw_mgmt_dir)
+    return hw_mgmt_dir
+
+def test_basic_functionality():
+    """Test basic function imports and constants"""
+    print("🧪 Testing basic functionality...")
+    
+    try:
+        from hw_management_sync import CONST, sdk_temp2degree, module_temp_populate
+        
+        # Test constants
+        assert CONST.SDK_FW_CONTROL == 0, f"SDK_FW_CONTROL should be 0, got {CONST.SDK_FW_CONTROL}"
+        assert CONST.SDK_SW_CONTROL == 1, f"SDK_SW_CONTROL should be 1, got {CONST.SDK_SW_CONTROL}"
+        print("✅ Constants test PASSED")
+        
+        # Test function existence
+        assert callable(module_temp_populate), "module_temp_populate should be callable"
+        assert callable(sdk_temp2degree), "sdk_temp2degree should be callable"
+        print("✅ Function existence test PASSED")
+        
+        return True
+    except Exception as e:
+        print(f"❌ Basic functionality test FAILED: {e}")
+        return False
+
+def test_temperature_conversion():
+    """Test sdk_temp2degree function with various inputs"""
+    print("🧪 Testing temperature conversion...")
+    
+    try:
+        from hw_management_sync import sdk_temp2degree
+        
+        test_cases = [
+            (0, 0, "Zero temperature"),
+            (25, 3125, "Normal positive temperature"),
+            (-10, 0xffff + (-10) + 1, "Normal negative temperature"), 
+        ]
+        
+        passed = 0
+        total = len(test_cases)
+        
+        for input_temp, expected, description in test_cases:
+            result = sdk_temp2degree(input_temp)
+            if result == expected:
+                print(f"  ✅ {description}: sdk_temp2degree({input_temp}) = {result}")
+                passed += 1
+            else:
+                print(f"  ❌ {description}: sdk_temp2degree({input_temp}) = {result}, expected {expected}")
+        
+        if passed == total:
+            print(f"✅ Temperature conversion test PASSED ({passed}/{total})")
+            return True
+        else:
+            print(f"❌ Temperature conversion test FAILED ({passed}/{total})")
+            return False
+            
+    except Exception as e:
+        print(f"❌ Temperature conversion test FAILED: {e}")
+        return False
+
+def test_random_module_states():
+    """Test with randomized module states as requested"""
+    print("🧪 Testing random module states (5 modules as requested)...")
+    
+    try:
+        from hw_management_sync import CONST
+        
+        # Generate 5 random module states as requested
+        random.seed(42)  # For reproducible results
+        module_states = []
+        
+        for i in range(5):
+            state = {
+                'present': random.choice([0, 1]),
+                'mode': random.choice([CONST.SDK_FW_CONTROL, CONST.SDK_SW_CONTROL]),
+                'temperature': random.randint(-50, 50),
+                'threshold_hi': random.randint(60, 80)
+            }
+            module_states.append(state)
+            
+            mode_str = "SDK_SW_CONTROL" if state['mode'] == CONST.SDK_SW_CONTROL else "SDK_FW_CONTROL"
+            present_str = "Present" if state['present'] else "Not Present"
+            print(f"  Module {i+1}: {mode_str}, {present_str}, Temp={state['temperature']}")
+        
+        # Test the logic expectations
+        fw_control_count = sum(1 for state in module_states if state['mode'] == CONST.SDK_FW_CONTROL)
+        sw_control_count = sum(1 for state in module_states if state['mode'] == CONST.SDK_SW_CONTROL)
+        present_count = sum(1 for state in module_states if state['present'] == 1)
+        
+        print(f"  📊 Summary: {fw_control_count} FW control, {sw_control_count} SW control, {present_count} present")
+        print("✅ Random module states test PASSED")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Random module states test FAILED: {e}")
+        return False
+
+def test_folder_agnostic_functionality(hw_mgmt_dir):
+    """Test that the folder-agnostic import worked correctly"""
+    print("🧪 Testing folder-agnostic functionality...")
+    
+    try:
+        import hw_management_sync
+        module_file = hw_management_sync.__file__
+        expected_dir = os.path.abspath(hw_mgmt_dir)
+        actual_dir = os.path.dirname(os.path.abspath(module_file))
+        
+        assert actual_dir == expected_dir, f"Module loaded from {actual_dir}, expected {expected_dir}"
+        
+        print(f"  ✅ Module loaded from: {actual_dir}")
+        print("✅ Folder-agnostic functionality test PASSED")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Folder-agnostic functionality test FAILED: {e}")
+        return False
+
+def main():
+    """Main test runner"""
+    parser = argparse.ArgumentParser(description='Comprehensive test runner for module_temp_populate')
+    parser.add_argument('--hw-mgmt-path', help='Path to hw_management_sync.py')
+    args = parser.parse_args()
+    
+    print("=" * 70)
+    print("🚀 MODULE_TEMP_POPULATE TEST SUITE")
+    print("=" * 70)
+    print(f"Python version: {sys.version}")
+    
+    try:
+        # Setup import path
+        hw_mgmt_dir = setup_import_path(args.hw_mgmt_path)
+        print(f"📂 Using hw_management_sync.py from: {hw_mgmt_dir}")
+        print("=" * 70)
+        
+        # Run all tests
+        tests = [
+            ("Basic Functionality", test_basic_functionality),
+            ("Temperature Conversion", test_temperature_conversion), 
+            ("Random Module States (5 modules)", test_random_module_states),
+            ("Folder-Agnostic Functionality", lambda: test_folder_agnostic_functionality(hw_mgmt_dir)),
+        ]
+        
+        passed = 0
+        total = len(tests)
+        
+        for test_name, test_func in tests:
+            print(f"\n🔬 Running: {test_name}")
+            print("-" * 40)
+            if test_func():
+                passed += 1
+            print()
+        
+        # Final results
+        print("=" * 70)
+        print("📋 FINAL TEST RESULTS")
+        print("=" * 70)
+        
+        for i, (test_name, _) in enumerate(tests):
+            status = "✅ PASSED" if i < passed else "❌ FAILED"
+            print(f"  {status} - {test_name}")
+        
+        print(f"\n🏆 Tests Passed: {passed}/{total}")
+        
+        if passed == total:
+            print("🎉 ALL TESTS PASSED!")
+            print("✅ The module_temp_populate test suite is working correctly!")
+            print("✅ Folder-agnostic functionality confirmed!")
+            print("✅ 5 modules with random parameters tested!")
+        else:
+            print("⚠️  Some tests failed. Please check the output above.")
+            
+        return 0 if passed == total else 1
+        
+    except Exception as e:
+        print(f"❌ Critical error: {e}")
+        return 1
+
+if __name__ == '__main__':
+    exit(main()) 

--- a/unittest/hw_mgmgt_sync/module_populate/run_module_tests.sh
+++ b/unittest/hw_mgmgt_sync/module_populate/run_module_tests.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Module Temperature Unit Test Runner
+# This script runs the comprehensive unit tests for module_temp_populate function
+
+echo "==================================="
+echo "Module Temperature Unit Test Runner"
+echo "==================================="
+echo
+
+# Check if test file exists
+if [ ! -f "test_module_temp_populate.py" ]; then
+    echo "Error: test_module_temp_populate.py not found!"
+    echo "Please ensure you're running this script from the correct directory."
+    exit 1
+fi
+
+# Check if main module exists
+if [ ! -f "hw_management_sync.py" ]; then
+    echo "Error: hw_management_sync.py not found!"
+    echo "Please ensure you're running this script from the correct directory."
+    exit 1
+fi
+
+echo "Running all module temperature tests..."
+echo
+
+# Run all tests with verbose output
+python3 -m unittest test_module_temp_populate -v
+
+TEST_RESULT=$?
+
+echo
+echo "==================================="
+
+if [ $TEST_RESULT -eq 0 ]; then
+    echo "✅ All tests PASSED!"
+    echo
+    echo "Test Coverage Summary:"
+    echo "- SW mode behavior (no thermal file modifications)"
+    echo "- FW mode with non-present modules (zeros in thermal files)"
+    echo "- FW mode with present modules (actual temperature values)"
+    echo "- Random combinations of all scenarios"
+    echo "- Helper function validation"
+    echo "- Constants validation"
+else
+    echo "❌ Some tests FAILED!"
+    echo
+    echo "Please check the test output above for details."
+fi
+
+echo "==================================="
+exit $TEST_RESULT 

--- a/unittest/hw_mgmgt_sync/module_populate/run_tests.sh
+++ b/unittest/hw_mgmgt_sync/module_populate/run_tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Test runner script for module_temp_populate unit tests
+# Usage: ./run_tests.sh <path_to_hw_management_sync.py> [--verbose]
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <path_to_hw_management_sync.py> [--verbose]"
+    echo "Example: $0 ./bin/hw_management_sync.py --verbose"
+    exit 1
+fi
+
+HW_MGMT_PATH="$1"
+VERBOSE_FLAG="$2"
+
+# Check if the file exists
+if [ ! -f "$HW_MGMT_PATH" ]; then
+    echo "Error: File $HW_MGMT_PATH does not exist"
+    exit 1
+fi
+
+# Run the tests
+echo "Running unit tests for module_temp_populate function..."
+echo "Using hw_management_sync.py from: $HW_MGMT_PATH"
+echo "=========================================="
+
+if [ "$VERBOSE_FLAG" = "--verbose" ] || [ "$VERBOSE_FLAG" = "-v" ]; then
+    python3 test_module_temp_populate.py "$HW_MGMT_PATH" --verbose
+else
+    python3 test_module_temp_populate.py "$HW_MGMT_PATH"
+fi 

--- a/unittest/hw_mgmgt_sync/module_populate/simple_test.py
+++ b/unittest/hw_mgmgt_sync/module_populate/simple_test.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Simple test to verify folder-agnostic functionality"""
+
+import sys
+import os
+import argparse
+
+def setup_import_path(hw_mgmt_path=None):
+    """Setup import path for hw_management_sync module"""
+    if hw_mgmt_path:
+        if os.path.isfile(hw_mgmt_path):
+            hw_mgmt_dir = os.path.dirname(os.path.abspath(hw_mgmt_path))
+        else:
+            hw_mgmt_dir = os.path.abspath(hw_mgmt_path)
+    else:
+        # Auto-detect
+        if os.path.exists('./hw_management_sync.py'):
+            hw_mgmt_dir = '.'
+        elif os.path.exists('./bin/hw_management_sync.py'):
+            hw_mgmt_dir = './bin'
+        else:
+            raise FileNotFoundError("Cannot find hw_management_sync.py")
+    
+    hw_mgmt_dir = os.path.abspath(hw_mgmt_dir)
+    if hw_mgmt_dir not in sys.path:
+        sys.path.insert(0, hw_mgmt_dir)
+    return hw_mgmt_dir
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple test for folder-agnostic functionality')
+    parser.add_argument('--hw-mgmt-path', help='Path to hw_management_sync.py')
+    args = parser.parse_args()
+
+    try:
+        hw_mgmt_dir = setup_import_path(args.hw_mgmt_path)
+        print(f"Found hw_management_sync.py in: {hw_mgmt_dir}")
+        
+        from hw_management_sync import CONST, sdk_temp2degree, module_temp_populate
+        print("✅ Import successful!")
+        print(f"✅ CONST.SDK_FW_CONTROL = {CONST.SDK_FW_CONTROL}")
+        print(f"✅ CONST.SDK_SW_CONTROL = {CONST.SDK_SW_CONTROL}")
+        print(f"✅ sdk_temp2degree(25) = {sdk_temp2degree(25)}")
+        print(f"✅ sdk_temp2degree(-10) = {sdk_temp2degree(-10)}")
+        
+        # Test temperature conversion formula
+        assert sdk_temp2degree(25) == 25 * 125, "Positive temperature conversion failed"
+        assert sdk_temp2degree(-10) == 0xffff + (-10) + 1, "Negative temperature conversion failed"
+        print("✅ Temperature conversion tests PASSED")
+        
+        # Test constants
+        assert CONST.SDK_FW_CONTROL == 0, "SDK_FW_CONTROL should be 0"
+        assert CONST.SDK_SW_CONTROL == 1, "SDK_SW_CONTROL should be 1"
+        print("✅ Constants tests PASSED")
+        
+        # Test function exists
+        assert callable(module_temp_populate), "module_temp_populate should be callable"
+        print("✅ Function existence tests PASSED")
+        
+        print("✅ ALL TESTS PASSED!")
+        print(f"✅ Successfully tested folder-agnostic import from: {hw_mgmt_dir}")
+        
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        return 1
+    
+    return 0
+
+if __name__ == '__main__':
+    exit(main()) 

--- a/unittest/hw_mgmgt_sync/module_populate/test_module_temp_populate.py
+++ b/unittest/hw_mgmgt_sync/module_populate/test_module_temp_populate.py
@@ -1,0 +1,276 @@
+#!/usr/bin/python3
+"""
+Unit test for hw_management_sync.py module_temp_populate function.
+This test is agnostic to the folder from where it is running.
+"""
+
+import os
+import sys
+import unittest
+import tempfile
+import shutil
+import random
+import argparse
+from unittest.mock import patch, MagicMock
+import importlib.util
+
+
+class TestModuleTempPopulate(unittest.TestCase):
+    """Test class for module_temp_populate function"""
+    
+    def setUp(self):
+        """Set up test fixtures before each test method."""
+        # Create temporary directories for testing
+        self.temp_dir = tempfile.mkdtemp()
+        self.thermal_dir = os.path.join(self.temp_dir, "var", "run", "hw-management", "thermal")
+        self.config_dir = os.path.join(self.temp_dir, "var", "run", "hw-management", "config")
+        self.module_src_dir = os.path.join(self.temp_dir, "sys", "module", "sx_core", "asic0")
+        
+        # Create directory structure
+        os.makedirs(self.thermal_dir, exist_ok=True)
+        os.makedirs(self.config_dir, exist_ok=True)
+        os.makedirs(self.module_src_dir, exist_ok=True)
+        
+        # Store original working directory
+        self.original_cwd = os.getcwd()
+        
+        # Module configuration
+        self.module_count = 5
+        self.offset = 1
+        
+        # Generate random module configurations
+        self.module_configs = []
+        for i in range(self.module_count):
+            config = {
+                'present': random.choice([0, 1]),
+                'mode': random.choice([0, 1]),  # 0 = SDK_FW_CONTROL, 1 = SDK_SW_CONTROL
+                'temperature_input': random.randint(20, 50),  # Temperature in SDK format
+                'temperature_threshold': random.randint(60, 80)  # Threshold temperature
+            }
+            self.module_configs.append(config)
+            print(f"Module {i+self.offset}: present={config['present']}, mode={config['mode']}, "
+                  f"temp={config['temperature_input']}, threshold={config['temperature_threshold']}")
+        
+        # Create module directories and files
+        self._setup_module_files()
+        
+    def tearDown(self):
+        """Clean up after each test method."""
+        # Remove temporary directory
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+        
+        # Restore original working directory
+        os.chdir(self.original_cwd)
+        
+    def _setup_module_files(self):
+        """Set up module files for testing"""
+        for idx, config in enumerate(self.module_configs):
+            module_dir = os.path.join(self.module_src_dir, f"module{idx}")
+            temp_dir = os.path.join(module_dir, "temperature")
+            
+            os.makedirs(temp_dir, exist_ok=True)
+            
+            # Create control file (mode)
+            with open(os.path.join(module_dir, "control"), 'w') as f:
+                f.write(str(config['mode']))
+                
+            # Create present file
+            with open(os.path.join(module_dir, "present"), 'w') as f:
+                f.write(str(config['present']))
+                
+            # Create temperature files if present
+            if config['present']:
+                with open(os.path.join(temp_dir, "input"), 'w') as f:
+                    f.write(str(config['temperature_input']))
+                    
+                with open(os.path.join(temp_dir, "threshold_hi"), 'w') as f:
+                    f.write(str(config['temperature_threshold']))
+    
+    def _load_hw_management_module(self, hw_mgmt_path):
+        """Dynamically load the hw_management_sync module from given path"""
+        spec = importlib.util.spec_from_file_location("hw_management_sync", hw_mgmt_path)
+        hw_mgmt_module = importlib.util.module_from_spec(spec)
+        
+        # Mock sys.modules to avoid import issues
+        sys.modules["hw_management_redfish_client"] = MagicMock()
+        
+        spec.loader.exec_module(hw_mgmt_module)
+        return hw_mgmt_module
+        
+    def _sdk_temp2degree(self, val):
+        """Convert SDK temperature format to degrees (copied from original)"""
+        if val >= 0:
+            temperature = val * 125
+        else:
+            temperature = 0xffff + val + 1
+        return temperature
+        
+    def test_module_temp_populate_all_scenarios(self):
+        """Test module_temp_populate with various module configurations"""
+        
+        # Load the module
+        hw_mgmt_module = self._load_hw_management_module(self.hw_mgmt_path)
+        
+        # Prepare arguments
+        arg_list = {
+            "fin": os.path.join(self.module_src_dir, "module{}/"),
+            "fout_idx_offset": self.offset,
+            "module_count": self.module_count
+        }
+        
+        # Track written files and their content
+        written_files = {}
+        original_open = open
+        original_islink = os.path.islink
+        
+        def mock_open_func(filename, mode='r', **kwargs):
+            # Redirect thermal directory paths to our temp directory
+            if filename.startswith('/var/run/hw-management/thermal/'):
+                filename = filename.replace('/var/run/hw-management/thermal/', 
+                                          self.thermal_dir + '/')
+            elif filename.startswith('/var/run/hw-management/config/'):
+                filename = filename.replace('/var/run/hw-management/config/', 
+                                          self.config_dir + '/')
+            
+            # Ensure directory exists for write operations
+            if 'w' in mode:
+                os.makedirs(os.path.dirname(filename), exist_ok=True)
+                # Track what files are being written to
+                written_files[filename] = None
+            
+            return original_open(filename, mode, **kwargs)
+        
+        def mock_islink_func(path):
+            # Redirect thermal directory paths to our temp directory
+            if path.startswith('/var/run/hw-management/thermal/'):
+                path = path.replace('/var/run/hw-management/thermal/', 
+                                   self.thermal_dir + '/')
+            # Always return False (no links exist in our test environment)
+            return False
+        
+        # Apply patches
+        with patch('builtins.open', side_effect=mock_open_func), \
+             patch('os.path.islink', side_effect=mock_islink_func):
+            
+            # Call the function under test
+            hw_mgmt_module.module_temp_populate(arg_list, None)
+            
+            # Verify results for each module
+            for idx, config in enumerate(self.module_configs):
+                module_name = f"module{idx + self.offset}"
+                
+                if config['mode'] == 1:  # SDK_SW_CONTROL
+                    # Files should NOT be created for SW control mode
+                    self._verify_files_not_created(module_name, written_files)
+                    print(f"✓ Module {module_name}: SW control mode - no files created")
+                    
+                else:  # SDK_FW_CONTROL
+                    if config['present'] == 0:
+                        # Files should contain zeros for absent modules
+                        self._verify_absent_module_files(module_name)
+                        print(f"✓ Module {module_name}: FW control, not present - zero values")
+                        
+                    else:
+                        # Files should contain actual temperature values
+                        expected_temp = self._sdk_temp2degree(config['temperature_input'])
+                        expected_crit = self._sdk_temp2degree(config['temperature_threshold'])
+                        self._verify_present_module_files(module_name, expected_temp, expected_crit)
+                        print(f"✓ Module {module_name}: FW control, present - actual values "
+                              f"(temp={expected_temp}, crit={expected_crit})")
+            
+            # Verify module counter file
+            self._verify_module_counter()
+            print("✓ Module counter file verified")
+    
+    def _verify_files_not_created(self, module_name, written_files):
+        """Verify that thermal files are not created for SW control modules"""
+        suffixes = ["_temp_input", "_temp_crit", "_temp_emergency", "_temp_fault", "_temp_trip_crit"]
+        
+        for suffix in suffixes:
+            filename = os.path.join(self.thermal_dir, f"{module_name}{suffix}")
+            self.assertFalse(os.path.exists(filename), 
+                           f"File {filename} should not exist for SW control module")
+            # Also check that it wasn't in the written files list
+            self.assertNotIn(filename, written_files,
+                           f"File {filename} should not have been written for SW control module")
+    
+    def _verify_absent_module_files(self, module_name):
+        """Verify thermal files contain zeros for absent modules"""
+        expected_values = {
+            "_temp_input": "0",
+            "_temp_crit": "0", 
+            "_temp_emergency": "0",
+            "_temp_fault": "0",
+            "_temp_trip_crit": "0"
+        }
+        
+        for suffix, expected_value in expected_values.items():
+            filename = os.path.join(self.thermal_dir, f"{module_name}{suffix}")
+            self.assertTrue(os.path.exists(filename), f"File {filename} should exist")
+            
+            with open(filename, 'r') as f:
+                content = f.read().strip()
+                self.assertEqual(content, expected_value,
+                               f"File {filename} should contain '{expected_value}', got '{content}'")
+    
+    def _verify_present_module_files(self, module_name, expected_temp, expected_crit):
+        """Verify thermal files contain correct values for present modules"""
+        expected_emergency = expected_crit + 10000  # CONST.MODULE_TEMP_EMERGENCY_OFFSET
+        expected_trip_crit = 120000  # CONST.MODULE_TEMP_CRIT_DEF
+        
+        expected_values = {
+            "_temp_input": str(expected_temp),
+            "_temp_crit": str(expected_crit),
+            "_temp_emergency": str(expected_emergency),
+            "_temp_fault": "0",
+            "_temp_trip_crit": str(expected_trip_crit)
+        }
+        
+        for suffix, expected_value in expected_values.items():
+            filename = os.path.join(self.thermal_dir, f"{module_name}{suffix}")
+            self.assertTrue(os.path.exists(filename), f"File {filename} should exist")
+            
+            with open(filename, 'r') as f:
+                content = f.read().strip()
+                self.assertEqual(content, expected_value,
+                               f"File {filename} should contain '{expected_value}', got '{content}'")
+    
+    def _verify_module_counter(self):
+        """Verify module counter file is created with correct count"""
+        counter_file = os.path.join(self.config_dir, "module_counter")
+        self.assertTrue(os.path.exists(counter_file), "module_counter file should exist")
+        
+        with open(counter_file, 'r') as f:
+            content = f.read().strip()
+            self.assertEqual(content, str(self.module_count),
+                           f"module_counter should contain '{self.module_count}', got '{content}'")
+
+
+def main():
+    """Main function to run tests with command line arguments"""
+    parser = argparse.ArgumentParser(description='Test module_temp_populate function')
+    parser.add_argument('hw_mgmt_path', 
+                       help='Path to hw_management_sync.py file')
+    parser.add_argument('--verbose', '-v', action='store_true',
+                       help='Verbose output')
+    
+    args, unittest_args = parser.parse_known_args()
+    
+    # Validate the hw_management_sync.py path
+    if not os.path.isfile(args.hw_mgmt_path):
+        print(f"Error: File {args.hw_mgmt_path} does not exist")
+        sys.exit(1)
+    
+    # Store the path for use in tests
+    TestModuleTempPopulate.hw_mgmt_path = os.path.abspath(args.hw_mgmt_path)
+    
+    print(f"Testing hw_management_sync.py from: {TestModuleTempPopulate.hw_mgmt_path}")
+    print("=" * 70)
+    
+    # Run the tests
+    unittest.main(argv=[sys.argv[0]] + unittest_args, 
+                 verbosity=2 if args.verbose else 1)
+
+
+if __name__ == '__main__':
+    main() 

--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -580,7 +580,7 @@ def module_temp_populate(arg_list, _dummy):
     fin = arg_list["fin"]
     module_count = arg_list["module_count"]
     offset = arg_list["fout_idx_offset"]
-    host_management_mode = None
+    module_updated = False
     for idx in range(module_count):
         module_name = "module{}".format(idx+offset)
         f_dst_name = "/var/run/hw-management/thermal/{}_temp_input".format(module_name)
@@ -588,9 +588,12 @@ def module_temp_populate(arg_list, _dummy):
             continue
 
         f_src_path = fin.format(idx)
-        module_present = 0
+        # If control mode is SW - skip temperature reading (independent mode) 
+        if is_module_host_management_mode(f_src_path):
+            continue
 
         # Check if module is present
+        module_present = 0
         f_src_present = os.path.join(f_src_path, "present")
         try:
             with open(f_src_present, 'r') as f:
@@ -606,13 +609,6 @@ def module_temp_populate(arg_list, _dummy):
         temperature_crit = "0"
 
         if module_present:
-            # If control mode is FW, skip temperature reading (independent mode)
-            if host_management_mode is None:
-                host_management_mode = is_module_host_management_mode(f_src_path)
-
-            if host_management_mode:
-                continue
-
             f_src_input = os.path.join(f_src_path, "temperature/input")
             f_src_crit = os.path.join(f_src_path, "temperature/threshold_hi")
 
@@ -649,9 +645,11 @@ def module_temp_populate(arg_list, _dummy):
             f_name = "/var/run/hw-management/thermal/{}{}".format(module_name, suffix)
             with open(f_name, 'w', encoding="utf-8") as f:
                 f.write("{}\n".format(value))
+        module_updated = True
 
-    with open("/var/run/hw-management/config/module_counter", 'w+', encoding="utf-8") as f:
-        f.write("{}\n".format(module_count))
+    if module_updated:
+        with open("/var/run/hw-management/config/module_counter", 'w+', encoding="utf-8") as f:
+            f.write("{}\n".format(module_count))
     return
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
If the module is in SW mode, hw-mgmt shouldn't update the
./thermal/moduleX_* attributes.

In our algorithm, if a module is not present, we fill its attributes with zeros.
In SW mode, the "present" status is "0", which caused a conflict with a
similar OS process when hw-mgmt overwrote the module attributes with
zeros.
If affect thermal algo because it try to set PWM based on wrong inputs
(module temperature is 0).

In SW mode, hw-mgmt shouldn't even check the module status and should
give priority to the OS for updating the attributes.

This commit adds a check for the module's "mode" first, and if it's in SW mode,
skips the update. We don't even need to read the "present" status in this case

Bug: 4494119

Unittests incuded.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
