### PR TITLE
hw-mgmt: scripts: Fix ASIC temperature reading issue

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -275,6 +275,33 @@ function get_psu_eeprom_type()
 	echo $eeprom_type
 }
 
+# Set ASIC ready state
+# $1 - sysfs path of PCI device
+# $2 - ASIC ready state (0 or 1)
+# return none
+function set_asic_ready()
+{
+	sysfs_picdev_path=$1
+	state=$2
+	[ -f "$config_path/asic_num" ] && asic_num=$(< $config_path/asic_num)
+	if [ $asic_num -gt 1 ]; then
+		pci_bus="${sysfs_picdev_path: -7}"
+		for ((asic_id=1; asic_id<=asic_num; asic_id+=1)); do
+			bus=$(< $config_path/asic"$asic_id"_pci_bus_id)
+			if [ "$bus" == "$pci_bus" ]; then
+				echo $state > $config_path/asic"$asic_id"_ready
+				if [ $asic_id -eq 1 ]; then
+					echo $state > $config_path/asic_ready
+				fi
+				break
+			fi
+		done
+	else
+		echo $state > $config_path/asic1_ready
+		echo $state > $config_path/asic_ready
+	fi
+}
+
 # Don't process udev events until service is started and directories are created
 if [ ! -f ${udev_ready} ]; then
 	exit 0
@@ -1140,6 +1167,7 @@ if [ "$1" == "add" ]; then
 			modprobe mlxsw_minimal
 		fi
 		/usr/bin/hw-management.sh chipup 0 "$4/$5"
+		set_asic_ready "$4/$5" 1
 	fi
 	if [ "$2" == "nvme_temp" ]; then
 		dev_name=$(cat "$3""$4"/name)
@@ -1494,6 +1522,7 @@ else
 	fi
 	if [ "$2" == "sxcore" ]; then
 		/usr/bin/hw-management.sh chipdown 0 "$4/$5"
+		set_asic_ready "$4/$5" 0
 	fi
 	if [ "$2" == "dpu" ]; then
 		sku=$(< /sys/devices/virtual/dmi/id/product_sku)


### PR DESCRIPTION
If we try to read asic temperature before SDK fully initialized
It can may result in error message in kernel:

sxd_kernel: [error] Command path in DPT for device 1 is not valid.
Aborting command SX_CMD_ACCESS_REG (register ID 0x900f)
sxd_kernel: [error] Register access failed (reg_id=0x900f, err=-22 [from CMD-IFC
status])

Fix: hw-management should use sysfs only after these events:

KOBJ_ADD or KOBJ_ONLINE from sx_core driver
and should not use sysfs after these events
KOBJ_REMOVE or KOBJ_OFFLINE from sx_core driver

Add asic{X}_ready flag which can be used to distinguish if ASIC initialized

Bug: 4497061

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
