### PR TITLE
hw-mgmt: bmc: speed up debug dump and CPLD grid collection

### DIFF
--- a/bmc/README.md
+++ b/bmc/README.md
@@ -172,8 +172,8 @@ Documentation and sample data only. Nothing here is required at runtime unless y
 | Script | Role |
 |--------|------|
 | **`hw-management-bmc-helpers-common.sh`** | From OpenBMC **`hw-management-helpers-common.sh`**: shared routines (**`log_event`**, **`log_cpld_dump`** — compact CPLD read for events), PHY **`mdio`** helpers, **`bmc_init_eth`**, **`get_mgmt_board_revision`**, etc.). **`hw-management-bmc-ready.sh`** sources it before **`hw-management-bmc-helpers.sh`**. Requires **bash** (uses **`[[ ]]`, `(( ))`, …). |
-| **`hw-management-bmc-cpld-dump.sh`** | **Merged** from OpenBMC **`recipes-phosphor/dump/files/cpld_dump.sh`** and **`dump_utils.sh`** (**`take_cpld_dump_internal`**, **`take_cpld_dump`** only). Full **grid** CPLD register dump, optional **`.tar.xz`** packaging (**`-p`**, **`-i`**). Uses **`log_message`** and **`${HW_MANAGEMENT_BMC_PLATFORM_CONF:-/etc/hw-management-bmc-platform.conf}`** (via **`hw-management-bmc-helpers-common.sh`**); no **`switch-erots-info.sh`**, no Phosphor **`add_copy_file`**. Requires **bash**. |
-| **`hw-management-bmc-generate-dump.sh`** | SONiC BMC debug bundle (same idea as host **`hw-management-generate-dump.sh`**). Collects **`dmesg`**, **`proc/`**, **`network/`**, **`i2c/`** (non-mux buses), CPLD (**`take_cpld_dump`**), **`systemctl/`** for **`hw-management-bmc*`**, **`systemd-analyze/`** (boot timing, **`blame`**, **`critical-chain`** — see below), and **`var_run_hw-management/`** (runtime tree + values; EEPROM via **`hexdump -C`**). Before archiving **`/var/run/hw-management`**, runs **`hw-management-bmc-show-reset-cause.sh`** and writes **`/var/run/hw-management/bmc/show-reset-cause`** so it is included in **`values/`** (as **`bmc_show-reset-cause.txt`**). Default output **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Requires **bash**. |
+| **`hw-management-bmc-cpld-dump.sh`** | **Merged** from OpenBMC **`recipes-phosphor/dump/files/cpld_dump.sh`** and **`dump_utils.sh`** (**`take_cpld_dump_internal`**, **`take_cpld_dump`** only). Full **16×16** CPLD grid via **256× `i2ctransfer … r1`** (one byte per offset), then prints the grid; optional **`.tar.xz`** CLI (**`-p`**, **`-i`**). Uses **`log_message`** and **`${HW_MANAGEMENT_BMC_PLATFORM_CONF:-/etc/hw-management-bmc-platform.conf}`** (via **`hw-management-bmc-helpers-common.sh`**); no Phosphor **`add_copy_file`**. Requires **bash**. |
+| **`hw-management-bmc-generate-dump.sh`** | SONiC BMC debug bundle (host analog **`hw-management-generate-dump.sh`**). **Parallel** collectors; default **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. **`-v` / `--verbose`** adds **`systemd-analyze/`** (~1 min). Without **`-v`**, writes **`systemd-analyze/skipped.txt`**. See **BMC debug bundle** below. Requires **bash**. |
 | **`hw-management-bmc-json-parser.sh`** | From OpenBMC **`switch_json_parser.sh`**: **`json_validate`**, **`json_get_nested_array_element`**, etc. (awk/BusyBox). Sourced by **`hw-management-bmc-a2d-leakage-config.sh`**, **`hw-management-bmc-early-i2c-init.sh`**, **`hw-management-bmc-gpio-set.sh`** (**`bmc_init_sysfs_gpio`**). |
 | **`hw-management-bmc-copy-cartridge-data.sh`** | **Cartridge SKUs:** sources **`/usr/bin/switch_json_parser.sh`** when **`/etc/hw-mgmt-bmc-copy-cartridge-data.json`** exists; reads cartridge FRU over I2C and programs SWB CPLD registers. See **`README-hw-management-bmc-copy-cartridge-data.md`**. |
 | **`hw-management-bmc-helpers.sh`** | Platform / ASIC helpers; sources **`hw-management-bmc-helpers-common.sh`** by absolute path. |
