### PR TITLE
remove root default password from code

### DIFF
--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -368,7 +368,6 @@ class BMCAccessor(object):
     BMC_DEFAULT_PASSWORD = '0penBmc'
     BMC_NOS_ACCOUNT = 'yormnAnb' # used for communication between NOS and BMC
     BMC_NOS_ACCOUNT_DEFAULT_PASSWORD = "ABYX12#14artb51" # default pwd of the NOS/BMC user, during the flow will be changed to tpm_pwd
-    BMC_ROOT_PASSWORD = "ABYX12#14artb" # root pwd which should be patched to
     BMC_DIR = "/host/bmc"
     BMC_PASS_FILE = "bmc_pass"
     BMC_TPM_HEX_FILE = "hw_mgmt_const.bin"


### PR DESCRIPTION
Issue: [#4497091](https://redmine.mellanox.com/issues/4497091)

Why I did it
The root user of bmc is not changed automatically, leaving this default password is a security risk

root password written but not used and not called in the code or in hw-management-sync.service calling it.
Tested locally on a running system.