### PR TITLE
hw-mgmt: thermal: Fan state validation after re-insertion

### DIFF
--- a/debian/Release.txt
+++ b/debian/Release.txt
@@ -8,6 +8,7 @@
 
 - Bug fixes
     o #4486661, hw-mgmt: thermal: Add fan state validation after re-insertion, and attention_fans config for SN5610/5640, d4a3149
+    o #4486661, hw-mgmt: thermal: Add fan state validation after re-insertion, and attention_fans config for SN4280, f5a618c3
 
 - Kernel Patches for New Features:
     o 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
-hw-management (1.mlnx.7.0050.1001) stable; urgency=low
+hw-management (1.mlnx.7.0050.1002) stable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Wed, 09 Jul 2025 11:11:57 +0300
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Mon, 14 Jul 2025 11:11:57 +0300
 
 
 

--- a/unittest/hw_mgmt_thermal_control_2_0/Fan_thermal_insert_fault_test.txt
+++ b/unittest/hw_mgmt_thermal_control_2_0/Fan_thermal_insert_fault_test.txt
@@ -1,0 +1,96 @@
+root@r-bobcat-02:~# dmidecode -t1 -t2
+# dmidecode 3.4
+Getting SMBIOS data from sysfs.
+SMBIOS 3.2.1 present.
+
+Handle 0x0001, DMI type 1, 27 bytes
+System Information
+        Manufacturer: Nvidia
+        Product Name: SN4280
+        Version: V0-C*GeGdFdRiRaEg-S*GbGbFcRaRaRaRaA0RaTcEiFcEi-D*TfGeGdFaRaRa-F*Tc
+        Serial Number: MT2428XZ0JXV
+        UUID: b908e90a-a121-11ef-8000-b0cf0e209200
+        Wake-up Type: Power Switch
+        SKU Number: HI160
+        Family: Not Specified
+
+Handle 0x0002, DMI type 2, 15 bytes
+Base Board Information
+        Manufacturer: Nvidia
+        Product Name: VMOD0019
+        Version: A2
+        Serial Number: MT2428XZ0HXA
+        Asset Tag: Not Specified
+        Features:
+                Board is a hosting board
+                Board is removable
+                Board is replaceable
+        Location In Chassis: Not Specified
+        Chassis Handle: 0x0003
+        Type: Motherboard
+        Contained Object Handles: 0
+
+root@r-bobcat-02:~# systemctl status hw-management-tc
+● hw-management-tc.service - Thermal control service (ver 2.0) of Mellanox systems
+     Loaded: loaded (/lib/systemd/system/hw-management-tc.service; enabled; preset: enabled)
+     Active: active (running) since Fri 2025-07-11 08:05:32 UTC; 42s ago
+       Docs: man:hw-management-tc.service(8)
+   Main PID: 19259 (hw_management_t)
+      Tasks: 1 (limit: 153549)
+     Memory: 17.4M
+     CGroup: /system.slice/hw-management-tc.service
+             └─19259 /usr/bin/python /usr/bin/hw_management_thermal_control.py
+
+Jul 11 08:05:32 r-bobcat-02 systemd[1]: Started hw-management-tc.service - Thermal control service (ver 2.0) of Mellanox systems.
+Jul 11 08:05:33 r-bobcat-02 hw-management-tc[19259]: NOTICE - Preinit thermal control ver 2.1.0
+Jul 11 08:05:33 r-bobcat-02 hw-management-tc[19259]: NOTICE - Set FAN PWM 100
+Jul 11 08:05:33 r-bobcat-02 hw-management-tc[19259]: NOTICE - Additional delay defined in ./config/thermal_delay (35 sec).
+Jul 11 08:05:33 r-bobcat-02 hw-management-tc[19259]: NOTICE - Mellanox thermal control is waiting for configuration (60 sec).
+
+root@r-bobcat-02:~# cat /var/run/hw-management/thermal/pwm1 
+255
+
+root@r-gaur-01:/var/run/hw-management/thermal# dvs_start.sh --sdk_bridge_mode=HYBRID
+
+root@r-bobcat-02:/var/run/hw-management/thermal# cat asic
+64000
+
+root@r-bobcat-02:/var/run/hw-management/thermal# cat pwm1 
+76
+
+# TC: Simulate fan insertion and fault condition for Fan drawer 1
+root@r-bobcat-02:/var/run/hw-management/thermal# unlink fan1_fault 
+root@r-bobcat-02:/var/run/hw-management/thermal# unlink fan1_status
+root@r-bobcat-02:/var/run/hw-management/thermal# unlink fan1_speed_get 
+root@r-bobcat-02:/var/run/hw-management/thermal# echo 0  > fan1_speed_get; echo 1 > fan1_fault; echo 0 > fan1_status
+# Wait for sometime
+root@r-bobcat-02:/var/run/hw-management/thermal# echo 1 > fan1_status
+root@r-bobcat-02:/var/run/hw-management/thermal# cat pwm1
+127
+
+
+=======================Snippet from /var/log/tc_log======================================
+2025-07-11 08:20:34,765 - INFO - drwr1:[1] tacho1=0 out of RPM range 3100:11000
+2025-07-11 08:20:34,767 - WARNING - drwr1:[1] status 0. Set PWM 20
+2025-07-11 08:20:34,767 - WARNING - drwr1:[1] incorrect rpm [0]. Set PWM  20
+2025-07-11 08:20:39,804 - INFO - drwr1:[1] tacho1=0 out of RPM range 3100:11000
+2025-07-11 08:20:39,805 - WARNING - drwr1:[1] status 0. Set PWM 20
+2025-07-11 08:20:39,805 - WARNING - drwr1:[1] incorrect rpm [0]. Set PWM  20
+2025-07-11 08:20:44,805 - INFO - drwr1:[1] tacho1=0 out of RPM range 3100:11000
+2025-07-11 08:20:44,806 - WARNING - drwr1:[1] status 0. Set PWM 20
+2025-07-11 08:20:44,807 - WARNING - drwr1:[1] incorrect rpm [0]. Set PWM  20
+2025-07-11 08:20:49,808 - INFO - drwr1:[1] tacho1=0 out of RPM range 3100:11000
+2025-07-11 08:20:49,809 - WARNING - drwr1:[1] incorrect rpm [0]. Set PWM  20
+2025-07-11 08:20:54,823 - INFO - drwr1:[1] tacho1=0 out of RPM range 3100:11000
+2025-07-11 08:20:54,824 - WARNING - drwr1:[1] incorrect rpm [0]. Set PWM  20
+2025-07-11 08:20:55,825 - NOTICE - drwr1:[1] fan not started after insertion
+2025-07-11 08:20:55,825 - INFO - Attention fan insertion failed, trying to recover
+2025-07-11 08:20:55,825 - NOTICE - @syslog Attention fan not started after insertion: Setting pwm to 50% from 30%
+2025-07-11 08:20:55,825 - INFO - Update chassis FAN PWM 50
+2025-07-11 08:20:55,825 - INFO - Write drwr1:[1] PWM 50
+2025-07-11 08:20:55,825 - INFO - Write drwr2:[2] PWM 50
+2025-07-11 08:20:55,826 - INFO - Write drwr3:[3] PWM 50
+2025-07-11 08:20:55,826 - INFO - Write drwr4:[4] PWM 50
+2025-07-11 08:20:55,826 - INFO - Waiting 10s for newly inserted fan to stabilize
+2025-07-11 08:21:05,827 - INFO - Resuming normal operation: Setting pwm back to 30%
+2025-07-11 08:21:05,827 - INFO - Update chassis FAN PWM 30

