### PR TITLE
hw-mgmt: scripts: Fix MSN3700/MSN3700C/MSN4700 detection in sync service

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -185,7 +185,7 @@ atttrib_list = {
          "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 66}
          }
     ],
-    "HI112|HI116|HI136": [
+    "HI112|HI116|HI136|MSN3700|MSN3700C": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
          "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
                  "asic1": {"fin": "/sys/module/sx_core/asic0/"}
@@ -215,7 +215,7 @@ atttrib_list = {
          "arg": {"fin": "/sys/module/sx_core/asic0/module{}/", "fout_idx_offset": 1, "module_count": 54}
          }
     ],
-    "HI122|HI156": [
+    "HI122|HI156|MSN4700": [
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
          "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
                  "asic1": {"fin": "/sys/module/sx_core/asic0/"}


### PR DESCRIPTION
Some MSN3700/MSN3700C/MSN4700 systems have been customized with incorrect SMBIOS SKU field. This causes system detection failures in HW-MGMT sync service. Fix the sync service to properly identify such systems.

Bug: 4520864, 4544349