### PR TITLE
hw-mgmt: service: Increase TC service stop timeout

### DIFF
--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -11,7 +11,7 @@ StartLimitBurst=5
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_control.py"
 ExecStop=/bin/kill $MAINPID
-TimeoutStopSec=1
+TimeoutStopSec=5
 
 Restart=on-failure
 RestartSec=60s


### PR DESCRIPTION
On some low-performance systems, stopping the hw-management-tc service
took longer than 1 second.
Fix: Increased the TimeoutStopSec value in the service file from 1 to 5
seconds.

Bug: 4543074

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
