### PR TITLE
hw-mgmt: kernel: Add support for Q3401-RD platform

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -402,6 +402,7 @@ Kernel-5.10
 |9006-mlxsw-core_hwmon-Downstream-Fix-module-sensor-number-for-QM3200.patch|           | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9007-platform-mellanox-mlx-platform-Change-register-0x28-.patch  |                    | Downstream;skip[sonic,cumulus]           |            |                                                |
 |9008-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Q3450                                          |
+|9009-platform-mellanox-Downstream-Add-support-for-Q3401-R.patch  |                    | Downstream accepted; skip[sonic,cumulus] |            | Q3401-RD                                       |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Kernel-5.14
@@ -738,6 +739,7 @@ Kernel-6.1
 |9007-mlxsw-core-Downstream-Fix-uninitialized-variable.patch      |                    | Downstream accepted;skip[sonic]          |            |                                                |
 |9008-platform-mellanox-mlx-platform-Change-register-0x28-.patch  |                    | Downstream;skip[sonic,cumulus]           |            |                                                |
 |9009-platform-mellanox-mlx-platform-Add-support-for-Q3450.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Q3450                                          |
+|9010-platform-mellanox-Downstream-Add-support-for-Q3401-R.patch  |                    | Downstream accepted; skip[sonic,cumulus] |            | Q3401-RD                                       |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Legend:

