### PR TITLE
hw-mgmt: kernel: patch: Modify reset cause add leak attributes for NV…

### DIFF
--- a/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -1,8 +1,8 @@
-From 00006a6046fa2604cfea07d4e971ae3e10c900da Mon Sep 17 00:00:00 2001
+From 0849d29f4645b73132a0b612aa92289469720dce Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 4 Jan 2024 07:40:04 +0000
-Subject: [PATCH 3/7] platform: mellanox: Downstream: Introduce support of
- Nvidia next genration L1 tray switch
+Subject: [PATCH platform-next 3/8] platform: mellanox: Downstream: Introduce
+ support of Nvidia next genration L1 tray switch
 
 Add support for new L1 tray switch node providing L1 connectivity for
 multi-node networking chassis.
@@ -17,11 +17,11 @@ of the all required platform driver.
 Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
 Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 1143 ++++++++++++++++++++--
- 1 file changed, 1043 insertions(+), 100 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 1155 ++++++++++++++++++++--
+ 1 file changed, 1055 insertions(+), 100 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 4be0f29cc..3787dc8fb 100644
+index 4be0f29cc..a867ba4f8 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -53,6 +53,7 @@
@@ -246,7 +246,7 @@ index 4be0f29cc..3787dc8fb 100644
  	{
  		.label = "erot1_recovery",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-@@ -7012,139 +7151,693 @@ static struct mlxreg_core_platform_data mlxplat_smart_switch_regs_io_data = {
+@@ -7012,139 +7151,705 @@ static struct mlxreg_core_platform_data mlxplat_smart_switch_regs_io_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_smart_switch_regs_io_data),
  };
  
@@ -584,6 +584,18 @@ index 4be0f29cc..3787dc8fb 100644
 +		.mode = 0444,
 +	},
 +	{
++		.label = "leakage5",
++		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "leakage6",
++		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
 +		.label = "leakage_status_clear",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET,
 +		.bit = GENMASK(5, 0),
@@ -722,7 +734,7 @@ index 4be0f29cc..3787dc8fb 100644
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_main_5v",
++		.label = "reset_main_51v",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0444,
@@ -1036,7 +1048,7 @@ index 4be0f29cc..3787dc8fb 100644
  		.capability = MLXPLAT_CPLD_LPC_REG_TACHO_SPEED_OFFSET,
  	},
  };
-@@ -7435,6 +8128,124 @@ static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
+@@ -7435,6 +8140,124 @@ static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
  		.version = 1,
  };
  
@@ -1161,7 +1173,7 @@ index 4be0f29cc..3787dc8fb 100644
  /* Watchdog type1: hardware implementation version1
   * (MSN2700, MSN2410, MSN2740, MSN2100 and MSN2140 systems).
   */
-@@ -7670,6 +8481,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7670,6 +8493,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1169,7 +1181,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -7734,6 +8546,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7734,6 +8558,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1178,7 +1190,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
-@@ -7755,6 +8569,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7755,6 +8581,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
@@ -1187,7 +1199,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -7797,6 +8613,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7797,6 +8625,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1195,7 +1207,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -7889,6 +8706,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7889,6 +8718,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1205,7 +1217,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
-@@ -7948,6 +8768,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7948,6 +8780,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
@@ -1215,7 +1227,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -7990,6 +8813,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -7990,6 +8825,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1223,7 +1235,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -8080,6 +8904,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8080,6 +8916,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1233,7 +1245,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
-@@ -8133,6 +8960,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8133,6 +8972,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
@@ -1243,7 +1255,7 @@ index 4be0f29cc..3787dc8fb 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -8201,6 +9031,17 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
+@@ -8201,6 +9043,17 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
  	  MLXPLAT_CPLD_LPC_SM_SW_MASK },
  };
  
@@ -1261,7 +1273,7 @@ index 4be0f29cc..3787dc8fb 100644
  struct mlxplat_mlxcpld_regmap_context {
  	void __iomem *base;
  };
