### PR TITLE
hw-mgmt: patches: Add mux completion notification

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -727,6 +727,9 @@ Kernel-6.1
 |0111-leds-mlxreg-Provide-conversion-for-hardware-LED-colo.patch  |                    | Downstream accepted                      |            |                                                |
 |0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch  |                    | Downstream accepted                      |            | raa228942 raa228943                            |
 |0113-net-usb-usbnet-restore-usb-d-name-exception-for-loca.patch  | 07f8bdce68b9       | Bugfix accepted;skip[nvos]               | v6.1.133   | Required for kernels 6.1.115-6.1.132           |
+|0114-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch  |                    | Downstream accepted                      |            | i2c-mux-reg completion_notify after adapters   |
+|0115-i2c-mux-regmap-Amend-completion-notify-flow.patch      |                    | Downstream accepted                      |            |                                                |
+|0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_post_init after last mux (4151613)     |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Rejected                                 |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |
@@ -823,6 +826,9 @@ Kernel-6.12
 |0062-Add-support-for-NXP-s-PCF85053A-RTC-chip.patch              |                    | Downstream accepted                      |            |                                                |
 |0063-reset-phy-using-polling-function-not-register-write.patch   |                    | Downstream accepted                      |            |                                                |
 |0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch  |                    | Downstream accepted                      |            | raa228942 raa228943                            |
+|0065-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch  |                    | Downstream accepted                      |            | i2c-mux-reg completion_notify after adapters   |
+|0066-i2c-mux-regmap-Amend-completion-notify-flow.patch      |                    | Downstream accepted                      |            |                                                |
+|0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_platdevs_init after last mux (4151613) |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8001-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Rejected                                 |            | Add SPI                                        |
 |8002-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |

