### PR TITLE
hw-mgmt: scripts: Adjust the check of usb0 interface configuration

### DIFF
--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -41,8 +41,14 @@ if [ -z "${ACTION}" ] || [ -z "${INTERFACE}" ]; then
 fi
 
 if [ ! -e /sys/class/net/${INTERFACE} ] ||
-   [ ! -e /etc/network/interfaces ] ||
-   ! ifquery -l --allow=hotplug | grep -q ${INTERFACE}; then
+   [ ! -e /etc/network/interfaces ]; then
+	exit 0
+fi
+
+AUTO=$(ifquery -l 2>/dev/null)
+HOTPLUG=$(ifquery -l --allow=hotplug 2>/dev/null)
+
+if ! echo $AUTO $HOTPLUG | grep -q ${INTERFACE}; then
 	exit 0
 fi
 


### PR DESCRIPTION
Currently the validity checks for usb0 interface configuration assime that it is defined as "allow-hotplug usb0" in cofiguration file /etc/network/interfaces. Some NOSes may define it as "auto usb0", and validity checks will fail. This can result in usb0 remaining unconfigured on host side after BMC reboot. Adjust the checks to allow "auto usb0".

Bug: 4491046