### PR TITLE
change BMC password to be platform based

### DIFF
--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -27,6 +27,8 @@ import time
 import re
 import shlex
 import os
+from sonic_py_common import device_info
+import base64
 
 # TBD:
 # Support token persistency later on and remove RedfishClient.__password
@@ -371,6 +373,12 @@ class BMCAccessor(object):
     BMC_DIR = "/host/bmc"
     BMC_PASS_FILE = "bmc_pass"
     BMC_TPM_HEX_FILE = "hw_mgmt_const.bin"
+    PLATFORM_LEGACY_LIST = {
+        "N5100_LD", "N5101_LD", "N5110_LD", "N5112_LD", "N5113_LD",
+        "N5200_LD", "N5201_LD", "N5210_LD", "N5212_LD", "N5240_LD",
+        "N5300_LD", "N5400_LD", "N5500_LD", "N5503_LD", "N5513_LD",
+        "N5600_LD", "N5700_LD"
+    }
 
     def __init__(self):
         # TBD: Token persistency.
@@ -418,80 +426,83 @@ class BMCAccessor(object):
         err_msg = f"'{self.__class__.__name__}' object has no attribute '{name}'"
         raise AttributeError(err_msg)
 
+
     def get_login_password(self):
         try:
-            pass_len = 13
-            attempt = 1
-            max_attempts = 100
-            max_repeat = int(3 + 0.09 * pass_len)
-            hex_data = "1300NVOS-BMC-USER-Const"
-            os.makedirs(self.BMC_DIR, exist_ok=True)
-            cmd = f'echo "{hex_data}" | xxd -r -p >  {self.BMC_DIR}/{self.BMC_TPM_HEX_FILE}'
-            subprocess.run(cmd, shell=True, check=True)
-
-            tpm_command = ["tpm2_createprimary", "-C", "o", "-u",  f"{self.BMC_DIR}/{self.BMC_TPM_HEX_FILE}", "-G", "aes256cfb"]
-            result = subprocess.run(tpm_command, capture_output=True, check=True, text=True)
-
-            while attempt <= max_attempts:
-                if attempt > 1:
-                    const = f"1300NVOS-BMC-USER-Const-{attempt}"
-                    mess = f"Password did not meet criteria; retrying with const: {const}"
-                    #print(mess)
-                    tpm_command = f'echo -n "{const}" | tpm2_createprimary -C o -G aes -u -'
-                    result = subprocess.run(tpm_command, shell=True, capture_output=True, check=True, text=True)
-
-                symcipher_pattern = r"symcipher:\s+([\da-fA-F]+)"
-                symcipher_match = re.search(symcipher_pattern, result.stdout)
-
-                if not symcipher_match:
+            platform_name = device_info.get_platform()
+            if any(p in platform_name.upper() for p in PLATFORM_LEGACY_LIST):
+                pass_len = 13
+                attempt = 1
+                max_attempts = 100
+                max_repeat = int(3 + 0.09 * pass_len)
+                hex_data = "1300NVOS-BMC-USER-Const"
+                os.makedirs(self.BMC_DIR, exist_ok=True)
+                cmd = f'echo "{hex_data}" | xxd -r -p >  {self.BMC_DIR}/{self.BMC_TPM_HEX_FILE}'
+                subprocess.run(cmd, shell=True, check=True)
+                tpm_command = ["tpm2_createprimary", "-C", "o", "-u",  f"{self.BMC_DIR}/{self.BMC_TPM_HEX_FILE}", "-G", "aes256cfb"]
+                result = subprocess.run(tpm_command, capture_output=True, check=True, text=True)
+                while attempt <= max_attempts:
+                    if attempt > 1:
+                        const = f"1300NVOS-BMC-USER-Const-{attempt}"
+                        mess = f"Password did not meet criteria; retrying with const: {const}"
+                        #print(mess)
+                        tpm_command = f'echo -n "{const}" | tpm2_createprimary -C o -G aes -u -'
+                        result = subprocess.run(tpm_command, shell=True, capture_output=True, check=True, text=True)
+                    symcipher_pattern = r"symcipher:\s+([\da-fA-F]+)"
+                    symcipher_match = re.search(symcipher_pattern, result.stdout)
+                    if not symcipher_match:
+                        raise Exception("Symmetric cipher not found in TPM output")
+                    # BMC dictates a password of 13 characters. Random from TPM is used with an append of A!
+                    symcipher_part = symcipher_match.group(1)[:pass_len-2]
+                    if symcipher_part.isdigit():
+                        symcipher_value = symcipher_part[:pass_len-3] + 'vA!'
+                    elif symcipher_part.isalpha() and symcipher_part.islower():
+                        symcipher_value = symcipher_part[:pass_len-3] + '9A!'
+                    else:
+                        symcipher_value = symcipher_part + 'A!'
+                    if len (symcipher_value) != pass_len:
+                        raise Exception("Bad cipher length from TPM output")
+                    
+                    # check for monotonic
+                    monotonic_check = True
+                    for i in range(len(symcipher_value) - 3): 
+                        seq = symcipher_value[i:i+4] 
+                        increments = [ord(seq[j+1]) - ord(seq[j]) for j in range(3)]
+                        if increments == [1, 1, 1] or increments == [-1, -1, -1]:
+                            monotonic_check = False
+                            break
+                    variety_check = len(set(symcipher_value)) >= 5
+                    repeating_pattern_check = sum(1 for i in range(pass_len - 1) if symcipher_value[i] == symcipher_value[i + 1]) <= max_repeat
+                    # check for consecutive_pairs
+                    count = 0
+                    for i in range(11):
+                        val1 = symcipher_value[i]
+                        val2 = symcipher_value[i + 1]
+                        if val2 == "v" or val1 == "v":
+                            continue
+                        if abs(int(val2, 16) - int(val1, 16)) == 1:
+                            count += 1
+                    consecutive_pair_check = count <= 4
+                    if consecutive_pair_check and variety_check and repeating_pattern_check and monotonic_check:
+                        os.remove(f"{self.BMC_DIR}/{self.BMC_TPM_HEX_FILE}")
+                        return symcipher_value
+                    else:
+                        attempt += 1
+                raise Exception("Failed to generate a valid password after maximum retries.")
+            else:
+                const = "1300NVOS-BMC-USER-Const"
+                tpm_command = f'echo -n "{const}" | tpm2_createprimary -C o -G aes -u -'
+                result = subprocess.run(tpm_command, shell=True, 
+                                        capture_output=True, check=True, 
+                                        text=True).stdout
+                match = re.search(r"symcipher:\s+([\da-fA-F]+)", result)
+                if not match:
                     raise Exception("Symmetric cipher not found in TPM output")
