### PR TITLE
hw-mgmt: patches: Update platform driver for SPC6 platforms

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0106-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
+++ b/recipes-kernel/linux/linux-6.1/0106-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
@@ -1,4 +1,4 @@
-From 1b27659828d6fab57fde84335320c63f27b8d429 Mon Sep 17 00:00:00 2001
+From be10bc8ec297096ff4919ad91eef8ca17ff0461c Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 15 Jun 2025 13:13:26 +0300
 Subject: [PATCH] platform/mellanox: nvsw-bmc: Add system control and
@@ -25,9 +25,9 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  drivers/platform/mellanox/nvsw-core.c         |  693 ++++
  drivers/platform/mellanox/nvsw-host-l1.c      |  736 +++++
  drivers/platform/mellanox/nvsw-host-spc5.c    |  944 ++++++
- drivers/platform/mellanox/nvsw-host-spc6.c    |  837 +++++
+ drivers/platform/mellanox/nvsw-host-spc6.c    |  853 +++++
  drivers/platform/mellanox/nvsw.h              |  298 ++
- 9 files changed, 6386 insertions(+), 4 deletions(-)
+ 9 files changed, 6402 insertions(+), 4 deletions(-)
  create mode 100644 drivers/platform/mellanox/nvsw-bmc-hid162.c
  create mode 100644 drivers/platform/mellanox/nvsw-core.c
  create mode 100644 drivers/platform/mellanox/nvsw-host-l1.c
@@ -36,10 +36,10 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  create mode 100644 drivers/platform/mellanox/nvsw.h
 
 diff --git a/Documentation/devicetree/bindings/trivial-devices.yaml b/Documentation/devicetree/bindings/trivial-devices.yaml
-index 8e6c0bc60..3cc1097bb 100644
+index 74d30c8f3..1e1d5c81c 100644
 --- a/Documentation/devicetree/bindings/trivial-devices.yaml
 +++ b/Documentation/devicetree/bindings/trivial-devices.yaml
-@@ -293,10 +293,10 @@ properties:
+@@ -291,10 +291,10 @@ properties:
            - national,lm85
              # I2C ±0.33°C Accurate, 12-Bit + Sign Temperature Sensor and Thermal Window Comparator
            - national,lm92
@@ -5348,10 +5348,10 @@ index 000000000..70c58b57c
 +
 diff --git a/drivers/platform/mellanox/nvsw-host-spc6.c b/drivers/platform/mellanox/nvsw-host-spc6.c
 new file mode 100644
-index 000000000..6e867ccd4
+index 000000000..a136c313f
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-host-spc6.c
-@@ -0,0 +1,837 @@
+@@ -0,0 +1,853 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia SPC6 host platform driver
@@ -5374,8 +5374,11 @@ index 000000000..6e867ccd4
 +
 +#define NVSW_HOST_DEVICE_NAME	"mlxplat"
 +
