### PR TITLE
hw-mgmt: thermal: Revert FAN max/min speed attributes

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1264,10 +1264,20 @@ msn27xx_msb_msx_specific()
 		*)
 			max_tachos=8
 			hotplug_fans=4
+
+			# Set according to front (inlet) fan max, 21800
+			echo 21000 > $config_path/fan_max_speed
+			# Set according to rear (outlet) fan min, 4600
+			echo 5400 > $config_path/fan_min_speed
+
+			# Set FAN front (inlet) speed limits
 			echo 21000 > $config_path/fan_front_max_speed
 			echo 6300 > $config_path/fan_front_min_speed
+
+			# Set FAN rear (outlet) speed limits 
 			echo 18000 > $config_path/fan_rear_max_speed
 			echo 5400 > $config_path/fan_rear_min_speed
+
 			echo 18000 > $config_path/psu_fan_max
 			echo 2000 > $config_path/psu_fan_min
 			echo "7 8 5 6 3 4 1 2" > $config_path/fan_inversed
@@ -1381,10 +1391,20 @@ mqmxxx_msn37x_msn34x_specific()
 	add_cpu_board_to_connection_table
 
 	max_tachos=12
+
+	# Set according to front (inlet) fan max, 21800
+	echo 23000 > $config_path/fan_max_speed
+	# Set according to rear (outlet) fan min, 4600
+	echo 4600 > $config_path/fan_min_speed
+
+	# Set FAN front (inlet) speed limits
 	echo 23000 > $config_path/fan_front_max_speed
 	echo 5400 > $config_path/fan_front_min_speed
+
+	# Set FAN rear (outlet) speed limits
 	echo 20500 > $config_path/fan_rear_max_speed
 	echo 4800 > $config_path/fan_rear_min_speed
+
 	echo 25000 > $config_path/psu_fan_max
 	echo 4600 > $config_path/psu_fan_min
 	echo 3 > $config_path/cpld_num
@@ -2483,7 +2503,12 @@ sn5640_specific()
 		connect_table+=(${sn5640_base_connect_table[@]})
 		add_cpu_board_to_connection_table $ng800_cpu_bus_offset
 	fi
-		
+
+	# Set according to front (inlet) fan max, 21800
+	echo 21800 > $config_path/fan_max_speed
+	# Set at 30% of rear (outlet) fan max, 20500 (according to fan vendor table)
+	echo 6468 > $config_path/fan_min_speed
+
 	# Set FAN front (inlet) speed limits
 	echo 21800 > $config_path/fan_front_max_speed
 	echo 6879 > $config_path/fan_front_min_speed


### PR DESCRIPTION
Revert FAN max/min speed attributes. These attributes was
removed because of implemented per-fan-direction speed definition.
But this breaks backward compatibility.

Reverted attributes:
./config/fan_min_speed
./config/fan_max_speed

Bug: 4505804

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