--- a/recipes-kernel/linux/linux-6.1/0114-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch
+++ b/recipes-kernel/linux/linux-6.1/0114-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch
@@ -1,0 +1,144 @@
+From fdfeec9fbcb0eb10aca6abf7184a0e4462346fab Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 4 May 2026 10:14:36 +0300
+Subject: [PATCH i2c-mux-ds 1/3] i2c: mux: reg: Downstream: Completion notify
+ after mux adapters exist
+
+Add optional handle and completion_notify to i2c_mux_reg_platform_data,
+mirroring i2c-mux-regmap, so platform code can run only after every mux
+channel adapter has been registered.
+
+If completion_notify returns an error, probe fails and the mux is torn
+down instead of continuing with partially initialized dependents.
+
+On abandon notify, pass the obtained parent adapter when muxc is NULL so
+completion_notify receives a non-NULL @parent whenever i2c_get_adapter()
+succeeded (matching the header contract).
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+drivers/i2c/muxes/i2c-mux-reg.c           | 51 ++++++++++++++++++++++++++++---
+ include/linux/platform_data/i2c-mux-reg.h | 10 ++++++
+ 2 files changed, 56 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/i2c/muxes/i2c-mux-reg.c b/drivers/i2c/muxes/i2c-mux-reg.c
+index 30a6de16..ce7d77cd 100644
+--- a/drivers/i2c/muxes/i2c-mux-reg.c
++++ b/drivers/i2c/muxes/i2c-mux-reg.c
+@@ -153,27 +153,54 @@ static int i2c_mux_reg_probe_dt(struct regmux *mux,
+ }
+ #endif
+ 
++static void i2c_mux_reg_notify_probe_abandon(struct platform_device *pdev,
++					     struct regmux *mux,
++					     struct i2c_mux_core *muxc,
++					     struct i2c_adapter *parent,
++					     int err, bool user_notify_called)
++{
++	const struct i2c_mux_reg_platform_data *pd;
++
++	if (user_notify_called || err == -EPROBE_DEFER)
++		return;
++	pd = mux ? &mux->data : dev_get_platdata(&pdev->dev);
++	if (!pd || !pd->completion_notify || !pd->handle)
++		return;
++	pd->completion_notify(pd->handle, muxc ? muxc->parent : parent, NULL);
++}
++
+ static int i2c_mux_reg_probe(struct platform_device *pdev)
+ {
+-	struct i2c_mux_core *muxc;
++	struct i2c_mux_core *muxc = NULL;
+ 	struct regmux *mux;
+ 	struct i2c_adapter *parent;
+ 	struct resource *res;
+ 	unsigned int class;
++	bool user_notify_called = false;
+ 	int i, ret, nr;
+ 
+ 	mux = devm_kzalloc(&pdev->dev, sizeof(*mux), GFP_KERNEL);
+-	if (!mux)
++	if (!mux) {
++		const struct i2c_mux_reg_platform_data *pd0 = dev_get_platdata(&pdev->dev);
++
++		if (pd0 && pd0->completion_notify && pd0->handle)
++			pd0->completion_notify(pd0->handle, NULL, NULL);
+ 		return -ENOMEM;
++	}
+ 
+ 	if (dev_get_platdata(&pdev->dev)) {
+ 		memcpy(&mux->data, dev_get_platdata(&pdev->dev),
+ 			sizeof(mux->data));
+ 	} else {
+ 		ret = i2c_mux_reg_probe_dt(mux, pdev);
+-		if (ret < 0)
+-			return dev_err_probe(&pdev->dev, ret,
+-					     "Error parsing device tree");
++		if (ret < 0) {
++			ret = dev_err_probe(&pdev->dev, ret,
++					    "Error parsing device tree");
++			if (ret != -EPROBE_DEFER)
++				i2c_mux_reg_notify_probe_abandon(pdev, mux, NULL,
++								 NULL, ret, false);
++			return ret;
++		}
+ 	}
+ 
+ 	parent = i2c_get_adapter(mux->data.parent);
+@@ -220,14 +247,28 @@ static int i2c_mux_reg_probe(struct platform_device *pdev)
+ 			goto err_del_mux_adapters;
+ 	}
+ 
++	if (mux->data.completion_notify) {
++		ret = mux->data.completion_notify(mux->data.handle, muxc->parent,
++						  muxc->adapter);
++		user_notify_called = true;
++		if (ret)
++			goto err_del_mux_adapters;
++	}
++
+ 	dev_dbg(&pdev->dev, "%d port mux on %s adapter\n",
+ 		 mux->data.n_values, muxc->parent->name);
+ 
+ 	return 0;
+ 
+ err_del_mux_adapters:
++	i2c_mux_reg_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					 user_notify_called);
+ 	i2c_mux_del_adapters(muxc);
++	goto put_parent;
+ err_put_parent:
++	i2c_mux_reg_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					 user_notify_called);
++put_parent:
+ 	i2c_put_adapter(parent);
+ 
+ 	return ret;
+diff --git a/include/linux/platform_data/i2c-mux-reg.h b/include/linux/platform_data/i2c-mux-reg.h
+index 2543c2a1..2d106bc6 100644
+--- a/include/linux/platform_data/i2c-mux-reg.h
++++ b/include/linux/platform_data/i2c-mux-reg.h
+@@ -22,6 +22,13 @@
+  * @idle_in_use: indicate if idle value is in use
+  * @reg: Virtual address of the register to switch channel
+  * @reg_size: register size in bytes
++ * @handle: Opaque pointer passed to @completion_notify as its first argument
++ * @completion_notify: Optional; called after every child adapter exists.
++ *	Return 0 on success or a negative errno; non-zero causes probe to fail
++ *	and the mux to be torn down (same contract as i2c-mux-regmap).
++ *	If probe fails before a successful call with a valid @adapters array,
++ *	the driver may invoke this once with @adapters NULL (and @parent NULL
++ *	if the parent adapter was never obtained) so waiters can unblock.
+  */
+ struct i2c_mux_reg_platform_data {
+ 	int parent;
+@@ -35,6 +42,9 @@ struct i2c_mux_reg_platform_data {
+ 	bool idle_in_use;
+ 	void __iomem *reg;
+ 	resource_size_t reg_size;
++	void *handle;
++	int (*completion_notify)(void *handle, struct i2c_adapter *parent,
++				 struct i2c_adapter *adapters[]);
+ };
+ 
+ #endif	/* __LINUX_PLATFORM_DATA_I2C_MUX_REG_H */

--- a/recipes-kernel/linux/linux-6.1/0115-i2c-mux-regmap-Amend-completion-notify-flow.patch
+++ b/recipes-kernel/linux/linux-6.1/0115-i2c-mux-regmap-Amend-completion-notify-flow.patch
@@ -1,0 +1,137 @@
+From 554c9ea0af15314e2837d56eaceb081080b09550 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 5 May 2026 08:35:02 +0300
+Subject: [PATCH] i2c: mux: regmap: Amend completion notify flow
+
+Add proper error flow handling. Skip abandon notify on -EPROBE_DEFER so
+mlx-platform mux counters are not advanced before reprobe (same as i2c-mux-reg).
+Pass the obtained parent adapter into abandon completion_notify when muxc is
+NULL, matching the i2c-mux-reg contract. Use err_put_parent teardown like
+i2c-mux-reg (abandon, then i2c_put_adapter) on all post-get_adapter errors.
+
+Track user_notify_called so err_i2c_mux_add_adapter does not invoke
+completion_notify a second time when the success-path callback already ran
+(e.g. mlxplat_post_init failure), avoiding double mux_added increments.
+
+---
+drivers/i2c/muxes/i2c-mux-regmap.c           | 56 +++++++++++++++++++++++-----
+ include/linux/platform_data/i2c-mux-regmap.h |  4 +-
+ 2 files changed, 49 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/i2c/muxes/i2c-mux-regmap.c b/drivers/i2c/muxes/i2c-mux-regmap.c
+index 1ab5f94a..79a9e578 100644
+--- a/drivers/i2c/muxes/i2c-mux-regmap.c
++++ b/drivers/i2c/muxes/i2c-mux-regmap.c
+@@ -49,21 +49,41 @@ static int i2c_mux_regmap_deselect(struct i2c_mux_core *muxc, u32 chan)
+ 	return regmap_write(mux->pdata.regmap, mux->pdata.sel_reg_addr, 0);
+ }
+ 
++static void i2c_mux_regmap_notify_probe_abandon(struct platform_device *pdev,
++						struct i2c_mux_regmap *mux,
++						struct i2c_mux_core *muxc,
++						struct i2c_adapter *parent,
++						int err, bool user_notify_called)
++{
++	const struct i2c_mux_regmap_platform_data *pd;
++
++	if (user_notify_called || err == -EPROBE_DEFER)
++		return;
++	pd = mux ? &mux->pdata : dev_get_platdata(&pdev->dev);
++	if (!pd || !pd->completion_notify || !pd->handle)
++		return;
++	pd->completion_notify(pd->handle, muxc ? muxc->parent : parent, NULL);
++}
++
+ /* Probe/reomove functions */
+ static int i2c_mux_regmap_probe(struct platform_device *pdev)
+ {
+ 	struct i2c_mux_regmap_platform_data *pdata = dev_get_platdata(&pdev->dev);
+ 	struct i2c_mux_regmap *mux;
+ 	struct i2c_adapter *parent;
+-	struct i2c_mux_core *muxc;
+-	int num, err;
++	struct i2c_mux_core *muxc = NULL;
++	bool user_notify_called = false;
++	int num, ret;
+ 
+ 	if (!pdata)
+ 		return -EINVAL;
+ 
+ 	mux = devm_kzalloc(&pdev->dev, sizeof(*mux), GFP_KERNEL);
+-	if (!mux)
++	if (!mux) {
++		if (pdata->completion_notify && pdata->handle)
++			pdata->completion_notify(pdata->handle, NULL, NULL);
+ 		return -ENOMEM;
++	}
+ 
+ 	memcpy(&mux->pdata, pdata, sizeof(*pdata));
+ 	parent = i2c_get_adapter(mux->pdata.parent);
+@@ -72,8 +92,10 @@ static int i2c_mux_regmap_probe(struct platform_device *pdev)
+ 
+ 	muxc = i2c_mux_alloc(parent, &pdev->dev, pdata->num_adaps, sizeof(*mux), 0,
+ 			     i2c_mux_regmap_select_chan, i2c_mux_regmap_deselect);
+-	if (!muxc)
+-		return -ENOMEM;
++	if (!muxc) {
++		ret = -ENOMEM;
++		goto err_put_parent;
++	}
+ 
+ 	platform_set_drvdata(pdev, muxc);
+ 	muxc->priv = mux;
+@@ -81,20 +103,34 @@ static int i2c_mux_regmap_probe(struct platform_device *pdev)
+ 
+ 	/* Create an adapter for each channel. */
+ 	for (num = 0; num < pdata->num_adaps; num++) {
+-		err = i2c_mux_add_adapter(muxc, 0, pdata->chan_ids[num], 0);
+-		if (err)
++		ret = i2c_mux_add_adapter(muxc, 0, pdata->chan_ids[num], 0);
++		if (ret)
+ 			goto err_i2c_mux_add_adapter;
+ 	}
+ 
+ 	/* Notify caller when all channels' adapters are created. */
+-	if (pdata->completion_notify)
+-		pdata->completion_notify(pdata->handle, muxc->parent, muxc->adapter);
++	if (pdata->completion_notify) {
++		ret = pdata->completion_notify(pdata->handle, muxc->parent,
++					       muxc->adapter);
++		user_notify_called = true;
++		if (ret)
++			goto err_i2c_mux_add_adapter;
++	}
+ 
+ 	return 0;
+ 
+ err_i2c_mux_add_adapter:
++	i2c_mux_regmap_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					  user_notify_called);
+ 	i2c_mux_del_adapters(muxc);
+-	return err;
++	goto put_parent;
++err_put_parent:
++	i2c_mux_regmap_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					  user_notify_called);
++put_parent:
++	i2c_put_adapter(parent);
++
++	return ret;
+ }
+ 
+ static int i2c_mux_regmap_remove(struct platform_device *pdev)
+diff --git a/include/linux/platform_data/i2c-mux-regmap.h b/include/linux/platform_data/i2c-mux-regmap.h
+index a06614e5..e018c530 100644
+--- a/include/linux/platform_data/i2c-mux-regmap.h
++++ b/include/linux/platform_data/i2c-mux-regmap.h
+@@ -17,7 +17,9 @@
+  * @sel_reg_addr - mux select register offset in CPLD space
+  * @reg_size: register size in bytes
+  * @handle: handle to be passed by callback
+- * @completion_notify: callback to notify when all the adapters are created
++ * @completion_notify: callback to notify when all the adapters are created.
++ *	May also be invoked once with @adapters NULL if probe fails after the
++ *	parent adapter exists, so waiters can unblock.
+  */
+ struct i2c_mux_regmap_platform_data {
+ 	void *regmap;

--- a/recipes-kernel/linux/linux-6.1/0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch
+++ b/recipes-kernel/linux/linux-6.1/0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch
@@ -1,0 +1,253 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 12 May 2026 12:00:00 +0300
+Subject: [PATCH] platform: mellanox: Defer post-init until I2C mux adapters
+ exist (6.1.y)
+
+Defer mlxplat_post_init() until i2c-mux-reg / i2c-mux-regmap completion_notify
+callbacks complete, with spinlock, completion, 120s timeout, NULL-adapter path,
+mux teardown vs late-notifier coordination, and unconditional mux completion_notify
+on i2c-mux-reg.
+
+Honor mux_platdevs_err after timeout when post_init is already running; skip
+!adapters handling when mux_abandon is set. Document why probe blocks up to 120s
+on mux_platdevs_done; log timeout only when muxes fail to complete, not when
+post_init exceeds the bound but later succeeds.
+
+Generated against linux-6.1.150 mlx-platform.c (parent of this patch in series).
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 142 ++++++++++++++++++++++++++++---
+ 1 file changed, 130 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index d5efcbb7..a23cfb5c 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -19,6 +19,9 @@
+ #include <linux/platform_data/mlxreg.h>
+ #include <linux/reboot.h>
+ #include <linux/regmap.h>
++#include <linux/completion.h>
++#include <linux/jiffies.h>
++#include <linux/spinlock.h>
+ 
+ #define MLX_PLAT_DEVICE_NAME		"mlxplat"
+ 
+@@ -423,8 +426,14 @@
+  * @regmap: device register map
+  * @hotplug_resources: system hotplug resources
+  * @hotplug_resources_size: size of system hotplug resources
+- * @hi2c_main_init_status: init status of I2C main bus
+- * @mux_added: number of added mux segments
++ * @i2c_main_init_status: init status of I2C main bus
++ * @mux_added: mux segments that have completed i2c-mux-reg/regmap probe (completion_notify)
++ * @mux_notify_lock: serializes mux_added and hotplug bus-nr fixup
++ * @mux_platdevs_done: signaled when deferred mlxplat_post_init() has finished
++ * @mux_platdevs_err: result of mlxplat_post_init() from completion_notify; updated with
++ *	WRITE_ONCE where the last notifier runs post_init outside mux_notify_lock
++ * @mux_abandon: mux topology is being torn down; last notifier skips post_init
++ * @mux_post_init_claimed: post_init is running (topology path may join on timeout)
+  * @irq_fpga: FPGA IRQ number
+  */
+ struct mlxplat_priv {
+@@ -441,6 +450,11 @@ struct mlxplat_priv {
+ 	unsigned int hotplug_resources_size;
+ 	u8 i2c_main_init_status;
+ 	int mux_added;
++	spinlock_t mux_notify_lock;
++	struct completion mux_platdevs_done;
++	int mux_platdevs_err;
++	bool mux_abandon;
++	bool mux_post_init_claimed;
+ 	int irq_fpga;
+ };
+ 
+@@ -9068,14 +9082,47 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ {
+ 	struct mlxplat_priv *priv = handle;
+ 	struct mlxreg_core_item *item;
++	bool run_post_init = false;
++	bool need_complete = false;
++	unsigned long flags;
++	int ret = 0;
+ 	int i, j;
+ 
++	/*
++	 * i2c-mux-reg / i2c-mux-regmap may call this with @adapters NULL when this
++	 * mux probe failed after mlx-platform began waiting (so mux_added still
++	 * reaches mlxplat_mux_num).
++	 */
++	if (!adapters) {
++		bool last;
++
++		spin_lock_irqsave(&priv->mux_notify_lock, flags);
++		if (priv->mux_abandon) {
++			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++			return -EIO;
++		}
++		if (!READ_ONCE(priv->mux_platdevs_err))
++			WRITE_ONCE(priv->mux_platdevs_err, -EIO);
++		last = (++priv->mux_added == mlxplat_mux_num);
++		spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++		if (last)
++			complete(&priv->mux_platdevs_done);
++		return -EIO;
++	}
++
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
+ 	/*
+ 	 * Hotplug platform driver data structure contains static mux channels for I2C hotplug
+ 	 * devices. These channels numbers can be updated dynamically and returned by mux callback
+ 	 * through the adapters array. Update mux channels according to the dynamic adapters data.
++	 *
++	 * The hotplug bus-nr fixup compares mux_added before this probe is counted toward mux_num,
++	 * while the post-init gate uses mux_added only after incrementing for this callback.
++	 * That asymmetry is intentional: fixup must observe the adapter map from the probe that
++	 * completes the hotplug_num-th mux segment, and post-init must run only after mux_num
++	 * probes have completed.
+ 	 */
+-	if (priv->mux_added == mlxplat_mux_hotplug_num) {
++	if (priv->mux_added == mlxplat_mux_hotplug_num && mlxplat_hotplug) {
+ 		item = mlxplat_hotplug->items;
+ 		for (i = 0; i < mlxplat_hotplug->counter; i++, item++) {
+ 			struct mlxreg_core_data *data = item->data;
+@@ -9087,15 +9134,34 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ 		}
+ 	}
+ 
+-	/* Start post initialization only after last nux segment is added */
+-	if (++priv->mux_added == mlxplat_mux_num)
+-		return mlxplat_post_init(priv);
++	/* Run post-init only after the last mux segment has finished probe. */
++	if (++priv->mux_added == mlxplat_mux_num) {
++		if (priv->mux_abandon || READ_ONCE(priv->mux_platdevs_err)) {
++			need_complete = true;
++		} else {
++			priv->mux_post_init_claimed = true;
++			run_post_init = true;
++		}
++	}
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++
++	if (run_post_init) {
++		ret = mlxplat_post_init(priv);
++		WRITE_ONCE(priv->mux_platdevs_err, ret);
++		spin_lock_irqsave(&priv->mux_notify_lock, flags);
++		priv->mux_post_init_claimed = false;
++		spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++		complete(&priv->mux_platdevs_done);
++	} else if (need_complete) {
++		complete(&priv->mux_platdevs_done);
++	}
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ {
++	unsigned long flags;
+ 	int i, err;
+ 
+ 	if (!priv->pdev_i2c) {
+@@ -9104,8 +9170,27 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ 	}
+ 
+ 	priv->i2c_main_init_status = MLXPLAT_I2C_MAIN_BUS_HANDLE_CREATED;
++	if (mlxplat_mux_num && !mlxplat_mux_data && !mlxplat_mux_regmap_data) {
++		err = -EINVAL;
++		return err;
++	}
++
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
++	priv->mux_added = 0;
++	priv->mux_abandon = false;
++	priv->mux_post_init_claimed = false;
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++	if (!mlxplat_mux_num)
++		return mlxplat_post_init(priv);
++
++	reinit_completion(&priv->mux_platdevs_done);
++	WRITE_ONCE(priv->mux_platdevs_err, 0);
++
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		if (mlxplat_mux_data) {
++			mlxplat_mux_data[i].handle = priv;
++			mlxplat_mux_data[i].completion_notify =
++				mlxplat_i2c_mux_complition_notify;
+ 			priv->pdev_mux[i] =
+ 				platform_device_register_resndata(&priv->pdev_i2c->dev,
+ 								  "i2c-mux-reg", i, NULL, 0,
+@@ -9115,7 +9200,7 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ 			mlxplat_mux_regmap_data[i].handle = priv;
+ 			mlxplat_mux_regmap_data[i].regmap = priv->regmap;
+ 			mlxplat_mux_regmap_data[i].completion_notify =
+-								mlxplat_i2c_mux_complition_notify;
++					mlxplat_i2c_mux_complition_notify;
+ 			priv->pdev_mux[i] =
+ 			platform_device_register_resndata(&priv->pdev_i2c->dev,
+ 							  "i2c-mux-regmap", i, NULL, 0,
+@@ -9128,14 +9213,45 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ 		}
+ 	}
+ 
+-	if (mlxplat_mux_regmap_data && mlxplat_mux_regmap_data->completion_notify)
+-		return 0;
+-
+-	return mlxplat_post_init(priv);
++	/*
++	 * Block until every mux completion_notify has run, including
++	 * mlxplat_post_init() from the last segment. Probe must not return before
++	 * dependent platform devices exist; 120s bounds stuck CPLD/firmware mux
++	 * bring-up (typical switch mux probe completes in seconds).
++	 */
++	if (!wait_for_completion_timeout(&priv->mux_platdevs_done,
++					 msecs_to_jiffies(120000))) {
++		spin_lock_irqsave(&priv->mux_notify_lock, flags);
++		if (priv->mux_post_init_claimed) {
++			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++			wait_for_completion(&priv->mux_platdevs_done);
++			err = READ_ONCE(priv->mux_platdevs_err);
++			if (err)
++				goto fail_platform_mux_register;
++		} else {
++			if (!READ_ONCE(priv->mux_platdevs_err))
++				WRITE_ONCE(priv->mux_platdevs_err, -ETIMEDOUT);
++			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++			dev_err(&priv->pdev_i2c->dev,
++				"timeout waiting for I2C mux probe\n");
++			err = -ETIMEDOUT;
++			goto fail_platform_mux_register;
++		}
++	}
++	err = READ_ONCE(priv->mux_platdevs_err);
++	if (err)
++		goto fail_platform_mux_register;
++	return 0;
+ 
+ fail_platform_mux_register:
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
++	priv->mux_abandon = true;
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
+ 	while (--i >= 0)
+ 		platform_device_unregister(priv->pdev_mux[i]);
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
++	priv->mux_added = 0;
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
+ 	return err;
+ }
+ 
+@@ -9234,6 +9350,8 @@ static int mlxplat_probe(struct platform_device *pdev)
+ 	priv->hotplug_resources = hotplug_resources;
+ 	priv->hotplug_resources_size = hotplug_resources_size;
+ 	priv->irq_fpga = irq_fpga;
++	spin_lock_init(&priv->mux_notify_lock);
++	init_completion(&priv->mux_platdevs_done);
+ 
+ 	if (!mlxplat_regmap_config)
+ 		mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config;
+
+-- 
+2.34.1

--- a/recipes-kernel/linux/linux-6.12/0065-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch
+++ b/recipes-kernel/linux/linux-6.12/0065-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch
@@ -1,0 +1,143 @@
+From cb78d4bf9772b96dfef9b4d124f2f383ef9f2928 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Mon, 4 May 2026 10:14:36 +0300
+Subject: [PATCH i2c-mux-ds 1/3] i2c: mux: reg: Downstream: Completion notify
+ after mux adapters exist
+
+Add optional handle and completion_notify to i2c_mux_reg_platform_data,
+mirroring i2c-mux-regmap, so platform code can run only after every mux
+channel adapter has been registered.
+
+If completion_notify returns an error, probe fails and the mux is torn
+down instead of continuing with partially initialized dependents.
+
+On abandon notify, pass the obtained parent adapter when muxc is NULL so
+completion_notify receives a non-NULL @parent whenever i2c_get_adapter()
+succeeded (matching the header contract).
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+drivers/i2c/muxes/i2c-mux-reg.c           | 51 ++++++++++++++++++++++++++++---
+ include/linux/platform_data/i2c-mux-reg.h | 10 ++++++
+ 2 files changed, 56 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/i2c/muxes/i2c-mux-reg.c b/drivers/i2c/muxes/i2c-mux-reg.c
+index ef765fcd..0d5841fc 100644
+--- a/drivers/i2c/muxes/i2c-mux-reg.c
++++ b/drivers/i2c/muxes/i2c-mux-reg.c
+@@ -153,26 +153,53 @@ static int i2c_mux_reg_probe_dt(struct regmux *mux,
+ }
+ #endif
+ 
++static void i2c_mux_reg_notify_probe_abandon(struct platform_device *pdev,
++					     struct regmux *mux,
++					     struct i2c_mux_core *muxc,
++					     struct i2c_adapter *parent,
++					     int err, bool user_notify_called)
++{
++	const struct i2c_mux_reg_platform_data *pd;
++
++	if (user_notify_called || err == -EPROBE_DEFER)
++		return;
++	pd = mux ? &mux->data : dev_get_platdata(&pdev->dev);
++	if (!pd || !pd->completion_notify || !pd->handle)
++		return;
++	pd->completion_notify(pd->handle, muxc ? muxc->parent : parent, NULL);
++}
++
+ static int i2c_mux_reg_probe(struct platform_device *pdev)
+ {
+-	struct i2c_mux_core *muxc;
++	struct i2c_mux_core *muxc = NULL;
+ 	struct regmux *mux;
+ 	struct i2c_adapter *parent;
+ 	struct resource *res;
++	bool user_notify_called = false;
+ 	int i, ret, nr;
+ 
+ 	mux = devm_kzalloc(&pdev->dev, sizeof(*mux), GFP_KERNEL);
+-	if (!mux)
++	if (!mux) {
++		const struct i2c_mux_reg_platform_data *pd0 = dev_get_platdata(&pdev->dev);
++
++		if (pd0 && pd0->completion_notify && pd0->handle)
++			pd0->completion_notify(pd0->handle, NULL, NULL);
+ 		return -ENOMEM;
++	}
+ 
+ 	if (dev_get_platdata(&pdev->dev)) {
+ 		memcpy(&mux->data, dev_get_platdata(&pdev->dev),
+ 			sizeof(mux->data));
+ 	} else {
+ 		ret = i2c_mux_reg_probe_dt(mux, pdev);
+-		if (ret < 0)
+-			return dev_err_probe(&pdev->dev, ret,
+-					     "Error parsing device tree");
++		if (ret < 0) {
++			ret = dev_err_probe(&pdev->dev, ret,
++					    "Error parsing device tree");
++			if (ret != -EPROBE_DEFER)
++				i2c_mux_reg_notify_probe_abandon(pdev, mux, NULL,
++								 NULL, ret, false);
++			return ret;
++		}
+ 	}
+ 
+ 	parent = i2c_get_adapter(mux->data.parent);
+@@ -218,14 +245,28 @@ static int i2c_mux_reg_probe(struct platform_device *pdev)
+ 			goto err_del_mux_adapters;
+ 	}
+ 
++	if (mux->data.completion_notify) {
++		ret = mux->data.completion_notify(mux->data.handle, muxc->parent,
++						  muxc->adapter);
++		user_notify_called = true;
++		if (ret)
++			goto err_del_mux_adapters;
++	}
++
+ 	dev_dbg(&pdev->dev, "%d port mux on %s adapter\n",
+ 		 mux->data.n_values, muxc->parent->name);
+ 
+ 	return 0;
+ 
+ err_del_mux_adapters:
++	i2c_mux_reg_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					 user_notify_called);
+ 	i2c_mux_del_adapters(muxc);
++	goto put_parent;
+ err_put_parent:
++	i2c_mux_reg_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					 user_notify_called);
++put_parent:
+ 	i2c_put_adapter(parent);
+ 
+ 	return ret;
+diff --git a/include/linux/platform_data/i2c-mux-reg.h b/include/linux/platform_data/i2c-mux-reg.h
+index e2e89576..63f842c9 100644
+--- a/include/linux/platform_data/i2c-mux-reg.h
++++ b/include/linux/platform_data/i2c-mux-reg.h
+@@ -21,6 +21,13 @@
+  * @idle_in_use: indicate if idle value is in use
+  * @reg: Virtual address of the register to switch channel
+  * @reg_size: register size in bytes
++ * @handle: Opaque pointer passed to @completion_notify as its first argument
++ * @completion_notify: Optional; called after every child adapter exists.
++ *	Return 0 on success or a negative errno; non-zero causes probe to fail
++ *	and the mux to be torn down (same contract as i2c-mux-regmap).
++ *	If probe fails before a successful call with a valid @adapters array,
++ *	the driver may invoke this once with @adapters NULL (and @parent NULL
++ *	if the parent adapter was never obtained) so waiters can unblock.
+  */
+ struct i2c_mux_reg_platform_data {
+ 	int parent;
+@@ -33,6 +40,9 @@ struct i2c_mux_reg_platform_data {
+ 	bool idle_in_use;
+ 	void __iomem *reg;
+ 	resource_size_t reg_size;
++	void *handle;
++	int (*completion_notify)(void *handle, struct i2c_adapter *parent,
++				 struct i2c_adapter *adapters[]);
+ };
+ 
+ #endif	/* __LINUX_PLATFORM_DATA_I2C_MUX_REG_H */

--- a/recipes-kernel/linux/linux-6.12/0066-i2c-mux-regmap-Amend-completion-notify-flow.patch
+++ b/recipes-kernel/linux/linux-6.12/0066-i2c-mux-regmap-Amend-completion-notify-flow.patch
@@ -1,0 +1,137 @@
+From c7a0e10de7157beb0c00d0f14254f295f8db3b56 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Tue, 5 May 2026 08:59:24 +0300
+Subject: [PATCH] i2c: mux: regmap: Amend completion notify flow
+
+Add proper error flow handling. Skip abandon notify on -EPROBE_DEFER so
+mlx-platform mux counters are not advanced before reprobe (same as i2c-mux-reg).
+Pass the obtained parent adapter into abandon completion_notify when muxc is
+NULL, matching the i2c-mux-reg contract. Use err_put_parent teardown like
+i2c-mux-reg (abandon, then i2c_put_adapter) on all post-get_adapter errors.
+
+Track user_notify_called so err_i2c_mux_add_adapter does not invoke
+completion_notify a second time when the success-path callback already ran
+(e.g. mlxplat_post_init failure), avoiding double mux_added increments.
+
+---
+drivers/i2c/muxes/i2c-mux-regmap.c           | 56 +++++++++++++++++++++++-----
+ include/linux/platform_data/i2c-mux-regmap.h |  4 +-
+ 2 files changed, 49 insertions(+), 11 deletions(-)
+
+diff --git a/drivers/i2c/muxes/i2c-mux-regmap.c b/drivers/i2c/muxes/i2c-mux-regmap.c
+index cd8b45fa..fa3568bc 100644
+--- a/drivers/i2c/muxes/i2c-mux-regmap.c
++++ b/drivers/i2c/muxes/i2c-mux-regmap.c
+@@ -62,21 +62,41 @@ static int i2c_mux_regmap_deselect(struct i2c_mux_core *muxc, u32 chan)
+ 	return regmap_write(mux->pdata.regmap, mux->pdata.sel_reg_addr, 0);
+ }
+ 
++static void i2c_mux_regmap_notify_probe_abandon(struct platform_device *pdev,
++						struct i2c_mux_regmap *mux,
++						struct i2c_mux_core *muxc,
++						struct i2c_adapter *parent,
++						int err, bool user_notify_called)
++{
++	const struct i2c_mux_regmap_platform_data *pd;
++
++	if (user_notify_called || err == -EPROBE_DEFER)
++		return;
++	pd = mux ? &mux->pdata : dev_get_platdata(&pdev->dev);
++	if (!pd || !pd->completion_notify || !pd->handle)
++		return;
++	pd->completion_notify(pd->handle, muxc ? muxc->parent : parent, NULL);
++}
++
+ /* Probe/reomove functions */
+ static int i2c_mux_regmap_probe(struct platform_device *pdev)
+ {
+ 	struct i2c_mux_regmap_platform_data *pdata = dev_get_platdata(&pdev->dev);
+ 	struct i2c_mux_regmap *mux;
+ 	struct i2c_adapter *parent;
+-	struct i2c_mux_core *muxc;
+-	int num, err;
++	struct i2c_mux_core *muxc = NULL;
++	bool user_notify_called = false;
++	int num, ret;
+ 
+ 	if (!pdata)
+ 		return -EINVAL;
+ 
+ 	mux = devm_kzalloc(&pdev->dev, sizeof(*mux), GFP_KERNEL);
+-	if (!mux)
++	if (!mux) {
++		if (pdata->completion_notify && pdata->handle)
++			pdata->completion_notify(pdata->handle, NULL, NULL);
+ 		return -ENOMEM;
++	}
+ 
+ 	memcpy(&mux->pdata, pdata, sizeof(*pdata));
+ 	parent = i2c_get_adapter(mux->pdata.parent);
+@@ -85,8 +105,10 @@ static int i2c_mux_regmap_probe(struct platform_device *pdev)
+ 
+ 	muxc = i2c_mux_alloc(parent, &pdev->dev, pdata->num_adaps, sizeof(*mux), 0,
+ 			     i2c_mux_regmap_select_chan, i2c_mux_regmap_deselect);
+-	if (!muxc)
+-		return -ENOMEM;
++	if (!muxc) {
++		ret = -ENOMEM;
++		goto err_put_parent;
++	}
+ 
+ 	platform_set_drvdata(pdev, muxc);
+ 	muxc->priv = mux;
+@@ -94,20 +116,34 @@ static int i2c_mux_regmap_probe(struct platform_device *pdev)
+ 
+ 	/* Create an adapter for each channel. */
+ 	for (num = 0; num < pdata->num_adaps; num++) {
+-		err = i2c_mux_add_adapter(muxc, 0, pdata->chan_ids[num]);
+-		if (err)
++		ret = i2c_mux_add_adapter(muxc, 0, pdata->chan_ids[num]);
++		if (ret)
+ 			goto err_i2c_mux_add_adapter;
+ 	}
+ 
+ 	/* Notify caller when all channels' adapters are created. */
+-	if (pdata->completion_notify)
+-		pdata->completion_notify(pdata->handle, muxc->parent, muxc->adapter);
++	if (pdata->completion_notify) {
++		ret = pdata->completion_notify(pdata->handle, muxc->parent,
++					       muxc->adapter);
++		user_notify_called = true;
++		if (ret)
++			goto err_i2c_mux_add_adapter;
++	}
+ 
+ 	return 0;
+ 
+ err_i2c_mux_add_adapter:
++	i2c_mux_regmap_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					  user_notify_called);
+ 	i2c_mux_del_adapters(muxc);
+-	return err;
++	goto put_parent;
++err_put_parent:
++	i2c_mux_regmap_notify_probe_abandon(pdev, mux, muxc, parent, ret,
++					  user_notify_called);
++put_parent:
++	i2c_put_adapter(parent);
++
++	return ret;
+ }
+ 
+ static void i2c_mux_regmap_remove(struct platform_device *pdev)
+diff --git a/include/linux/platform_data/i2c-mux-regmap.h b/include/linux/platform_data/i2c-mux-regmap.h
+index f92db6ca..196590d7 100644
+--- a/include/linux/platform_data/i2c-mux-regmap.h
++++ b/include/linux/platform_data/i2c-mux-regmap.h
+@@ -17,7 +17,9 @@
+  * @sel_reg_addr - mux select register offset in CPLD space
+  * @reg_size: register size in bytes
+  * @handle: handle to be passed by callback
+- * @completion_notify: callback to notify when all the adapters are created
++ * @completion_notify: callback to notify when all the adapters are created.
++ *	May also be invoked once with @adapters NULL if probe fails after the
++ *	parent adapter exists, so waiters can unblock.
+  * @mux_access_grant: callback to validate if mux access is granted
+  */
+ struct i2c_mux_regmap_platform_data {

--- a/recipes-kernel/linux/linux-6.12/0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch
+++ b/recipes-kernel/linux/linux-6.12/0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch
@@ -1,0 +1,252 @@
+From 8d3aa0e6790cec41f3d18cde9c389bb07083ea52 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 6 May 2026 08:34:09 +0300
+Subject: [PATCH] platform: mellanox: Downstream: Defer platdevs init until I2C
+ mux exist (6.12.y)
+
+Defer mlxplat_platdevs_init() until i2c-mux-reg / i2c-mux-regmap completion_notify
+callbacks complete, with spinlock, completion, 120s timeout, NULL-adapter path,
+mux teardown vs late-notifier coordination, and unconditional regmap notify hooks.
+
+Honor mux_platdevs_err after timeout when platdevs_init is already running; skip
+!adapters handling when mux_abandon is set. Document why probe blocks up to 120s
+on mux_platdevs_done; log timeout only when muxes fail to complete, not when
+platdevs_init exceeds the bound but later succeeds.
+
+Generated against linux-6.12.65 mlx-platform.c (parent of this patch in series).
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 142 ++++++++++++++++++++++++++++---
+ 1 file changed, 130 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 5542ef9a..0c3bb01a 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -19,6 +19,9 @@
+ #include <linux/platform_data/mlxreg.h>
+ #include <linux/reboot.h>
+ #include <linux/regmap.h>
++#include <linux/completion.h>
++#include <linux/jiffies.h>
++#include <linux/spinlock.h>
+ 
+ #define MLX_PLAT_DEVICE_NAME		"mlxplat"
+ 
+@@ -426,8 +429,14 @@
+  * @regmap: device register map
+  * @hotplug_resources: system hotplug resources
+  * @hotplug_resources_size: size of system hotplug resources
+- * @hi2c_main_init_status: init status of I2C main bus
+- * @mux_added: number of added mux segments
++ * @i2c_main_init_status: init status of I2C main bus
++ * @mux_added: mux segments that have completed i2c-mux-reg/regmap probe (completion_notify)
++ * @mux_notify_lock: serializes mux_added while counting mux completion callbacks
++ * @mux_platdevs_done: signaled when deferred mlxplat_platdevs_init() has finished
++ * @mux_platdevs_err: result of mlxplat_platdevs_init() from completion_notify; updated with
++ *	WRITE_ONCE where the last notifier runs platdevs_init outside mux_notify_lock
++ * @mux_abandon: mux topology is being torn down; last notifier skips platdevs_init
++ * @mux_post_init_claimed: platdevs_init is running (topology path may join on timeout)
+  * @irq_fpga: FPGA IRQ number
+  */
+ struct mlxplat_priv {
+@@ -444,6 +453,11 @@ struct mlxplat_priv {
+ 	unsigned int hotplug_resources_size;
+ 	u8 i2c_main_init_status;
+ 	int mux_added;
++	spinlock_t mux_notify_lock;
++	struct completion mux_platdevs_done;
++	int mux_platdevs_err;
++	bool mux_abandon;
++	bool mux_post_init_claimed;
+ 	int irq_fpga;
+ };
+ 
+@@ -9052,14 +9066,47 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ {
+ 	struct mlxplat_priv *priv = handle;
+ 	struct mlxreg_core_item *item;
++	bool run_platdevs_init = false;
++	bool need_complete = false;
++	unsigned long flags;
++	int ret = 0;
+ 	int i, j;
+ 
++	/*
++	 * i2c-mux-reg / i2c-mux-regmap may call this with @adapters NULL when this
++	 * mux probe failed after mlx-platform began waiting (so mux_added still
++	 * reaches mlxplat_mux_num).
++	 */
++	if (!adapters) {
++		bool last;
++
++		spin_lock_irqsave(&priv->mux_notify_lock, flags);
++		if (priv->mux_abandon) {
++			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++			return -EIO;
++		}
++		if (!READ_ONCE(priv->mux_platdevs_err))
++			WRITE_ONCE(priv->mux_platdevs_err, -EIO);
++		last = (++priv->mux_added == mlxplat_mux_num);
++		spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++		if (last)
++			complete(&priv->mux_platdevs_done);
++		return -EIO;
++	}
++
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
+ 	/*
+ 	 * Hotplug platform driver data structure contains static mux channels for I2C hotplug
+ 	 * devices. These channels numbers can be updated dynamically and returned by mux callback
+ 	 * through the adapters array. Update mux channels according to the dynamic adapters data.
++	 *
++	 * The hotplug bus-nr fixup compares mux_added before this probe is counted toward mux_num,
++	 * while the platdevs-init gate uses mux_added only after incrementing for this callback.
++	 * That asymmetry is intentional: fixup must observe the adapter map from the probe that
++	 * completes the hotplug_num-th mux segment, and platdevs init must run only after mux_num
++	 * probes have completed.
+ 	 */
+-	if (priv->mux_added == mlxplat_mux_hotplug_num) {
++	if (priv->mux_added == mlxplat_mux_hotplug_num && mlxplat_hotplug) {
+ 		item = mlxplat_hotplug->items;
+ 		for (i = 0; i < mlxplat_hotplug->count; i++, item++) {
+ 			struct mlxreg_core_data *data = item->data;
+@@ -9072,15 +9119,34 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ 	}
+ 
+ 
+-	/* Start post initialization only after last nux segment is added */
+-	if (++priv->mux_added == mlxplat_mux_num)
+-		return mlxplat_platdevs_init(priv);
++	/* Run platdevs init only after the last mux segment has finished probe. */
++	if (++priv->mux_added == mlxplat_mux_num) {
++		if (priv->mux_abandon || READ_ONCE(priv->mux_platdevs_err)) {
++			need_complete = true;
++		} else {
++			priv->mux_post_init_claimed = true;
++			run_platdevs_init = true;
++		}
++	}
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++
++	if (run_platdevs_init) {
++		ret = mlxplat_platdevs_init(priv);
++		WRITE_ONCE(priv->mux_platdevs_err, ret);
++		spin_lock_irqsave(&priv->mux_notify_lock, flags);
++		priv->mux_post_init_claimed = false;
++		spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++		complete(&priv->mux_platdevs_done);
++	} else if (need_complete) {
++		complete(&priv->mux_platdevs_done);
++	}
+ 
+-	return 0;
++	return ret;
+ }
+ 
+ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ {
++	unsigned long flags;
+ 	int i, err;
+ 
+ 	if (!priv->pdev_i2c) {
+@@ -9089,8 +9155,27 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ 	}
+ 
+ 	priv->i2c_main_init_status = MLXPLAT_I2C_MAIN_BUS_HANDLE_CREATED;
++	if (mlxplat_mux_num && !mlxplat_mux_data && !mlxplat_mux_regmap_data) {
++		err = -EINVAL;
++		return err;
++	}
++
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
++	priv->mux_added = 0;
++	priv->mux_abandon = false;
++	priv->mux_post_init_claimed = false;
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++	if (!mlxplat_mux_num)
++		return mlxplat_platdevs_init(priv);
++
++	reinit_completion(&priv->mux_platdevs_done);
++	WRITE_ONCE(priv->mux_platdevs_err, 0);
++
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+ 		if (mlxplat_mux_data) {
++			mlxplat_mux_data[i].handle = priv;
++			mlxplat_mux_data[i].completion_notify =
++				mlxplat_i2c_mux_complition_notify;
+ 			priv->pdev_mux[i] =
+ 				platform_device_register_resndata(&priv->pdev_i2c->dev,
+ 								  "i2c-mux-reg", i, NULL, 0,
+@@ -9100,7 +9185,7 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ 			mlxplat_mux_regmap_data[i].handle = priv;
+ 			mlxplat_mux_regmap_data[i].regmap = priv->regmap;
+ 			mlxplat_mux_regmap_data[i].completion_notify =
+-								mlxplat_i2c_mux_complition_notify;
++					mlxplat_i2c_mux_complition_notify;
+ 			priv->pdev_mux[i] =
+ 			platform_device_register_resndata(&priv->pdev_i2c->dev,
+ 							  "i2c-mux-regmap", i, NULL, 0,
+@@ -9113,14 +9198,45 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+ 		}
+ 	}
+ 
+-	if (mlxplat_mux_regmap_data && mlxplat_mux_regmap_data->completion_notify)
+-		return 0;
+-
+-	return mlxplat_platdevs_init(priv);
++	/*
++	 * Block until every mux completion_notify has run, including
++	 * mlxplat_platdevs_init() from the last segment. Probe must not return before
++	 * dependent platform devices exist; 120s bounds stuck CPLD/firmware mux
++	 * bring-up (typical switch mux probe completes in seconds).
++	 */
++	if (!wait_for_completion_timeout(&priv->mux_platdevs_done,
++					 msecs_to_jiffies(120000))) {
++		spin_lock_irqsave(&priv->mux_notify_lock, flags);
++		if (priv->mux_post_init_claimed) {
++			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++			wait_for_completion(&priv->mux_platdevs_done);
++			err = READ_ONCE(priv->mux_platdevs_err);
++			if (err)
++				goto fail_platform_mux_register;
++		} else {
++			if (!READ_ONCE(priv->mux_platdevs_err))
++				WRITE_ONCE(priv->mux_platdevs_err, -ETIMEDOUT);
++			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++			dev_err(&priv->pdev_i2c->dev,
++				"timeout waiting for I2C mux probe\n");
++			err = -ETIMEDOUT;
++			goto fail_platform_mux_register;
++		}
++	}
++	err = READ_ONCE(priv->mux_platdevs_err);
++	if (err)
++		goto fail_platform_mux_register;
++	return 0;
+ 
+ fail_platform_mux_register:
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
++	priv->mux_abandon = true;
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
+ 	while (i--)
+ 		platform_device_unregister(priv->pdev_mux[i]);
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
++	priv->mux_added = 0;
++	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
+ 	return err;
+ }
+ 
+@@ -9221,6 +9337,8 @@ static int mlxplat_probe(struct platform_device *pdev)
+ 	priv->hotplug_resources = hotplug_resources;
+ 	priv->hotplug_resources_size = hotplug_resources_size;
+ 	priv->irq_fpga = irq_fpga;
++	spin_lock_init(&priv->mux_notify_lock);
++	init_completion(&priv->mux_platdevs_done);
+ 
+ 	if (!mlxplat_regmap_config)
+ 		mlxplat_regmap_config = &mlxplat_mlxcpld_regmap_config;
+
+-- 
+2.34.1

--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -3,6 +3,8 @@
 #
 i2c-i801
 i2c-mux-mlxcpld
+i2c-mux-reg
+i2c-mux-regmap
 i2c-dev
 pmbus
 tps53679


### PR DESCRIPTION
Add optional handle and completion_notify to i2c_mux_reg_platform_data, mirroring i2c-mux-regmap, so platform code can run only after every mux channel adapter has been registered.

Bug: #4151613