### PR TITLE
hw-mgmt: thermal: Fix fan dir logs duplicate from TC service

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2347,11 +2347,11 @@ class fan_sensor(system_device):
                 self.log.warning("{} dir \"{}\" unsupported in configuration. Using default: {}".format(self.name,
                                                                                                         fan_dir,
                                                                                                         fan_dir_def),
-                                 id="{} dir".format(self.name), repeat=1)
+                                 id="{} dir get param".format(self.name), repeat=1)
             fan_dir = fan_dir_def
         else:
             # Print "finalization" message to indicate that the error is resolved. Print only once.
-            self.log.notice(None, id="{} dir".format(self.name))
+            self.log.notice(None, id="{} dir get param".format(self.name))
 
         param = self.fan_param[fan_dir]
         return param

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2694,11 +2694,11 @@ class fan_sensor(system_device):
                 self.log.warning("{} dir \"{}\" unsupported in configuration. Using default: {}".format(self.name,
                                                                                                         fan_dir,
                                                                                                         fan_dir_def),
-                                 id="{} dir".format(self.name), repeat=1)
+                                 id="{} dir get param".format(self.name), repeat=1)
             fan_dir = fan_dir_def
         else:
             # Print "finalization" message to indicate that the error is resolved. Print only once.
-            self.log.notice(None, id="{} dir".format(self.name))
+            self.log.notice(None, id="{} dir get param".format(self.name))
 
         param = self.fan_param[fan_dir]
         return param


### PR DESCRIPTION
Failure Summary:
While testing fan direction fault scenarios, it is observed that
hw-management-tc generates both NOTICE and WARNING logs for the same FAN
direction issue, even though the NOTICE log already includes repeat
count and duration intended to prevent log flooding.

Fix: fic log id to correct

Bug: 4967076

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
