### PR TITLE
hw-mgmt: Use 0x2E for MP29502 Power Controller in Juliet system

### DIFF
--- a/usr/etc/hw-management-sensors/n51xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n51xxld_sensors.conf
@@ -485,7 +485,7 @@ bus "i2c-12" "i2c-9-mux (chan_id 3)"
 	    label temp2     "PWR_CONV1 Temp"
 	    ignore temp3
 	    
-	chip "mp29502-i2c-*-60"
+	chip "mp29502-i2c-*-2e"
 	    label in1       "PWR_CONV1 VinDC Volt (in)"
 	    ignore in2
 	    label in3       "PWR_CONV1 Vout Volt (out)"

--- a/usr/etc/hw-management-sensors/n5500ld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n5500ld_sensors.conf
@@ -493,7 +493,7 @@ bus "i2c-12" "i2c-9-mux (chan_id 3)"
 	    label temp2     "PWR_CONV1 Temp"
 	    ignore temp3
 	    
-	chip "mp29502-i2c-*-60"
+	chip "mp29502-i2c-*-2e"
 	    label in1       "PWR_CONV1 VinDC Volt (in)"
 	    ignore in2
 	    label in3       "PWR_CONV1 Vout Volt (out)"


### PR DESCRIPTION
MPS MP29502 uses I2C address 0x2E; Renesas RAA228004 stays at 0x60. Update mp29502 chip patterns so lm_sensors applies PWR_CONV1 labels to the correct sysfs node.

- n51xxld_sensors.conf: Juliet SKUs using the default n51xxld lm_sensors file.
- n5500ld_sensors.conf: HI176 (GB300).

Traceability: ECR-014990 (GB300 Juliet alternate HSCC source).

(cherry picked from commit c3a128b3563cdc3b433be6e785fa2fcc791aae6e)