--- a/recipes-kernel/linux/linux-5.10/9009-platform-mellanox-Downstream-Add-support-for-Q3401-R.patch
+++ b/recipes-kernel/linux/linux-5.10/9009-platform-mellanox-Downstream-Add-support-for-Q3401-R.patch
@@ -1,0 +1,210 @@
+From c5bb10dcd8544a662b4bc81ab8930749e343475f Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Thu, 22 May 2025 19:31:38 +0300
+Subject: [PATCH] platform: mellanox: Downstream: Add support for Q3401-RD
+ Nvidia XDR DGX flavor switch.
+
+This system is based on Nvidia Q3400 Nvidia Quantum-3 36x800Gb/s Switch, with the
+following key changes:
+
+Key changes:
+- New Power Supply: AC/DC PSUs power repaced by rack busbar input power ORv3 DC 48V-54V.
+- Dimensions MGX/DGX 1U compliance Tool-less top cover (fast cover opening with no screw)
+- Air Cooled: 7 + 1 redundant fan units C2P not reversable 80x80mm 48V (instead of 9 +1 60x60mm)
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 144 +++++++++++++++++++++++++++++--
+ 1 file changed, 137 insertions(+), 7 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index d71f254..fa8c92c 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -719,9 +719,9 @@ static struct i2c_mux_reg_platform_data mlxplat_ng800_mux_data[] = {
+ 		.values = mlxplat_msn21xx_channels,
+ 		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
+ 	},
+-
+ };
+ 
++
+ /* Platform channels for XDR system family */
+ static const int mlxplat_xdr_channels[] = {
+ 	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+@@ -754,6 +754,40 @@ static struct i2c_mux_reg_platform_data mlxplat_xdr_mux_data[] = {
+ 	},
+ };
+ 
++/* Platform XDR mux data with separated CPU bus adapter id */
++static struct i2c_mux_reg_platform_data mlxplat_xdr_ext_mux_data[] = {
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_xdr_channels,
++		.n_values = ARRAY_SIZE(mlxplat_xdr_channels),
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH2_XDR,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG3,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_modular_upper_channel,
++		.n_values = ARRAY_SIZE(mlxplat_modular_upper_channel),
++	},
++	{
++		.parent = MLXPLAT_CPLD_CH2_XDR,
++		.base_nr = MLXPLAT_CPLD_CH2_XDR+1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_msn21xx_channels,
++		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
++	},
++};
++
+ /* Platform channels for L1 scale out system family */
+ static const int mlxplat_l1_scale_out_channels[] = {
+ 	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+@@ -2183,6 +2217,82 @@ static struct mlxreg_core_item mlxplat_mlxcpld_xdr_items[] = {
+ 	},
+ };
+ 
++static struct mlxreg_core_item mlxplat_mlxcpld_xdr_dgx_items[] = {
++	{
++		.data = mlxplat_mlxcpld_dgx_pdb_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_PSU_MASK_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pdb_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_dgx_pwr_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_PWR_MASK_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pwr_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_FAN_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic1_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic1_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic2_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic2_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic3_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC3_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic3_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic4_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC4_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic4_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++};
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_leakage_items_data[] = {
+ 	{
+ 		.label = "leakage1",
+@@ -2350,6 +2460,17 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_xdr_liq_data = {
+ 	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_FRU | MLXPLAT_CPLD_LOW_AGGR_MASK_MULTI_ASICS,
+ };
+ 
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_xdr_dgx_data = {
++	.items = mlxplat_mlxcpld_xdr_dgx_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_xdr_dgx_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_FRU | MLXPLAT_CPLD_LOW_AGGR_MASK_MULTI_ASICS,
++};
++
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+ 	{
+ 		.label = "pwr1",
+@@ -10103,15 +10224,24 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
+ 			mlxplat_mlxcpld_xdr_pwr_items_data[i].hpdev.nr =
+ 			mlxplat_mlxcpld_xdr_pwr_nr_fixup[i];
+ 	}
++	if (!strcmp(sku, "HI179")) {
++		mlxplat_hotplug = &mlxplat_mlxcpld_xdr_dgx_data;
++		mlxplat_hotplug->deferred_nr =
++			mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++		mlxplat_regs_io = &mlxplat_dgx_ng_regs_io_data;
++		mlxplat_mux_num = ARRAY_SIZE(mlxplat_xdr_ext_mux_data);
++		mlxplat_mux_data = mlxplat_xdr_ext_mux_data;
++	} else {
++		mlxplat_hotplug = &mlxplat_mlxcpld_xdr_data;
++		mlxplat_hotplug->deferred_nr =
++			mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++		mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++		mlxplat_mux_num = ARRAY_SIZE(mlxplat_xdr_mux_data);
++		mlxplat_mux_data = mlxplat_xdr_mux_data;
++	}
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
+-	mlxplat_mux_num = ARRAY_SIZE(mlxplat_xdr_mux_data);
+-	mlxplat_mux_data = mlxplat_xdr_mux_data;
+-	mlxplat_hotplug = &mlxplat_mlxcpld_xdr_data;
+-	mlxplat_hotplug->deferred_nr =
+-		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+ 	mlxplat_led = &mlxplat_xdr_led_data;
+-	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
+ 	mlxplat_fan = &mlxplat_xdr_fan_data;
+ 	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
+ 		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
+-- 
+2.8.4
+

--- a/recipes-kernel/linux/linux-6.1/9010-platform-mellanox-Downstream-Add-support-for-Q3401-R.patch
+++ b/recipes-kernel/linux/linux-6.1/9010-platform-mellanox-Downstream-Add-support-for-Q3401-R.patch
@@ -1,0 +1,355 @@
+From 275e85ac97abb0c04e38087641adcf1434af24dc Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@nvidia.com>
+Date: Thu, 22 May 2025 19:32:19 +0300
+Subject: [PATCH] platform: mellanox: Downstream: Add support for Q3401-RD
+ Nvidia XDR DGX flavor switch.
+
+This system is based on Nvidia Q3400 Nvidia Quantum-3 36x800Gb/s Switch, with the
+following key changes:
+
+Key changes:
+- New Power Supply: AC/DC PSUs power repaced by rack busbar input power ORv3 DC 48V-54V.
+- Dimensions MGX/DGX 1U compliance Tool-less top cover (fast cover opening with no screw)
+- Air Cooled: 7 + 1 redundant fan units C2P not reversable 80x80mm 48V (instead of 9 +1 60x60mm)
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 257 ++++++++++++++++++++++-
+ 1 file changed, 251 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 7608a6a25029..9c31c2f4554a 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -756,6 +756,40 @@ static struct i2c_mux_reg_platform_data mlxplat_xdr_mux_data[] = {
+ 	},
+ };
+ 
++/* Platform XDR mux data with separated CPU bus adapter id */
++static struct i2c_mux_reg_platform_data mlxplat_xdr_ext_mux_data[] = {
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG1,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_xdr_channels,
++		.n_values = ARRAY_SIZE(mlxplat_xdr_channels),
++	},
++	{
++		.parent = 1,
++		.base_nr = MLXPLAT_CPLD_CH2_XDR,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG3,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_modular_upper_channel,
++		.n_values = ARRAY_SIZE(mlxplat_modular_upper_channel),
++	},
++	{
++		.parent = MLXPLAT_CPLD_CH2_XDR,
++		.base_nr = MLXPLAT_CPLD_CH2_XDR+1,
++		.write_only = 1,
++		.reg = (void __iomem *)MLXPLAT_CPLD_LPC_REG2,
++		.reg_size = 1,
++		.idle_in_use = 1,
++		.values = mlxplat_msn21xx_channels,
++		.n_values = ARRAY_SIZE(mlxplat_msn21xx_channels),
++	},
++};
++
+ /* Platform channels for L1 scale out system family */
+ static const int mlxplat_l1_scale_out_channels[] = {
+ 	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+@@ -2185,6 +2219,82 @@ static struct mlxreg_core_item mlxplat_mlxcpld_xdr_items[] = {
+ 	},
+ };
+ 
++static struct mlxreg_core_item mlxplat_mlxcpld_xdr_dgx_items[] = {
++	{
++		.data = mlxplat_mlxcpld_dgx_pdb_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_PSU_MASK_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PSU_OFFSET,
++		.mask = MLXPLAT_CPLD_PSU_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pdb_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_dgx_pwr_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_PWR_MASK_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_PWR_OFFSET,
++		.mask = MLXPLAT_CPLD_PWR_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_dgx_pwr_items_data),
++		.inversed = 0,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_fan_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_FAN_OFFSET,
++		.mask = MLXPLAT_CPLD_FAN_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_FAN_DRW_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_FAN_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_fan_items_data),
++		.inversed = 1,
++		.health = false,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic1_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic1_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic2_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic2_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic3_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC3_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic3_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++	{
++		.data = mlxplat_mlxcpld_xdr_asic4_items_data,
++		.aggr_mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF,
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC4_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_XDR_MASK,
++		.capability = MLXPLAT_CPLD_LPC_REG_ASIC_CAP_OFFSET,
++		.capability_mask = MLXPLAT_CPLD_ASIC_CAP_MASK,
++		.count = ARRAY_SIZE(mlxplat_mlxcpld_xdr_asic4_items_data),
++		.inversed = 0,
++		.health = true,
++	},
++};
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_leakage_items_data[] = {
+ 	{
+ 		.label = "leakage1",
+@@ -2353,6 +2463,17 @@ struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_xdr_liq_data = {
+ 	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_FRU | MLXPLAT_CPLD_LOW_AGGR_MASK_MULTI_ASICS,
+ };
+ 
++static
++struct mlxreg_core_hotplug_platform_data mlxplat_mlxcpld_xdr_dgx_data = {
++	.items = mlxplat_mlxcpld_xdr_dgx_items,
++	.counter = ARRAY_SIZE(mlxplat_mlxcpld_xdr_dgx_items),
++	.cell = MLXPLAT_CPLD_LPC_REG_AGGR_OFFSET,
++	.mask = MLXPLAT_CPLD_AGGR_MASK_NG_DEF | MLXPLAT_CPLD_AGGR_MASK_COMEX,
++	.cell_low = MLXPLAT_CPLD_LPC_REG_AGGRLO_OFFSET,
++	.mask_low = MLXPLAT_CPLD_LOW_AGGR_MASK_FRU | MLXPLAT_CPLD_LOW_AGGR_MASK_MULTI_ASICS,
++};
++
++
+ static struct mlxreg_core_data mlxplat_mlxcpld_modular_pwr_items_data[] = {
+ 	{
+ 		.label = "pwr1",
+@@ -5950,6 +6071,24 @@ static struct mlxreg_core_data mlxplat_mlxcpld_dgx_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "cpld5_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD5_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld6_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD6_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld7_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD7_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "cpld1_pn",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_PN_OFFSET,
+@@ -5978,6 +6117,27 @@ static struct mlxreg_core_data mlxplat_mlxcpld_dgx_ng_regs_io_data[] = {
+ 		.mode = 0444,
+ 		.regnum = 2,
+ 	},
++	{
++		.label = "cpld5_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD5_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld6_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD6_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
++	{
++		.label = "cpld7_pn",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD7_PN_OFFSET,
++		.bit = GENMASK(15, 0),
++		.mode = 0444,
++		.regnum = 2,
++	},
+ 	{
+ 		.label = "cpld1_version_min",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_MVER_OFFSET,
+@@ -6002,12 +6162,43 @@ static struct mlxreg_core_data mlxplat_mlxcpld_dgx_ng_regs_io_data[] = {
+ 		.bit = GENMASK(7, 0),
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "cpld5_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD5_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld6_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD6_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld7_version_min",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD7_MVER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "asic_reset",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
+ 		.mask = GENMASK(7, 0) & ~BIT(3),
+ 		.mode = 0200,
+ 	},
++	{
++		.label = "asic2_reset",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0200,
++	},
++	{
++		.label = "clk_brd_prog_en",
++		.reg = MLXPLAT_CPLD_LPC_REG_PWM_CONTROL_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0644,
++		.secured = 1,
++	},
+ 	{
+ 		.label = "reset_long_pb",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
+@@ -6184,6 +6375,27 @@ static struct mlxreg_core_data mlxplat_mlxcpld_dgx_ng_regs_io_data[] = {
+ 		.bit = 1,
+ 		.mode = 0444,
+ 	},
++	{
++		.label = "asic2_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC2_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
++	{
++		.label = "asic3_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC3_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
++	{
++		.label = "asic4_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC4_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "fan_dir",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_FAN_DIRECTION,
+@@ -6246,6 +6458,30 @@ static struct mlxreg_core_data mlxplat_mlxcpld_dgx_ng_regs_io_data[] = {
+ 		.mask = GENMASK(7, 0) & ~BIT(5),
+ 		.mode = 0644,
+ 	},
++	{
++		.label = "clk_brd1_boot_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "clk_brd2_boot_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "clk_brd_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "asic_pg_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP4_RO_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
+ 	{
+ 		.label = "config1",
+ 		.reg = MLXPLAT_CPLD_LPC_REG_CONFIG1_OFFSET,
+@@ -10132,15 +10368,24 @@ static int __init mlxplat_dmi_xdr_matched(const struct dmi_system_id *dmi)
+ 			mlxplat_mlxcpld_xdr_pwr_items_data[i].hpdev.nr =
+ 			mlxplat_mlxcpld_xdr_pwr_nr_fixup[i];
+ 	}
++	if (!strcmp(sku, "HI179")) {
++		mlxplat_hotplug = &mlxplat_mlxcpld_xdr_dgx_data;
++		mlxplat_hotplug->deferred_nr =
++			mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++		mlxplat_regs_io = &mlxplat_dgx_ng_regs_io_data;
++		mlxplat_mux_num = ARRAY_SIZE(mlxplat_xdr_ext_mux_data);
++		mlxplat_mux_data = mlxplat_xdr_ext_mux_data;
++	} else {
++		mlxplat_hotplug = &mlxplat_mlxcpld_xdr_data;
++		mlxplat_hotplug->deferred_nr =
++			mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
++		mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
++		mlxplat_mux_num = ARRAY_SIZE(mlxplat_xdr_mux_data);
++		mlxplat_mux_data = mlxplat_xdr_mux_data;
++	}
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
+-	mlxplat_mux_num = ARRAY_SIZE(mlxplat_xdr_mux_data);
+-	mlxplat_mux_data = mlxplat_xdr_mux_data;
+-	mlxplat_hotplug = &mlxplat_mlxcpld_xdr_data;
+-	mlxplat_hotplug->deferred_nr =
+-		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+ 	mlxplat_led = &mlxplat_xdr_led_data;
+-	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
+ 	mlxplat_fan = &mlxplat_xdr_fan_data;
+ 	for (i = 0; i < ARRAY_SIZE(mlxplat_mlxcpld_wd_set_type2); i++)
+ 		mlxplat_wd_data[i] = &mlxplat_mlxcpld_wd_set_type2[i];
+-- 
+2.20.1
+


### PR DESCRIPTION
Add support for Q3401-RD platform to kernel 5.10/6.1

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
