### PR TITLE
hw-mgmt: thermal: Fix amb sensor logs Incorrect duration in TC service

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -1258,12 +1258,12 @@ class system_device(hw_management_file_op):
         err_flag = False
         if sensor_value > self.val_max:
             self.log.warn("{}: file {} value({}) > max({})".format(self.name, val_read_file, sensor_value, self.val_max),
-                          id="{} value > max".format(self.name),
+                          id="{} value > max".format(val_read_file),
                           repeat=1, log_repeat=5)
             err_flag = True
         else:
             # Print "finalization" message to indicate that the error is resolved. Print only once.
-            self.log.notice(None, id="{} value > max".format(self.name))
+            self.log.notice(None, id="{} value > max".format(val_read_file))
 
         if sensor_value < self.val_min:
             self.log.debug("{}: file {} value({}) < min({})".format(self.name,

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -1533,12 +1533,12 @@ class system_device(hw_management_file_op):
         err_flag = False
         if sensor_value > self.val_max:
             self.log.warn("{}: file {} value({}) > max({})".format(self.name, val_read_file, sensor_value, self.val_max),
-                          id="{} value > max".format(self.name),
+                          id="{} value > max".format(val_read_file),
                           repeat=1, log_repeat=5)
             err_flag = True
         else:
             # Print "finalization" message to indicate that the error is resolved. Print only once.
-            self.log.notice(None, id="{} value > max".format(self.name))
+            self.log.notice(None, id="{} value > max".format(val_read_file))
 
         if sensor_value < self.val_min:
             self.log.debug("{}: file {} value({}) < min({})".format(self.name,


### PR DESCRIPTION
Failure Summary:
while simulating a high temperature condition for the ambient
sensor (port_amb), hw-management-tc logs are generated indicating
threshold breach. However, the alert metadata fields "duration" and
"repeat" are not behaving as expected.

Fix: change log id on sensor max threshold validation

Bug: 4970442

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
