### PR TITLE
hw-mgmt: bmc: add AST2700 reset-cause exporter and update docs

### DIFF
--- a/bmc/FILE_MAPPING.md
+++ b/bmc/FILE_MAPPING.md
@@ -87,7 +87,8 @@ On the target system the **hw-management-bmc** Debian package installs this tree
 | .../spc6-ast2700-a1/.../i2c-slave-config.sh | usr/usr/bin/**hw-management-bmc-i2c-slave-config.sh** |
 | ~~spc6-svn-check.sh~~ | removed (Microsoft doesn't need) |
 | meta-nvidia/meta-switch/recipes-phosphor/**dump**/files/**cpld_dump.sh** + **dump_utils.sh** ( **`take_cpld_dump_internal`**, **`take_cpld_dump`** only) | usr/usr/bin/**hw-management-bmc-cpld-dump.sh** (merged SONiC script; no **`switch-erots-info`** / Phosphor **`add_copy_file`**; **`log_message`** + **`hw-management-bmc-platform.conf`** via **`helpers-common`**) |
-| *(SONiC BMC; analogous to host **`usr/usr/bin/hw-management-generate-dump.sh`**) | usr/usr/bin/**hw-management-bmc-generate-dump.sh** — bundle: **`dmesg`**, **`/proc/interrupts`**, **`ifconfig`**, **`i2cdetect -y`** per non-mux bus (**`i2cdetect -l \| grep -v mux`**), CPLD (**`take_cpld_dump`**), **`systemctl`** (**`hw-management-bmc*`**), **`/var/run/hw-management`** (**`hexdump -C`** on EEPROM) → **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. |
+| *(SONiC BMC; analogous to host **`usr/usr/bin/hw-management-generate-dump.sh`**) | usr/usr/bin/**hw-management-bmc-generate-dump.sh** — bundle: **`dmesg`**, **`/proc/interrupts`**, **`ifconfig`**, **`i2cdetect -y`** per non-mux bus (**`i2cdetect -l \| grep -v mux`**), CPLD (**`take_cpld_dump`**), **`systemctl`** (**`hw-management-bmc*`**), **`/var/run/hw-management`** (**`hw-management-bmc-show-reset-cause.sh`** → **`bmc/show-reset-cause`** (dump adds **`.txt`** under **`values/`**), then tree + values + **`hexdump -C`** on EEPROM) → **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. |
+| *(SONiC BMC reset-cause viewer)* | usr/usr/bin/**hw-management-bmc-show-reset-cause.sh** — sections **`bmc`**, **`host`**, **`bmc-domain`**, **`bmc-raw`**; default all. |
 
 ---
 

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -135,6 +135,8 @@ bmc/
         ├── hw-management-bmc-ready.sh
         ├── hw-management-bmc-ready-common.sh
         ├── hw-management-bmc-recovery-handler.sh
+        ├── hw-management-bmc-get-reset-cause.sh
+        ├── hw-management-bmc-show-reset-cause.sh
         ├── hw-management-bmc-reset-cause-logger.sh
         ├── hw-management-bmc-set-extra-params.sh
         └── hw-management-bmc.sh
@@ -168,13 +170,15 @@ Documentation and sample data only. Nothing here is required at runtime unless y
 |--------|------|
 | **`hw-management-bmc-helpers-common.sh`** | From OpenBMC **`hw-management-helpers-common.sh`**: shared routines (**`log_event`**, **`log_cpld_dump`** — compact CPLD read for events), PHY **`mdio`** helpers, **`bmc_init_eth`**, **`get_mgmt_board_revision`**, etc.). **`hw-management-bmc-ready.sh`** sources it before **`hw-management-bmc-helpers.sh`**. Requires **bash** (uses **`[[ ]]`, `(( ))`, …). |
 | **`hw-management-bmc-cpld-dump.sh`** | **Merged** from OpenBMC **`recipes-phosphor/dump/files/cpld_dump.sh`** and **`dump_utils.sh`** (**`take_cpld_dump_internal`**, **`take_cpld_dump`** only). Full **grid** CPLD register dump, optional **`.tar.xz`** packaging (**`-p`**, **`-i`**). Uses **`log_message`** and **`${HW_MANAGEMENT_BMC_PLATFORM_CONF:-/etc/hw-management-bmc-platform.conf}`** (via **`hw-management-bmc-helpers-common.sh`**); no **`switch-erots-info.sh`**, no Phosphor **`add_copy_file`**. Requires **bash**. |
-| **`hw-management-bmc-generate-dump.sh`** | SONiC BMC debug bundle (same idea as host **`hw-management-generate-dump.sh`**). Collects **`dmesg`**, **`proc/`**, **`network/`**, **`i2c/`** (non-mux buses), CPLD (**`take_cpld_dump`**), **`systemctl/`** for **`hw-management-bmc*`**, **`systemd-analyze/`** (boot timing, **`blame`**, **`critical-chain`** — see below), and **`var_run_hw-management/`** (runtime tree + values; EEPROM via **`hexdump -C`**). Default output **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Requires **bash**. |
+| **`hw-management-bmc-generate-dump.sh`** | SONiC BMC debug bundle (same idea as host **`hw-management-generate-dump.sh`**). Collects **`dmesg`**, **`proc/`**, **`network/`**, **`i2c/`** (non-mux buses), CPLD (**`take_cpld_dump`**), **`systemctl/`** for **`hw-management-bmc*`**, **`systemd-analyze/`** (boot timing, **`blame`**, **`critical-chain`** — see below), and **`var_run_hw-management/`** (runtime tree + values; EEPROM via **`hexdump -C`**). Before archiving **`/var/run/hw-management`**, runs **`hw-management-bmc-show-reset-cause.sh`** and writes **`/var/run/hw-management/bmc/show-reset-cause`** so it is included in **`values/`** (as **`bmc_show-reset-cause.txt`**). Default output **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Requires **bash**. |
 | **`hw-management-bmc-json-parser.sh`** | From OpenBMC **`switch_json_parser.sh`**: **`json_validate`**, **`json_get_nested_array_element`**, etc. (awk/BusyBox). Sourced by **`hw-management-bmc-a2d-leakage-config.sh`**, **`hw-management-bmc-early-i2c-init.sh`**, **`hw-management-bmc-gpio-set.sh`** (**`bmc_init_sysfs_gpio`**). |
 | **`hw-management-bmc-helpers.sh`** | Platform / ASIC helpers; sources **`hw-management-bmc-helpers-common.sh`** by absolute path. |
 | **`hw-management-bmc-a2d-leakage-read.sh`** | From OpenBMC **`a2d_leakage_read.sh`**: walks **`/var/run/hw-management/leakage/<idx>/<bus>-<addr>/`** (after **`hw-management-bmc-a2d-leakage-config.sh`**), reads **ADS1015** / **ADS7924** (IIO symlink or **`i2ctransfer`**) and writes per-channel **`value`** (volts); **MAX1363** path is still a placeholder. Requires **`bash`**, **`bc`**, **`i2ctransfer`**. |
 | **`hw-management-bmc-max1363-force-alarm.sh`** | From OpenBMC **`max1363_force_alarm.sh`**: debug — programs tight/safe per-channel thresholds so selected channels hit alarm (**`i2ctransfer`**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-max1363-read-status.sh`** | From OpenBMC **`max1363_read_status.sh`**: debug — prints first read bytes / decoded status flags (**`i2ctransfer`**, **`awk`**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-bios-recovery-flash.sh`** | From OpenBMC **`bios-recovery-flash.sh`**: BMC-side host BIOS recovery — writes CPLD **`spi_chnl_select`** then **`flashcp`** to **`spidev`** (default **`/dev/spidev1.0`**). Requires **`mtd-utils`**, hw-management runtime (**`/var/run/hw-management/system/spi_chnl_select`**). **`#!/bin/bash`**. |
+| **`hw-management-bmc-get-reset-cause.sh`** | Reset-cause exporter under **`bmc/usr/usr/bin/`**. Reads SCU reset logs from U-Boot env keys (**`reset_cause_scu0_0`**, **`reset_cause_scu0_2`**, **`reset_cause_scu1_0`**, **`reset_cause_scu1_3`**) with per-register `devmem` fallback, writes raw SCU words under **`/var/run/hw-management/bmc/`**. **`reset_power_on`** plus **`reset_watchdog`**, **`reset_software`**, **`reset_cpu`**, **`reset_security_watchdog2`**, **`reset_others`** live at that root; domain-detail flags (**`reset_ahb`**, **`reset_caliptra`**, **`reset_emmc`**, **`reset_espi`**, **`reset_external`**, **`reset_msi`**, **`reset_soc`**, **`reset_spi`**, **`reset_usb`**) under **`/var/run/hw-management/bmc/domains/`**. |
+| **`hw-management-bmc-show-reset-cause.sh`** | Operator view of reset causes: **`bmc`** (BMC root **`reset_*`** with value 1), **`host`** (**`/var/run/hw-management/system/reset_*`**, same idea as host **`hw-management.sh reset-cause`**), **`bmc-domain`** (**`.../bmc/domains/reset_*`**), **`bmc-raw`** (**`raw_scu*_reset_event_log*`** under the BMC dir). With no arguments, prints all four sections. Overrides: **`BMC_DIR`**, **`BMC_DOMAINS_DIR`**, **`HOST_SYSTEM_DIR`**. **`#!/bin/sh`**. |
 
 ### BIOS recovery flash (`hw-management-bmc-bios-recovery-flash.sh`)
 
@@ -187,9 +191,24 @@ Stand-alone operator tool — **no** **`systemd`** unit; invoke from the shell w
 | **Usage** | **`hw-management-bmc-bios-recovery-flash.sh <bios_image> [spidev] [channel]`** — **`channel`** is **`0`** or **`1`** for CPLD mux (default **`1`**). Run with no arguments to print a short usage summary. |
 | **Safety** | Use a verified image and the correct **`spidev`** / channel for your SKU; flashing the wrong device or a bad image can brick the host flash path. |
 
+### Reset-cause policy (`hw-management-bmc-get-reset-cause.sh`)
+
+Policy for collecting and exporting reset cause on SONiC BMC:
+
+| Topic | Policy |
+|-------|--------|
+| **Source priority** | For each SCU log, read U-Boot env first (**`reset_cause_scu0_0`**, **`reset_cause_scu0_2`**, **`reset_cause_scu1_0`**, **`reset_cause_scu1_3`**) via **`fw_printenv -n`**. If missing/invalid, fallback to `devmem` at **`0x12c02050`**, **`0x12c02070`**, **`0x14c02050`**, **`0x14c02080`** respectively. |
+| **`devmem` fallback** | Run **`devmem <addr> 32 || busybox devmem <addr> 32`** (stderr discarded; same **`32`**-bit read). |
+| **Normalization / validation** | Env and `devmem` values are normalized to `0x...` and validated as hex (`[0-9A-Fa-f]` digits only). |
+| **Published raw values** | Store all SCU words as `0x%08x`: **`raw_scu0_reset_event_log0`**, **`raw_scu0_reset_event_log2`**, **`raw_scu1_reset_event_log0`**, **`raw_scu1_reset_event_log3`**. |
+| **Published semantic files** | Under **`/var/run/hw-management/bmc/`**: **`reset_power_on`**, **`reset_watchdog`**, **`reset_software`**, **`reset_cpu`**, **`reset_security_watchdog2`**, **`reset_others`**. Under **`/var/run/hw-management/bmc/domains/`** only: **`reset_external`**, **`reset_soc`**, **`reset_ahb`**, **`reset_caliptra`**, **`reset_usb`**, **`reset_spi`**, **`reset_espi`**, **`reset_emmc`**, **`reset_msi`**. |
+| **Failure behavior** | If any required SCU word cannot be obtained from env or `devmem`, exit non-zero and print an error to stderr. |
+| **AST2700 event-log policy** | Primary logs are **SCU0 0x050**, **SCU0 0x070**, **SCU1 0x050**, **SCU1 0x080**. |
+| **AST2700 mapping policy** | Combine SCU0+SCU1 where applicable: **`power_on`** from PWRST (SCU0/SCU1), **`external`** from EXTRST/SRST (SCU0/SCU1), **`soc`** and **`ahb`** from both domains, **`usb`** from SCU1 USB2D/USB2C/UHCI plus SCU0 USB bus/VHUB/UHCI mask. **`watchdog`** uses SCU1 non-SW WDT bits plus SCU0 watchdog evidence; **`software`** uses SCU1 SW WDT bits; **`security_watchdog2`** is SCU1 WDT2 nibble. **`reset_others`** is 1 only when **`power_on`**, **`watchdog`**, **`software`**, **`cpu`**, and **`security_watchdog2`** are all 0 (domain **`reset_*`** under **`bmc/domains/`** do not affect **`reset_others`**). |
+
 ### BMC debug bundle (`hw-management-bmc-generate-dump.sh`)
 
-Archive default path: **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Top-level entries include **`dmesg.txt`**, **`uname.txt`**, **`proc/`** (**`interrupts.txt`**), **`network/`** (**`ifconfig.txt`** or **`ip addr`** fallback), **`i2c/`** (**`i2cdetect -l`**, **`i2cdetect-l_grep-v-mux.txt`**, per-bus **`i2cdetect-y_<N>.txt`**), **`systemctl/`** (**`list-units`**, **`list-unit-files`**, per-unit **`.status.txt`** / **`.show.txt`**), **`cpld/`**, **`var_run_hw-management/`** (**`tree/`**, **`values/`**).
+Archive default path: **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Top-level entries include **`dmesg.txt`**, **`uname.txt`**, **`proc/`** (**`interrupts.txt`**), **`network/`** (**`ifconfig.txt`** or **`ip addr`** fallback), **`i2c/`** (**`i2cdetect -l`**, **`i2cdetect-l_grep-v-mux.txt`**, per-bus **`i2cdetect-y_<N>.txt`**), **`systemctl/`** (**`list-units`**, **`list-unit-files`**, per-unit **`.status.txt`** / **`.show.txt`**), **`cpld/`**, **`var_run_hw-management/`** (**`tree/`**, **`values/`** — live **`bmc/show-reset-cause`** is captured as **`values/bmc_show-reset-cause.txt`**).
 
 **`systemd-analyze/`** — best-effort; if **`systemd-analyze`** is not in **`PATH`**, **`skipped.txt`** is written and the rest of the bundle is unchanged.
 
@@ -201,6 +220,7 @@ Archive default path: **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Top-level entries incl
 | **`critical-chain_default.target.txt`** | **`systemd-analyze critical-chain default.target`**. |
 | **`critical-chain_sysinit.target.txt`** | **`systemd-analyze critical-chain sysinit.target`**. |
 | **`critical-chain_per_unit/`** | **`systemd-analyze critical-chain <unit>`** for each **`hw-management-bmc*.service`** (filename = unit with **`/` `@` `:`** → **`_`**). Capped count per run; if truncated, **`README_cap.txt`** notes the limit. |
+| **`var_run_hw-management/values/`** (reset cause) | **`hw-management-bmc-show-reset-cause.sh`** (all sections) is written to live **`/var/run/hw-management/bmc/show-reset-cause`** as the first step of runtime collection, then copied like any other file under **`/var/run/hw-management`** (archive **`values/bmc_show-reset-cause.txt`**). BMC **`reset_*`** / **`raw_scu*`** files remain under **`var_run_hw-management/values/`** when present. |
 
 ### Shell portability (BusyBox `ash` vs bash)
 
@@ -217,7 +237,9 @@ SONiC BMC images often ship **BusyBox** (`/bin/sh` → **ash**) and may also inc
 | **`hw-management-bmc-powerctrl.sh`** | **bash** | **`#!/bin/bash`**, **`set -euo pipefail`**, **`logger`** for journal messages; requires **`bash`**. |
 | **`hw-management-bmc-boot-complete.sh`** | Yes | **`#!/bin/sh`**: waits on **`/var/run/hw-management/`** entry counts vs **`/etc/hw-management-bmc-boot-complete.conf`**. |
 | **`hw-management-bmc-cpld-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`BASH_SOURCE`**, brace expansion in **`take_cpld_dump_internal`**, sourced **`return`** guard for **`timeout bash -c '. …; take_cpld_dump_internal'`**. |
-| **`hw-management-bmc-generate-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`source`** **`hw-management-bmc-cpld-dump.sh`** (**`take_cpld_dump`**), **`find`**, **`timeout`**, **`systemd-analyze`** (optional). Uses **`tar cf - \| gzip -9`** (not GNU **`tar -I`**) and **`ls -ld`** per path (not GNU **`find -ls`**) so BusyBox **tar/find** work; **`readlink_canonical`** if **`readlink -f`** missing. Needs **`gzip`** in **`PATH`** (BusyBox or GNU). |
+| **`hw-management-bmc-generate-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`source`** **`hw-management-bmc-cpld-dump.sh`** (**`take_cpld_dump`**), **`find`**, **`timeout`**, **`systemd-analyze`** (optional). Uses **`tar cf - \| gzip -9`** (not GNU **`tar -I`**) and **`ls -ld`** per path (not GNU **`find -ls`**) so BusyBox **tar/find** work; **`readlink_canonical`** if **`readlink -f`** missing. Needs **`gzip`** in **`PATH`** (BusyBox or GNU). Invokes **`hw-management-bmc-show-reset-cause.sh`** into **`/var/run/hw-management/bmc/show-reset-cause`** before archiving **`/var/run/hw-management`**. |
+| **`hw-management-bmc-show-reset-cause.sh`** | Yes | **`#!/bin/sh`**: lists active **`reset_*`** (value 1) or raw SCU lines; no bashisms. |
+| **`hw-management-bmc-get-reset-cause.sh`** | Yes | **`#!/bin/sh`**: SCU read / semantic export. |
 | **`hw-management-bmc-bios-recovery-flash.sh`** | **bash** | **`#!/bin/bash`**, **`set -e`**: **`flashcp`** (**`mtd-utils`**), **`spi_chnl_select`** sysfs. |
 
 If **`/usr/bin/hw-management-bmc-helpers.sh`** is sourced, it is written for bash but parses under BusyBox ash; some code paths use bash-style arithmetic — prefer **`bash`** where the full helper API is used.
@@ -267,7 +289,7 @@ flowchart TB
 | **hw-management-bmc-i2c-slave-setup** | oneshot | `/usr/bin/hw-management-bmc-i2c-slave-setup.sh` | `WantedBy=multi-user.target` | **`After=multi-user.target`**. **`Before=`** `hw-management-bmc-recovery-handler`. **`ConditionPathExists=/etc/hw-management-bmc-recovery.conf`**. |
 | **hw-management-bmc-recovery-handler** | simple | `/usr/bin/hw-management-bmc-recovery-handler.sh` | `WantedBy=multi-user.target` | **`After=`** `multi-user.target`, **`hw-management-bmc-i2c-slave-setup`**. **`Requires=`** i2c-slave-setup. **`EnvironmentFile=/etc/hw-management-bmc-recovery.conf`**. **`ConditionPathExists=/etc/hw-management-bmc-recovery.conf`**. **`Restart=always`**. |
 
-Scripts **`hw-management-bmc-powerctrl.sh`**, **`hw-management-bmc-devtree.sh`**, **`hw-management-bmc-gpio-set.sh`**, **`hw-management-bmc-leakage-handler.sh`**, etc., are invoked by other scripts, **udev**, or operators; they are not tied 1:1 to a dedicated systemd unit in this package.
+Scripts **`hw-management-bmc-powerctrl.sh`**, **`hw-management-bmc-devtree.sh`**, **`hw-management-bmc-gpio-set.sh`**, **`hw-management-bmc-leakage-handler.sh`**, **`hw-management-bmc-get-reset-cause.sh`**, **`hw-management-bmc-show-reset-cause.sh`**, etc., are invoked by other scripts, **udev**, or operators; they are not tied 1:1 to a dedicated systemd unit in this package. The logger unit uses **`hw-management-bmc-reset-cause-logger.sh`** for boot diagnostics, while **`hw-management-bmc-get-reset-cause.sh`** exports reset-cause sysfs-style files: most primary flags at **`/var/run/hw-management/bmc/`**, domain-detail **`reset_*`** under **`/var/run/hw-management/bmc/domains/`** (see reset-cause policy table), raw SCU words at the bmc runtime root.
 
 ### Platform deploy (what plat-specific-preps does)
 

--- a/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
@@ -44,6 +44,10 @@
 # tar|gzip pipeline (not GNU tar -I), find + ls -ld (not GNU find -ls),
 # readlink fallback if -f unsupported. grep/awk/sort/cat/timeout/hexdump from
 # BusyBox are OK when those applets are enabled.
+#
+# Reset cause: collect_hw_management_runtime() writes hw-management-bmc-show-reset-cause.sh
+# (all sections) to ${HW_MGMT}/bmc/show-reset-cause first; that file is then archived with
+# the rest of /var/run/hw-management (tree + values).
 ################################################################################
 
 # Best-effort canonical path (GNU readlink -f, BusyBox readlink, or realpath).
@@ -83,6 +87,8 @@ Usage: hw-management-bmc-generate-dump.sh [output_tarball]
   systemctl status/show for all hw-management-bmc* units, systemd-analyze time/blame
   (plus hw-management-bmc-only lines) and critical-chain for default.target/sysinit.target,
   and /var/run/hw-management tree + values (EEPROM paths: hexdump -C).
+  Before archiving, hw-management-bmc-show-reset-cause.sh output is written to
+  /var/run/hw-management/bmc/show-reset-cause so it is included with the runtime snapshot.
 
   Default output: /tmp/hw-mgmt-bmc-dump.tar.gz
 EOF
@@ -125,11 +131,23 @@ is_eeprom_path()
 collect_hw_management_runtime()
 {
 	local out_root=$1
-	local tree_dir values_dir
+	local tree_dir values_dir show
 
 	tree_dir="${out_root}/tree"
 	values_dir="${out_root}/values"
 	mkdir -p "$tree_dir" "$values_dir"
+
+	if [ -d "$HW_MGMT" ]; then
+		mkdir -p "${HW_MGMT}/bmc"
+		show="/usr/bin/hw-management-bmc-show-reset-cause.sh"
+		if [ -x "$show" ]; then
+			"$show" >"${HW_MGMT}/bmc/show-reset-cause" 2>&1 \
+				|| log_message warning "hw-management-bmc-show-reset-cause.sh returned non-zero"
+		else
+			log_message warning "hw-management-bmc-show-reset-cause.sh not installed — stub ${HW_MGMT}/bmc/show-reset-cause"
+			echo "hw-management-bmc-show-reset-cause.sh not found or not executable" >"${HW_MGMT}/bmc/show-reset-cause"
+		fi
+	fi
 
 	if [ ! -d "$HW_MGMT" ]; then
 		log_message warning "Missing $HW_MGMT — skipping runtime tree"

--- a/bmc/usr/usr/bin/hw-management-bmc-get-reset-cause.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-get-reset-cause.sh
@@ -1,0 +1,211 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list, and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# Export BMC reset cause into hw-management style files.
+# BusyBox ash (/bin/sh): POSIX sh + C-style 0x arithmetic and bitwise ops; no bashisms.
+#
+# AST2700 primary source:
+#   SCU1 0x050 (Reset Event Log Set 1) + SCU1 0x080 (Reset Event Log Set 4)
+#   and SCU0 0x070 as additional watchdog evidence.
+#   SCU0 0x050 is also read for eMMC/MSI reset logs.
+#   AST2700 SCU base uses +0x2000 window (e.g. 0x12c02050, 0x14c02080).
+#
+# U-Boot env names (per SCU register):
+#   reset_cause_scu0_0 -> SCU0 0x050
+#   reset_cause_scu0_2 -> SCU0 0x070
+#   reset_cause_scu1_0 -> SCU1 0x050
+#   reset_cause_scu1_3 -> SCU1 0x080
+#
+# Domain-detail flags (ahb, caliptra, emmc, espi, external, msi, soc, spi, usb)
+# go under OUT_DIR/domains/. reset_power_on, watchdog, software, cpu,
+# security_watchdog2, and others stay in OUT_DIR.
+################################################################################
+
+OUT_DIR="${OUT_DIR:-/var/run/hw-management/bmc}"
+DOMAINS_DIR="${DOMAINS_DIR:-${OUT_DIR}/domains}"
+SCU0_LOG2_ADDR="${SCU0_LOG2_ADDR:-0x12c02070}"
+SCU0_LOG0_ADDR="${SCU0_LOG0_ADDR:-0x12c02050}"
+SCU1_LOG0_ADDR="${SCU1_LOG0_ADDR:-0x14c02050}"
+SCU1_LOG3_ADDR="${SCU1_LOG3_ADDR:-0x14c02080}"
+ENV_SCU0_LOG0="${ENV_SCU0_LOG0:-reset_cause_scu0_0}"
+ENV_SCU0_LOG2="${ENV_SCU0_LOG2:-reset_cause_scu0_2}"
+ENV_SCU1_LOG0="${ENV_SCU1_LOG0:-reset_cause_scu1_0}"
+ENV_SCU1_LOG3="${ENV_SCU1_LOG3:-reset_cause_scu1_3}"
+
+umask 022
+mkdir -p "${OUT_DIR}"
+mkdir -p "${DOMAINS_DIR}"
+
+normalize_hex() {
+	in="$1"
+	case "${in}" in
+	0x* | 0X*) hex="${in}" ;;
+	*) hex="0x${in}" ;;
+	esac
+	digits="${hex#0x}"
+	digits="${digits#0X}"
+	case "${digits}" in
+	'' | *[!0-9A-Fa-f]*)
+		return 1
+		;;
+	esac
+	val=$((${hex}))
+	return 0
+}
+
+read_devmem_val() {
+	addr="$1"
+	outvar="$2"
+	raw="$(devmem "${addr}" 32 2>/dev/null || busybox devmem "${addr}" 32 2>/dev/null || true)"
+	[ -n "${raw}" ] || return 1
+	normalize_hex "${raw}" || return 1
+	eval "${outvar}=\$val"
+	return 0
+}
+
+read_env_val() {
+	envname="$1"
+	outvar="$2"
+	raw="$(fw_printenv -n "${envname}" 2>/dev/null || true)"
+	[ -n "${raw}" ] || return 1
+	normalize_hex "${raw}" || return 1
+	eval "${outvar}=\$val"
+	return 0
+}
+
+set_reset_file() {
+	name="$1"
+	value="$2"
+	case "${name}" in
+	ahb|caliptra|emmc|espi|external|msi|soc|spi|usb)
+		echo "${value}" >"${DOMAINS_DIR}/reset_${name}"
+		;;
+	*)
+		echo "${value}" >"${OUT_DIR}/reset_${name}"
+		;;
+	esac
+}
+
+# Prefer per-register U-Boot env values; fallback to devmem for missing values.
+scu0_log2_ok=0
+scu0_log0_ok=0
+scu1_log0_ok=0
+scu1_log3_ok=0
+
+if command -v fw_printenv >/dev/null 2>&1; then
+	if read_env_val "${ENV_SCU0_LOG0}" scu0_log0; then
+		scu0_log0_ok=1
+	fi
+	if read_env_val "${ENV_SCU0_LOG2}" scu0_log2; then
+		scu0_log2_ok=1
+	fi
+	if read_env_val "${ENV_SCU1_LOG0}" scu1_log0; then
+		scu1_log0_ok=1
+	fi
+	if read_env_val "${ENV_SCU1_LOG3}" scu1_log3; then
+		scu1_log3_ok=1
+	fi
+fi
+
+if [ "${scu0_log2_ok}" -ne 1 ] && read_devmem_val "${SCU0_LOG2_ADDR}" scu0_log2; then
+	scu0_log2_ok=1
+fi
+if [ "${scu0_log0_ok}" -ne 1 ] && read_devmem_val "${SCU0_LOG0_ADDR}" scu0_log0; then
+	scu0_log0_ok=1
+fi
+if [ "${scu1_log0_ok}" -ne 1 ] && read_devmem_val "${SCU1_LOG0_ADDR}" scu1_log0; then
+	scu1_log0_ok=1
+fi
+if [ "${scu1_log3_ok}" -ne 1 ] && read_devmem_val "${SCU1_LOG3_ADDR}" scu1_log3; then
+	scu1_log3_ok=1
+fi
+
+if [ "${scu0_log2_ok}" -ne 1 ] || [ "${scu0_log0_ok}" -ne 1 ] || [ "${scu1_log0_ok}" -ne 1 ] || [ "${scu1_log3_ok}" -ne 1 ]; then
+	echo "cannot get complete reset causes from env/devmem (SCU0_LOG2, SCU0_LOG0, SCU1_LOG0, SCU1_LOG3)" >&2
+	exit 1
+fi
+
+# Store raw SCU reset-log words.
+echo "$(printf '0x%08x' "${scu0_log0}")" >"${OUT_DIR}/raw_scu0_reset_event_log0"
+echo "$(printf '0x%08x' "${scu0_log2}")" >"${OUT_DIR}/raw_scu0_reset_event_log2"
+echo "$(printf '0x%08x' "${scu1_log0}")" >"${OUT_DIR}/raw_scu1_reset_event_log0"
+echo "$(printf '0x%08x' "${scu1_log3}")" >"${OUT_DIR}/raw_scu1_reset_event_log3"
+
+# AST2700 semantic mapping.
+# Combine SCU1/SCU0 PWRST indications for power_on.
+power_on=$((((scu1_log0 >> 11) & 1) | ((scu0_log0 >> 11) & 1)))
+external=$((((scu1_log0 >> 1) & 1) | (scu1_log0 & 1) | ((scu0_log0 >> 1) & 1) | (scu0_log0 & 1)))
+cpu=$(((scu1_log0 >> 12) & 1))
+soc=$((((scu1_log0 >> 13) & 1) | ((scu0_log0 >> 13) & 1)))
+ahb=$((((scu1_log0 >> 14) & 1) | ((scu0_log0 >> 14) & 1)))
+caliptra=$(((scu1_log0 >> 16) & 1))
+# USB reset evidence from SCU1 USB2D/USB2C/UHCI and SCU0 USB bus/VHUB/UHCI logs.
+scu0_usb_mask=$((0x001F0000))
+usb=$((((scu1_log0 >> 22) & 1) | ((scu1_log0 >> 20) & 1) | ((scu1_log0 >> 18) & 1) | ((scu0_log0 & scu0_usb_mask) != 0)))
+spi=$((((scu1_log0 >> 27) & 1) | ((scu1_log0 >> 26) & 1) | ((scu1_log0 >> 25) & 1)))
+espi=$((((scu1_log0 >> 29) & 1) | ((scu1_log0 >> 28) & 1) | ((scu1_log0 >> 5) & 1) | ((scu1_log0 >> 4) & 1)))
+emmc=$(((scu0_log0 >> 31) & 1))
+msi=$(((scu0_log0 >> 30) & 1))
+
+# SCU1 0x080: each nibble is WDTx {SW,SOC,ARM,FULL}.
+soft_wdt_mask=$((0x88888888))
+non_soft_wdt_mask=$((0x77777777))
+software=$(((scu1_log3 & soft_wdt_mask) != 0))
+watchdog=$((((scu1_log3 & non_soft_wdt_mask) != 0) | (scu0_log2 != 0)))
+
+# WDT2 group at bits [11:8] in SCU1 0x080.
+security_watchdog2=$((((scu1_log3 >> 8) & 0xF) != 0))
+
+# reset_others = 1 only when none of the dedicated (non-domain) reset causes is set.
+# Domain-detail flags live under OUT_DIR/domains/ and are excluded from this mask.
+others=$((!(power_on | watchdog | software | cpu | security_watchdog2)))
+
+set_reset_file power_on "${power_on}"
+set_reset_file external "${external}"
+set_reset_file watchdog "${watchdog}"
+set_reset_file software "${software}"
+set_reset_file cpu "${cpu}"
+set_reset_file soc "${soc}"
+set_reset_file ahb "${ahb}"
+set_reset_file caliptra "${caliptra}"
+set_reset_file usb "${usb}"
+set_reset_file spi "${spi}"
+set_reset_file espi "${espi}"
+set_reset_file emmc "${emmc}"
+set_reset_file msi "${msi}"
+set_reset_file security_watchdog2 "${security_watchdog2}"
+set_reset_file others "${others}"
+
+exit 0

--- a/bmc/usr/usr/bin/hw-management-bmc-ready.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ready.sh
@@ -134,9 +134,14 @@ bmc_debug_step()
 #   1 BMC_READY not asserted, due to failure in ready sequence
 bmc_ready_sequence()
 {
-	bmc_debug_step "bmc_ready_sequence: start (wait standby, EEPROM, A2D, hook post)"
+	bmc_debug_step "bmc_ready_sequence: start (wait standby, reset cause, EEPROM, A2D, hook post)"
 
 	wait_bmc_standby_ready 10 1
+
+	# Export BMC reset cause (SCU / U-Boot env) to /var/run/hw-management/bmc/.
+	if ! hw-management-bmc-get-reset-cause.sh; then
+		logger -t "${LOG_TAG}" -p daemon.warning "hw-management-bmc-get-reset-cause.sh failed; reset_* under /var/run/hw-management/bmc/ may be missing"
+	fi
 
 	# Obtain CPU type.
 	get_cpu_type

--- a/bmc/usr/usr/bin/hw-management-bmc-show-reset-cause.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-show-reset-cause.sh
@@ -1,0 +1,177 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list, and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# Print reset-cause attribute names (or raw SCU values) from hw-management
+# runtime, mirroring host hw-management.sh reset-cause for reset_* files.
+# BusyBox ash: POSIX sh only.
+#
+# Usage:
+#   hw-management-bmc-show-reset-cause.sh              # all sections
+#   hw-management-bmc-show-reset-cause.sh bmc          # BMC root reset_* only
+#   hw-management-bmc-show-reset-cause.sh host         # host system reset_*
+#   hw-management-bmc-show-reset-cause.sh bmc-domain   # .../bmc/domains/reset_*
+#   hw-management-bmc-show-reset-cause.sh bmc-raw      # raw_scu* words under bmc/
+################################################################################
+
+BMC_DIR="${BMC_DIR:-/var/run/hw-management/bmc}"
+BMC_DOMAINS_DIR="${BMC_DOMAINS_DIR:-${BMC_DIR}/domains}"
+HOST_SYSTEM_DIR="${HOST_SYSTEM_DIR:-/var/run/hw-management/system}"
+
+usage()
+{
+	cat <<'EOF'
+Usage: hw-management-bmc-show-reset-cause.sh [-h|--help] [SECTION...]
+
+  With no SECTION arguments, prints all sections in order: bmc, host,
+  bmc-domain, bmc-raw.
+
+  SECTION is one of:
+    bmc          reset_* files directly under the BMC runtime directory
+    host         reset_* under the host system path (SONiC switch runtime)
+    bmc-domain   reset_* under bmc/domains/
+    bmc-raw      raw_scu*_reset_event_log* files under the BMC runtime dir
+
+  Environment overrides:
+    BMC_DIR, BMC_DOMAINS_DIR, HOST_SYSTEM_DIR
+EOF
+}
+
+# Echo basename of each reset_* regular file in $1 whose first line is integer 1.
+# $2 is section tag (bmc | host | bmc-domain) for the "no files" diagnostic only.
+emit_active_reset_basenames()
+{
+	dir="$1"
+	ctx="${2:-bmc}"
+	if [ ! -d "$dir" ]; then
+		echo "(directory missing: ${dir})"
+		return 0
+	fi
+	found=0
+	seen_any=0
+	for f in "${dir}"/reset_*; do
+		[ -f "$f" ] || continue
+		seen_any=1
+		read -r v _ <"$f" || continue
+		case "$v" in
+		'' | *[!0-9]*) continue ;;
+		esac
+		if [ "$v" -eq 1 ]; then
+			found=1
+			basename "$f"
+		fi
+	done
+	if [ "$found" -eq 0 ]; then
+		if [ "$seen_any" -eq 0 ]; then
+			case "$ctx" in
+			host)
+				echo "(no reset_* files — host reset-cause attributes not present under this directory)"
+				;;
+			*)
+				echo "(no reset_* files — BMC reset-cause export missing; run hw-management-bmc-get-reset-cause.sh)"
+				;;
+			esac
+		else
+			echo "(no reset_* with value 1)"
+		fi
+	fi
+}
+
+section_bmc()
+{
+	printf '%s\n' "=== bmc (${BMC_DIR}) ==="
+	emit_active_reset_basenames "${BMC_DIR}" bmc
+}
+
+section_host()
+{
+	printf '%s\n' "=== host (${HOST_SYSTEM_DIR}) ==="
+	emit_active_reset_basenames "${HOST_SYSTEM_DIR}" host
+}
+
+section_bmc_domain()
+{
+	printf '%s\n' "=== bmc-domain (${BMC_DOMAINS_DIR}) ==="
+	emit_active_reset_basenames "${BMC_DOMAINS_DIR}" bmc-domain
+}
+
+section_bmc_raw()
+{
+	printf '%s\n' "=== bmc-raw (${BMC_DIR}) ==="
+	if [ ! -d "${BMC_DIR}" ]; then
+		echo "(directory missing: ${BMC_DIR})"
+		return 0
+	fi
+	found=0
+	for f in "${BMC_DIR}"/raw_scu*_reset_event_log*; do
+		[ -f "$f" ] || continue
+		found=1
+		printf '%s: %s\n' "$(basename "$f")" "$(cat "$f" 2>/dev/null)"
+	done
+	if [ "$found" -eq 0 ]; then
+		echo "(no raw_scu*_reset_event_log* files)"
+	fi
+}
+
+run_section()
+{
+	case "$1" in
+	bmc) section_bmc ;;
+	host) section_host ;;
+	bmc-domain) section_bmc_domain ;;
+	bmc-raw) section_bmc_raw ;;
+	*)
+		echo "hw-management-bmc-show-reset-cause.sh: unknown section: $1" >&2
+		return 1
+		;;
+	esac
+	echo
+}
+
+case "${1:-}" in
+-h | --help)
+	usage
+	exit 0
+	;;
+esac
+
+if [ "$#" -eq 0 ]; then
+	run_section bmc && run_section host && run_section bmc-domain && run_section bmc-raw
+	exit $?
+fi
+
+for arg in "$@"; do
+	run_section "$arg" || exit 1
+done
+exit 0


### PR DESCRIPTION
Add hw-management-bmc-get-reset-cause.sh (AST2700 BMC reset-cause exporter):
 - Read SCU reset-log words from U-Boot env (reset_cause_scu0_0/_2, reset_cause_scu1_0/_3) with per-register devmem fallback.
 - Write raw SCU words and semantic reset_* files under /var/run/hw-management/bmc/ (domain-detail reset_* under bmc/domains/).

Add hw-management-bmc-show-reset-cause.sh: operator-facing reset-cause viewer (bmc, host, bmc-domain, bmc-raw sections) for /var/run/hw-management paths.

Call the exporter from hw-management-bmc-ready.sh inside bmc_ready_sequence() after wait_bmc_standby_ready; on failure log daemon.warning and continue the ready sequence.

Rework hw-management-bmc-generate-dump.sh reset-cause collection:
 - Drop collect_reset_cause_bundle() and the separate reset_cause/ archive tree.
 - At the start of collect_hw_management_runtime(), run hw-management-bmc-show-reset-cause.sh into /var/run/hw-management/bmc/show-reset-cause (no filename suffix; the values/ snapshot adds .txt as for other runtime files).

Refresh bmc/README.md and bmc/FILE_MAPPING.md for exporter policy, ready/dump integration, and logger vs exporter roles.