### PR TITLE
hw-mgmt: scripts: Make usb0 interface configuration more robust

### DIFF
--- a/usr/lib/udev/rules.d/70-hw-management-bmc.rules
+++ b/usr/lib/udev/rules.d/70-hw-management-bmc.rules
@@ -1,5 +1,5 @@
 ###########################################################################
-# Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -30,11 +30,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-# These rules handle USB net up/down events.
+# These rules handle USB net events.
 
-# Bring up the USB network interface when it is plugged in.
-SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", NAME="usb0", RUN+="/usr/bin/hw-management-ifupdown.sh usb0 up"
+# Rename the interface if it starts with the old 'eth*' prefix
+SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", KERNEL=="eth*", NAME="usb0", RUN+="/usr/bin/logger 'hw-management: renaming %k to usb0'"
 
-# Bring down the USB network interface when it is unplugged.
-SUBSYSTEM=="net", ACTION=="remove", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", RUN+="/usr/bin/hw-management-ifupdown.sh usb0 down"
-
+# Trigger script if the kernel named it 'usb0' natively or renamed it in the previous rule
+SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", KERNEL=="usb0", RUN+="/usr/bin/logger 'hw-management: configuring usb0'", RUN+="/usr/bin/hw-management-ifupdown.sh usb0"

--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ###########################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -31,32 +31,68 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# This script is executed by udev rules to up/down USB network interface
+# This script is executed by udev rule to bring up USB network interface
+# Usage: hw-management-ifupdown.sh <interface>
 
-ACTION=$2
+source /usr/bin/hw-management-helpers.sh
+
 INTERFACE=$1
 
-if [ -z "${ACTION}" ] || [ -z "${INTERFACE}" ]; then
-	echo "Missing parameters"
+if [ -z "${INTERFACE}" ]; then
+	log_err "Missing interface parameter"
 	exit 1
 fi
 
-if [ ! -e /sys/class/net/${INTERFACE} ] ||
-   [ ! -e /etc/network/interfaces ]; then
-	exit 0
+if [ ! -e /etc/network/interfaces ]; then
+	log_err "/etc/network/interfaces is missing"
+	exit 1
 fi
 
-AUTO=$(ifquery -l 2>/dev/null)
-HOTPLUG=$(ifquery -l --allow=hotplug 2>/dev/null)
+# In kernel 6.1 the interface is renamed from ethX to usb0
+# Wait for usb0 to become available
+MAX_RETRIES=10
+RETRY_DELAY=0.1
+for ((i=1; i<=MAX_RETRIES; i++)); do
+	if [ -d "/sys/class/net/$INTERFACE" ] && ip link show "$INTERFACE" >/dev/null 2>&1; then
+		log_info "Interface $INTERFACE existence check succeeded on attempt $i"
+		break
+	fi
 
-if ! echo $AUTO $HOTPLUG | grep -q ${INTERFACE}; then
-	exit 0
+	if [ "$i" -lt "$MAX_RETRIES" ]; then
+		log_info "Interface $INTERFACE existence check unsuccessful. Retrying in ${RETRY_DELAY} seconds..."
+		sleep "${RETRY_DELAY}"
+	fi
+done
+
+if [ ! -d "/sys/class/net/$INTERFACE" ]; then
+	log_err "Interface $INTERFACE does not exist"
+	exit 1
 fi
 
-if [ "${ACTION}" = "up" ]; then
-	ifup ${INTERFACE}
-else
-	ifdown ${INTERFACE}
+# Now check if interface is defined in /etc/network/interfaces
+if ! ifquery "$INTERFACE" >/dev/null 2>&1; then
+	log_err "Interface $INTERFACE is not defined in /etc/network/interfaces"
+	exit 1
 fi
 
-exit 0
+# Retry ifup to work around locking conflicts with Debian networking service.
+# Since usb0 is the only hotplug interface in the system, running this retry
+# loop and blocking UDEV for maximum 8 seconds from processing further events
+# for the same device path is an acceptable tradeoff.
+MAX_RETRIES=5
+RETRY_DELAY=2
+for ((i=1; i<=MAX_RETRIES; i++)); do
+	if ifup "${INTERFACE}"; then
+		log_info "ifup ${INTERFACE} succeeded on attempt $i"
+		exit 0
+	fi
+
+	if [ "$i" -lt "$MAX_RETRIES" ]; then
+		log_info "Unsuccessful attempt $i to ifup ${INTERFACE}. Retrying in ${RETRY_DELAY} seconds..."
+		sleep "${RETRY_DELAY}"
+	fi
+done
+
+log_err "Failed to ifup interface ${INTERFACE}"
+exit 1
+


### PR DESCRIPTION
1. Add logging to udev rule and interface configuration script
2. Update udev rules to correctly handle 6.1 and 6.12 kernels
3. Add retries to interface configuration script

Bug: 4949322