### PR TITLE
hw-mgmt: thermal: Increase TC service max reload limit

### DIFF
--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -6,7 +6,7 @@ PartOf=hw-management.service
 Documentation=man:hw-management-tc.service(8)
 
 StartLimitIntervalSec=1200
-StartLimitBurst=5
+StartLimitBurst=15
 
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_control.py"


### PR DESCRIPTION
In some cases, when reloading the TC service, it reports:
"Failed because start of the service was attempted too often."

This happens because we have a limit set for TC service reloads: 5 times
per 1200 seconds (20 minutes).
This limit was introduced to prevent high CPU load in case of a TC
crash.

However, this limitation (5 times) is too strict and can block TC start
even in regular scenarios.

With this fix, the reload limit is increased to 15 times per 1200
seconds.

Bug: 4582500

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
