### PR TITLE
hw-mgmt: scripts: Fix potential issues caused by system datetime changes

### DIFF
--- a/usr/usr/bin/hw_management_lib.py
+++ b/usr/usr/bin/hw_management_lib.py
@@ -425,7 +425,7 @@ class HW_Mgmt_Logger:
 
             def timed_error_handler(record):
                 """Wrap original handleError with time-based suppression."""
-                current_time = time.time()
+                current_time = time.clock_gettime(time.CLOCK_MONOTONIC)
 
                 # Thread-safe check and update of error state
                 with self._lock:
@@ -750,13 +750,13 @@ class RepeatedTimer:
             Run function in separate thread
         """
         while not self._stop_event.is_set():
-            start = time.time()
+            start = time.clock_gettime(time.CLOCK_MONOTONIC)
             try:
                 self.func()
             except Exception as e:
                 print(f"Error in periodic task: {e}")
             # Sleep remaining time if func took less than interval
-            elapsed = time.time() - start
+            elapsed = time.clock_gettime(time.CLOCK_MONOTONIC) - start
             sleep_time = max(0, self.interval - elapsed)
             if self._stop_event.wait(timeout=sleep_time):  # Interruptible sleep
                 break  # Event was set, exit immediately

--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -461,7 +461,7 @@ class BMCAccessor(object):
             timeout_sec = self.FLOCK_TIMEOUT_SEC
 
         lock_path = os.path.join(self.LOCK_DIR, self.LOCK_FILE)
-        deadline = time.time() + timeout_sec
+        deadline = time.clock_gettime(time.CLOCK_MONOTONIC) + timeout_sec
         while True:
             try:
                 lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o666)
@@ -472,7 +472,7 @@ class BMCAccessor(object):
                 return lock_fd
             except BlockingIOError:
                 os.close(lock_fd)
-                if time.time() >= deadline:
+                if time.clock_gettime(time.CLOCK_MONOTONIC) >= deadline:
                     raise Exception(
                         f"Cannot acquire TPM lock within {timeout_sec}s (timeout)"
                     )


### PR DESCRIPTION
If an application relies on delay loops based on the system wall-clock
time, it may fail when the datetime is adjusted.

Fix: Replace wall-clock time.time() with CLOCK_MONOTONIC. This ensures
that NTP or manual clock updates do not disrupt or skew poll-driven
execution.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
