### PR TITLE
hw-mgmt: scripts: Update sysfs monitor scripts

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=HW management Fast Lables Monitor
+Description=HW Management Fast Completion Monitor
 After=hw-management.service
 Requires=hw-management.service
 PartOf=hw-management.service

--- a/debian/hw-management.hw-management-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-sysfs-monitor.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=HW management Lables Monitor
+Description=HW Management Completion Monitor
 After=hw-management.service
 Requires=hw-management.service
 PartOf=hw-management.service

--- a/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-fast-sysfs-monitor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -60,6 +60,10 @@ do_start_fast_sysfs_monitor()
     declare -A DEVICE_ADDED  # Track added devices per file name.
     ELAPSED=0
     log_info "Monitoring ${TOTAL_FILES} files..."
+
+    # Clear the ready file in case this is a service restart
+    [ -f "$FAST_SYSFS_MONITOR_RDY_FILE" ] && rm -f "$FAST_SYSFS_MONITOR_RDY_FILE"
+
     while (( ELAPSED < FAST_SYSFS_MONITOR_TIMEOUT )); do
     # Check and add missing devices from devtree_file.
     if [ -e "$devtree_file" ] && [ -d "$eeprom_path" ] && [[ ${#DEVICE_ADDED[@]} -lt ${#DEV_FILES[@]} ]]; then
@@ -114,14 +118,14 @@ do_stop_fast_sysfs_monitor()
         FAST_MONITOR_PID=$(cat "$FAST_SYSFS_MONITOR_PID_FILE")
         if kill -0 "$FAST_MONITOR_PID" 2>/dev/null; then
             if kill "$FAST_MONITOR_PID"; then
-                log_info "HW Mangement old fast sysfs monitor process killed succesfully."
+                log_info "HW Management old fast sysfs monitor process killed succesfully."
                 rm -f "$FAST_SYSFS_MONITOR_PID_FILE"
             else
-                log_info "HW Mangement failed to kill old fast sysfs monitor process."
+                log_info "HW Management failed to kill old fast sysfs monitor process."
                 exit 1
             fi
         else
-            log_info "HW Mangement old fast sysfs monitor process $FAST_MONITOR_PID already dead, remove the pid file."
+            log_info "HW Management old fast sysfs monitor process $FAST_MONITOR_PID already dead, remove the pid file."
             rm -f "$FAST_SYSFS_MONITOR_PID_FILE"
         fi
     fi
@@ -130,9 +134,8 @@ do_stop_fast_sysfs_monitor()
 case $FAST_SYSFS_MONITOR_ACTION in
     start)
         # Save the PID of the Fast Sysfs Monitor process.
-        touch "$FAST_SYSFS_MONITOR_PID_FILE"
-        echo $! > "$FAST_SYSFS_MONITOR_PID_FILE"
-        log_info "HW Mangement Fast Sysfs Monitor process created."
+        echo $$ > "$FAST_SYSFS_MONITOR_PID_FILE"
+        log_info "HW Management Fast Sysfs Monitor process created."
         do_start_fast_sysfs_monitor
     ;;
     stop)
@@ -141,6 +144,8 @@ case $FAST_SYSFS_MONITOR_ACTION in
     restart|force-reload)
         do_stop_fast_sysfs_monitor
         sleep 5
+        # Save the PID of the Fast Sysfs Monitor process.
+        echo $$ > "$FAST_SYSFS_MONITOR_PID_FILE"
         do_start_fast_sysfs_monitor
     ;;
     *)

--- a/usr/usr/bin/hw-management-sysfs-monitor.sh
+++ b/usr/usr/bin/hw-management-sysfs-monitor.sh
@@ -112,14 +112,14 @@ do_stop_sysfs_monitor()
         MONITOR_PID=$(cat "$SYSFS_MONITOR_PID_FILE")
         if kill -0 "$MONITOR_PID" 2>/dev/null; then
             if kill "$MONITOR_PID"; then
-                log_info "HW Mangement old sysfs monitor process killed succesfully."
+                log_info "HW Management old sysfs monitor process killed succesfully."
                 rm -f "$SYSFS_MONITOR_PID_FILE"
             else
-                log_info "HW Mangement failed to kill old sysfs monitor process."
+                log_info "HW Management failed to kill old sysfs monitor process."
                 exit 1
             fi
         else
-            log_info "HW Mangement old sysfs monitor process $MONITOR_PID already dead, remove the pid file."
+            log_info "HW Management old sysfs monitor process $MONITOR_PID already dead, remove the pid file."
             rm -f "$SYSFS_MONITOR_PID_FILE"
         fi
     fi
@@ -128,9 +128,8 @@ do_stop_sysfs_monitor()
 case $SYSFS_MONITOR_ACTION in
     start)
         # Save the PID of the sysfs monitor process.
-        touch "$SYSFS_MONITOR_PID_FILE"
-        echo $! > "$SYSFS_MONITOR_PID_FILE"
-        log_info "HW Mangement Sysfs Monitor process created."
+        echo $$ > "$SYSFS_MONITOR_PID_FILE"
+        log_info "HW Management Sysfs Monitor process created."
         do_start_sysfs_monitor
     ;;
     stop)
@@ -139,6 +138,8 @@ case $SYSFS_MONITOR_ACTION in
     restart|force-reload)
         do_stop_sysfs_monitor
         sleep 5
+        # Save the PID of the sysfs monitor process.
+        echo $$ > "$SYSFS_MONITOR_PID_FILE"
         do_start_sysfs_monitor
     ;;
     *)


### PR DESCRIPTION
1. Use $$ (Current Process ID) instead of $! (Last Background Process ID) to generate PID files
2. Remove FAST_SYSFS_MONITOR_RDY_FILE at the start of fast sysfs monitor to prevent a stale ready signal on service restart