### PR TITLE
hw-mgmt: leakage: Add missed entries for GB300 and Kyber high density

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2396,6 +2396,7 @@ n51xxld_specific()
 			add_i2c_dynamic_bus_dev_connection_table "${so_cartridge_eeprom_connect_table[@]}"
 			echo -n "${so_cartridge_eeprom_connect_table[@]}" >> "$devtree_file"
 			echo 4 > $config_path/cartridge_counter
+			echo 2 > $config_path/cpld_num
 			;;
 		HI177)	# Kyber
 			echo 0 > $config_path/cartridge_counter

--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -302,7 +302,14 @@ atttrib_list = {
                  "asic2": {"fin": "/sys/module/sx_core/asic1/"}
                  }
          },
-
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage1",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE1 {arg1}"],
+         "poll": 2, "ts": 0},
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage2",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE2 {arg1}"],
+         "poll": 2, "ts": 0},
         {"fin": None,
          "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
@@ -316,6 +323,14 @@ atttrib_list = {
                  "asic3": {"fin": "/sys/module/sx_core/asic2/"}
                  }
          },
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage1",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE1 {arg1}"],
+         "poll": 2, "ts": 0},
+        {"fin": "/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage2",
+         "fn": "run_cmd",
+         "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE2 {arg1}"],
+         "poll": 2, "ts": 0},
         {"fin": None,
          "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],


### PR DESCRIPTION
Add missed entries of synch process.

Fixes: #4564230: fix leak detection in cpu side on gb300