### PR TITLE
hw-mgmt: sensors: Fix module counter for SN5600 switch

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -174,7 +174,7 @@ atttrib_list = {
                  }
          },
         {"fin": None, "fn": "module_temp_populate", "poll": 20, "ts": 0,
-         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 66}
+         "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 65}
          }
     ],
     "HI112|HI116|HI136": [


### PR DESCRIPTION
Fix module counter for SN5600 switch. Switch have 65 ports/modules.

Change module count:
66 -> 65

Bug: 4540295

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