-@@ -8323,6 +9164,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_smart_switch = {
+@@ -8323,6 +9176,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_smart_switch = {
  	.reg_write = mlxplat_mlxcpld_reg_write,
  };
  
@@ -1282,7 +1294,7 @@ index 4be0f29cc..3787dc8fb 100644
  /* Wait completion routine for indirect access for register map */
  static int mlxplat_fpga_completion_wait(struct mlxplat_mlxcpld_regmap_context *ctx)
  {
-@@ -8448,6 +9303,8 @@ static struct spi_board_info *mlxplat_spi;
+@@ -8448,6 +9315,8 @@ static struct spi_board_info *mlxplat_spi;
  static struct pci_dev *lpc_bridge;
  static struct pci_dev *i2c_bridge;
  static struct pci_dev *jtag_bridge;
@@ -1291,7 +1303,7 @@ index 4be0f29cc..3787dc8fb 100644
  
  /* Platform default reset function */
  static int mlxplat_reboot_notifier(struct notifier_block *nb, unsigned long action, void *unused)
-@@ -8480,6 +9337,26 @@ static void mlxplat_poweroff(void)
+@@ -8480,6 +9349,26 @@ static void mlxplat_poweroff(void)
  	kernel_halt();
  }
  
@@ -1318,7 +1330,7 @@ index 4be0f29cc..3787dc8fb 100644
  static int __init mlxplat_register_platform_device(void)
  {
  	mlxplat_dev = platform_device_register_simple(MLX_PLAT_DEVICE_NAME, -1,
-@@ -9011,6 +9888,38 @@ static int __init mlxplat_dmi_ng400_hi171_matched(const struct dmi_system_id *dm
+@@ -9011,6 +9900,38 @@ static int __init mlxplat_dmi_ng400_hi171_matched(const struct dmi_system_id *dm
  	return mlxplat_register_platform_device();
  }
  
@@ -1357,7 +1369,7 @@ index 4be0f29cc..3787dc8fb 100644
  static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  	{
  		.callback = mlxplat_dmi_default_wc_matched,
-@@ -9165,6 +10074,40 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -9165,6 +10086,40 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI172"),
  		},
  	},
@@ -1398,7 +1410,7 @@ index 4be0f29cc..3787dc8fb 100644
  	{
  		.callback = mlxplat_dmi_msn274x_matched,
  		.matches = {
-@@ -9253,8 +10196,8 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9253,8 +10208,8 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  	int shift, i;
  
  	/* Scan adapters from expected id to verify it is free. */
@@ -1409,7 +1421,7 @@ index 4be0f29cc..3787dc8fb 100644
  	     mlxplat_max_adap_num; i++) {
  		search_adap = i2c_get_adapter(i);
  		if (search_adap) {
-@@ -9263,7 +10206,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9263,7 +10218,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  		}
  
  		/* Return if expected parent adapter is free. */
@@ -1418,7 +1430,7 @@ index 4be0f29cc..3787dc8fb 100644
  			return 0;
  		break;
  	}
-@@ -9285,7 +10228,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9285,7 +10240,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  	}
  
  	/* Shift bus only if mux provided by 'mlxplat_mux_data'. */
@@ -1428,5 +1440,5 @@ index 4be0f29cc..3787dc8fb 100644
  
  	return 0;
 -- 
-2.20.1
+2.34.1
 

--- a/recipes-kernel/linux/linux-5.10/9007-platform-mellanox-mlx-platform-Change-register-0x28-.patch
+++ b/recipes-kernel/linux/linux-5.10/9007-platform-mellanox-mlx-platform-Change-register-0x28-.patch
@@ -1,8 +1,8 @@
-From f6f41b1dddd256c9cf73ceda341fd08e2e34606f Mon Sep 17 00:00:00 2001
+From 7b5980f8bec608ec12f974fae46436b620c77f76 Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 13 Jan 2025 12:49:33 +0200
-Subject: [PATCH 6/7] platform: mellanox: mlx-platform: Change register 0x28
- name
+Subject: [PATCH platform-next v2 5/8] platform: mellanox: mlx-platform: Change
+ register 0x28 name
 
 Register 0x28 was repurposed on new systems. Change its name
 to correctly reflect the new functionality.
@@ -14,7 +14,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 3787dc8fb..6b3bcf719 100644
+index 288dbb42eaf6..979bc93dae6b 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -53,7 +53,7 @@
@@ -26,7 +26,7 @@ index 3787dc8fb..6b3bcf719 100644
  #define MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION	0x2a
  #define MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET	0x2b
  #define MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET	0x2d
-@@ -8481,7 +8481,6 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -8552,7 +8552,6 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -34,7 +34,7 @@ index 3787dc8fb..6b3bcf719 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -8613,7 +8612,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8684,7 +8683,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -43,7 +43,7 @@ index 3787dc8fb..6b3bcf719 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -8813,7 +8812,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8884,7 +8883,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -53,5 +53,5 @@ index 3787dc8fb..6b3bcf719 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
 -- 
-2.20.1
+2.34.1
 

--- a/recipes-kernel/linux/linux-5.10/9008-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch
+++ b/recipes-kernel/linux/linux-5.10/9008-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch
@@ -1,8 +1,8 @@
-From 2cf7d91f288ec50f17a990c4ddb04b860efe1bc4 Mon Sep 17 00:00:00 2001
+From 134a14e85de64c63c3e74a65993a259312ef58da Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 13 Jan 2025 17:40:59 +0200
-Subject: [PATCH 7/7] platform: mellanox: mlx-platform: Add support for
- Q3450-LD Nvidia XDR switch
+Subject: [PATCH platform-next 7/8] platform: mellanox: mlx-platform: Add
+ support for Q3450-LD Nvidia XDR switch
 
 Q3450-LD is XDR Infiniband CPO switch with 144 XDR ports, based on
 Nvidia Quantum-3 ASIC. It provides up-to 800Gbps full bidirectional
@@ -24,7 +24,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 294 insertions(+)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 6b3bcf719..8ef8c9121 100644
+index dac299f4f..d71f254f5 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -38,6 +38,7 @@
@@ -357,7 +357,7 @@ index 6b3bcf719..8ef8c9121 100644
      {
  		.label = "leakage_status_clear",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-@@ -8585,6 +8845,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8597,6 +8857,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET:
@@ -365,7 +365,7 @@ index 6b3bcf719..8ef8c9121 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -8597,6 +8858,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8609,6 +8870,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN1_OFFSET:
@@ -373,7 +373,7 @@ index 6b3bcf719..8ef8c9121 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP3_OFFSET:
-@@ -8731,6 +8993,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8743,6 +9005,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
@@ -381,7 +381,7 @@ index 6b3bcf719..8ef8c9121 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -8785,6 +9048,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8797,6 +9060,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET:
@@ -389,7 +389,7 @@ index 6b3bcf719..8ef8c9121 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -8797,6 +9061,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8809,6 +9073,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN1_OFFSET:
@@ -397,7 +397,7 @@ index 6b3bcf719..8ef8c9121 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP3_OFFSET:
-@@ -8923,6 +9188,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8935,6 +9200,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
@@ -405,7 +405,7 @@ index 6b3bcf719..8ef8c9121 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -9843,6 +10109,27 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
+@@ -9855,6 +10121,27 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
  	return mlxplat_register_platform_device();
  }
  
@@ -433,7 +433,7 @@ index 6b3bcf719..8ef8c9121 100644
  static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -10047,6 +10334,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -10059,6 +10346,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI159"),
  		},
  	},
@@ -448,5 +448,5 @@ index 6b3bcf719..8ef8c9121 100644
  		.callback = mlxplat_dmi_xdr_matched,
  		.matches = {
 -- 
-2.20.1
+2.34.1
 

--- a/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -1,8 +1,8 @@
-From 3c19eefb4c4735afb9fa9c3b6f9a6d99f508958d Mon Sep 17 00:00:00 2001
+From c94c92ad2a651f4be0c35e73b86140b2beb865e2 Mon Sep 17 00:00:00 2001
 From: Oleksandr Shamray <oleksandrs@nvidia.com>
 Date: Fri, 11 Oct 2024 11:16:01 +0300
-Subject: [PATCH 2/6] platform: mellanox: Downstream: Introduce support of
- Nvidia next genration L1 tray switch
+Subject: [PATCH platform-next v2 2/8] platform: mellanox: Downstream:
+ Introduce support of Nvidia next genration L1 tray switch
 
 Add support for new L1 tray switch node providing L1 connectivity for
 multi-node networking chassis.
@@ -17,11 +17,11 @@ of the all required platform driver.
 Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
 Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 1150 ++++++++++++++++++++--
- 1 file changed, 1062 insertions(+), 88 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 1162 ++++++++++++++++++++--
+ 1 file changed, 1074 insertions(+), 88 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 4a8cc6a74cab..c308bd95bac5 100644
+index 4a8cc6a74cab..288dbb42eaf6 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -53,6 +53,7 @@
@@ -282,7 +282,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	{
  		.label = "erot1_recovery",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-@@ -7044,121 +7212,675 @@ static struct mlxreg_core_platform_data mlxplat_smart_switch_regs_io_data = {
+@@ -7044,121 +7212,687 @@ static struct mlxreg_core_platform_data mlxplat_smart_switch_regs_io_data = {
  		.counter = ARRAY_SIZE(mlxplat_mlxcpld_smart_switch_regs_io_data),
  };
  
@@ -608,6 +608,18 @@ index 4a8cc6a74cab..c308bd95bac5 100644
 +		.mode = 0444,
 +	},
 +	{
++		.label = "leakage5",
++		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "leakage6",
++		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
 +		.label = "leakage_status_clear",
 +		.reg = MLXPLAT_CPLD_LPC_REG_LEAK_EVENT_OFFSET,
 +		.bit = GENMASK(5, 0),
@@ -746,7 +758,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_main_5v",
++		.label = "reset_main_51v",
 +		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(6),
 +		.mode = 0444,
@@ -1042,7 +1054,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	{
  		.label = "tacho13",
  		.reg = MLXPLAT_CPLD_LPC_REG_TACHO13_OFFSET,
-@@ -7465,6 +8187,124 @@ static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
+@@ -7465,6 +8199,124 @@ static struct mlxreg_core_platform_data mlxplat_xdr_fan_data = {
  		.version = 1,
  };
  
@@ -1167,7 +1179,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  /* Watchdog type1: hardware implementation version1
   * (MSN2700, MSN2410, MSN2740, MSN2100 and MSN2140 systems).
   */
-@@ -7700,6 +8540,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7700,6 +8552,7 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1175,7 +1187,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -7764,6 +8605,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7764,6 +8617,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SN_MASK_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1184,7 +1196,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
  	case MLXPLAT_CPLD_LPC_REG_WD_CLEAR_OFFSET:
-@@ -7785,6 +8628,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -7785,6 +8640,8 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM4_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET:
@@ -1193,7 +1205,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -7827,6 +8672,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7827,6 +8684,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1201,7 +1213,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -7919,6 +8765,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7919,6 +8777,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1211,7 +1223,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
-@@ -7978,6 +8827,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -7978,6 +8839,9 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
@@ -1221,7 +1233,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -8020,6 +8872,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8020,6 +8884,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -1229,7 +1241,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -8110,6 +8963,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8110,6 +8975,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_EVENT_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LC_SD_MASK_OFFSET:
@@ -1239,7 +1251,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_LC_PWR_ON:
  	case MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_SPI_CHNL_SELECT:
-@@ -8163,6 +9019,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8163,6 +9031,9 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CONFIG2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CONFIG3_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_UFM_VERSION_OFFSET:
@@ -1249,7 +1261,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	case MLXPLAT_CPLD_LPC_REG_EXT_MIN_OFFSET ... MLXPLAT_CPLD_LPC_REG_EXT_MAX_OFFSET:
  		return true;
  	}
-@@ -8229,6 +9088,17 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
+@@ -8229,6 +9100,17 @@ static const struct reg_default mlxplat_mlxcpld_regmap_smart_switch[] = {
  	{ MLXPLAT_CPLD_LPC_REG_WD3_ACT_OFFSET, 0x00 },
  };
  
@@ -1267,7 +1279,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  struct mlxplat_mlxcpld_regmap_context {
  	void __iomem *base;
  };
-@@ -8351,6 +9221,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_smart_switch = {
+@@ -8351,6 +9233,20 @@ static const struct regmap_config mlxplat_mlxcpld_regmap_config_smart_switch = {
  	.reg_write = mlxplat_mlxcpld_reg_write,
  };
  
@@ -1288,7 +1300,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  /* Wait completion routine for indirect access for register map */
  static int mlxplat_fpga_completion_wait(struct mlxplat_mlxcpld_regmap_context *ctx)
  {
-@@ -8476,6 +9360,8 @@ static struct spi_board_info *mlxplat_spi;
+@@ -8476,6 +9372,8 @@ static struct spi_board_info *mlxplat_spi;
  static struct pci_dev *lpc_bridge;
  static struct pci_dev *i2c_bridge;
  static struct pci_dev *jtag_bridge;
@@ -1297,7 +1309,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  
  /* Platform default reset function */
  static int mlxplat_reboot_notifier(struct notifier_block *nb, unsigned long action, void *unused)
-@@ -8508,6 +9394,26 @@ static void mlxplat_poweroff(void)
+@@ -8508,6 +9406,26 @@ static void mlxplat_poweroff(void)
  	kernel_halt();
  }
  
@@ -1324,7 +1336,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  static int __init mlxplat_register_platform_device(void)
  {
  	mlxplat_dev = platform_device_register_simple(MLX_PLAT_DEVICE_NAME, -1,
-@@ -9018,6 +9924,40 @@ static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *d
+@@ -9018,6 +9936,40 @@ static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *d
  	return mlxplat_register_platform_device();
  }
  
@@ -1365,7 +1377,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  static int __init mlxplat_dmi_ng400_hi171_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -9179,6 +10119,40 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -9179,6 +10131,40 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_MATCH(DMI_BOARD_NAME, "VMOD0019"),
  		},
  	},
@@ -1406,7 +1418,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	{
  		.callback = mlxplat_dmi_ng400_hi171_matched,
  		.matches = {
-@@ -9281,8 +10255,8 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9281,8 +10267,8 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  	int i, shift = 0;
  
  	/* Scan adapters from expected id to verify it is free. */
@@ -1417,7 +1429,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  	     mlxplat_max_adap_num; i++) {
  		search_adap = i2c_get_adapter(i);
  		if (search_adap) {
-@@ -9291,7 +10265,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9291,7 +10277,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  		}
  
  		/* Return if expected parent adapter is free. */
@@ -1426,7 +1438,7 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  			return 0;
  		break;
  	}
-@@ -9313,7 +10287,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
+@@ -9313,7 +10299,7 @@ static int mlxplat_mlxcpld_verify_bus_topology(int *nr)
  	}
  
  	/* Shift bus only if mux provided by 'mlxplat_mux_data'. */
@@ -1436,5 +1448,5 @@ index 4a8cc6a74cab..c308bd95bac5 100644
  
  	return 0;
 -- 
-2.20.1
+2.34.1
 

--- a/recipes-kernel/linux/linux-6.1/9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch
+++ b/recipes-kernel/linux/linux-6.1/9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch
@@ -1,8 +1,8 @@
-From a3b350a4ed5379b32bdd866d58e156f32fe0a1eb Mon Sep 17 00:00:00 2001
+From 7b5980f8bec608ec12f974fae46436b620c77f76 Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 13 Jan 2025 12:49:33 +0200
-Subject: [PATCH 5/6] platform: mellanox: mlx-platform: Change register 0x28
- name
+Subject: [PATCH platform-next v2 5/8] platform: mellanox: mlx-platform: Change
+ register 0x28 name
 
 Register 0x28 was repurposed on new systems. Change its name
 to correctly reflect the new functionality.
@@ -14,7 +14,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 3 insertions(+), 4 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index c308bd95bac5..deb80d3dd619 100644
+index 288dbb42eaf6..979bc93dae6b 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -53,7 +53,7 @@
@@ -26,7 +26,7 @@ index c308bd95bac5..deb80d3dd619 100644
  #define MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION	0x2a
  #define MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET	0x2b
  #define MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET	0x2d
-@@ -8540,7 +8540,6 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
+@@ -8552,7 +8552,6 @@ static bool mlxplat_mlxcpld_writeable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -34,7 +34,7 @@ index c308bd95bac5..deb80d3dd619 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GP1_OFFSET:
-@@ -8672,7 +8671,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8684,7 +8683,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -43,7 +43,7 @@ index c308bd95bac5..deb80d3dd619 100644
  	case MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION:
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
-@@ -8872,7 +8871,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8884,7 +8883,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_LED6_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED7_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_LED8_OFFSET:
@@ -53,5 +53,5 @@ index c308bd95bac5..deb80d3dd619 100644
  	case MLXPLAT_CPLD_LPC_REG_GP0_RO_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_GPCOM0_OFFSET:
 -- 
-2.20.1
+2.34.1
 

--- a/recipes-kernel/linux/linux-6.1/9009-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch
+++ b/recipes-kernel/linux/linux-6.1/9009-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch
@@ -1,8 +1,8 @@
-From 974ee125f14f1e98ff13113fff00bb1eb40c875f Mon Sep 17 00:00:00 2001
+From 529ed9fc5192525355c0280984f631b3bd7d55b1 Mon Sep 17 00:00:00 2001
 From: Felix Radensky <fradensky@nvidia.com>
 Date: Mon, 13 Jan 2025 17:02:32 +0200
-Subject: [PATCH 6/6] platform: mellanox: mlx-platform: Add support for
- Q3450-LD Nvidia XDR switch
+Subject: [PATCH platform-next v2 6/8] platform: mellanox: mlx-platform: Add
+ support for Q3450-LD Nvidia XDR switch
 
 Q3450-LD is XDR Infiniband CPO switch with 144 XDR ports, based on
 Nvidia Quantum-3 ASIC. It provides up-to 800Gbps full bidirectional
@@ -24,7 +24,7 @@ Reviewed-by: Vadim Pasternak <vadimp@nvidia.com>
  1 file changed, 294 insertions(+), 28 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index deb80d3dd619..828bed662ff7 100644
+index 979bc93dae6b..7608a6a25029 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -38,6 +38,7 @@
@@ -392,7 +392,7 @@ index deb80d3dd619..828bed662ff7 100644
      {
  		.label = "leakage_status_clear",
  		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
-@@ -8644,6 +8876,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8656,6 +8888,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET:
@@ -400,7 +400,7 @@ index deb80d3dd619..828bed662ff7 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -8656,6 +8889,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8668,6 +8901,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN1_OFFSET:
@@ -408,7 +408,7 @@ index deb80d3dd619..828bed662ff7 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP3_OFFSET:
-@@ -8790,6 +9024,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+@@ -8802,6 +9036,7 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
@@ -416,7 +416,7 @@ index deb80d3dd619..828bed662ff7 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -8844,6 +9079,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8856,6 +9091,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET:
@@ -424,7 +424,7 @@ index deb80d3dd619..828bed662ff7 100644
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD1_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD2_PN_OFFSET:
-@@ -8856,6 +9092,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8868,6 +9104,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_PN1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD6_PN1_OFFSET:
@@ -432,7 +432,7 @@ index deb80d3dd619..828bed662ff7 100644
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_RESET_GP3_OFFSET:
-@@ -8982,6 +9219,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+@@ -8994,6 +9231,7 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
  	case MLXPLAT_CPLD_LPC_REG_CPLD3_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD4_MVER_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET:
@@ -440,7 +440,7 @@ index deb80d3dd619..828bed662ff7 100644
  	case MLXPLAT_CPLD_LPC_REG_PWM1_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM2_OFFSET:
  	case MLXPLAT_CPLD_LPC_REG_PWM3_OFFSET:
-@@ -9900,6 +10138,27 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
+@@ -9912,6 +10150,27 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
  	return mlxplat_register_platform_device();
  }
  
@@ -468,7 +468,7 @@ index deb80d3dd619..828bed662ff7 100644
  static int __init mlxplat_dmi_smart_switch_matched(const struct dmi_system_id *dmi)
  {
  	int i;
-@@ -10106,6 +10365,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+@@ -10118,6 +10377,13 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
  			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "HI159"),
  		},
  	},
@@ -483,5 +483,5 @@ index deb80d3dd619..828bed662ff7 100644
  		.callback = mlxplat_dmi_xdr_matched,
  		.matches = {
 -- 
-2.20.1
+2.34.1
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2392,7 +2392,7 @@ n51xxld_specific()
 
 	cpld_num=4
 	max_tachos=8
-    leakage_count=4
+	leakage_count=6
 	erot_count=3
 
 	case $sku in

--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -83,6 +83,14 @@ atttrib_list = {
          "fn": "run_cmd",
          "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE4 {arg1}"],
          "poll": 2, "ts": 0},
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage5",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE5 {arg1}"],
+         "poll": 2, "ts": 0},
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage6",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE6 {arg1}"],
+         "poll": 2, "ts": 0},
 
         {"fin": "/var/run/hw-management/system/power_button_evt",
          "fn": "run_power_button_event",
@@ -90,17 +98,17 @@ atttrib_list = {
          "poll": 1, "ts": 0},
 
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"}
-                },
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"}
+                 },
+         },
 
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 36}
-        },
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 36}
+         },
         {"fin": None,
-         "fn": "redfish_get_sensor", "arg" : ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
+         "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
     "HI166|HI167|HI169|HI170": [
         {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/fan1",
@@ -131,6 +139,14 @@ atttrib_list = {
          "fn": "run_cmd",
          "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE4 {arg1}"],
          "poll": 2, "ts": 0},
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage5",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE5 {arg1}"],
+         "poll": 2, "ts": 0},
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage6",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE6 {arg1}"],
+         "poll": 2, "ts": 0},
 
         {"fin": "/var/run/hw-management/system/graseful_pwr_off",
          "fn": "run_power_button_event",
@@ -138,174 +154,174 @@ atttrib_list = {
          "poll": 1, "ts": 0},
 
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 36}
-        },
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 36}
+         },
         {"fin": None,
-         "fn": "redfish_get_sensor", "arg" : ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
+         "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
     "HI171|HI172|HI144|HI147|HI148|HI174": [
         {"fin": "/var/run/hw-management/system/graseful_pwr_off", "fn": "run_power_button_event",
          "arg": [], "poll": 1, "ts": 0},
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 66}
-        }        
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 66}
+         }
     ],
     "HI112|HI116|HI136": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 32}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 32}
