### PR TITLE
hw-mgmt: config: Disable IPMI module for n5500ld

### DIFF
--- a/usr/usr/local/bin/hw-management-process-blacklist.sh
+++ b/usr/usr/local/bin/hw-management-process-blacklist.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 ################################################################################
-# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -74,6 +75,16 @@ process_blacklist()
 		# ASF bus is used by MCTP, this loading order ensures that MCTP will use i2c bus 4.
 		echo blacklist i2c_asf >> $BLACKLIST_FILE
 		echo blacklist i2c-diolan-u2c >> $BLACKLIST_FILE
+		;;
+	HI176)
+		# Blacklist Designware, ASF I2C controller drivers and ipmi
+		echo blacklist i2c_designware_platform >> $BLACKLIST_FILE
+		echo blacklist i2c_designware_core >> $BLACKLIST_FILE
+		echo blacklist i2c_asf >> $BLACKLIST_FILE
+		echo blacklist ipmi_si >> $BLACKLIST_FILE
+		echo blacklist ipmi_ssif >> $BLACKLIST_FILE
+		echo blacklist ipmi_devintf >> $BLACKLIST_FILE
+		echo blacklist ipmi_msghandler >> $BLACKLIST_FILE
 		;;
 	*)
 		# Blacklist Designware and ASF I2C controller drivers


### PR DESCRIPTION
## Summary
Cherry-pick commit 0bad29db05ce1bae450b605c6ca0d1a499b42b65 to add IPMI module blacklisting for n5500ld (HI176) systems.

## Description
This PR disables all IPMI kernel modules due to hardware signal integrity issues on n5500ld systems. The following IPMI modules will be blacklisted for HI176 systems:

- `ipmi_si`
- `ipmi_ssif` 
- `ipmi_devintf`
- `ipmi_msghandler`

## Changes
- Added HI176 case to `hw-management-process-blacklist.sh` with IPMI module blacklisting
- Updated copyright headers with SPDX format

## Bug Reference
Bug #4432197

## Testing
- [ ] Verified IPMI modules are blacklisted for HI176 systems
- [ ] Confirmed no impact on other system types

## Signed-off-by
- Vadim Pasternak <vadimp@nvidia.com> (original author)
- Abraham Coifman <acoifman@nvidia.com> (cherry-pick)