--- a/usr/etc/hw-management-thermal/tc_config_sn4280.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn4280.json
@@ -36,6 +36,7 @@
 			"1" : {"rpm_min":3100, "rpm_max":11000, "slope": 98.8, "pwm_min" : 20, "pwm_max_reduction" : 10, "rpm_tolerance" : 30}
 		}
 	},
+	"general_config" : {"attention_fans" : ["drwr1", "drwr2", "drwr3", "drwr4"], "fan_steady_state_delay" : 10, "fan_steady_state_pwm" : 50},
 	"dev_parameters" : {
 		"asic\\d*":           {"pwm_min": 30, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":100}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!105000", "poll_time": 3, "sensor_read_error":100},

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -95,6 +95,10 @@ class CONST(object):
     SYS_CONF_SENSOR_LIST_PARAM = "sensor_list"
     SYS_CONF_ERR_MASK = "error_mask"
     SYS_CONF_REDUNDANCY_PARAM = "redundancy"
+    SYS_CONF_GENERAL_CONFIG_PARAM = "general_config"
+    SYS_CONF_FAN_STEADY_STATE_DELAY = "fan_steady_state_delay"
+    SYS_CONF_FAN_STEADY_STATE_PWM = "fan_steady_state_pwm"
+    SYS_CONF_FAN_STEADY_ATTENTION_ITEMS = "attention_fans"
 
     # *************************
     # Folders definition
@@ -168,6 +172,10 @@ class CONST(object):
     PWM_VALIDATE_TIME = 30
     # FAN RPM tolerance in percent
     FAN_RPM_TOLERANCE = 30
+
+    # attention fan insertion recovery defaults
+    FAN_STEADY_STATE_DELAY_DEF = 0
+    FAN_STEADY_STATE_PWM_DEF = 50
 
     # default system devices
     PSU_COUNT_DEF = 2
@@ -2035,6 +2043,11 @@ class fan_sensor(system_device):
 
         self.rpm_valid_state = True
 
+        self.insert_status = 0
+        self.insert_event_ts = 0
+        self.insert_failed = False
+        self.insert_event = False
+
     # ----------------------------------------------------------------------
     def sensor_configure(self):
         """
@@ -2052,6 +2065,11 @@ class fan_sensor(system_device):
         self.drwr_param = self._get_fan_drwr_param()
         self.fan_shutdown(False)
         self.pwm_set = self.read_pwm(CONST.PWM_MIN)
+
+        self.insert_status = 0
+        self.insert_event_ts = 0
+        self.insert_failed = False
+        self.insert_event = False
 
     # ----------------------------------------------------------------------
     def refresh_attr(self):
@@ -2115,6 +2133,42 @@ class fan_sensor(system_device):
             except BaseException:
                 self.log.error("Value reading from file: {}".format(status_filename))
         return status
+
+    # ----------------------------------------------------------------------
+    def update_insert_state(self):
+        """
+        @summary: Update insert state
+        """
+        status = self._get_status()
+        if status:
+            if not self.insert_status:
+                self.insert_event_ts = self.get_timestump()
+                self.insert_event = True
+        else:
+            self.insert_event = 0
+            self.insert_failed = False
+        self.insert_status = status
+
+    # ----------------------------------------------------------------------
+    def is_insert_failed(self):
+        """
+        @summary: Check if insert failed
+        """
+        if self.insert_event:
+            if self.insert_event_ts + CONST.FAN_RELAX_TIME * 1000 <= self.get_timestump():
+                fan_fault_list = self._get_fault()
+                if any(x == 1 for x in fan_fault_list):
+                    self.insert_failed = True
+                self.insert_event = False
+
+        return self.insert_failed
+
+    # ----------------------------------------------------------------------
+    def reset_insert_failed_state(self):
+        """
+        @summary: Reset insert failed state
+        """
+        self.insert_failed = False
 
     # ----------------------------------------------------------------------
     def _get_fault(self):
@@ -2687,6 +2741,18 @@ class ThermalManagement(hw_managemet_file_op):
                 self.exit.wait(10)
             self.log.notice("PWM control activated", 1)
 
+        self.attention_fans_lst = get_dict_val_by_path(self.sys_config, [CONST.SYS_CONF_GENERAL_CONFIG_PARAM, CONST.SYS_CONF_FAN_STEADY_ATTENTION_ITEMS])
+        if self.attention_fans_lst:
+            self.fan_steady_state_delay = get_dict_val_by_path(self.sys_config, [CONST.SYS_CONF_GENERAL_CONFIG_PARAM, CONST.SYS_CONF_FAN_STEADY_STATE_DELAY])
+            if not self.fan_steady_state_delay:
+                self.fan_steady_state_delay = CONST.FAN_STEADY_STATE_DELAY_DEF
+            self.fan_steady_state_pwm = get_dict_val_by_path(self.sys_config, [CONST.SYS_CONF_GENERAL_CONFIG_PARAM, CONST.SYS_CONF_FAN_STEADY_STATE_PWM])
+            if not self.fan_steady_state_pwm:
+                self.fan_steady_state_delay = CONST.FAN_STEADY_STATE_PWM_DEF
+            self.log.info("Fan {} insertion recovery enabled: delay {}s, pwm {}%".format(self.attention_fans_lst,
+                                                                                         self.fan_steady_state_delay,
+                                                                                         self.fan_steady_state_pwm))
+
         # Set PWM to the default state while we are waiting for system configuration
         self.log.notice("Set FAN PWM {}".format(self.pwm_target), 1)
         if not self.write_pwm(self.pwm_target, validate=True):
@@ -2935,6 +3001,30 @@ class ThermalManagement(hw_managemet_file_op):
             pref_dir = CONST.P2C
 
         return pref_dir
+
+    # ---------------------------------------------------------------------
+    def _is_attention_fan_insertion_fail(self):
+        fan_insert_failed = False
+        for fan_obj in self.attention_fans:
+            fan_obj.update_insert_state()
+            if fan_obj.is_insert_failed():
+                self.log.notice("{} fan not started after insertion".format(fan_obj.name))
+                fan_obj.reset_insert_failed_state()
+                fan_insert_failed = True
+                break
+        return fan_insert_failed
+
+    # ---------------------------------------------------------------------
+    def _attention_fan_insertion_recovery(self):
+        pwm = self.read_pwm(100)
+        self.log.notice("Attention fan not started after insertion: Setting pwm to {}% from {}%".format(self.fan_steady_state_pwm, pwm), 1)
+        self._update_chassis_fan_speed(self.fan_steady_state_pwm, force=True)
+        self.log.info("Waiting {}s for newly inserted fan to stabilize".format(self.fan_steady_state_delay))
+        timeout = current_milli_time() + 1000 * self.fan_steady_state_delay
+        while timeout > current_milli_time():
+            self.exit.wait(1)
+        self.log.info("Resuming normal operation: Setting pwm back to {}%".format(pwm))
+        self._update_chassis_fan_speed(pwm, force=True)
 
     # ----------------------------------------------------------------------
     def _update_psu_fan_speed(self, pwm):
@@ -3313,6 +3403,9 @@ class ThermalManagement(hw_managemet_file_op):
         if CONST.SYS_CONF_REDUNDANCY_PARAM not in sys_config:
             sys_config[CONST.SYS_CONF_REDUNDANCY_PARAM] = {}
 
+        if CONST.SYS_CONF_GENERAL_CONFIG_PARAM not in sys_config:
+            sys_config[CONST.SYS_CONF_GENERAL_CONFIG_PARAM] = {}
+
         self.sys_config = sys_config
 
     # ----------------------------------------------------------------------
@@ -3522,6 +3615,16 @@ class ThermalManagement(hw_managemet_file_op):
         self.dev_obj_list.sort(key=lambda x: x.name)
         self.write_file(CONST.PERIODIC_REPORT_FILE, self.periodic_report_time)
 
+        self.attention_fans = []
+        if self.attention_fans_lst:
+            for fan_drwr_name in self.attention_fans_lst:
+                fan_drwr_obj = self._get_dev_obj(fan_drwr_name)
+                if not fan_drwr_obj:
+                    self.log.warn("Dev name {} missing in system_config".format(fan_drwr_name))
+                    continue
+                self.attention_fans.append(fan_drwr_obj)
+                self.log.info("{} added to attention_fans".format(fan_drwr_name))
+
     # ----------------------------------------------------------------------
     def start(self, reason=""):
         """
@@ -3625,6 +3728,11 @@ class ThermalManagement(hw_managemet_file_op):
             if self._is_i2c_control_with_bmc():
                 self.stop(reason="BMC has taken over i2c bus")
                 self.exit.wait(30)
+                continue
+
+            if self._is_attention_fan_insertion_fail():
+                self.log.info("Attention fan insertion failed, trying to recover")
+                self._attention_fan_insertion_recovery()
                 continue
 
             if self._is_suspend():

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -992,11 +992,11 @@ class hw_managemet_file_op(object):
         try:
             mlxreg_get_cmd = CONST.MLXREG_GET_CMD_STR.format(pcidev=self.asic_pcidev)
             self.log.debug("get mlxreg pwm cmd:{}".format(mlxreg_get_cmd))
-            result =subprocess.run('{} | grep pwm'.format(mlxreg_get_cmd), shell=True,
-                           check=False,
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE,
-                           text=True)
+            result = subprocess.run('{} | grep pwm'.format(mlxreg_get_cmd), shell=True,
+                                    check=False,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    text=True)
             ret = result.stdout
             pwm = int(ret.strip(), 16)
             pwm_out = int(pwm / 2.55 + 0.5)


### PR DESCRIPTION
    A customer (case #4486661) was reported regarding
    the fan start issues after re-insertion. After re-inserting
    fans in some systems, it may fail to start rotating.
    
    A stuck fan can start rotating by either of the following actions:
      1) Pulling out and reinserting an additional fans.
      2) Lowering the PWM of all fans for a few seconds.
    
    The commit ff627 introduced FR #4521169 to Thermal
    control 2.5. This patch enables the feature for Thermal
    control 2.0.
    
    Bugs:  #4360106
    NVBug: #5317658
    
    Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
    Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
