### PR TITLE
hw-mgmt: scripts: Re-instantiate mlxreg-dpu devices

### DIFF
--- a/debian/Release.txt
+++ b/debian/Release.txt
@@ -1,4 +1,28 @@
 ================================================================================
+- V.7.0040.4033
+- Mon, 29 Sep 2025
+--------------------------------------------------------------------------------
+
+- New features
+    o 
+
+- Bug fixes
+    o #4228063, hw-mgmt: scripts: Re-instantiate mlxreg-dpu devices, a8f3f70
+
+- Kernel Patches for New Features:
+    o 
+
+- For detailed patch list: Please view: https://github.com/Mellanox/hw-mgmt/blob/V.7.0040.4033/recipes-kernel/linux/Patch_Status_Table.txt
+
+- Known issues and limitations:
+    o Systems like sn2700 which contain delta 460 PSU may have "Error getting sensor data: dps460/#25: Can't read"
+      which is a temporary inaccessibility of certain alarm attributes read from the PSU.
+    o Systems may show a message of WARNING kernel: Ã¢â‚¬Â¦ supply vcc not found, using dummy regulator" 
+    o Systems SN2010, SN2100, SN2410, SN2700 and SN2740 (and their "-B" variants) require the following flag in kernel cmdline:
+      "acpi_enforce_resources=lax acpi=noirq". 
+
+
+================================================================================
 - V.7.0040.4032
 - Sun, 21 Sep 2025
 --------------------------------------------------------------------------------

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
-hw-management (1.mlnx.7.0040.4032) unstable; urgency=low
+hw-management (1.mlnx.7.0040.4033) unstable; urgency=low
   [ MLNX ] 
 
- -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Sun, 21 Sep 2025 09:26:35 +0300
+ -- NBU BSP <NBU-System-SW-BSP@exchange.nvidia.com> Mon, 29 Sep 2025 09:26:35 +0300
 
 
 

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -726,6 +726,7 @@ Kernel-6.1
 |8011-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch    |                    | Downstream accepted                      |            |                                                |
 |8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch  |                    | Downstream accepted                      |            |                                                |
 |8013-hwmon-pmbus-mp2975-Clear-interrupts-at-probe.patch          |                    | Downstream accepted                      |            |                                                |
+|8014-platform-mellanox-mlxreg-dpu-Debug-trace-for-dpu-pro.patch  |                    | Downstream accepted                      |            |                                                |
 |9000-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-regmap-debugfs-FT-Enable-writing-to-the-regmap-debug.patch  |                    | Downstream;skip[ALL];take[opt]           |            | BF3 (FT purpose)                               |

--- a/recipes-kernel/linux/linux-6.1/8014-platform-mellanox-mlxreg-dpu-Debug-trace-for-dpu-pro.patch
+++ b/recipes-kernel/linux/linux-6.1/8014-platform-mellanox-mlxreg-dpu-Debug-trace-for-dpu-pro.patch
@@ -1,0 +1,32 @@
+From e7838edd2acc793f3b43ab04b3693a340273c330 Mon Sep 17 00:00:00 2001
+From: Ciju Rajan K <crajank@nvidia.com>
+Date: Fri, 19 Sep 2025 09:51:17 +0300
+Subject: platform: mellanox: mlxreg-dpu: Debug trace for dpu probing
+
+Signed-off-by: Ciju Rajan K <crajank@nvidia.com>
+---
+ drivers/platform/mellanox/mlxreg-dpu.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-dpu.c b/drivers/platform/mellanox/mlxreg-dpu.c
+index c79531481..1074c4853 100644
+--- a/drivers/platform/mellanox/mlxreg-dpu.c
++++ b/drivers/platform/mellanox/mlxreg-dpu.c
+@@ -537,9 +537,13 @@ static int mlxreg_dpu_probe(struct platform_device *pdev)
+ 	if (!data || !data->hpdev.brdinfo)
+ 		return -EINVAL;
+ 
++	dev_info(&pdev->dev, "Probing for adapter %d\n", data->hpdev.nr);
+ 	data->hpdev.adapter = i2c_get_adapter(data->hpdev.nr);
+-	if (!data->hpdev.adapter)
++	if (!data->hpdev.adapter) {
++		dev_info(&pdev->dev, "Will try a deferred probing for %d\n",
++			data->hpdev.nr);
+ 		return -EPROBE_DEFER;
++	}
+ 
+ 	mlxreg_dpu = devm_kzalloc(&pdev->dev, sizeof(*mlxreg_dpu), GFP_KERNEL);
+ 	if (!mlxreg_dpu)
+-- 
+2.47.2
+

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -65,6 +65,13 @@ case $board in
 			modprobe nvidia_drm
 		fi
 		;;
+	VMOD0019)
+		# Trying to re-instatiate mlxreg-dpu driver for smart switch if there
+		# was a problem during initialization.
+		if [ "$sku" == "HI160" ]; then
+			check_and_recreate_dpu_devices
+		fi
+		;;
 	*)
 		;;
 esac


### PR DESCRIPTION
Very rarely on some smart switches, during a random
kernel boot, some of the DPUs are not initialized.
mlxreg-dpu driver fails to initialize. DPU attributes
will not be available.

There is a timing issue with mlx-platform driver and
mlxreg-dpu driver. By the time, mlxreg-dpu driver tries
to initialize the dpu, the relevant platform i2c bus is
not created. Kernel provides a mechanism called deferred
probing. In most of the cases, it does help, and we will
get mlxreg-dpu probing done successfully. Very rarely,
deferred probing timeout exceeds and we will end up
having this issue.

This is a workaround to re-instantiate mlxreg-dpu if the
kernel driver initialization failed. There is also a small
kernel patch to print the traces, which will be helpful
for debugging.

Bug: #4228063

Signed-off-by: Ciju Rajan K <crajank@nvidia.com>