### PR TITLE
hw-mgmt: service: Restart sysfs monitor services when hw-mgmt service…

### DIFF
--- a/debian/hw-management.hw-management-fast-sysfs-monitor.service
+++ b/debian/hw-management.hw-management-fast-sysfs-monitor.service
@@ -1,5 +1,8 @@
 [Unit]
 Description=HW management Fast Lables Monitor
+After=hw-management.service
+Requires=hw-management.service
+PartOf=hw-management.service
 
 StartLimitIntervalSec=1200
 StartLimitBurst=5

--- a/debian/hw-management.hw-management.service
+++ b/debian/hw-management.hw-management.service
@@ -2,6 +2,8 @@
 Description=Chassis HW management service of Mellanox systems
 Documentation=man:hw-management.service(8)
 Wants=hw-management-sync.service
+Wants=hw-management-sysfs-monitor.service
+Wants=hw-management-fast-sysfs-monitor.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
… is restarted

Modify service unit files to make sure that sysfs-monitor and fast-sysfs-monitor services are restarted when hw-mgmt service is restarted.

Bug: 4968565