@@ -212,19 +212,43 @@ Policy for collecting and exporting reset cause on SONiC BMC:
 
 ### BMC debug bundle (`hw-management-bmc-generate-dump.sh`)
 
-Archive default path: **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. Top-level entries include **`dmesg.txt`**, **`uname.txt`**, **`proc/`** (**`interrupts.txt`**), **`network/`** (**`ifconfig.txt`** or **`ip addr`** fallback), **`i2c/`** (**`i2cdetect -l`**, **`i2cdetect-l_grep-v-mux.txt`**, per-bus **`i2cdetect-y_<N>.txt`**), **`systemctl/`** (**`list-units`**, **`list-unit-files`**, per-unit **`.status.txt`** / **`.show.txt`**), **`cpld/`**, **`var_run_hw-management/`** (**`tree/`**, **`values/`** — live **`bmc/show-reset-cause`** is captured as **`values/bmc_show-reset-cause.txt`**).
+**Usage:** **`hw-management-bmc-generate-dump.sh [-v|--verbose] [output_tarball]`** (default tarball **`/tmp/hw-mgmt-bmc-dump.tar.gz`**).
 
-**`systemd-analyze/`** — best-effort; if **`systemd-analyze`** is not in **`PATH`**, **`skipped.txt`** is written and the rest of the bundle is unchanged.
+| Mode | Behavior | Typical wall time (4-core BMC, order of magnitude) |
+|------|----------|------------------------------------------------------|
+| **default** | All sections below except full **`systemd-analyze`** (writes **`systemd-analyze/skipped.txt`**) | **~20s** |
+| **`-v` / `--verbose`** | Also collects **`systemd-analyze/`** (time, blame, target critical-chains, per-unit critical-chains) | **~70s** ( **`systemd-analyze`** is usually the critical path) |
+
+Collectors run **in parallel** (disjoint subdirs under **`/tmp/hw-mgmt-bmc-dump/`**). Each logs **`collect <name>: start` / `end (Ns)`** via **`log_message`** (syslog tag **`hw-management-bmc-generate-dump`**). After **`wait`**, **`pkill -P $$`** cleans stray child processes, then **`tar \| gzip -9`**.
+
+**Environment (optional overrides):**
+
+| Variable | Default | Used for |
+|----------|---------|----------|
+| **`MAX_PARALLEL`** | **`nproc + 1`** ( **`4`** if **`nproc`** missing) | Worker cap when section-specific vars unset |
+| **`HW_MGMT_BMC_DUMP_WORKERS`** | **`$MAX_PARALLEL`** | **`var_run_hw-management`** value capture (stride workers) |
+| **`HW_MGMT_CAPTURE_PARALLEL_MAX`** | fallback for **`HW_MGMT_BMC_DUMP_WORKERS`** | same |
+| **`SYSTEMD_ANALYZE_PARALLEL_MAX`** | **`$MAX_PARALLEL`** | Per-unit **`systemd-analyze critical-chain`** pool (verbose only) |
+
+Archive top-level: **`dmesg.txt`**, **`uname.txt`**, **`proc/`**, **`network/`**, **`i2c/`**, **`systemctl/`**, **`cpld/`** (**`cpld_dump.log`** via **`take_cpld_dump`**), **`var_run_hw-management/`** (**`tree/`**, **`values/`**).
+
+**`var_run_hw-management/`** — single **`find`** over **`/var/run/hw-management`**, then parallel capture of file/symlink values (EEPROM: **`hexdump -C`**). **`hw-management-bmc-show-reset-cause.sh`** runs first into live **`bmc/show-reset-cause`** (archive **`values/bmc_show-reset-cause.txt`**). For **mlxreg-io** sysfs nodes that are **write-only** (**`--w-------`**), **`[ -r file ]`** may still succeed as root; the dump runs **`cat`** and records **`cat`** errors plus **`(cat returned non-zero; likely write-only or EIO)`** when read fails.
+
+**`systemd-analyze/`** (only with **`-v`**): if **`systemd-analyze`** is missing, **`skipped.txt`**. Otherwise parallel **`time`**, **`blame`**, **`critical-chain`** for **`default.target`** / **`sysinit.target`**, then per-unit chains for **`hw-management-bmc*.service`** (cap **16** units). Sub-steps log **`systemd-analyze <label>: start/end`**.
 
 | File / directory | Contents |
 |------------------|----------|
