### PR TITLE
hw-mgmt: thermal: thermal control fix misprint in config load fuction

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -3626,7 +3626,7 @@ class ThermalManagement(hw_management_file_op):
         if CONST.SYS_CONF_REDUNDANCY_PARAM not in sys_config:
             sys_config[CONST.SYS_CONF_REDUNDANCY_PARAM] = {}
 
-        if CONST.SYS_CONF_REDUNDANCY_PARAM not in sys_config:
+        if CONST.SYS_CONF_GENERAL_CONFIG_PARAM not in sys_config:
             sys_config[CONST.SYS_CONF_GENERAL_CONFIG_PARAM] = {}
 
         self.sys_config = sys_config


### PR DESCRIPTION
We had copy-paste issue in TC config load function.

Affect configuration parameter:
"pwm_update_period"

Not critical,  Low risk

Fix:
CONST.SYS_CONF_REDUNDANCY_PARAM -> SYS_CONF_GENERAL_CONFIG_PARAM

Bug: 4499238

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
