### PR TITLE
hw-mgmt: thermal: Fix misprint in Q3450 thermal config

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_q3450.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3450.json
@@ -39,7 +39,7 @@
 
 		"drivetemp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": 100000, "poll_time": 60}
 	},
-	"error_mask" : {"psu" : ["direction", "present"]},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "asic2", "asic3", "asic4", "cpu", "pch", "drivetemp", "sodimm1", "sodimm2", "drwr1", "drwr2", "sensor_amb",
 			 "swb1_voltmon1", "swb1_voltmon2", "swb1_voltmon3", "swb1_voltmon4", "swb1_voltmon5", "swb1_voltmon6",
 			 "swb2_voltmon1", "swb2_voltmon2", "swb2_voltmon3", "swb2_voltmon4", "swb2_voltmon5", "swb2_voltmon6"


### PR DESCRIPTION
Fix Q3450 thermal config. In "err_mask" field should be
changed "psu" -> "psu_err":

Change:

"error_mask" : {"psu" : ["direction", "present"]},
to
"error_mask" : {"psu_err" : ["direction", "present"]},

Bug: 4611676

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
