### PR TITLE
hw-mgmt: thermal: Add "start message" marker for initial log entry

### DIFF
--- a/usr/usr/bin/hw_management_lib.py
+++ b/usr/usr/bin/hw_management_lib.py
@@ -739,6 +739,8 @@ class HW_Mgmt_Logger:
                             msg=msg,
                             max_repeat=repeat,
                         )
+                        # special "start" marker to indicate that message is new
+                        msg = "{} (+)".format(msg)
                         log_hash[id_hash] = msg_state
                         self._msg_hash_garbage_collect(log_hash)
                     if msg_state.seen_count <= msg_state.max_repeat:


### PR DESCRIPTION
Introduce a special marker "(+)" for the first message in a log
sequence. This helps identify the point at which TC error/warning events
begin.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
