### PR TITLE
hw-mgmt: thermal: Fix TC init/close flow issue

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -623,7 +623,6 @@ class Logger(object):
 
     def close_tc_log_handler(self):
         if self.logger_fh:
-            self.logger_fh.flush()
             self.logger_fh.close()
             self.logger.removeHandler(self.logger_fh)
 
@@ -2712,6 +2711,7 @@ class ThermalManagement(hw_managemet_file_op):
         self.log.info("periodic report {} sec".format(self.periodic_report_time))
 
         self.dev_obj_list = []
+        self.sys_config = {}
 
         self.pwm_max_reduction = CONST.PWM_MAX_REDUCTION
         self.pwm_worker_poll_time = CONST.PWM_WORKER_POLL_TIME
@@ -2721,13 +2721,19 @@ class ThermalManagement(hw_managemet_file_op):
         self.is_fault_state = False
         self.fan_drwr_num = 0
 
+        # Load configuration
+        try:
+            self.sys_config = self.load_configuration()
+        except Exception as e:
+            self.log.error("Failed to load configuration: {}".format(e), 1)
+            sys.exit(1)
+
         signal.signal(signal.SIGTERM, self.sig_handler)
         signal.signal(signal.SIGINT, self.sig_handler)
         signal.signal(signal.SIGHUP, self.sig_handler)
         self.exit = Event()
         self.exit_flag = False
 
-        self.load_configuration()
         if not str2bool(self.sys_config.get("platform_support", 1)):
             self.log.notice("Platform Board:'{}', SKU:'{}' is not supported.".format(self.board_type, self.sku), 1)
             self.log.notice("Set TC to idle.")
@@ -3406,7 +3412,7 @@ class ThermalManagement(hw_managemet_file_op):
         if CONST.SYS_CONF_GENERAL_CONFIG_PARAM not in sys_config:
             sys_config[CONST.SYS_CONF_GENERAL_CONFIG_PARAM] = {}
 
-        self.sys_config = sys_config
+        return sys_config
 
     # ----------------------------------------------------------------------
     def add_psu_sensor(self, name):


### PR DESCRIPTION
In rare cases, when stopping the TC service immediately after it starts,
it may crash. This occurs because the shutdown cleanup flow uses the
system_config variable before it has been initialized.

This fix adds proper initialization of this variable to ensure
it is ready before use.

Also added optimization for logger close on TC stop: removed the
redundant
log handler flush() call. It is unnecessary because flush() is already
called within log handler stop().

Bug: 4545880

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
