### PR TITLE
hw-mgmt: thermal: Fix TC log level for "User config not defined" message

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -4024,7 +4024,7 @@ class ThermalManagement(hw_management_file_op):
                     self.log.error("User config file {} load failed. Skip it".format(user_config_file_name), 1)
                     pass
         if not user_config:
-            self.log.warn("User config not defined", 1)
+            self.log.info("User config not defined")
         sys_config[CONST.SYS_CONF_USER_CONFIG_PARAM] = user_config
         return sys_config
 


### PR DESCRIPTION
Fix TC log level for "User config not defined" message.
This message is only informational, indicating a missing optional user
configuration file.

The log level of this message should be "info".

Fix:
Change message severity level from "warning" -> "info"

Bug: 4583302

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
