### PR TITLE
hw-mgmt: scripts: Fix initial timestamps of sysfs monitor service

### DIFF
--- a/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -60,6 +60,10 @@ do_start_fast_sysfs_monitor()
     declare -A DEVICE_ADDED  # Track added devices per file name.
     ELAPSED=0
     log_info "Monitoring ${TOTAL_FILES} files..."
+
+    # Clear the ready file in case this is a service restart
+    [ -f "$FAST_SYSFS_MONITOR_RDY_FILE" ] && rm -f "$FAST_SYSFS_MONITOR_RDY_FILE"
+
     while (( ELAPSED < FAST_SYSFS_MONITOR_TIMEOUT )); do
     # Check and add missing devices from devtree_file.
     if [ -e "$devtree_file" ] && [ -d "$eeprom_path" ] && [[ ${#DEVICE_ADDED[@]} -lt ${#DEV_FILES[@]} ]]; then
@@ -131,7 +135,7 @@ case $FAST_SYSFS_MONITOR_ACTION in
     start)
         # Save the PID of the Fast Sysfs Monitor process.
         touch "$FAST_SYSFS_MONITOR_PID_FILE"
-        echo $! > "$FAST_SYSFS_MONITOR_PID_FILE"
+        echo $$ > "$FAST_SYSFS_MONITOR_PID_FILE"
         log_info "HW Mangement Fast Sysfs Monitor process created."
         do_start_fast_sysfs_monitor
     ;;

--- a/usr/usr/bin/hw-management-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-sysfs-monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -50,9 +50,19 @@ Options:
 do_start_sysfs_monitor()
 {
     log_info "Starting hw-mngmt-sysfs-monitor logic."
+
+    # Initialize timestamp to current time to avoid stale data
+    local current_time
+    current_time=$(awk '{print int($1 * 1000)}' /proc/uptime)
+    echo "$current_time" > "$SYSFS_MONITOR_RESET_FILE_A"
+    echo "$current_time" > "$SYSFS_MONITOR_RESET_FILE_B"
+
+    # Clear the ready file in case this is a service restart
+    [ -f "$SYSFS_MONITOR_RDY_FILE" ] && rm -f "$SYSFS_MONITOR_RDY_FILE"
+
     while true; do
         # Get the current time with milliseconds.
-        local current_time=$(awk '{print int($1 * 1000)}' /proc/uptime)
+        current_time=$(awk '{print int($1 * 1000)}' /proc/uptime)
         # Read the last update time from both reset files.
         local last_reset_time_A=$(cat "$SYSFS_MONITOR_RESET_FILE_A" 2>/dev/null || echo 0)
         local last_reset_time_B=$(cat "$SYSFS_MONITOR_RESET_FILE_B" 2>/dev/null || echo 0)
@@ -109,7 +119,7 @@ case $SYSFS_MONITOR_ACTION in
     start)
         # Save the PID of the sysfs monitor process.
         touch "$SYSFS_MONITOR_PID_FILE"
-        echo $! > "$SYSFS_MONITOR_PID_FILE"
+        echo $$ > "$SYSFS_MONITOR_PID_FILE"
         log_info "HW Mangement Sysfs Monitor process created."
         do_start_sysfs_monitor
     ;;


### PR DESCRIPTION
When the sysfs-monitor service is restarted without restarting hw-management the timestamp files contain stale values from previous hw-management initialization.

The sysfs monitor should initialize its own timestamp to current uptime at start, rather than relying on potentially stale files from previous runs.

Bug: 4840120