### PR TITLE
hw-mgmt: kernel: 6.1: mp2975: Clear interrupts at probe

### DIFF
--- a/debian/Release.txt
+++ b/debian/Release.txt
@@ -1,4 +1,28 @@
 ================================================================================
+- V.7.0040.4031
+- Wed, 17 Sep 2025
+--------------------------------------------------------------------------------
+
+- New features
+    o 
+
+- Bug fixes
+    o NVBug #5360318, #4501831, bobcat COMEX sensor alarm is triggered which caused test_sensors failure
+
+- Kernel Patches for New Features:
+    o 
+
+- For detailed patch list: Please view: https://github.com/Mellanox/hw-mgmt/blob/V.7.0040.4031/recipes-kernel/linux/Patch_Status_Table.txt
+
+- Known issues and limitations:
+    o Systems like sn2700 which contain delta 460 PSU may have "Error getting sensor data: dps460/#25: Can't read"
+      which is a temporary inaccessibility of certain alarm attributes read from the PSU.
+    o Systems may show a message of WARNING kernel: Ã¢â‚¬Â¦ supply vcc not found, using dummy regulator" 
+    o Systems SN2010, SN2100, SN2410, SN2700 and SN2740 (and their "-B" variants) require the following flag in kernel cmdline:
+      "acpi_enforce_resources=lax acpi=noirq". 
+
+
+================================================================================
 - V.7.0040.4030
 - Thu, 21 Aug 2025
 --------------------------------------------------------------------------------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
-hw-management (1.mlnx.7.0040.4030) unstable; urgency=low
+hw-management (1.mlnx.7.0040.4031) unstable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Thu, 21 Aug 2025 08:42:00 +0300
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Wed, 17 Sep 2025 08:42:00 +0300
 
 
 

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -725,6 +725,7 @@ Kernel-6.1
 |8010-mlxsw-i2c-Downstream-Add-retry-mechanism-for-failed-.patch  |                    | Downstream accepted                      |            |                                                |
 |8011-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch    |                    | Downstream accepted                      |            |                                                |
 |8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch  |                    | Downstream accepted                      |            |                                                |
+|8013-hwmon-pmbus-mp2975-Clear-interrupts-at-probe.patch          |                    | Downstream accepted                      |            |                                                |
 |9000-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-regmap-debugfs-FT-Enable-writing-to-the-regmap-debug.patch  |                    | Downstream;skip[ALL];take[opt]           |            | BF3 (FT purpose)                               |

--- a/recipes-kernel/linux/linux-6.1/8013-hwmon-pmbus-mp2975-Clear-interrupts-at-probe.patch
+++ b/recipes-kernel/linux/linux-6.1/8013-hwmon-pmbus-mp2975-Clear-interrupts-at-probe.patch
@@ -1,0 +1,74 @@
+From 8d8f4d52f5655747df20317ceaf628e29070475e Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Tue, 9 Sep 2025 08:48:47 +0300
+Subject: hwmon: pmbus: mp2975: Clear interrupts at probe
+
+In some switches after power on, ALARM is seen for
+power_1 input. According to MPS, driver should clear
+the faults by writing 0 to CLEAR_CAT_FAULTS (0xFD)
+register and CLEAR_FAULTS (0x03) register, during
+the probe.
+
+NVBug: #5360318
+
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/hwmon/pmbus/mp2975.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/drivers/hwmon/pmbus/mp2975.c b/drivers/hwmon/pmbus/mp2975.c
+index 51986adfb..47f092259 100644
+--- a/drivers/hwmon/pmbus/mp2975.c
++++ b/drivers/hwmon/pmbus/mp2975.c
+@@ -33,6 +33,7 @@
+ #define MP2975_MFR_READ_VREF_R2		0xa3
+ #define MP2975_MFR_OVP_TH_SET		0xe5
+ #define MP2975_MFR_UVP_SET		0xe6
++#define MP2975_CLEAR_CAT_FAULTS 	0xfd
+ 
+ #define MP2975_VOUT_FORMAT		BIT(15)
+ #define MP2975_VID_STEP_SEL_R1		BIT(4)
+@@ -659,6 +660,28 @@ mp2975_vout_per_rail_config_get(struct i2c_client *client,
+ 	return 0;
+ }
+ 
++static int
++mp2975_clear_interrupts(struct i2c_client *client,
++			struct mp2975_data *data)
++{
++	int i = 0;
++	int ret = 0;
++
++	for (i = 0; i < data->info.pages; i++) {
++		ret = i2c_smbus_write_byte_data(client, PMBUS_PAGE, i);
++		if (ret < 0)
++			return ret;
++		ret = i2c_smbus_write_byte_data(client, PMBUS_CLEAR_FAULTS, 0);
++		if (ret < 0)
++			return ret;
++		ret = i2c_smbus_write_byte_data(client, MP2975_CLEAR_CAT_FAULTS, 0);
++		if (ret < 0)
++			return ret;
++	}
++
++	return ret;
++}
++
+ static struct pmbus_driver_info mp2975_info = {
+ 	.pages = 1,
+ 	.format[PSC_VOLTAGE_IN] = linear,
+@@ -736,6 +759,11 @@ static int mp2975_probe(struct i2c_client *client)
+ 	if (ret)
+ 		return ret;
+ 
++	/* Clear interrupts. */
++	ret = mp2975_clear_interrupts(client, data);
++	if (ret)
++		return ret;
++
+ 	return pmbus_do_probe(client, info);
+ }
+ 
+-- 
+2.47.2
+


### PR DESCRIPTION
In some switches after power on, ALARM is seen for
power_1 input. According to MPS, driver should clear
the faults by writing 0 to CLEAR_CAT_FAULTS (0xFD)
register and CLEAR_FAULTS (0x03) register, during
the probe.

Bug:   #4501831
NVBug: #5360318
    
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>