### PR TITLE
hw-mgmt: thermal: Fix system name in TC config for q3450

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_q3450.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3450.json
@@ -1,5 +1,5 @@
  {
-	"name": "q3450",
+	"name": "q3450/q3450_ld",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {


### PR DESCRIPTION
Fix system name in TC config for q3450.
Add support for name variant q3450_ld

Bug: 4430499

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
