### PR TITLE
hw-mgmt: scripts: Fix SN4280 sensors config

### DIFF
--- a/usr/etc/hw-management-sensors/sn4280_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn4280_sensors.conf
@@ -388,7 +388,7 @@ bus "i2c-21" "i2c-1-mux (chan_id 20)"
         ignore in4 
         label temp1 "PMIC-12 DPU4 VDD VDD_DDR Temp 1"
         ignore temp2 
-        label power1 "PMIC-12 12V DPU3 VDD VDDQ_DDR (in)"
+        label power1 "PMIC-12 12V DPU4 VDD VDDQ_DDR (in)"
         label power2 "PMIC-12 DPU4 VDD Rail Pwr (out1)"
         label power3 "PMIC-12 DPU4 VDD_DDR Rail Pwr (out1)"
         ignore power4 
@@ -403,7 +403,7 @@ bus "i2c-21" "i2c-1-mux (chan_id 20)"
         ignore in4 
         label temp1 "PMIC-12 DPU4 VDD VDD_DDR Temp 1"
         ignore temp2 
-        label power1 "PMIC-12 12V DPU3 VDD VDDQ_DDR (in)"
+        label power1 "PMIC-12 12V DPU4 VDD VDDQ_DDR (in)"
         label power2 "PMIC-12 DPU4 VDD Rail Pwr (out1)"
         label power3 "PMIC-12 DPU4 VDD_DDR Rail Pwr (out1)"
         ignore power4 


### PR DESCRIPTION
This commit corrects a few typos for DPU sensor
attribute name configurations.

Bug: #4601092