### PR TITLE
hw-mgmt: service: Fix service start-limit issue

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -5,7 +5,7 @@ Requires=hw-management.service
 PartOf=hw-management.service
 
 StartLimitIntervalSec=1200
-StartLimitBurst=5
+StartLimitBurst=10
 
 [Service]
 Type=oneshot

--- a/debian/hw-management.hw-management-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-sysfs-monitor.service
@@ -5,7 +5,7 @@ Requires=hw-management.service
 PartOf=hw-management.service
 
 StartLimitIntervalSec=1200
-StartLimitBurst=5
+StartLimitBurst=10
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Sometimes, when starting the hw-mgmt service, the following error may appear:

"Failed with result 'start-limit-hit'"

This can occur for the hw-management-sysfs-monitor or
hw-management-fast-sysfs-monitor services. The reason is that these services are
limited to 5 starts within 20 minutes. If a user restarts hw-mgmt or any of
the listed services more than 5 times within that period, this error will occur.

The current limit of 5 restarts per 20 minutes is often too low and can be
triggered frequently during testing or normal usage. To prevent this issue,
restart limit can be increased to 10 times per 20 minutes.

Change in .service file:
StartLimitBurst 5 -> 10

Bug 4647168

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