+         }
     ],
     "HI120": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 60}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 60}
+         }
     ],
     "HI121": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 54}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 54}
+         }
     ],
     "HI122|HI156": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 32}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 32}
+         }
     ],
     "HI123|HI124": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 64}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 64}
+         }
     ],
     "HI146": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 32}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 32}
+         }
     ],
     "HI160": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 28}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 28}
+         }
     ],
     "HI157": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 37}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 37}
+         }
     ],
     "HI158": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"},
-                    "asic3": {"fin": "/sys/module/sx_core/asic2/"},
-                    "asic4": {"fin": "/sys/module/sx_core/asic3/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"},
+                 "asic3": {"fin": "/sys/module/sx_core/asic2/"},
+                 "asic4": {"fin": "/sys/module/sx_core/asic3/"}
+                 }
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 73}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 73}
+         }
     ],
     "HI175": [
-       {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"},
-                    "asic3": {"fin": "/sys/module/sx_core/asic2/"},
-                    "asic4": {"fin": "/sys/module/sx_core/asic3/"}
+        {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"},
+                 "asic3": {"fin": "/sys/module/sx_core/asic2/"},
+                 "asic4": {"fin": "/sys/module/sx_core/asic3/"}
                  }
-        },
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 91}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 91}
+         }
     ],
     "HI176": [
         {"fin": "/var/run/hw-management/system/graseful_pwr_off", "fn": "run_power_button_event",
          "arg": [], "poll": 1, "ts": 0},
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"}
+                 }
+         },
 
         {"fin": None,
-         "fn": "redfish_get_sensor", "arg" : ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}     
+         "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
     "HI177": [
         {"fin": "/var/run/hw-management/system/graseful_pwr_off", "fn": "run_power_button_event",
          "arg": [], "poll": 1, "ts": 0},
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic2": {"fin": "/sys/module/sx_core/asic1/"},
-                    "asic3": {"fin": "/sys/module/sx_core/asic2/"}
-                }
-        },
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic2": {"fin": "/sys/module/sx_core/asic1/"},
+                 "asic3": {"fin": "/sys/module/sx_core/asic2/"}
+                 }
+         },
         {"fin": None,
-         "fn": "redfish_get_sensor", "arg" : ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}   
+         "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
     "HI178": [
-       {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
-         "arg" : {  "asic":  {"fin": "/sys/module/sx_core/asic0/"},
-                    "asic1": {"fin": "/sys/module/sx_core/asic0/"},
+        {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
+         "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
+                 "asic1": {"fin": "/sys/module/sx_core/asic0/"},
                  }
-        },
+         },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg" : {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 24}
-        }
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 24}
+         }
     ],
     "def": [
-         {"fin": "/var/run/hw-management/config/thermal_enforced_full_spped",
+        {"fin": "/var/run/hw-management/config/thermal_enforced_full_spped",
          "fn": "run_cmd",
          "arg": ["if [[ -f /var/run/hw-management/config/thermal_enforced_full_spped && "
                  "$(</var/run/hw-management/config/thermal_enforced_full_spped) == \"1\" ]]; then "
@@ -313,12 +329,13 @@ atttrib_list = {
          "poll": 5, "ts": 0},
     ],
     "test": [
-         {"fin": "/tmp/power_button_clr",
+        {"fin": "/tmp/power_button_clr",
          "fn": "run_power_button_event",
          "arg": [],
          "poll": 1, "ts": 0},
     ]
 }
+
 
 class CONST(object):
     # inde1pendent mode - module reading temperature via SDK sysfs
@@ -336,6 +353,7 @@ class CONST(object):
     MODULE_TEMP_CRIT_DEF = 120000
     MODULE_TEMP_EMERGENCY_OFFSET = 10000
 
+
 REDFISH_OBJ = None
 
 """
@@ -349,21 +367,23 @@ in 'Thresholds' reasponnse:
     'UpperCritical': {'Reading': 108.0}
 }
 """
-redfish_attr = {"Temperature" : {"folder" : "/var/run/hw-management/thermal",
-                                 "LowerCaution" : "min",
-                                 "UpperCaution" : "max",
-                                 "LowerCritical" :"lcrit",
-                                 "UpperCritical" :"crit"
+redfish_attr = {"Temperature": {"folder": "/var/run/hw-management/thermal",
+                                "LowerCaution": "min",
+                                "UpperCaution": "max",
+                                "LowerCritical": "lcrit",
+                                "UpperCritical": "crit"
                                 },
-                "Voltage" : {"folder" : "/var/run/hw-management/environment",
-                             "LowerCaution" : "min",
-                             "UpperCaution" : "max",
-                             "LowerCritical" :"lcrit",
-                             "UpperCritical" :"crit"
+                "Voltage": {"folder": "/var/run/hw-management/environment",
+                            "LowerCaution": "min",
+                            "UpperCaution": "max",
+                            "LowerCritical": "lcrit",
+                            "UpperCritical": "crit"
                             }
-               }
+                }
 
 # ----------------------------------------------------------------------
+
+
 def redfish_init():
     bmc_accessor = BMCAccessor()
     ret = bmc_accessor.login()
@@ -373,6 +393,8 @@ def redfish_init():
     return bmc_accessor
 
 # ----------------------------------------------------------------------
+
+
 def redfish_get_req(path):
     global REDFISH_OBJ
     response = None
@@ -392,6 +414,8 @@ def redfish_get_req(path):
     return response
 
 # ----------------------------------------------------------------------
+
+
 def redfish_post_req(path, data_dict):
     global REDFISH_OBJ
     ret = None
@@ -407,6 +431,8 @@ def redfish_post_req(path, data_dict):
     return ret
 
 # ----------------------------------------------------------------------
+
+
 def redfish_get_sensor(argv, _dummy):
     sensor_path = argv[0]
     response = redfish_get_req(sensor_path)
@@ -428,7 +454,7 @@ def redfish_get_sensor(argv, _dummy):
     sensor_path = sensor_redfish_attr["folder"]
     sensor_name = argv[1]
     sensor_scale = argv[2]
-    sensor_attr = {sensor_name : int(response["Reading"] * sensor_scale)}
+    sensor_attr = {sensor_name: int(response["Reading"] * sensor_scale)}
     for responce_trh_name in response["Thresholds"].keys():
         if responce_trh_name in sensor_redfish_attr.keys():
             trh_name = "{}_{}".format(sensor_name, sensor_redfish_attr[responce_trh_name])
@@ -438,9 +464,11 @@ def redfish_get_sensor(argv, _dummy):
     for attr_name, attr_val in sensor_attr.items():
         attr_path = os.path.join(sensor_path, attr_name)
         with open(attr_path, "w") as attr_file:
-            attr_file.write(str(attr_val)+"\n")
+            attr_file.write(str(attr_val) + "\n")
 
 # ----------------------------------------------------------------------
+
+
 def run_power_button_event(argv, val):
     cmd = "/usr/bin/hw-management-chassis-events.sh hotplug-event POWER_BUTTON {}".format(val)
     os.system(cmd)
@@ -454,12 +482,16 @@ def run_power_button_event(argv, val):
         redfish_post_req(req_path, req_data)"""
 
 # ----------------------------------------------------------------------
+
+
 def run_cmd(cmd_list, arg):
     for cmd in cmd_list:
         cmd = cmd + " 2> /dev/null 1> /dev/null"
         os.system(cmd.format(arg1=arg))
 
 # ----------------------------------------------------------------------
+
+
 def sync_fan(fan_id, val):
     if int(val) == 0:
         status = 1
@@ -473,6 +505,8 @@ def sync_fan(fan_id, val):
     os.system(cmd)
 
 # ----------------------------------------------------------------------
+
+
 def sdk_temp2degree(val):
     if val >= 0:
         temperature = val * 125
@@ -481,6 +515,8 @@ def sdk_temp2degree(val):
     return temperature
 
 # ----------------------------------------------------------------------
+
+
 def is_module_host_management_mode(f_module_path):
     """
     @summary: Check if ASIC in independent mode
@@ -492,7 +528,7 @@ def is_module_host_management_mode(f_module_path):
         with open(f_module_control_path, 'r') as f:
             # reading module control. 1 - SW(independent), 0 - FW(dependent)
             module_mode = int(f.read().strip())
-    except:
+    except BaseException:
         # by default use FW control (dependent mode)
         module_mode = CONST.SDK_FW_CONTROL
 
@@ -500,6 +536,8 @@ def is_module_host_management_mode(f_module_path):
     return module_mode == CONST.SDK_SW_CONTROL
 
 # ----------------------------------------------------------------------
+
+
 def is_asic_ready(asic_name, asic_attr):
     asic_ready = False
     if os.path.exists(asic_attr["fin"]):
@@ -507,11 +545,13 @@ def is_asic_ready(asic_name, asic_attr):
         try:
             with open(f_asic_ready, 'r') as f:
                 asic_ready = int(f.read().strip())
-        except:
+        except BaseException:
             asic_ready = True
     return bool(asic_ready)
 
 # ----------------------------------------------------------------------
+
+
 def asic_temp_reset(asic_name, f_asic_src_path):
     # Default temperature values
     file_paths = {
@@ -527,6 +567,8 @@ def asic_temp_reset(asic_name, f_asic_src_path):
             f.write("{}\n".format(value))
 
 # ----------------------------------------------------------------------
+
+
 def asic_temp_populate(arg_list, arg):
     """
     @summary: Update asic attributes
@@ -559,11 +601,11 @@ def asic_temp_populate(arg_list, arg):
             with open(f_src_input, 'r') as f:
                 val = f.read()
             temperature = sdk_temp2degree(int(val))
-            temperature_min =  CONST.ASIC_TEMP_MIN_DEF
+            temperature_min = CONST.ASIC_TEMP_MIN_DEF
             temperature_max = CONST.ASIC_TEMP_MAX_DEF
             temperature_fault = CONST.ASIC_TEMP_FAULT_DEF
             temperature_crit = CONST.ASIC_TEMP_CRIT_DEF
-        except:
+        except BaseException:
             temperature = ""
             temperature_min = ""
             temperature_max = ""
@@ -592,7 +634,7 @@ def asic_temp_populate(arg_list, arg):
         with open(asic_num_fname, 'r', encoding="utf-8") as f:
             asic_num = f.read().rstrip('\n')
             asic_num = int(asic_num)
-    except:
+    except BaseException:
         asic_num = 255
 
     if asic_chipup_completed >= asic_num:
@@ -601,12 +643,14 @@ def asic_temp_populate(arg_list, arg):
         asics_init_done = 0
 
     with open(asics_init_done_fname, 'w+', encoding="utf-8") as f:
-        f.write(str(asics_init_done)+"\n")
+        f.write(str(asics_init_done) + "\n")
 
     with open(asic_chipup_completed_fname, 'w', encoding="utf-8") as f:
-        f.write(str(asic_chipup_completed)+"\n")
+        f.write(str(asic_chipup_completed) + "\n")
 
 # ----------------------------------------------------------------------
+
+
 def module_temp_populate(arg_list, _dummy):
     ''
     fin = arg_list["fin"]
@@ -614,13 +658,13 @@ def module_temp_populate(arg_list, _dummy):
     offset = arg_list["fout_idx_offset"]
     module_updated = False
     for idx in range(module_count):
-        module_name = "module{}".format(idx+offset)
+        module_name = "module{}".format(idx + offset)
         f_dst_name = "/var/run/hw-management/thermal/{}_temp_input".format(module_name)
         if os.path.islink(f_dst_name):
             continue
 
         f_src_path = fin.format(idx)
-        # If control mode is SW - skip temperature reading (independent mode) 
+        # If control mode is SW - skip temperature reading (independent mode)
         if is_module_host_management_mode(f_src_path):
             continue
 
@@ -630,7 +674,7 @@ def module_temp_populate(arg_list, _dummy):
         try:
             with open(f_src_present, 'r') as f:
                 module_present = int(f.read().strip())
-        except:
+        except BaseException:
             pass  # Module is not present or file reading failed
 
         # Default temperature values
@@ -667,7 +711,7 @@ def module_temp_populate(arg_list, _dummy):
                 else:
                     temperature_trip_crit = CONST.MODULE_TEMP_CRIT_DEF
 
-            except:
+            except BaseException:
                 pass
 
         # Write the temperature data to files
@@ -692,6 +736,8 @@ def module_temp_populate(arg_list, _dummy):
     return
 
 # ----------------------------------------------------------------------
+
+
 def update_attr(attr_prop):
     """
     @summary: Update hw-mgmt attributes and invoke cmd per attr change
@@ -713,7 +759,7 @@ def update_attr(attr_prop):
                     if "oldval" not in attr_prop.keys() or attr_prop["oldval"] != val:
                         globals()[fn_name](argv, val)
                         attr_prop["oldval"] = val
-                except:
+                except BaseException:
                     # File exists but read error
                     globals()[fn_name](argv, "")
                     attr_prop["oldval"] = ""
@@ -723,8 +769,9 @@ def update_attr(attr_prop):
         else:
             try:
                 globals()[fn_name](argv, None)
-            except:
+            except BaseException:
                 pass
+
 
 def init_attr(attr_prop):
     if "hwmon" in str(attr_prop["fin"]):
@@ -735,6 +782,7 @@ def init_attr(attr_prop):
             attr_prop["hwmon"] = hwmon_name[0]
         except Exception as e:
             attr_prop["hwmon"] = ""
+
 
 def main():
     """
@@ -767,6 +815,7 @@ def main():
         for attr in sys_attr:
             update_attr(attr)
         time.sleep(1)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
…L systems family

Add leakage5/leakage6 attributes for GB200 systems. Modify reset cause attribute name s/reset_main_5v/reset_main_51v.

Bugfixes: #4486391 #4484710 #4484741 #4486220 #4436366 #4489418 #4486221 #4486012