### PR TITLE
hw-mgmt: scripts: Fix usb0 interface udev rules

### DIFF
--- a/usr/lib/udev/rules.d/70-hw-management-bmc.rules
+++ b/usr/lib/udev/rules.d/70-hw-management-bmc.rules
@@ -36,4 +36,4 @@
 SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", KERNEL=="eth*", NAME="usb0", RUN+="/usr/bin/logger 'hw-management: renaming %k to usb0'"
 
 # Trigger script if the kernel named it 'usb0' natively or renamed it in the previous rule
-SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", KERNEL=="usb0", RUN+="/usr/bin/logger 'hw-management: configuring usb0'", RUN+="/usr/bin/hw-management-ifupdown.sh usb0"
+SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", NAME=="usb0", RUN+="/usr/bin/logger 'hw-management: configuring usb0'", RUN+="/usr/bin/hw-management-ifupdown.sh usb0"


### PR DESCRIPTION
Previous modification of the rules resulted in second rule not beeing invoked when BMC is rebooted. Revert the name matching logic of the second rule to fix the problem. Since kernel 6.12 is not suppoted in this branch, the fix is safe.

Bug: 5011600