### PR TITLE
hw-mgmt: scripts: Add hw-mgmt tree dump to sysfs monitor service

### DIFF
--- a/usr/usr/bin/hw-management-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-sysfs-monitor.sh
@@ -76,6 +76,9 @@ do_start_sysfs_monitor()
             log_info "sysfs monitor done!"
             # Write the current time into the sysfs ready file.
             echo "$current_time" > "$SYSFS_MONITOR_RDY_FILE"
+            # Generate debug dump of hw-mgmt tree
+            find -L $hw_management_path -maxdepth 4 ! -name '*_info' ! -name '*_eeprom' \
+               ! -name '*.sh' ! -name '*.py' ! -name 'led_*_state' -exec ls -la {} \; -exec cat {} \; > /var/log/hw-mgmt-val.log 2>/dev/null
             # Exit the sysfs monitor.
             exit 0
         fi


### PR DESCRIPTION
Adding the hw-mgmt tree dump before termination of sysfs monitor service to facilitate service debugging.

Bug: 4603973