### PR TITLE
hw-mgmt: scripts: Fix thermal/chassis updater service scheduler

### DIFF
--- a/usr/usr/bin/hw_management_peripheral_updater.py
+++ b/usr/usr/bin/hw_management_peripheral_updater.py
@@ -38,14 +38,17 @@
 
 try:
     import os
-    import time
     import json
     import re
     import argparse
     import traceback
     import signal
     import threading
-    from hw_management_lib import HW_Mgmt_Logger as Logger, exit_wait
+    from hw_management_lib import (
+        HW_Mgmt_Logger as Logger,
+        exit_wait,
+        current_milli_time,
+    )
     from collections import Counter
 
     from hw_management_redfish_client import RedfishClient, BMCAccessor
@@ -492,7 +495,7 @@ def update_peripheral_attr(attr_prop):
     input file and invokes the appropriate function only when the value changes,
     implementing change-based triggering for peripheral monitoring.
     """
-    ts = time.time()
+    ts = current_milli_time() // 1000
     if ts >= attr_prop["ts"]:
         # update timestamp
         attr_prop["ts"] = ts + attr_prop["poll"]

--- a/usr/usr/bin/hw_management_thermal_updater.py
+++ b/usr/usr/bin/hw_management_thermal_updater.py
@@ -48,13 +48,17 @@ of ASICs and optical modules with different poll intervals and lifecycle managem
 
 try:
     import os
-    import time
     import re
     import argparse
     import traceback
     import signal
     import threading
-    from hw_management_lib import HW_Mgmt_Logger as Logger, atomic_file_write, exit_wait
+    from hw_management_lib import (
+        HW_Mgmt_Logger as Logger,
+        atomic_file_write,
+        exit_wait,
+        current_milli_time,
+    )
     from collections import Counter
     from hw_management_platform_config import (
         PLATFORM_CONFIG,
@@ -479,7 +483,7 @@ def update_thermal_attr(attr_prop):
     at the configured polling interval. It invokes the appropriate thermal function
     (e.g., asic_temp_populate, module_temp_populate) to read and update temperature data.
     """
-    ts = time.time()
+    ts = current_milli_time() // 1000
     if ts >= attr_prop["ts"]:
         # update timestamp
         attr_prop["ts"] = ts + attr_prop["poll"]


### PR DESCRIPTION
Replace wall-clock time.time() with integer seconds derived from
hw_management_lib.current_milli_time() (CLOCK_MONOTONIC) so NTP or
manual clock changes do not delay or bunch poll-driven work.

Bug: 4966264

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
