### PR TITLE
hw-mgmt: thermal: Infrastructure to support fan speed reduction after a corner fan re-insertion

### DIFF
--- a/debian/Release.txt
+++ b/debian/Release.txt
@@ -1,4 +1,27 @@
 ================================================================================
+- V.7.0040.4020
+- Fri, 4 Jul 2025
+--------------------------------------------------------------------------------
+
+- New features
+    o 
+
+- Bug fixes
+    o #4521169 hw-mgmt: thermal: Thermal: Infrastructure to support fan speed reduction after a corner fan re-inserted
+
+- Kernel Patches for New Features:
+    o 
+
+- For detailed patch list: Please view: https://github.com/Mellanox/hw-mgmt/blob/V.7.0040.4019/recipes-kernel/linux/Patch_Status_Table.txt
+
+- Known issues and limitations:
+    o Systems like sn2700 which contain delta 460 PSU may have "Error getting sensor data: dps460/#25: Can't read"
+      which is a temporary inaccessibility of certain alarm attributes read from the PSU.
+    o Systems may show a message of WARNING kernel: Ã¢â‚¬Â¦ supply vcc not found, using dummy regulator" 
+    o Systems SN2010, SN2100, SN2410, SN2700 and SN2740 (and their "-B" variants) require the following flag in kernel cmdline:
+      "acpi_enforce_resources=lax acpi=noirq". 
+
+
 - V.7.0040.4019
 - Thu, 26 Jun 2025
 --------------------------------------------------------------------------------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
-hw-management (1.mlnx.7.0040.4019) unstable; urgency=low
+hw-management (1.mlnx.7.0040.4020) unstable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Thu, 26 Jun 2025 15:04:49 +0300
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Fri, 4 Jul 2025 15:04:49 +0300
 
 
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2485,6 +2485,8 @@ sn5640_specific()
 	echo -n "${named_busses[@]}" > $config_path/named_busses
 	echo "$reset_dflt_attr_num" > $config_path/reset_attr_num
 	echo 0 > "$config_path"/labels_ready
+	echo 10 > "$config_path"/fan_steady_state_delay
+	echo 50 > "$config_path"/fan_steady_state_pwm
 }
 
 system_cleanup_specific()


### PR DESCRIPTION
There was an issue reported by a customer 4486661.

After reinserting fans in SN5610 fan fails to start rotating.
Only fans in the leftmost or rightmost slots exhibit the issue.
It does not occur with fans in the center. A stuck fan will
start to rotate by either of the following actions:
1) Pull out and reinsert an additional fans. 2) Lower the PWM of
all fans for several seconds.

This is happening because reinserted fan fails to generate
enough starting torque to overcome opposing pressure generated
by the operating fans.

This commit introduces two configurable hw-mgmt config options:

 1) fan_steady_state_delay: This is the value in seconds for which
    the TC will be paused in case if there is a corner fan insertion.
    This is set to 10s by default.
 2) fan_steady_state_pwm: This is the pwm value (in percentage) that
    will be set for fan_steady_state_delay seconds when the corner
    fan is inserted. Pwm will be moved back to the previous value
    after this timeout. This is set to 50% by default.

Thermal control 2.5 is made aware of these new config options and
added the logic to find if there is a corner fan re-insertion and
adjust the pwm based on the requirements.

FR: #4521169

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
[Uinit_Test_oci_fan_thermal_enhancement.txt](https://github.com/user-attachments/files/21057165/Uinit_Test_oci_fan_thermal_enhancement.txt)
