### PR TITLE
hw-mgmt: scripts: Fix typo "graseful_pwr_off" -> "graceful_pwr_off"

### DIFF
--- a/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-5.10/9005-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -882,7 +882,7 @@ index 4be0f29cc..a867ba4f8 100644
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "graseful_pwr_off",
++		.label = "graceful_pwr_off",
 +		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0644,

--- a/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
+++ b/recipes-kernel/linux/linux-6.1/9004-platform-mellanox-Downstream-Introduce-support-of-Nv.patch
@@ -906,7 +906,7 @@ index 4a8cc6a74cab..288dbb42eaf6 100644
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "graseful_pwr_off",
++		.label = "graceful_pwr_off",
 +		.reg = MLXPLAT_CPLD_LPC_REG_GP_RST_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0644,

--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -149,7 +149,7 @@ atttrib_list = {
          "arg": ["/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE6 {arg1}"],
          "poll": 2, "ts": 0},
 
-        {"fin": "/var/run/hw-management/system/graseful_pwr_off",
+        {"fin": "/var/run/hw-management/system/graceful_pwr_off",
          "fn": "run_power_button_event",
          "arg": [],
          "poll": 1, "ts": 0},
@@ -294,7 +294,7 @@ atttrib_list = {
          }
     ],
     "HI176": [
-        {"fin": "/var/run/hw-management/system/graseful_pwr_off", "fn": "run_power_button_event",
+        {"fin": "/var/run/hw-management/system/graceful_pwr_off", "fn": "run_power_button_event",
          "arg": [], "poll": 1, "ts": 0},
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
          "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},
@@ -314,7 +314,7 @@ atttrib_list = {
          "fn": "redfish_get_sensor", "arg": ["/redfish/v1/Chassis/MGX_BMC_0/Sensors/BMC_TEMP", "bmc", 1000], "poll": 30, "ts": 0}
     ],
     "HI177": [
-        {"fin": "/var/run/hw-management/system/graseful_pwr_off", "fn": "run_power_button_event",
+        {"fin": "/var/run/hw-management/system/graceful_pwr_off", "fn": "run_power_button_event",
          "arg": [], "poll": 1, "ts": 0},
         {"fin": None, "fn": "asic_temp_populate", "poll": 3, "ts": 0,
          "arg": {"asic": {"fin": "/sys/module/sx_core/asic0/"},


### PR DESCRIPTION
Fix typo "graseful_pwr_off" -> "graceful_pwr_off"

Bug: 4583871

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
