### PR TITLE
hw-mgmt: scripts: Fix unexpected reset module counter

### DIFF
--- a/usr/usr/bin/hw_management_peripheral_updater.py
+++ b/usr/usr/bin/hw_management_peripheral_updater.py
@@ -54,11 +54,14 @@ except ImportError as e:
 
 # Import platform configuration - SINGLE SOURCE OF TRUTH
 try:
-    from hw_management_platform_config import get_module_count
+    from hw_management_platform_config import get_module_count, get_platform_config
 except ImportError:
     # Fallback if platform config not available
     def get_module_count(sku):
         return 0
+
+    def get_platform_config(sku):
+        return []
 
 VERSION = "1.0.0"
 
@@ -550,13 +553,22 @@ def write_module_counter(product_sku):
     This is done in peripheral_updater to ensure availability even if
     thermal_updater is disabled by the customer.
 
+    If product_sku does not match any entry in PLATFORM_CONFIG, the file is not
+    created or modified (unsupported platform — leave existing content intact).
+
     @param product_sku: Platform SKU identifier to load correct config
     """
+    if not get_platform_config(product_sku):
+        LOGGER.notice(
+            "hw-management-peripheral-updater: module_counter skipped (platform not in config)"
+        )
+        return
+
     # Get module count from centralized platform configuration
     # This is the SINGLE SOURCE OF TRUTH for module counts
     module_count = get_module_count(product_sku)
 
-    # Always write module_counter (even 0) so other services can reliably read it
+    # Write module_counter (including 0) for supported platforms only
     try:
         with open("/var/run/hw-management/config/module_counter", 'w', encoding="utf-8") as f:
             f.write("{}\n".format(module_count))


### PR DESCRIPTION
For systems that are not supported  in peripheral updater - it still can
reset module_counter (0). It can affect TC and other system parts.

Fix: ignore module_counter update in case system not supported

Bug: 4954687

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
