### PR TITLE
hw-mgmt: script: Fix ThermalControl service disable logic

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -336,9 +336,9 @@ check_simx()
 check_tc_is_supported()
 {
 	if grep -q '"platform_support" : 0' $config_path/tc_config.json; then
-		return 1
-	else
 		return 0
+	else
+		return 1
 	fi
 }
 


### PR DESCRIPTION
On systems that do not support thermal control, the thermal service
should be disabled. By mistake, we had the logic for thermal control
support detection inverted.

This commit fixes the TC support check logic:

Return 1 if TC is supported

Return 0 otherwise

Bug: 4567911

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