-+/* Bus number of mux device */
-+#define NVSW_I2C_MUX_BUS_NR		2
++/* Bus number of mux parent device */
++#define NVSW_I2C_MUX_PARENT_BUS_NR	2
++
++/* Bus number of the last host I2C bus */
++#define NVSW_I2C_LAST_HOST_BUS_NR	3
 +
 +/* Platform mux channels */
 +static int nvsw_host_spc6_mux_channels[] = {
@@ -6040,7 +6043,7 @@ index 000000000..6e867ccd4
 +{
 +	int i, err;
 +
-+    /* Allocate the platform device structure */
++	/* Allocate the platform device structure */
 +	nvsw_host_pdev =
 +		platform_device_alloc(NVSW_HOST_DEVICE_NAME, PLATFORM_DEVID_NONE);
 +	if (!nvsw_host_pdev)
@@ -6082,16 +6085,29 @@ index 000000000..6e867ccd4
 +
 +static int nvsw_host_probe(struct platform_device *pdev)
 +{
++	struct i2c_adapter *last_host_adapter;
 +	struct nvsw_core *nvsw_core;
 +	int i, err;
 +
-+	/* Get I2C adapter at the top of host I2C tree */
-+	nvsw_host_mux_i2c_adapter = i2c_get_adapter(NVSW_I2C_MUX_BUS_NR);
-+	if (!nvsw_host_mux_i2c_adapter) {
++	/* Ensure the I2C host driver has finished registering
++	 * all 4 buses (0-3) to prevent the mux from stealing bus 3
++	 */
++	last_host_adapter = i2c_get_adapter(NVSW_I2C_LAST_HOST_BUS_NR);
++	if (!last_host_adapter) {
 +		dev_info(&pdev->dev,
 +			 "I2C adapter for bus %d is not ready, deferring probe\n",
-+			 NVSW_I2C_MUX_BUS_NR);
++			 NVSW_I2C_LAST_HOST_BUS_NR);
 +		return -EPROBE_DEFER;
++	}
++	i2c_put_adapter(last_host_adapter);
++
++	/* Get I2C mux parent adapter */
++	nvsw_host_mux_i2c_adapter = i2c_get_adapter(NVSW_I2C_MUX_PARENT_BUS_NR);
++	if (!nvsw_host_mux_i2c_adapter) {
++		dev_err(&pdev->dev,
++			 "I2C adapter for bus %d is not available\n",
++			 NVSW_I2C_MUX_PARENT_BUS_NR);
++		return -ENODEV;
 +	}
 +
 +	/* Create device at the top of host I2C tree */
@@ -6101,8 +6117,8 @@ index 000000000..6e867ccd4
 +	if (IS_ERR(nvsw_host_mux_i2c_client)) {
 +		dev_err(&pdev->dev,
 +			"Failed to create client %s at bus %d at addr 0x%02x\n",
-+			nvsw_host_mux_brdinfo->type, NVSW_I2C_MUX_BUS_NR,
-+		    nvsw_host_mux_brdinfo->addr);
++			nvsw_host_mux_brdinfo->type, NVSW_I2C_MUX_PARENT_BUS_NR,
++			nvsw_host_mux_brdinfo->addr);
 +		err = PTR_ERR(nvsw_host_mux_i2c_client);
 +		goto i2c_new_client_device_fail;
 +	}

--- a/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
+++ b/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
@@ -1,8 +1,8 @@
-From f6e2ca2988939ac8543b3de097e3f2cadd655ed7 Mon Sep 17 00:00:00 2001
+From 7d0f9191f8e282b28411b21fd33d166c4efafc68 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 4 Jul 2024 23:50:27 +0300
-Subject: [PATCH platform-next 1/1] platform/mellanox: nvsw-bmc: Add system
- control and monitoring driver for Nvidia BMC
+Subject: [PATCH] platform/mellanox: nvsw-bmc: Add system control and
+ monitoring driver for Nvidia BMC
 
 The driver allows system control and monitoring of Nvidia switches
 through CPLD/FPGA devices from Based Management Controller SoC.
@@ -25,9 +25,9 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  drivers/platform/mellanox/nvsw-core.c         |  693 ++++
  drivers/platform/mellanox/nvsw-host-l1.c      |  770 ++++
  drivers/platform/mellanox/nvsw-host-spc5.c    |  943 +++++
- drivers/platform/mellanox/nvsw-host-spc6.c    |  836 +++++
+ drivers/platform/mellanox/nvsw-host-spc6.c    |  852 +++++
  drivers/platform/mellanox/nvsw.h              |  297 ++
- 9 files changed, 6896 insertions(+)
+ 9 files changed, 6912 insertions(+)
  create mode 100644 drivers/platform/mellanox/nvsw-bmc-hid162.c
  create mode 100644 drivers/platform/mellanox/nvsw-core.c
  create mode 100644 drivers/platform/mellanox/nvsw-host-l1.c
@@ -5855,10 +5855,10 @@ index 000000000..e54bd4109
 +
 diff --git a/drivers/platform/mellanox/nvsw-host-spc6.c b/drivers/platform/mellanox/nvsw-host-spc6.c
 new file mode 100644
-index 000000000..880c7760e
+index 000000000..449ba5ffd
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-host-spc6.c
-@@ -0,0 +1,836 @@
+@@ -0,0 +1,852 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
 + * Nvidia SPC6 host platform driver
@@ -5881,8 +5881,11 @@ index 000000000..880c7760e
 +
 +#define NVSW_HOST_DEVICE_NAME	"mlxplat"
 +
-+/* Bus number of mux device */
-+#define NVSW_I2C_MUX_BUS_NR		2
++/* Bus number of mux parent device */
++#define NVSW_I2C_MUX_PARENT_BUS_NR	2
++
++/* Bus number of the last host I2C bus */
++#define NVSW_I2C_LAST_HOST_BUS_NR	3
 +
 +/* Platform mux channels */
 +static int nvsw_host_spc6_mux_channels[] = {
@@ -6589,16 +6592,29 @@ index 000000000..880c7760e
 +
 +static int nvsw_host_probe(struct platform_device *pdev)
 +{
++	struct i2c_adapter *last_host_adapter;
 +	struct nvsw_core *nvsw_core;
 +	int i, err;
 +
-+	/* Get I2C adapter at the top of host I2C tree */
-+	nvsw_host_mux_i2c_adapter = i2c_get_adapter(NVSW_I2C_MUX_BUS_NR);
-+	if (!nvsw_host_mux_i2c_adapter) {
++	/* Ensure the I2C host driver has finished registering
++	 * all 4 buses (0-3) to prevent the mux from stealing bus 3
++	 */
++	last_host_adapter = i2c_get_adapter(NVSW_I2C_LAST_HOST_BUS_NR);
++	if (!last_host_adapter) {
 +		dev_info(&pdev->dev,
 +			 "I2C adapter for bus %d is not ready, deferring probe\n",
-+			 NVSW_I2C_MUX_BUS_NR);
++			 NVSW_I2C_LAST_HOST_BUS_NR);
 +		return -EPROBE_DEFER;
++	}
++	i2c_put_adapter(last_host_adapter);
++
++	/* Get I2C mux parent adapter */
++	nvsw_host_mux_i2c_adapter = i2c_get_adapter(NVSW_I2C_MUX_PARENT_BUS_NR);
++	if (!nvsw_host_mux_i2c_adapter) {
++		dev_err(&pdev->dev,
++			 "I2C adapter for bus %d is not available\n",
++			 NVSW_I2C_MUX_PARENT_BUS_NR);
++		return -ENODEV;
 +	}
 +
 +	/* Create device at the top of host I2C tree */
@@ -6608,8 +6624,8 @@ index 000000000..880c7760e
 +	if (IS_ERR(nvsw_host_mux_i2c_client)) {
 +		dev_err(&pdev->dev,
 +			"Failed to create client %s at bus %d at addr 0x%02x\n",
-+			nvsw_host_mux_brdinfo->type, NVSW_I2C_MUX_BUS_NR,
-+		    nvsw_host_mux_brdinfo->addr);
++			nvsw_host_mux_brdinfo->type, NVSW_I2C_MUX_PARENT_BUS_NR,
++			nvsw_host_mux_brdinfo->addr);
 +		err = PTR_ERR(nvsw_host_mux_i2c_client);
 +		goto i2c_new_client_device_fail;
 +	}


### PR DESCRIPTION
Ensure that driver waits for initialization of all host I2C buses before initializing i2c mux driver, to prevent the mux driver from stealing the bus number 3, reserved for host buses. This guarantees the correct mux bus numbering, as expected by user space tools.

Bug: 43251541