### PR TITLE
hw-mgmt: scripts: Update usb0 hotplug handling

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -720,6 +720,7 @@ Kernel-6.1
 |0106-hwmon-pmbus-xdpe1a2g7b-XDPE1A2G7B-Digital-Multi-phas.patch  |                    | Downstream accepted;os[nvos]             |            | xdpe1a2g7b                                     |
 |0107-nvme-pci-try-function-level-reset-on-init-failure.patch     | 5b2c214a9594       | Bugfix upstream                          | 6.17       | NVME SSD fallback recovery                     |
 |0108-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch  |                    | Downstream accepted                      |            |                                                |
+|0109-net-usb-usbnet-restore-usb-d-name-exception-for-loca.patch  | 07f8bdce68b9       | Bugfix accepted;skip[nvos]               | v6.1.133   |                                                |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Downstream;skip[sonic,cumulus]           |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |

--- a/recipes-kernel/linux/linux-6.1/0109-net-usb-usbnet-restore-usb-d-name-exception-for-loca.patch
+++ b/recipes-kernel/linux/linux-6.1/0109-net-usb-usbnet-restore-usb-d-name-exception-for-loca.patch
@@ -1,0 +1,82 @@
+From 07f8bdce68b99edab662f0beec746e5c1911f0fb Mon Sep 17 00:00:00 2001
+From: Dominique Martinet <dominique.martinet@atmark-techno.com>
+Date: Wed, 26 Mar 2025 17:32:36 +0900
+Subject: [PATCH] net: usb: usbnet: restore usb%d name exception for local mac
+ addresses
+
+commit 2ea396448f26d0d7d66224cb56500a6789c7ed07 upstream.
+
+commit 8a7d12d674ac ("net: usb: usbnet: fix name regression") assumed
+that local addresses always came from the kernel, but some devices hand
+out local mac addresses so we ended up with point-to-point devices with
+a mac set by the driver, renaming to eth%d when they used to be named
+usb%d.
+
+Userspace should not rely on device name, but for the sake of stability
+restore the local mac address check portion of the naming exception:
+point to point devices which either have no mac set by the driver or
+have a local mac handed out by the driver will keep the usb%d name.
+
+(some USB LTE modems are known to hand out a stable mac from the locally
+administered range; that mac appears to be random (different for
+mulitple devices) and can be reset with device-specific commands, so
+while such devices would benefit from getting a OUI reserved, we have
+to deal with these and might as well preserve the existing behavior
+to avoid breaking fragile openwrt configurations and such on upgrade.)
+
+Link: https://lkml.kernel.org/r/20241203130457.904325-1-asmadeus@codewreck.org
+Fixes: 8a7d12d674ac ("net: usb: usbnet: fix name regression")
+Cc: stable@vger.kernel.org
+Tested-by: Ahmed Naseef <naseefkm@gmail.com>
+Signed-off-by: Dominique Martinet <dominique.martinet@atmark-techno.com>
+Acked-by: Oliver Neukum <oneukum@suse.com>
+Link: https://patch.msgid.link/20250326-usbnet_rename-v2-1-57eb21fcff26@atmark-techno.com
+Signed-off-by: Jakub Kicinski <kuba@kernel.org>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ drivers/net/usb/usbnet.c | 21 +++++++++++++++------
+ 1 file changed, 15 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/net/usb/usbnet.c b/drivers/net/usb/usbnet.c
+index ae1282487b02..73bddd1645d9 100644
+--- a/drivers/net/usb/usbnet.c
++++ b/drivers/net/usb/usbnet.c
+@@ -178,6 +178,17 @@ int usbnet_get_ethernet_addr(struct usbnet *dev, int iMACAddress)
+ }
+ EXPORT_SYMBOL_GPL(usbnet_get_ethernet_addr);
+ 
++static bool usbnet_needs_usb_name_format(struct usbnet *dev, struct net_device *net)
++{
++	/* Point to point devices which don't have a real MAC address
++	 * (or report a fake local one) have historically used the usb%d
++	 * naming. Preserve this..
++	 */
++	return (dev->driver_info->flags & FLAG_POINTTOPOINT) != 0 &&
++		(is_zero_ether_addr(net->dev_addr) ||
++		 is_local_ether_addr(net->dev_addr));
++}
++
+ static void intr_complete (struct urb *urb)
+ {
+ 	struct usbnet	*dev = urb->context;
+@@ -1761,13 +1772,11 @@ usbnet_probe (struct usb_interface *udev, const struct usb_device_id *prod)
+ 		if (status < 0)
+ 			goto out1;
+ 
+-		// heuristic:  "usb%d" for links we know are two-host,
+-		// else "eth%d" when there's reasonable doubt.  userspace
+-		// can rename the link if it knows better.
++		/* heuristic: rename to "eth%d" if we are not sure this link
++		 * is two-host (these links keep "usb%d")
++		 */
+ 		if ((dev->driver_info->flags & FLAG_ETHER) != 0 &&
+-		    ((dev->driver_info->flags & FLAG_POINTTOPOINT) == 0 ||
+-		     /* somebody touched it*/
+-		     !is_zero_ether_addr(net->dev_addr)))
++		    !usbnet_needs_usb_name_format(dev, net))
+ 			strscpy(net->name, "eth%d", sizeof(net->name));
+ 		/* WLAN devices should always be named "wlan%d" */
+ 		if ((dev->driver_info->flags & FLAG_WLAN) != 0)
+-- 
+2.34.1
+

