### PR TITLE
hw-mgmt: thermal: Fix thermal data for sn5600

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn5600.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn5600.json
@@ -46,6 +46,7 @@
 		"drivetemp":      {"pwm_min": 30, "pwm_max": 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},
 		"ibc\\d+":         {"pwm_min": 30, "pwm_max": 100, "val_min": "!80000", "val_max": "!110000", "poll_time": 60}
 	},
+	"error_mask" : {"psu_err" : ["direction", "present"]},
 	"sensor_list" : ["asic1", "cpu", "drivetemp", "drwr1", "drwr2", "drwr3", "drwr4", "ibc1", "ibc2", "ibc3", "ibc4", "psu1", "psu2", 
 	"sensor_amb", "sodimm1", "sodimm2", "voltmon1", "voltmon2", "voltmon3", "voltmon4", "voltmon5", "voltmon6", "voltmon7", "voltmon8", "voltmon9", "voltmon10", "voltmon11"]
 }


### PR DESCRIPTION
Fix thermal data for sn5600.
Mask psu errors:

"psu_err" : ["direction", "present"]}

Bug: 4649699

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
