### PR TITLE
hw-mgmt: scripts: Fix the number of ports for SN5400 system

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -146,7 +146,7 @@ atttrib_list = {
         {"fin": None,
          "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
-    "HI144|HI147|HI148|HI174": [
+    "HI144|HI174": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
          "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
                  "asic1": {"fin": "/sys/module/sx_core/asic0/"}
@@ -156,7 +156,7 @@ atttrib_list = {
          "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 65}
          }
     ],
-    "HI171|HI172": [
+    "HI147|HI171|HI172": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
          "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
                  "asic1": {"fin": "/sys/module/sx_core/asic0/"}


### PR DESCRIPTION
SN5400 system has 66 front panel ports, fix the number of ports in sync service

Bug: 4540295