### PR TITLE
hw-mgmt: scripts: Fix Nvidia vendor name in log messages

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -227,7 +227,7 @@ check_cpu_type()
 
 find_i2c_bus()
 {
-    # Find physical bus number of Mellanox I2C controller. The default
+    # Find physical bus number of Nvidia I2C controller. The default
     # number is 1, but it could be assigned to others id numbers on
     # systems with different CPU types.
     if [ -f $config_path/i2c_bus_offset ]; then

--- a/usr/usr/bin/hw-management-parse-eeprom.sh
+++ b/usr/usr/bin/hw-management-parse-eeprom.sh
@@ -133,7 +133,7 @@ function do_conv ( )
 					# Sanity ok.
 					continue
 				else
-					echo Mellanox sanity checker fail
+					echo Nvidia sanity checker fail
 					exit 1;
 				fi
 		fi

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2794,7 +2794,7 @@ class ThermalManagement(hw_managemet_file_op):
                 self.log.notice("Wait...")
                 self.exit.wait(10)
 
-        self.log.notice("Mellanox thermal control is waiting for configuration ({} sec).".format(CONST.THERMAL_WAIT_FOR_CONFIG), 1)
+        self.log.notice("Nvidia thermal control is waiting for configuration ({} sec).".format(CONST.THERMAL_WAIT_FOR_CONFIG), 1)
         timeout = current_milli_time() + 1000 * CONST.THERMAL_WAIT_FOR_CONFIG
         while timeout > current_milli_time():
             if not self.write_pwm(self.pwm_target):

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -3300,7 +3300,7 @@ class ThermalManagement(hw_management_file_op):
                 self.log.notice("Wait...")
                 self.exit.wait(10)
 
-        self.log.notice("Mellanox thermal control is waiting for configuration ({} sec).".format(CONST.THERMAL_WAIT_FOR_CONFIG), 1)
+        self.log.notice("Nvidia thermal control is waiting for configuration ({} sec).".format(CONST.THERMAL_WAIT_FOR_CONFIG), 1)
         timeout = current_milli_time() + 1000 * CONST.THERMAL_WAIT_FOR_CONFIG
         while timeout > current_milli_time():
             if not self.write_pwm(self.pwm_target):


### PR DESCRIPTION
Fix Nvidia vendor name in log messages:
replace Mellanox -> Nvidia vendor name.

Bug: 4565558

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