-| **`time.txt`** | **`systemd-analyze time`** — firmware / loader / kernel / userspace summary. |
-| **`blame.txt`** | **`systemd-analyze blame`** — units sorted by startup time (includes **oneshot** services in the boot graph). |
-| **`blame_hw-management-bmc_only.txt`** | Lines from **`blame.txt`** containing **`hw-management-bmc`**. |
+| **`time.txt`** | **`systemd-analyze time`**. |
+| **`blame.txt`** | **`systemd-analyze blame`**. |
+| **`blame_hw-management-bmc_only.txt`** | **`grep hw-management-bmc`** on **`blame.txt`**. |
 | **`critical-chain_default.target.txt`** | **`systemd-analyze critical-chain default.target`**. |
 | **`critical-chain_sysinit.target.txt`** | **`systemd-analyze critical-chain sysinit.target`**. |
-| **`critical-chain_per_unit/`** | **`systemd-analyze critical-chain <unit>`** for each **`hw-management-bmc*.service`** (filename = unit with **`/` `@` `:`** → **`_`**). Capped count per run; if truncated, **`README_cap.txt`** notes the limit. |
-| **`var_run_hw-management/values/`** (reset cause) | **`hw-management-bmc-show-reset-cause.sh`** (all sections) is written to live **`/var/run/hw-management/bmc/show-reset-cause`** as the first step of runtime collection, then copied like any other file under **`/var/run/hw-management`** (archive **`values/bmc_show-reset-cause.txt`**). BMC **`reset_*`** / **`raw_scu*`** files remain under **`var_run_hw-management/values/`** when present. |
+| **`critical-chain_per_unit/`** | Per **`hw-management-bmc*.service`**; **`README_cap.txt`** if capped. |
+| **`skipped.txt`** | Written when **`-v`** was **not** used (routine fast dump). |
+
+### CPLD grid dump (`hw-management-bmc-cpld-dump.sh`)
+
+**`take_cpld_dump_internal`** — reads offsets **0x00–0xFF** with **`i2ctransfer -f -y $CPLD_I2C_BUS w2@0x31 0x25 0x<off> r1`**, stores each byte in a bash array, then prints a **16×16** hex grid (header row **0x00–0x0f**, data rows **0x00**–**0xf0**). **`take_cpld_dump <dir>`** writes **`cpld_dump.log`** (or a file path); **`hw-management-bmc-generate-dump.sh`** calls it for **`cpld/`**. Stand-alone CLI: **`hw-management-bmc-cpld-dump.sh -p <dest> -i <id>`** → **`.tar.xz`**. I2C time is ~**3s** for 256 reads on a quiet bus; total collector time includes shell/format overhead (~**10s** in parallel dumps).
 
 ### Shell portability (BusyBox `ash` vs bash)
 
@@ -240,8 +264,8 @@ SONiC BMC images often ship **BusyBox** (`/bin/sh` → **ash**) and may also inc
 | **`hw-management-bmc-devtree.sh`**, **`hw-management-bmc-devtree-check.sh`**, **`hw-management-bmc.sh`** | **bash** | Associative arrays / bash-only syntax; require **`bash`**. |
 | **`hw-management-bmc-powerctrl.sh`** | **bash** | **`#!/bin/bash`**, **`set -euo pipefail`**, **`logger`** for journal messages; requires **`bash`**. |
 | **`hw-management-bmc-boot-complete.sh`** | Yes | **`#!/bin/sh`**: waits on **`/var/run/hw-management/`** entry counts vs **`/etc/hw-management-bmc-boot-complete.conf`**. |
