### PR TITLE
hw-mgmt: scripts: Fix potential issues caused by system datetime changes

### DIFF
--- a/usr/usr/bin/hw_management_sync.py
+++ b/usr/usr/bin/hw_management_sync.py
@@ -5,7 +5,7 @@
 # pylint: disable=R0913:
 ########################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -814,7 +814,7 @@ def update_attr(attr_prop):
     """
     @summary: Update hw-mgmt attributes and invoke cmd per attr change
     """
-    ts = time.time()
+    ts = time.clock_gettime(time.CLOCK_MONOTONIC)
     if ts >= attr_prop["ts"]:
         # update timestamp
         attr_prop["ts"] = ts + attr_prop["poll"]

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2,7 +2,7 @@
 # pylint: disable=line-too-long
 # pylint: disable=C0103
 ########################################################################
-# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -430,7 +430,7 @@ def current_milli_time():
         get current time in milliseconds
     @return: int value time in milliseconds
     """
-    return round(time.clock_gettime(1) * 1000)
+    return round(time.clock_gettime(time.CLOCK_MONOTONIC) * 1000)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
If an application relies on delay loops based on the system wall-clock
time, it may fail when the datetime is adjusted.

Fix: Replace wall-clock time.time() with CLOCK_MONOTONIC. This ensures
that NTP or manual clock updates do not disrupt or skew poll-driven
execution.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
