### PR TITLE
hw-mgmt: scripts: Create PSU EEPROM symbolic links only if actual fil…

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -988,7 +988,11 @@ if [ "$1" == "add" ]; then
 				psu_eeprom_type=$(< "$config_path"/psu_eeprom_type)
 			fi
 			echo "$psu_eeprom_type" 0x"$psu_eeprom_addr" > /sys/class/i2c-dev/i2c-"$bus"/device/new_device
-			ln -sf "$eeprom_file" "$eeprom_path"/"$eeprom_name" 2>/dev/null
+			for ((i=0; i<2; i++)); do
+				[ -f "$eeprom_file" ] && break
+				sleep 0.5
+			done
+			check_n_link "$eeprom_file" "$eeprom_path"/"$eeprom_name" 2>/dev/null
 			chmod 400 "$eeprom_path"/"$eeprom_name" 2>/dev/null
 			echo 1 > $config_path/"$psu_name"_eeprom_us
 		else


### PR DESCRIPTION
…es exist

In case hw-mgmt fails to initialize PSU EEPROM driver, the EEPROM file under /sys will not be created. In that situation PSU EEPROM symbolic link under hw-mgmt tree should not be created to avoid generating dangling links.

Bug: 4478004