-| **`hw-management-bmc-cpld-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`BASH_SOURCE`**, brace expansion in **`take_cpld_dump_internal`**, sourced **`return`** guard for **`timeout bash -c '. …; take_cpld_dump_internal'`**. |
-| **`hw-management-bmc-generate-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`source`** **`hw-management-bmc-cpld-dump.sh`** (**`take_cpld_dump`**), **`find`**, **`timeout`**, **`systemd-analyze`** (optional). Uses **`tar cf - \| gzip -9`** (not GNU **`tar -I`**) and **`ls -ld`** per path (not GNU **`find -ls`**) so BusyBox **tar/find** work; **`readlink_canonical`** if **`readlink -f`** missing. Needs **`gzip`** in **`PATH`** (BusyBox or GNU). Invokes **`hw-management-bmc-show-reset-cause.sh`** into **`/var/run/hw-management/bmc/show-reset-cause`** before archiving **`/var/run/hw-management`**. |
+| **`hw-management-bmc-cpld-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`BASH_SOURCE`**, **`take_cpld_dump_internal`** (256× **`r1`**, array + grid print), sourced **`return`** guard; **`take_cpld_dump`** uses **`timeout bash -c '. …; take_cpld_dump_internal'`**. |
+| **`hw-management-bmc-generate-dump.sh`** | **bash** | **`#!/bin/bash`**: parallel **`run_collect_bg`** collectors, **`MAX_PARALLEL`**, **`-v`** for **`systemd-analyze`**, **`source`** **`hw-management-bmc-cpld-dump.sh`**, single-pass **`find`** + stride workers for **`/var/run/hw-management`**. **`tar cf - \| gzip -9`**; BusyBox-friendly **`find`** / **`readlink_canonical`**. Needs **`gzip`**, **`bash`**. |
 | **`hw-management-bmc-show-reset-cause.sh`** | Yes | **`#!/bin/sh`**: lists active **`reset_*`** (value 1) or raw SCU lines; no bashisms. |
 | **`hw-management-bmc-get-reset-cause.sh`** | Yes | **`#!/bin/sh`**: SCU read / semantic export. |
 | **`hw-management-bmc-bios-recovery-flash.sh`** | **bash** | **`#!/bin/bash`**, **`set -e`**: **`flashcp`** (**`mtd-utils`**), **`spi_chnl_select`** sysfs. |

--- a/bmc/usr/usr/bin/hw-management-bmc-cpld-dump.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-cpld-dump.sh
@@ -97,14 +97,42 @@ cleanup()
 	return "$res_ret"
 }
 
+# Normalize i2ctransfer r1 output (e.g. "0x12") to a grid cell token.
+cpld_format_byte()
+{
+	local raw=$1
+	local b
+
+	raw=${raw#"${raw%%[![:space:]]*}"}
+	raw=${raw%"${raw##*[![:space:]]}"}
+
+	case "$raw" in
+	0x* | 0X*)
+		b=${raw#0x}
+		b=${b#0X}
+		b=${b,,}
+		if [[ $b =~ ^[0-9a-f]{2}$ ]]; then
+			printf '%s' "$b"
+			return 0
+		fi
+		;;
+	*ER*)
+		printf 'ER'
+		return 0
+		;;
+	*NA*)
+		printf 'NA'
+		return 0
+		;;
+	esac
+	printf '--'
+}
+
 # Hex grid dump to stdout (archive content; not sent to syslog).
 take_cpld_dump_internal()
 {
-	echo -n "Offset "
-	for col in {0..15}; do
-		printf "%02x " "$col"
-	done
-	echo
+	local -a cpld_bytes=()
+	local offset hex_offset raw_output row col cell
 
 	if [ -f "$PLATFORM_CONFIG_FILE" ]; then
 		# shellcheck source=/dev/null
@@ -113,25 +141,24 @@ take_cpld_dump_internal()
 		CPLD_I2C_BUS=5
 	fi
 
+	for ((offset = 0; offset < 256; offset++)); do
+		printf -v hex_offset '%02x' "$offset"
+		raw_output=$(i2ctransfer -f -y "$CPLD_I2C_BUS" w2@0x31 0x25 "0x${hex_offset}" r1 2>/dev/null)
+		cpld_bytes[offset]=$(cpld_format_byte "$raw_output")
+	done
+
+	echo -n "Offset "
+	for ((col = 0; col < 16; col++)); do
+		printf "%02x " "$col"
+	done
+	echo
+
 	for ((row = 0; row <= 240; row += 16)); do
 		printf "0x%02x:  " "$row"
-
 		for ((col = 0; col < 16; col++)); do
 			offset=$((row + col))
-			hex_offset=$(printf "%02x" "$offset")
-
-			raw_output=$(i2ctransfer -f -y "$CPLD_I2C_BUS" w2@0x31 0x25 "0x${hex_offset}" r1 2>/dev/null)
-			byte=$(echo "$raw_output" | awk 'match($0, /0x[0-9a-fA-F]{2}/) {print substr($0, RSTART+2, 2)}')
-
-			if [[ $byte =~ ^[0-9a-fA-F]{2}$ ]]; then
-				printf "%02x " "0x$byte" | tr '[:upper:]' '[:lower:]'
-			elif [[ $byte == "ER" ]]; then
-				printf "ER "
-			elif [[ $byte == "NA" ]]; then
-				printf "NA "
-			else
-				printf '%s' '-- '
-			fi
+			cell=${cpld_bytes[offset]}
+			printf '%s ' "$cell"
 		done
 		echo
 	done
@@ -144,27 +171,23 @@ take_cpld_dump()
 
 	log_message info "Starting CPLD data collection..."
 
-	local tmp_log
-	tmp_log=$(mktemp /tmp/cpld_dump.XXXXXX.log)
-	local _my_script="${BASH_SOURCE[0]}"
+	local out _my_script="${BASH_SOURCE[0]}"
 
 	if [ "1${output_path}" = "1add_copy_file" ]; then
 		log_message err "output mode add_copy_file is not supported (Phosphor dump integration only)"
-		rm -f "$tmp_log"
 		return 1
 	fi
 
-	if ! timeout 20s bash -c ". $(printf '%q' "$_my_script"); take_cpld_dump_internal" >"$tmp_log" 2>&1; then
-		log_message warning "CPLD dump command timed out or returned non-zero (partial data may be in temp file)"
-	fi
-
 	if [ -d "$output_path" ]; then
-		cp -f "$tmp_log" "${output_path}/cpld_dump.log"
+		out="${output_path}/cpld_dump.log"
 	else
-		cp -f "$tmp_log" "$output_path"
+		out="$output_path"
 	fi
 
-	rm -f "$tmp_log"
+	if ! timeout 20s bash -c ". $(printf '%q' "$_my_script"); take_cpld_dump_internal" >"$out" 2>&1; then
+		log_message warning "CPLD dump command timed out or returned non-zero (partial data may be in $out)"
+	fi
+
 	log_message info "CPLD data collection completed"
 }
 

