### PR TITLE
hw-mgmt: udev: more strict match for mlxsw PCI udev rules.

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -144,8 +144,8 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/*/NVSN2201:*/i2c_mlxcpld*/i2c-*/i2c-*/*-0048/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm switch %S %p"
 
 # Switch - FAN tachometers and ASIC and ports temperatures and faults (PCI).
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/0000:*/0000:*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add switch %S %p"
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/0000:*/0000:*/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm switch %S %p"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/0000:*/0000:*/hwmon/hwmon*", ATTR{name}=="mlxsw", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add switch %S %p"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/pci0000:00/0000:*/0000:*/hwmon/hwmon*", ATTR{name}=="mlxsw", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm switch %S %p"
 
 # Cooling device.
 SUBSYSTEM=="thermal", KERNEL=="cooling_device*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add cooling_device %S %p %k"


### PR DESCRIPTION
Restrict the generic PCI hwmon path rules to ATTR{name}=="mlxsw" so
non-mlxsw devices under the same pattern do not trigger thermal events.
In hw-management-thermal-events.sh switch removal, run module/gearbox
symlink teardown and mlxsw-specific asic/fan cleanup only when the
hwmon name is mlxsw, aligning script behavior with the udev filter.

Bug: 4968939

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
