### PR TITLE
hw-mgmt: thermal: Fix not recover PWM after asic sensor reading error

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -1077,6 +1077,7 @@ class system_device(hw_managemet_file_op):
         @param val_read_file: file from which value was obtained
         @return: True if value is in critical range, False otherwise (value check passed
         """
+        err_flag = False
         if ((self.val_hcrit is not None and value >= self.val_hcrit) or
                 (self.val_lcrit is not None and value <= self.val_lcrit)):
             # fmt: off
@@ -1089,11 +1090,12 @@ class system_device(hw_managemet_file_op):
                             repeat=1)
             # fmt: on
             self.fread_err.handle_err(val_read_file)
-            return True
+            err_flag = True
         else:
             self.fread_err.handle_err(val_read_file, reset=True)
             self.log.info(None, id="{} crit".format(self.name))
-            return False
+            err_flag = False
+        return err_flag
 
     # ----------------------------------------------------------------------
     def validate_value_in_min_max_range(self):
@@ -1101,10 +1103,12 @@ class system_device(hw_managemet_file_op):
         @summary:
             Validate value against min/max thresholds and log error if value is out of range
         """
+        err_flag = False
         if self.value > self.val_max:
             self.log.warn("{} value({}) > ({})".format(self.name, self.value, self.val_max),
                           id="{} value > max".format(self.name),
                           repeat=1)
+            err_flag = True
         else:
             self.log.info(None, id="{} value > max".format(self.name))
 
@@ -1112,6 +1116,7 @@ class system_device(hw_managemet_file_op):
             self.log.debug("{} value({}) < min({})".format(self.name,
                                                            self.value,
                                                            self.val_min))
+        return err_flag
 
     # ----------------------------------------------------------------------
     def check_sensor_blocked(self, name=None):
@@ -1497,7 +1502,6 @@ class thermal_asic_sensor(thermal_module_sensor):
                 else:
                     self.asic_fault_err.handle_err(val_read_file, reset=True)
                     self.log.info(None, id="{} Incorrect value in the file: {}".format(self.name, val_read_file))
-                    return
 
                 if self.validate_value_in_crit_range(value, val_read_file) == False:
                     self.update_value(value)

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -1680,6 +1680,7 @@ class system_device(hw_management_file_op):
         @param val_read_file: file from which value was obtained
         @return: True if value is in critical range, False otherwise (value check passed
         """
+        err_flag = False
         if ((self.val_hcrit is not None and value >= self.val_hcrit) or
                 (self.val_lcrit is not None and value <= self.val_lcrit)):
             # fmt: off
@@ -1692,11 +1693,12 @@ class system_device(hw_management_file_op):
                             repeat=1)
             # fmt: on
             self.fread_err.handle_err(val_read_file)
-            return True
+            err_flag = True
         else:
             self.fread_err.handle_err(val_read_file, reset=True)
             self.log.info(None, id="{} crit".format(self.name))
-            return False
+            err_flag = False
+        return err_flag
 
     # ----------------------------------------------------------------------
     def validate_value_in_min_max_range(self):
@@ -1704,10 +1706,12 @@ class system_device(hw_management_file_op):
         @summary:
             Validate value against min/max thresholds and log error if value is out of range
         """
+        err_flag = False
         if self.value > self.val_max:
             self.log.warn("{} value({}) > ({})".format(self.name, self.value, self.val_max),
                           id="{} value > max".format(self.name),
                           repeat=1)
+            err_flag = True
         else:
             self.log.info(None, id="{} value > max".format(self.name))
 
@@ -1715,6 +1719,7 @@ class system_device(hw_management_file_op):
             self.log.debug("{} value({}) < min({})".format(self.name,
                                                            self.value,
                                                            self.val_min))
+        return err_flag
 
     # ----------------------------------------------------------------------
     def check_sensor_blocked(self, name=None):


### PR DESCRIPTION
In TC when simulating asic read error we continuously see error logs,
even after asic error recovered.
This commit fix error.

Bug: 4545207

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