--- a/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
@@ -74,29 +74,58 @@ source /usr/bin/hw-management-bmc-helpers-common.sh
 
 DUMP_FOLDER="/tmp/hw-mgmt-bmc-dump"
 HW_MGMT="/var/run/hw-management"
-OUTPUT_TAR="${1:-/tmp/hw-mgmt-bmc-dump.tar.gz}"
+OUTPUT_TAR="/tmp/hw-mgmt-bmc-dump.tar.gz"
+VERBOSE=0
 dump_process_pid=$$
 
 help()
 {
 	cat <<EOF
-Usage: hw-management-bmc-generate-dump.sh [output_tarball]
+Usage: hw-management-bmc-generate-dump.sh [-v|--verbose] [output_tarball]
 
   Collects dmesg, /proc/interrupts, ifconfig (fallback: ip addr), i2cdetect -y
   for each bus from "i2cdetect -l | grep -v mux", CPLD dump (hw-management-bmc-cpld-dump),
-  systemctl status/show for all hw-management-bmc* units, systemd-analyze time/blame
-  (plus hw-management-bmc-only lines) and critical-chain for default.target/sysinit.target,
-  and /var/run/hw-management tree + values (EEPROM paths: hexdump -C).
+  systemctl status/show for all hw-management-bmc* units, and /var/run/hw-management tree
+  + values (EEPROM paths: hexdump -C).
   Before archiving, hw-management-bmc-show-reset-cause.sh output is written to
   /var/run/hw-management/bmc/show-reset-cause so it is included with the runtime snapshot.
+
+  -v, --verbose   Also collect systemd-analyze (time, blame, critical-chain); slow (~1 min).
 
   Default output: /tmp/hw-mgmt-bmc-dump.tar.gz
 EOF
 }
 
-if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
-	help
-	exit 0
+parse_args()
+{
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		-h | --help)
+			help
+			exit 0
+			;;
+		-v | --verbose)
+			VERBOSE=1
+			;;
+		-*)
+			log_message err "Unknown option: $1"
+			help
+			exit 1
+			;;
+		*)
+			OUTPUT_TAR="$1"
+			;;
+		esac
+		shift
+	done
+}
+
+parse_args "$@"
+
+# Default worker count for parallel sections (hw-mgmt values, systemd-analyze per-unit).
+if [ -z "${MAX_PARALLEL:-}" ]; then
+	_cpus=$(nproc 2>/dev/null) || _cpus=4
+	MAX_PARALLEL=$((_cpus + 1))
 fi
 
 safe_unit_fname()
@@ -156,39 +185,74 @@ collect_hw_management_runtime()
 	fi
 
 	ls -Rla "$HW_MGMT" >"${tree_dir}/ls-Rla.txt" 2>&1
