### PR TITLE
Hw-mgmt: kernel 5.10 6.1: patch: Fix inconsistent name for PDB items

### DIFF
--- a/recipes-kernel/linux/linux-5.10/0305-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
+++ b/recipes-kernel/linux/linux-5.10/0305-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
@@ -25,7 +25,7 @@ index 18e0206..b4e506c 100644
  };
  
 +/* Platform hotplug dgx data */
-+static struct mlxreg_core_data mlxplat_mlxcpld_dgx_psu_items_data[] = {
++static struct mlxreg_core_data mlxplat_mlxcpld_dgx_pdb_items_data[] = {
 +	{
 +		.label = "psu1",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
@@ -59,11 +59,11 @@ index 18e0206..b4e506c 100644
  
 +static struct mlxreg_core_item mlxplat_mlxcpld_ext_dgx_items[] = {
 +	{
-+		.data = mlxplat_mlxcpld_dgx_psu_items_data,
++		.data = mlxplat_mlxcpld_dgx_pdb_items_data,
 +		.aggr_mask = MLXPLAT_CPLD_AGGR_PSU_MASK_DEF,
 +		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
 +		.mask = MLXPLAT_CPLD_PSU_MASK,
-+		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_psu_items_data),
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pdb_items_data),
 +		.inversed = 1,
 +		.health = false,
 +	},

--- a/recipes-kernel/linux/linux-6.1/0098-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
+++ b/recipes-kernel/linux/linux-6.1/0098-platform-mellanox-Downstream-Add-support-for-new-Nvi.patch
@@ -25,7 +25,7 @@ index 5796e46..9346c76 100644
  };
  
 +/* Platform hotplug dgx data */
-+static struct mlxreg_core_data mlxplat_mlxcpld_dgx_psu_items_data[] = {
++static struct mlxreg_core_data mlxplat_mlxcpld_dgx_pdb_items_data[] = {
 +	{
 +		.label = "pdb1",
 +		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
@@ -59,11 +59,11 @@ index 5796e46..9346c76 100644
  
 +static struct mlxreg_core_item mlxplat_mlxcpld_ext_dgx_items[] = {
 +	{
-+		.data = mlxplat_mlxcpld_dgx_psu_items_data,
++		.data = mlxplat_mlxcpld_dgx_pdb_items_data,
 +		.aggr_mask = MLXPLAT_CPLD_AGGR_PSU_MASK_DEF,
 +		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
 +		.mask = MLXPLAT_CPLD_PSU_MASK,
-+		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_psu_items_data),
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pdb_items_data),
 +		.inversed = 1,
 +		.health = false,
 +	},


### PR DESCRIPTION
For DGX Systems without PSU should be used "pdb" suffix in config const name.

Change:
"mlxplat_mlxcpld_dgx_psu_items_data" -> "mlxplat_mlxcpld_dgx_pdb_items_data"

Spell fix. No functional impact.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
