### PR TITLE
hw-mgmt: scripts: Add I2C bus ownership check and reporting for VMOD0021 systems.

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2444,6 +2444,21 @@ smart_switch_common()
 
 n51xxld_specific()
 {
+	# Report I2C bus ownership for VMOD0021 systems at early initialization
+	bmc_to_cpu_ctrl_path=$(ls /sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/bmc_to_cpu_ctrl 2>/dev/null | head -n1)
+	if [ -f "$bmc_to_cpu_ctrl_path" ]; then
+		bus_ownership=$(< "$bmc_to_cpu_ctrl_path")
+		if [ "$bus_ownership" = "0" ]; then
+			log_info "I2C bus ownership: CPU (bmc_to_cpu_ctrl=0)"
+		elif [ "$bus_ownership" = "1" ]; then
+			log_info "I2C bus ownership: BMC (bmc_to_cpu_ctrl=1)"
+		else
+			log_err "I2C bus ownership: Unknown value (bmc_to_cpu_ctrl=$bus_ownership)"
+		fi
+	else
+		log_err "I2C bus ownership: bmc_to_cpu_ctrl file not found"
+	fi
+
 	local cpu_bus_offset=55
 	if [ ! -e "$devtree_file" ]; then
 		connect_table+=(${n5110ld_base_connect_table[@]})


### PR DESCRIPTION
Implement a check for I2C bus ownership on VMOD0021 systems to determine
if it is controlled by the CPU or BMC.
Typically, ownership should be with the CPU; if not, report an error.

Bug: 4597390
Signed-off-by: Michael Shych <michaelsh@nvidia.com>