-	find "$HW_MGMT" -xdev 2>/dev/null | LC_ALL=C sort >"${tree_dir}/find_paths_sorted.txt"
-	# GNU find -ls is not in BusyBox; use ls -ld per path (bash process substitution).
+
+	# Single-pass find: walk $HW_MGMT once, save NUL-separated paths, then reuse
+	# the listing for sorted paths, ls -ld per path, and the value-capture loop.
+	local paths_nul="${tree_dir}/.paths.nul"
+	find "$HW_MGMT" -xdev -print0 2>/dev/null >"$paths_nul"
+
+	tr '\0' '\n' <"$paths_nul" | LC_ALL=C sort >"${tree_dir}/find_paths_sorted.txt"
+
+	# GNU find -ls is not in BusyBox; iterate the same listing with ls -ld per path.
 	{
 		while IFS= read -r -d '' p; do
 			ls -ld "$p" 2>/dev/null || printf '%s\n' "$p"
-		done < <(find "$HW_MGMT" -xdev -print0 2>/dev/null)
+		done <"$paths_nul"
 	} >"${tree_dir}/find_ls.txt" 2>&1
 
-	local f rel outf
+	local -a all_paths=()
+	local f
 	while IFS= read -r -d '' f; do
-		[ -e "$f" ] || continue
-		[ -d "$f" ] && continue
-		[ -p "$f" ] && continue
-		[ -S "$f" ] && continue
+		all_paths+=("$f")
+	done <"$paths_nul"
+	rm -f "$paths_nul"
 
-		rel=$(safe_rel_fname "$f")
-		outf="${values_dir}/${rel}.txt"
+	local total="${#all_paths[@]}"
+	local workers="${HW_MGMT_BMC_DUMP_WORKERS:-${HW_MGMT_CAPTURE_PARALLEL_MAX:-$MAX_PARALLEL}}"
+	[ "$workers" -lt 1 ] && workers=1
+	if [ "$total" -gt 0 ] && [ "$workers" -gt "$total" ]; then
+		workers="$total"
+	fi
 
-		{
-			echo "=== path: $f ==="
-			if [ -L "$f" ]; then
-				echo "symlink: $(readlink "$f" 2>/dev/null)"
-				readlink_canonical "$f" | sed 's/^/resolved: /'
-			fi
-			if [ ! -r "$f" ] && [ ! -L "$f" ]; then
-				echo "(not readable)"
-			elif is_eeprom_path "$f"; then
-				timeout 60 hexdump -C "$f" 2>&1
-			else
-				timeout 20 cat "$f" 2>&1
-			fi
-		} >"$outf" || log_message warning "Failed to capture: $f"
-	done < <(find "$HW_MGMT" -xdev \( -type f -o -type l \) ! -type s ! -type p -print0 2>/dev/null)
+	_hwm_value_worker() {
+		local stride=$1 offset=$2
+		local j f rel outf
+		for ((j = offset; j < total; j += stride)); do
+			f="${all_paths[$j]}"
+			[ -e "$f" ] || [ -L "$f" ] || continue
+			[ -d "$f" ] && continue
+			[ -p "$f" ] && continue
+			[ -S "$f" ] && continue
+
+			rel=$(safe_rel_fname "$f")
+			outf="${values_dir}/${rel}.txt"
+
+			{
+				echo "=== path: $f ==="
+				if [ -L "$f" ]; then
+					echo "symlink: $(readlink "$f" 2>/dev/null)"
+					readlink_canonical "$f" | sed 's/^/resolved: /'
+				fi
+				# -r follows symlinks: write-only targets get a one-line marker
+				# instead of a failed cat and a syslog warning per file.
+				if [ ! -r "$f" ]; then
+					echo "(not readable / write-only)"
+				elif is_eeprom_path "$f"; then
+					timeout 60 hexdump -C "$f" 2>&1 || echo "(hexdump returned non-zero)"
+				else
+					timeout 20 cat "$f" 2>&1 || echo "(cat returned non-zero; likely write-only or EIO)"
+				fi
+			} >"$outf"
+		done
+	}
+
+	if [ "$total" -gt 0 ]; then
+		local i
+		for ((i = 0; i < workers; i++)); do
+			_hwm_value_worker "$workers" "$i" &
+		done
+		wait
+	fi
 }
 
 collect_systemctl_bmc()
@@ -214,10 +278,44 @@ collect_systemctl_bmc()
 	done
 }
 
