### PR TITLE
hw-mgmt: scripts: fix init errors of GPIOs for JTAG on AMD based syst…

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -839,7 +839,7 @@ set_jtag_gpio()
 		fi
 	fi
 
-	if [ "$board_type" == "VMOD0021" -o "$board_type" == "VMOD0022" ]; then
+	if [ "$cpu_type" == "$AMD_SNW_CPU" ]; then
 		return 0
 	fi
 


### PR DESCRIPTION
…ems.

CPLD update on AMD based systems is done through LPC CPLD interface. So, GPIOs for JTAG are not relevant and shouldn't be initialized.

Bug: 4512069