### PR TITLE
hw-mgmt: scripts: Re-instantiate mlxreg-dpu devices

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -989,3 +989,22 @@ get_ui_tree_archive_file()
 	esac
 	echo $ui_tree_archive
 }
+
+# Due to a very rare race condition in the kernel, mlxreg-dpu devices fail
+# to instantiate during the kernel initialization. This function will try
+# to re-instantiate if there was a failure. Needs to be invoked from
+# hw-management-start-post.sh
+check_and_recreate_dpu_devices()
+{
+	for bus in {18..21}; do
+		if ! ls /sys/bus/i2c/devices/${bus}-0068/mlxreg-io* >/dev/null 2>&1; then
+			log_info "Device mlxreg-io* not found on i2c-$bus. Recreating device..."
+			# Delete the device on this bus with address 0x68
+			echo 0x68 > /sys/bus/i2c/devices/i2c-${bus}/delete_device >/dev/null 2>&1
+			# Create the device again
+			echo "mlxreg-dpu 0x68" > /sys/bus/i2c/devices/i2c-${bus}/new_device >/dev/null 2>&1
+		else
+			log_info "Found mlxreg-io on i2c-$bus"
+		fi
+	done
+}

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -65,6 +65,13 @@ case $board in
 			modprobe nvidia_drm
 		fi
 		;;
+	VMOD0019)
+		# Trying to re-instatiate mlxreg-dpu driver for smart switch if there
+		# was a problem during initialization
+		if [ "$sku" == "HI160" ]; then
+			check_and_recreate_dpu_devices
+		fi
+		;;
 	*)
 		;;
 esac


### PR DESCRIPTION
Very rarely on some smart switches, during a random kernel boot, some of the DPUs are not initialized. mlxreg-dpu driver fails to initialize. DPU attributes will not be available.

There is a timing issue with mlx-platfom driver and mlxreg-dpu driver. By the time, mlxreg-dpu driver tries to initialize the dpu, the relevant platform i2c bus is not created. Kernel provides a mechanism called deferred probing. In most of the cases, it does help, and we will get mlxreg-dpu probing done successfully. Very rarely, deferred probing timeout exceeds and we will end up having this issue.

This is a workaround to re-instantiate mlxreg-dpu if the kernel driver initialization failed

Bug: #4228063