+# Run one systemd-analyze subcommand in background (separate outfile per caller).
+run_systemd_analyze_cmd_bg()
+{
+	local timeout_sec=$1
+	local outfile=$2
+	local label
+	shift 2
+
+	label=$(basename "$outfile" .txt)
+
+	(
+		local t0=$SECONDS rc elapsed
+
+		log_message info "systemd-analyze ${label}: start"
+		if timeout "$timeout_sec" systemd-analyze "$@" --no-pager >"$outfile" 2>&1; then
+			rc=0
+		else
+			rc=$?
+			log_message warning "systemd-analyze $* failed or timed out"
+		fi
+		elapsed=$((SECONDS - t0))
+		if [ "$rc" -eq 0 ]; then
+			log_message info "systemd-analyze ${label}: end (${elapsed}s)"
+		else
+			log_message warning "systemd-analyze ${label}: end (${elapsed}s, exit=${rc})"
+		fi
+		exit "$rc"
+	) &
+}
+
 # systemd-analyze: boot/startup timing, per-unit blame (incl. oneshot duration), critical-chain.
+# Independent subcommands run in parallel; per-unit critical-chain uses a concurrency cap.
 collect_systemd_analyze()
 {
 	local d=$1
+	local u uf units n max_cc max_parallel pid
+	local -a pids
+
 	mkdir -p "$d"
 	if ! command -v systemd-analyze >/dev/null 2>&1; then
 		log_message warning "systemd-analyze not found — skipping boot timing section"
@@ -225,27 +323,22 @@ collect_systemd_analyze()
 		return 0
 	fi
 
-	timeout 30 systemd-analyze time --no-pager >"${d}/time.txt" 2>&1 \
-		|| log_message warning "systemd-analyze time failed or timed out"
+	max_cc=16
+	max_parallel="${SYSTEMD_ANALYZE_PARALLEL_MAX:-$MAX_PARALLEL}"
 
+	run_systemd_analyze_cmd_bg 30 "${d}/time.txt" time
 	# Blame lists units sorted by startup time (oneshots included as wall-clock in chain).
-	timeout 120 systemd-analyze blame --no-pager >"${d}/blame.txt" 2>&1 \
-		|| log_message warning "systemd-analyze blame failed or timed out"
+	run_systemd_analyze_cmd_bg 120 "${d}/blame.txt" blame
+	run_systemd_analyze_cmd_bg 90 "${d}/critical-chain_default.target.txt" critical-chain default.target
+	run_systemd_analyze_cmd_bg 90 "${d}/critical-chain_sysinit.target.txt" critical-chain sysinit.target
+	wait
 
 	if [ -f "${d}/blame.txt" ]; then
 		grep 'hw-management-bmc' "${d}/blame.txt" >"${d}/blame_hw-management-bmc_only.txt" 2>/dev/null \
 			|| echo "(no hw-management-bmc lines in blame output)" >"${d}/blame_hw-management-bmc_only.txt"
 	fi
 
-	timeout 90 systemd-analyze critical-chain default.target --no-pager >"${d}/critical-chain_default.target.txt" 2>&1 \
-		|| log_message warning "systemd-analyze critical-chain default.target failed or timed out"
-	timeout 90 systemd-analyze critical-chain sysinit.target --no-pager >"${d}/critical-chain_sysinit.target.txt" 2>&1 \
-		|| log_message warning "systemd-analyze critical-chain sysinit.target failed or timed out"
-
 	# Per-unit critical-chain for hw-management-bmc *.service (oneshot ordering); cap count/time so dumps stay bounded.
-	local u uf units n max_cc
-	n=0
-	max_cc=16
 	units=$(
 		(
 			systemctl list-unit-files --no-legend 2>/dev/null
@@ -253,6 +346,8 @@ collect_systemd_analyze()
 		) | awk '$1 ~ /^hw-management-bmc/ && $1 ~ /\.service$/ {print $1}' | sort -u
 	)
 	mkdir -p "${d}/critical-chain_per_unit"
+	pids=()
+	n=0
 	for u in $units; do
 		[ -n "$u" ] || continue
 		n=$((n + 1))
@@ -262,8 +357,16 @@ collect_systemd_analyze()
 			break
 		fi
 		uf=$(safe_unit_fname "$u")
-		timeout 25 systemd-analyze critical-chain "$u" --no-pager >"${d}/critical-chain_per_unit/${uf}.txt" 2>&1 \
-			|| log_message warning "systemd-analyze critical-chain $u failed or timed out"
+		run_systemd_analyze_cmd_bg 25 "${d}/critical-chain_per_unit/${uf}.txt" critical-chain "$u"
+		pids+=($!)
+		if [ "${#pids[@]}" -ge "$max_parallel" ]; then
+			pid=${pids[0]}
+			pids=("${pids[@]:1}")
+			wait "$pid" 2>/dev/null || true
+		fi
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid" 2>/dev/null || true
 	done
 }
 