-
-                # BMC dictates a password of 13 characters. Random from TPM is used with an append of A!
-                symcipher_part = symcipher_match.group(1)[:pass_len-2]
-                if symcipher_part.isdigit():
-                    symcipher_value = symcipher_part[:pass_len-3] + 'vA!'
-                elif symcipher_part.isalpha() and symcipher_part.islower():
-                    symcipher_value = symcipher_part[:pass_len-3] + '9A!'
-                else:
-                    symcipher_value = symcipher_part + 'A!'
-                if len (symcipher_value) != pass_len:
-                    raise Exception("Bad cipher length from TPM output")
-                
-                # check for monotonic
-                monotonic_check = True
-                for i in range(len(symcipher_value) - 3): 
-                    seq = symcipher_value[i:i+4] 
-                    increments = [ord(seq[j+1]) - ord(seq[j]) for j in range(3)]
-                    if increments == [1, 1, 1] or increments == [-1, -1, -1]:
-                        monotonic_check = False
-                        break
-
-                variety_check = len(set(symcipher_value)) >= 5
-                repeating_pattern_check = sum(1 for i in range(pass_len - 1) if symcipher_value[i] == symcipher_value[i + 1]) <= max_repeat
-
-                # check for consecutive_pairs
-                count = 0
-                for i in range(11):
-                    val1 = symcipher_value[i]
-                    val2 = symcipher_value[i + 1]
-                    if val2 == "v" or val1 == "v":
-                        continue
-                    if abs(int(val2, 16) - int(val1, 16)) == 1:
-                        count += 1
-                consecutive_pair_check = count <= 4
-
-                if consecutive_pair_check and variety_check and repeating_pattern_check and monotonic_check:
-                    os.remove(f"{self.BMC_DIR}/{self.BMC_TPM_HEX_FILE}")
-                    return symcipher_value
-                else:
-                    attempt += 1
-
-            raise Exception("Failed to generate a valid password after maximum retries.")
-
+                # Extract symcipher and encode to base64
+                return base64.b64encode(bytes.fromhex(match.group(1))).decode("ascii")
         except subprocess.CalledProcessError as e:
             #print(f"Error executing TPM command: {e}")
             raise Exception("Failed to communicate with TPM")
-
         except Exception as e:
             #print(f"Error: {e}")
             raise


### PR DESCRIPTION
Issue: [#4410461](https://redmine.mellanox.com/issues/4410461)
HLD: [BMC Credenials](https://confluence.nvidia.com/pages/viewpage.action?pageId=3984211056)

Why I did it
Strengthen the bmc credentials without breaking backward compatibility

How I did it
the TPM generation password now depends on platform number