### PR TITLE
hw-mgmt: kernel 6.1: Upgrade patches to support version up to 6.1.168

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For detailed information, see the documentation [here](https://github.com/Mellan
 ## Supported Kernel versions:
 - 5.10.103, 5.10.140, 5.10.179, 5.10.218, 5.10.226
 - 5.14 all up to 5.14.21
-- 6.1.38, 6.1.90, ,6.1.94, 6.1.119, 6.1.123, .. 6.1.155
+- 6.1.38, 6.1.90, ,6.1.94, 6.1.119, 6.1.123, .. 6.1.169
 - 6.12.38, 6.12.41, 6.12.44, .. 6.12.62
 
 ## Sysfs attributes:

--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -697,7 +697,7 @@ Kernel-6.1
 |0081-UBUNTU-SAUCE-mlxbf-ptm-power-and-thermal-management-.patch  |                    | Downstream;skip[sonic,cumulus]           |            | BF3                                            |
 |0082-UBUNTU-SAUCE-mlxbf-ptm-update-license.patch                 |                    | Downstream;skip[sonic,cumulus]           |            | BF3                                            |
 |0083-UBUNTU-SAUCE-mlxbf-ptm-use-0444-instead-of-S_IRUGO.patch    |                    | Downstream;skip[sonic,cumulus]           |            | BF3                                            |
-|0085-hwmon-mlxreg-fan-Separate-methods-of-fan-setting-com.patch  |                    | Bugfix pending                           |            |                                                |
+|0085-hwmon-mlxreg-fan-Separate-methods-of-fan-setting-com.patch  | 1e11552ee54d       | Bugfix upstream                          | v6.1.155   |                                                |
 |0087-platform-mellanox-indicate-deferred-I2C-bus-creation.patch  |                    | Bugfix pending                           |            | SN2201                                         |
 |0087-platform_data-mlxreg-Add-capability-bit-and-mask-fie.patch  |                    | Downstream accepted                      |            |                                                |
 |0088-platform-mellanox-mlxreg-hotplug-Add-support-for-new.patch  |                    | Downstream accepted                      |            |                                                |


### PR DESCRIPTION
Upgrade patches to support version up to 6.1.169

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