@@ -341,6 +444,28 @@ collect_i2c_non_mux()
 	done
 }
 
+# Run a collector in a background subshell; log start/end and wall time (journal + stderr).
+run_collect_bg()
+{
+	local name=$1
+	shift
+
+	(
+		local t0=$SECONDS rc elapsed
+
+		log_message info "collect ${name}: start"
+		"$@"
+		rc=$?
+		elapsed=$((SECONDS - t0))
+		if [ "$rc" -eq 0 ]; then
+			log_message info "collect ${name}: end (${elapsed}s)"
+		else
+			log_message warning "collect ${name}: end (${elapsed}s, exit=${rc})"
+		fi
+		exit "$rc"
+	) &
+}
+
 # --- main ---
 rm -rf "$DUMP_FOLDER"
 mkdir -p "$DUMP_FOLDER"
@@ -350,14 +475,22 @@ uname -a >"${DUMP_FOLDER}/uname.txt" 2>&1
 
 timeout 20 dmesg >"${DUMP_FOLDER}/dmesg.txt" 2>&1 || log_message warning "dmesg failed or timed out"
 
-collect_proc_interrupts "${DUMP_FOLDER}/proc"
-collect_network_ifconfig "${DUMP_FOLDER}/network"
-collect_i2c_non_mux "${DUMP_FOLDER}/i2c"
+run_collect_bg proc_interrupts collect_proc_interrupts "${DUMP_FOLDER}/proc"
+run_collect_bg network_ifconfig collect_network_ifconfig "${DUMP_FOLDER}/network"
+run_collect_bg i2c_non_mux collect_i2c_non_mux "${DUMP_FOLDER}/i2c"
+run_collect_bg systemctl_bmc collect_systemctl_bmc "${DUMP_FOLDER}/systemctl"
+if [ "$VERBOSE" -eq 1 ]; then
+	run_collect_bg systemd_analyze collect_systemd_analyze "${DUMP_FOLDER}/systemd-analyze"
+else
+	mkdir -p "${DUMP_FOLDER}/systemd-analyze"
+	echo "systemd-analyze collection skipped (use -v or --verbose)" \
+		>"${DUMP_FOLDER}/systemd-analyze/skipped.txt"
+	log_message info "systemd-analyze skipped (not verbose mode)"
+fi
+run_collect_bg cpld collect_cpld "${DUMP_FOLDER}/cpld"
+run_collect_bg hw_management_runtime collect_hw_management_runtime "${DUMP_FOLDER}/var_run_hw-management"
 
-collect_systemctl_bmc "${DUMP_FOLDER}/systemctl"
-collect_systemd_analyze "${DUMP_FOLDER}/systemd-analyze"
-collect_cpld "${DUMP_FOLDER}/cpld"
-collect_hw_management_runtime "${DUMP_FOLDER}/var_run_hw-management"
+wait
 
 pkill -P "$dump_process_pid" 2>/dev/null || true
 
@@ -367,6 +500,8 @@ if ! command -v gzip >/dev/null 2>&1; then
 	rm -rf "$DUMP_FOLDER"
 	exit 1
 fi
+archive_t0=$SECONDS
+log_message info "archive: start"
 set -o pipefail 2>/dev/null || true
 if ! tar cf - -C "$DUMP_FOLDER" . | gzip -9 >"$OUTPUT_TAR"; then
 	log_message err "Failed to create archive $OUTPUT_TAR"
@@ -374,6 +509,7 @@ if ! tar cf - -C "$DUMP_FOLDER" . | gzip -9 >"$OUTPUT_TAR"; then
 	exit 1
 fi
 set +o pipefail 2>/dev/null || true
+log_message info "archive: end ($((SECONDS - archive_t0))s)"
 
 rm -rf "$DUMP_FOLDER"
 log_message info "BMC dump created: $OUTPUT_TAR"


### PR DESCRIPTION
Parallelize BMC debug bundle collectors and runtime/CPLD capture;
add -v for systemd-analyze.
CPLD dump reads 256 bytes via i2ctransfer r1 into an array then prints the grid without per-cell awk.
Document usage, MAX_PARALLEL, and typical timings in bmc/README.md.