### PR TITLE
hw-mgmt: thermal: Fix thermal data for sn5610/5640 systems

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_sn5610.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5610.json
@@ -11,7 +11,7 @@
 				"present": {"-127:120": 30},
 				"direction": {"-127:120": 30}
 			},
-			"sensor_read_error" : {"-127:120": 80}
+			"sensor_read_error" : {"-127:120": 70}
 		},
 		"P2C": {
 			"fan_err": {

--- a/usr/etc/hw-management-thermal/tc_config_sn5640.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5640.json
@@ -11,7 +11,7 @@
 				"present": {"-127:120": 30},
 				"direction": {"-127:120": 30}
 			},
-			"sensor_read_error" : {"-127:120": 80}
+			"sensor_read_error" : {"-127:120": 70}
 		},
 		"P2C": {
 			"fan_err": {


### PR DESCRIPTION
Fix thermal data for sn5610/5640 systems.
"C2P:Sensor read failure" PWM level changed 80 -> 70 (aligned to value provided by HW)

bug: 4528191