### PR TITLE
hw-mgmt: scripts: Correct dependency for systemd startup

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=HW management Fast Lables Monitor
+After=hw-management.service
+Requires=hw-management.service
+PartOf=hw-management.service
 
 StartLimitIntervalSec=1200
 StartLimitBurst=5

--- a/debian/hw-management.hw-management.service
+++ b/debian/hw-management.hw-management.service
@@ -2,6 +2,8 @@
 Description=Chassis HW management service of Nvidia systems
 Documentation=man:hw-management.service(8)
 Wants=hw-management-sync.service
+Wants=hw-management-sysfs-monitor.service
+Wants=hw-management-fast-sysfs-monitor.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The hw-management-sysfs-monitor does not automatically start when hw-mgmt is restarted. It is because the PartOf= directive only causes stop and restart operations on the main service to be propagated to the dependent. It does not cause a standard "start" or "restart" to also start the dependent if it was previously inactive. If hw-management-sysfs-monitor is not active at the moment hw-mgmt is restarted, it will stay inactive.

To make sure hw-management-sysfs-monitor also (re)starts whenever hw-mgmt is started or restarted, adding
'Wants=' directive to hw-management service.

Bug: 4540628, 4556756

Cursor Review
=========
Technical Analysis
✅ Positive Aspects:
Correct Solution: Adding Wants= to the main service ensures dependent services start when the main service starts
Proper Systemd Usage: The combination of Wants=, Requires=, After=, and PartOf= creates a robust dependency chain
Clear Documentation: Good commit message explaining the technical issue and solution
Bug Tracking: Proper reference to bug numbers for traceability
🔍 Technical Details:
Wants= in main service: Ensures dependents start with the main service
Requires= in dependent: Creates a hard dependency (dependent fails if main fails)
After= in dependent: Ensures proper startup order
PartOf= in dependent: Propagates stop/restart operations
Impact Assessment
Risk Level: Low - These are standard systemd dependency patterns
Scope: Affects systemd service startup behavior for hardware management services
Backward Compatibility: Should not break existing functionality
Recommendations
The changes look technically sound and address the described issue appropriately. This is a well-documented bug fix that follows systemd best practices for service dependencies.