--- a/usr/lib/udev/rules.d/70-hw-management-bmc.rules
+++ b/usr/lib/udev/rules.d/70-hw-management-bmc.rules
@@ -29,11 +29,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-
 # These rules handle USB net events.
 
-# Rename the interface if it starts with the old 'eth*' prefix
-SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", KERNEL=="eth*", NAME="usb0", RUN+="/usr/bin/logger 'hw-management: renaming %k to usb0'"
-
-# Trigger script if the kernel named it 'usb0' natively or renamed it in the previous rule
-SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", NAME=="usb0", RUN+="/usr/bin/logger 'hw-management: configuring usb0'", RUN+="/usr/bin/hw-management-ifupdown.sh usb0"
+# Configure usb0 network interface
+SUBSYSTEM=="net", ACTION=="add", ATTRS{idVendor}=="0525", ATTRS{idProduct}=="a4a2", KERNEL=="usb0", RUN+="/usr/bin/logger 'hw-management: configuring usb0'", RUN+="/usr/bin/hw-management-ifupdown.sh usb0"

--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -38,38 +38,25 @@ source /usr/bin/hw-management-helpers.sh
 
 INTERFACE=$1
 
+# Check if interface parameter exists
 if [ -z "${INTERFACE}" ]; then
-	log_err "Missing interface parameter"
+	log_err "Interface parameter is missing"
 	exit 1
 fi
 
+# Check if /etc/network/interfaces exists
 if [ ! -e /etc/network/interfaces ]; then
 	log_err "/etc/network/interfaces is missing"
 	exit 1
 fi
 
-# In kernel 6.1 the interface is renamed from ethX to usb0
-# Wait for usb0 to become available
-MAX_RETRIES=10
-RETRY_DELAY=0.1
-for ((i=1; i<=MAX_RETRIES; i++)); do
-	if [ -d "/sys/class/net/$INTERFACE" ] && ip link show "$INTERFACE" >/dev/null 2>&1; then
-		log_info "Interface $INTERFACE existence check succeeded on attempt $i"
-		break
-	fi
-
-	if [ "$i" -lt "$MAX_RETRIES" ]; then
-		log_info "Interface $INTERFACE existence check unsuccessful. Retrying in ${RETRY_DELAY} seconds..."
-		sleep "${RETRY_DELAY}"
-	fi
-done
-
+# Check if interface exists
 if [ ! -d "/sys/class/net/$INTERFACE" ]; then
 	log_err "Interface $INTERFACE does not exist"
 	exit 1
 fi
 
-# Now check if interface is defined in /etc/network/interfaces
+# Check if interface is defined in /etc/network/interfaces
 if ! ifquery "$INTERFACE" >/dev/null 2>&1; then
 	log_err "Interface $INTERFACE is not defined in /etc/network/interfaces"
 	exit 1


### PR DESCRIPTION
Previous udev rule modifications have broken NVOS, the rules were not invoked since in NVOS kernel 6.1.94 the interface is named usb0 from the start, so the first rule was not matched and the second rule, that relied on renaming in the first rule also failed to apply.

The usb network interface naming was broken in kernel 6.1 between versions 6.1.115 and 6.1.132 by the following commit: d9edc3428c7: net: usb: usbnet: fix name regression As a result, the interface was named ethN instead of usb0.

The problem was fixed in kernel 6.1.133 by the following commit: 07f8bdce68b: net: usb: usbnet: restore usb%d name exception for local mac addresses

This patch does the following:

 1. Adds new patch that applies the naming fix to affected kernel versions. The patch is skipped for NVOS that uses kernel version 6.1.94
 2. Updates udev rules to remove the redundant interface renaming and updates the matching criteria of the rule that runs configuration script.
 3. Removes redundant delay loop in the configuration script related to interface renaming.
 4. Updates configuration script comments and log messages

Bug: 5020389