### PR TITLE
hw-mgmt: udev rules: disable TPM runtime power management.

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -890,3 +890,6 @@ SUBSYSTEM=="pci", DRIVERS=="sx_core", ACTION=="offline", RUN+="/usr/bin/hw-manag
 # DPU
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-001f/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add dpu %S %p"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*/*-001f/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm dpu %S %p"
+
+# TPM - disable TPM runtime power management
+SUBSYSTEM=="tpm", KERNEL=="tpm0", ATTR{power/control}="on"


### PR DESCRIPTION
Disable TPM runtime power management, i.e. TPM will always remain power-on.
It will allow avoiding rare cases of access to TPM when it's suspended.
The effect of always power-on the TPM on common power consumption is minimal.

Bug #4542714

Signed-off-by: Michael Shych <michaelsh@nvidia.com>
