### PR TITLE
Revert ASIC temperature reading fix to prevent critical regression

### DIFF
--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -275,33 +275,6 @@ function get_psu_eeprom_type()
 	echo $eeprom_type
 }
 
-# Set ASIC ready state
-# $1 - sysfs path of PCI device
-# $2 - ASIC ready state (0 or 1)
-# return none
-function set_asic_ready()
-{
-	sysfs_picdev_path=$1
-	state=$2
-	[ -f "$config_path/asic_num" ] && asic_num=$(< $config_path/asic_num)
-	if [ $asic_num -gt 1 ]; then
-		pci_bus="${sysfs_picdev_path: -7}"
-		for ((asic_id=1; asic_id<=asic_num; asic_id+=1)); do
-			bus=$(< $config_path/asic"$asic_id"_pci_bus_id)
-			if [ "$bus" == "$pci_bus" ]; then
-				echo $state > $config_path/asic"$asic_id"_ready
-				if [ $asic_id -eq 1 ]; then
-					echo $state > $config_path/asic_ready
-				fi
-				break
-			fi
-		done
-	else
-		echo $state > $config_path/asic1_ready
-		echo $state > $config_path/asic_ready
-	fi
-}
-
 # Don't process udev events until service is started and directories are created
 if [ ! -f ${udev_ready} ]; then
 	exit 0
@@ -1167,7 +1140,6 @@ if [ "$1" == "add" ]; then
 			modprobe mlxsw_minimal
 		fi
 		/usr/bin/hw-management.sh chipup 0 "$4/$5"
-		set_asic_ready "$4/$5" 1
 	fi
 	if [ "$2" == "nvme_temp" ]; then
 		dev_name=$(cat "$3""$4"/name)
@@ -1522,7 +1494,6 @@ else
 	fi
 	if [ "$2" == "sxcore" ]; then
 		/usr/bin/hw-management.sh chipdown 0 "$4/$5"
-		set_asic_ready "$4/$5" 0
 	fi
 	if [ "$2" == "dpu" ]; then
 		sku=$(< /sys/devices/virtual/dmi/id/product_sku)


### PR DESCRIPTION
## Summary
Reverts commit df943c6cc38e7bc09136d2f69722c0dd46990f6d to prevent critical regression while documenting the original issue as a known limitation.

## Background
- Original issue: ASIC temperature reading problem (Redmine #4497061)
- Previous fix introduced critical regression (Redmine #4574847)
- Management decision: Revert fix to avoid critical bug, accept original issue as known limitation

## Changes
- Reverts ASIC temperature reading fixes from hw-management-thermal-events.sh
- Documents the ASIC temperature reading issue as a known issue in Release.txt

## Testing
- Critical regression (Redmine #4574847) should no longer occur
- Original ASIC temperature reading issue (Redmine #4497061) will return but is documented as known limitation