### PR TITLE
hw-mgmt: scripts: Fix voltage threshold calculation for Delta 1100 PSU

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -1068,7 +1068,7 @@ if [ "$1" == "add" ]; then
 		fi
 
 		if [[ "$cap" == "1100" && $mfr == "DELTA" ]]; then
-			out_crit=$(<"$thermal_path"/"$psu_name"_volt_out_crit)
+			out_crit=$(<"$power_path"/"$psu_name"_volt_out_crit)
 			out_lcrit=$(((out_crit*662)/1000))
 			out_min=$(((out_crit*745)/1000))
 			out_max=$(((out_crit*952)/1000))


### PR DESCRIPTION
The fix for bug 3874682 has added voltage threshold calculations for Delta 1100 PSU based on the value of critical max threshold. However the reading of this value was done incorrectly, resulting in all calculated theresholds being defined as 0. This patch fixes the threshold calculation.

Bug: 4505817