### PR TITLE
hw-mgmt: thermal: TC fix module periodic report log

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2033,7 +2033,7 @@ class thermal_module_sensor(system_device):
         if CONST.SENSOR_READ_ERR in fault_list:
             value = "N/A"
         else:
-            value = self.value
+            value = round(self.value,1)
 
         if self.pwm > self.pwm_prev:
             sign = u'\u2191' # up arrow
@@ -2043,7 +2043,7 @@ class thermal_module_sensor(system_device):
             sign = '' # no change
         self.pwm_prev = self.pwm
         info_str = "\"{: <8}\" temp:{: <5}, tmin:{: <5}, tmax:{: <5}, [{}], faults:[{}], pwm: {}{}, {}".format(self.name,
-                                                                                          round(value,1),
+                                                                                          value,
                                                                                           round(self.val_min,1),
                                                                                           round(self.val_max,1),
                                                                                           str(self.pwm_regulator),


### PR DESCRIPTION
If module reading was failed we had issue with printing periodic report.
It happens because issue in module temperature value convert to float
in case value is not a numeric: "N/A".

Fix: convert to float only in case temperature value is numeric

Bug: 4502817

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
