### PR TITLE
hw-mgmt: scripts: Update SN5640 virtual sensor attributes

### DIFF
--- a/usr/etc/hw-management-virtual/HI171/thermal
+++ b/usr/etc/hw-management-virtual/HI171/thermal
@@ -1,0 +1,7 @@
+drivetemp 43850
+drivetemp_crit 109850
+drivetemp_max 99850
+drivetemp_min -150
+cpu_pack 37750
+cpu_pack_crit 100000
+cpu_pack_max 95000

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -76,7 +76,7 @@ fi
 if check_simx; then
         if check_if_simx_supported_platform; then
                 case $sku in
-                        HI166|HI176)
+                        HI166|HI176|HI171)
                                 process_simx_links
                                 ;;
                         *)


### PR DESCRIPTION
Adding the missing sensor (for the sensors which doesn't have the emulation drivers) attributes as static values in SN5640 platform. This will be helpful for running TC.

Bugs: #4546019, #4545909