### PR TITLE
hw-mgmt: bmc: services: Modify dependency

### DIFF
--- a/bmc/usr/lib/systemd/system/hw-management-bmc-early-config.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-early-config.service
@@ -4,6 +4,7 @@ Description=Hardware management early config (copy platform files from /etc/<HID
 Documentation=file:///usr/share/doc/hw-management-bmc/README.md
 DefaultDependencies=no
 After=local-fs.target hw-management-bmc-plat-specific-preps.service
+Requires=hw-management-bmc-plat-specific-preps.service
 Before=systemd-modules-load.service
 Before=hw-management-bmc-early-i2c-init.service
 

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-early-i2c-init.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-early-i2c-init.service
@@ -3,6 +3,7 @@
 Description=BMC Early I2C Device Initialization
 DefaultDependencies=no
 After=hw-management-bmc-early-config.service
+Requires=hw-management-bmc-early-config.service
 Before=nvidia_update_mac.service
 
 [Service]


### PR DESCRIPTION
Add dependency "Requires".

Starting hw-management-bmc-early-i2c-init always starts hw-management-bmc-early-config first and waits for it to finish successfully; starting early-config always starts hw-management-bmc-plat-specific-preps first.
So the deploy + copy path runs before the I2C oneshot.

If plat-specific-preps or early-config ever fail (non-zero exit), early-i2c will not start.