### PR TITLE
hw-mgmt: bmc: fix SONiC first-boot console stall in hw-management-bmc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ sudo apt-get install devscripts build-essential lintian
 or 'export LM_DEPENDS=0 && dpkg-buildpackage -us -uc -b'
 - Find in upper folder the builded `.deb` package (for example `hw-management_1.mlnx.18.12.2018_amd64.deb`).
 
+**SONiC BMC (`hw-management-bmc`):** the same source tree also builds **`hw-management-bmc_<version>_<arch>.deb`** (payload under **`bmc/`**, profiles in **`debian/rules`**). Packaging uses custom **`debian/hw-management-bmc.postinst`** and **`debian/hw-management-bmc.prerm`** so first-boot **`apt`** from **`rc.local`** does not block on synchronous **`bmc_init_main`** (issue **#4992267**). Details: **`bmc/README.md`** and **`bmc/FILE_MAPPING.md`** § *Debian package scripts*.
+
 **For converting .deb package to .rpm package:**
 - On a Debian-based system, install the `alien` program: `sudo apt-get install alien`
 - `alien --to-rpm hw-management_1.mlnx.18.12.2018_amd64.deb`

--- a/bmc/FILE_MAPPING.md
+++ b/bmc/FILE_MAPPING.md
@@ -10,6 +10,16 @@ Use this as a checklist when copying or updating files from the OpenBMC meta-nvi
 
 ---
 
+## 0. Debian package scripts (repo root `debian/`, not under `bmc/usr/`)
+
+| File | Role |
+|------|------|
+| **`debian/hw-management-bmc.postinst`** | Custom **`configure`**: **`daemon-reload`**; fresh-install **`systemctl start --no-block`** (non-blocking first-boot under **`rc.local`**). See **`bmc/README.md`** § *Debian maintainer scripts*. Issue **#4992267**. |
+| **`debian/hw-management-bmc.prerm`** | Custom **`remove`**: parallel **`systemctl stop`** for nine BMC units. Upgrade path no-op. |
+| **`debian/rules`** (BMC **`override_dh_systemd_*`**) | Single positional **`dh_systemd_enable`** / **`dh_systemd_start --no-start --no-restart-after-upgrade`** allow-list (nine services). |
+
+---
+
 ## 1. systemd units → `bmc/usr/lib/systemd/system/`
 
 | Source file | Destination |

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -40,6 +40,19 @@ Built **`*.deb`** files appear in the **parent** of the build directory (e.g. **
 
 **What `debian/rules` installs into `hw-management-bmc` today** (under **`override_dh_auto_install`**, when **`with_bmc=1`**): **`bmc/usr/lib/systemd/system/*.service`** → **`/lib/systemd/system/`**; **`bmc/usr/lib/udev/rules.d/*`** → **`/lib/udev/rules.d/`**; **`bmc/usr/usr/bin/*`** → **`/usr/bin/`**; **`bmc/usr/etc/HI189/*`** → **`/etc/HI189/`** (source tree keeps **`bmc/usr/etc/<HID>/`**; on the image that becomes **`/etc/<HID>/`**). Extend **`debian/rules`** when new trees under **`bmc/usr/`** must be shipped (e.g. additional **`etc/<HID>/`** or **`usr/etc/systemd/network/`**).
 
+### Debian maintainer scripts (`debian/hw-management-bmc.postinst`, `debian/hw-management-bmc.prerm`)
+
+SONiC BMC first-boot installs **`hw-management-bmc`** from **`rc.local`** while **`serial-getty@ttyS12`** waits for **`rc-local.service`**. Issue **#4992267** replaces debhelper’s blocking **`postinst` start** and the **`9×9` `dh_systemd_enable`** trap with custom maintainer scripts (see **`debian/rules`** BMC block: one positional **`dh_systemd_enable`** / **`dh_systemd_start --no-start --no-restart-after-upgrade`** per package).
+
+| Script | Role |
+|--------|------|
+| **`debian/hw-management-bmc.postinst`** | After **`#DEBHELPER#`**: **`systemctl daemon-reload`** on configure (fresh + upgrade); on **fresh install** only, **`systemctl start --no-block`** for **`boot-complete`**, **`health-monitor`**, **`i2c-slave-setup`**, **`recovery-handler`**, **`reset-cause-logger`**. **Upgrade** does not start/restart (operator **`systemctl restart hw-management-bmc-init.service`** or reboot). **`DPKG_ROOT`** guard skips systemd when configuring a staging rootfs. **`abort-*`** cases are explicit no-ops. |
+| **`debian/hw-management-bmc.prerm`** | On **`remove`**: one **`systemctl stop`** for all nine BMC units (parallel). On **upgrade** / **deconfigure** / **failed-upgrade**: no-op. Needed because **`--no-start --no-restart-after-upgrade`** suppresses debhelper’s **`prerm`** stop snippets. |
+
+**Operator note:** **`apt install hw-management-bmc=NEW`** on a running BMC installs files and re-enables units but does **not** auto-restart the init chain.
+
+**Verify built `.deb`:** `dpkg-deb --ctrl-tarfile hw-management-bmc_*.deb | tar -xO ./postinst` → **9** `deb-systemd-helper unmask`, **0** `deb-systemd-invoke start` lines.
+
 ## Deployment of BMC kernel patches
 
 Vendor kernel patches for the BMC live under **`recipes-kernel/linux/linux-<kver>/`** in the **hw-mgmt** repository (same tree as **`debian/`**). Integration uses **`recipes-kernel/linux/deploy_kernel_patches.py`**, which copies patches into the customer’s kernel tree and can append to a **`series`** file.

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-boot-complete.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-boot-complete.service
@@ -2,8 +2,14 @@
 [Unit]
 Description=BMC Ready Configuration
 After=hw-management-bmc-early-i2c-init.service hw-management-bmc-init.service
-Requires=hw-management-bmc-early-i2c-init.service
-Wants=hw-management-bmc-init.service
+# Why init is Requires=, not Wants=: with the previous Wants=init, if init
+# failed (e.g. BMC standby never went ready, A2D probe failed) systemd would
+# not propagate the failure to boot-complete -- boot-complete would activate
+# anyway and spin on its 1800-s timeout polling /var/run/hw-management/
+# {system,thermal,eeprom} counters that init never populated.  With Requires=,
+# init failure deactivates boot-complete immediately so `systemctl --failed`
+# surfaces it.  See issue #4992267.
+Requires=hw-management-bmc-early-i2c-init.service hw-management-bmc-init.service
 
 [Service]
 Restart=no

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-early-config.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-early-config.service
@@ -3,8 +3,13 @@
 Description=Hardware management early config (copy platform files from /etc/<HID> to /etc and /usr/bin)
 Documentation=file:///usr/share/doc/hw-management-bmc/README.md
 DefaultDependencies=no
-After=local-fs.target hw-management-bmc-plat-specific-preps.service
+# Requires= (in addition to After=) makes the chain self-contained for ad-hoc
+# starts.  With only After=, an ad-hoc `systemctl start
+# hw-management-bmc-boot-complete.service` would not pull plat-specific-preps
+# into the transaction, and downstream units (early-i2c-init) would then run
+# before this unit deploys their JSON config.  See issue #4992267.
 Requires=hw-management-bmc-plat-specific-preps.service
+After=local-fs.target hw-management-bmc-plat-specific-preps.service
 Before=systemd-modules-load.service
 Before=hw-management-bmc-early-i2c-init.service
 

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-early-i2c-init.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-early-i2c-init.service
@@ -2,8 +2,11 @@
 [Unit]
 Description=BMC Early I2C Device Initialization
 DefaultDependencies=no
-After=hw-management-bmc-early-config.service
+# Requires= (in addition to After=) pulls early-config into the same
+# transaction on ad-hoc starts so the JSON config it deploys is on disk
+# before this unit reads it.  See issue #4992267.
 Requires=hw-management-bmc-early-config.service
+After=hw-management-bmc-early-config.service
 Before=nvidia_update_mac.service
 
 [Service]

--- a/debian/hw-management-bmc.postinst
+++ b/debian/hw-management-bmc.postinst
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Custom postinst for hw-management-bmc.  See issue #4992267.
+#
+# The default debhelper-generated start path (dh_systemd_start without
+# --no-start) is BLOCKING via deb-systemd-invoke.  Running it inside
+# SONiC's rc.local-driven first-boot apt-get install blocks the box for
+# the full duration of bmc_init_main (~40 s) and prevents
+# serial-getty@ttyS12 from coming up (it is ordered after rc-local.service).
+#
+# debian/rules passes --no-start --no-restart-after-upgrade to
+# dh_systemd_start for every BMC service, so:
+#  - the synchronous "deb-systemd-invoke start" block is suppressed,
+#  - the synchronous "deb-systemd-invoke restart" upgrade block is suppressed.
+#
+# Note: with that flag combination dh_systemd_start emits NO postinst snippet
+# at all (verified against debhelper 13: dh_systemd_start lines 247-260 skip
+# both the restart and the start template), so this custom postinst is the
+# ONLY thing that calls daemon-reload after the new unit files land on disk.
+# A daemon-reload is therefore required on both fresh-install AND upgrade,
+# otherwise systemd would keep stale unit definitions in memory until the
+# next reboot.
+#
+# Fresh install also needs to actually start the chain.  We trigger
+# hw-management-bmc-boot-complete.service with `systemctl start --no-block`
+# so dpkg returns immediately; the Requires= chain in the .service files
+# pulls plat-specific-preps -> early-config -> early-i2c-init -> init ->
+# boot-complete into one transaction in declared After= order.
+
+set -e
+
+#DEBHELPER#
+
+case "$1" in
+    configure)
+        # DPKG_ROOT is set when dpkg is configuring this package inside a
+        # rootfs staging area (chroot, image build).  In that case we must
+        # NOT touch the host's running systemd.  Debhelper-generated
+        # autoscripts apply the same guard.
+        if [ -z "${DPKG_ROOT:-}" ] && [ -d /run/systemd/system ]; then
+            # Always reload so systemd picks up new/changed unit files on
+            # BOTH fresh-install and upgrade.  With our debian/rules flag
+            # combination, no dh_systemd_start snippet runs the reload for
+            # us — see header note.
+            if ! systemctl --system daemon-reload; then
+                echo "WARNING: hw-management-bmc.postinst: systemctl daemon-reload failed; systemd may keep stale unit definitions until reboot — run 'systemctl daemon-reload' before restarting HW-MGMT services" >&2
+            fi
+
+            if [ -z "$2" ]; then
+                # Fresh-install path.  Why these five services:
+                #
+                #   boot-complete       readiness gate; via the Requires=
+                #                       chain on the unit it pulls
+                #                       plat-specific-preps, early-config,
+                #                       early-i2c-init, init into the same
+                #                       transaction, in declared After= order.
+                #                       Single start = whole chain.
+                #
+                #   health-monitor      long-running BMC health daemon
+                #                       (detects unexpected reboots).
+                #                       Independent of the init chain; want
+                #                       it running ASAP after install so
+                #                       the first boot's reboot cause is
+                #                       captured if anything goes wrong.
+                #
+                #   i2c-slave-setup     guarded by ConditionPathExists=/etc/
+                #     recovery-handler  hw-management-bmc-recovery.conf.  On
+                #                       platforms where that conf is not
+                #                       shipped (default HI189), systemd
+                #                       skips them silently (is-active stays
+                #                       inactive, no failure).  Listing them
+                #                       here is a no-op on those platforms
+                #                       and the right thing on platforms
+                #                       that ship recovery.
+                #
+                #   reset-cause-logger  normally Before=sysinit.target so it
+                #                       runs early.  By this point sysinit
+                #                       is past, but starting it now still
+                #                       logs this install boot's watchdog
+                #                       bootstatus to /var/log/
+                #                       bmc-reset-cause.log, which is the
+                #                       only persistent record of reset
+                #                       cause across reboots.
+                #
+                # --no-block: systemctl queues the start jobs and returns
+                # in milliseconds.  dpkg moves on immediately; bmc_init_main
+                # then runs in the background under systemd's control.  We
+                # warn on failure (instead of silent `|| true`) so a broken
+                # queueing path is visible in the install log rather than
+                # producing a successful-looking package configure that
+                # leaves HW-MGMT unstarted.  Suppress systemctl chatter on
+                # success (>/dev/null 2>&1); real failures hit the WARNING below.
+                if ! systemctl start --no-block \
+                        hw-management-bmc-boot-complete.service \
+                        hw-management-bmc-health-monitor.service \
+                        hw-management-bmc-i2c-slave-setup.service \
+                        hw-management-bmc-recovery-handler.service \
+                        hw-management-bmc-reset-cause-logger.service \
+                        >/dev/null 2>&1; then
+                    echo "WARNING: hw-management-bmc.postinst: failed to queue HW-MGMT BMC startup; package configure will continue, but HW-MGMT will only come up on the next reboot" >&2
+                fi
+            fi
+            # Upgrade path ($2 is the old version): deliberately no start /
+            # no restart.  apt upgrade runs on a fully booted system; the
+            # operator can `systemctl restart hw-management-bmc-init.service`
+            # or reboot.  Auto-restarting hw-management-bmc-init.service
+            # from postinst would re-run bmc_init_main (~40 s, writes
+            # fw_setenv, touches BMC sysfs) — not safe to do silently as an
+            # apt side effect.  See debian/rules'
+            # --no-restart-after-upgrade comment.
+        fi
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure|abort-install)
+        # abort-install: dpkg aborting a failed first-time configure; no-op.
+        ;;
+esac
+
+exit 0

--- a/debian/hw-management-bmc.prerm
+++ b/debian/hw-management-bmc.prerm
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Custom prerm for hw-management-bmc.  See issue #4992267.
+#
+# debian/rules passes --no-start --no-restart-after-upgrade to every BMC
+# `dh_systemd_start` call.  With BOTH flags set, dh_systemd_start emits NO
+# prerm snippet at all (verified against debhelper 13: dh_systemd_start
+# lines 264-270 skip both prerm-systemd-restart and prerm-systemd templates).
+# Result: without this script, `apt remove hw-management-bmc` would leave
+# the long-running BMC services (health-monitor, recovery-handler) running
+# even though their /usr/bin/* executables were just deleted.
+#
+# Stop semantics we want:
+#   remove        — stop all BMC services, so processes are not running
+#                   against deleted package files.
+#   upgrade       — do NOT stop; debian/rules' --no-restart-after-upgrade
+#                   explicitly opts out of apt side-effects on running
+#                   HW-MGMT.  The operator restarts manually or reboots.
+#   deconfigure / — do NOT stop.
+#     failed-upgrade
+
+set -e
+
+case "$1" in
+    remove)
+        # DPKG_ROOT is set when dpkg is removing this package inside a
+        # rootfs staging area.  Skip in that case for the same reason the
+        # debhelper autoscripts do.
+        if [ -z "${DPKG_ROOT:-}" ] && [ -d /run/systemd/system ]; then
+            # One systemctl stop stops all units in parallel.  deb-systemd-invoke
+            # stop runs systemctl stop once per argument sequentially; with
+            # health-monitor's default 90 s TimeoutStopSec that can hold apt
+            # remove for minutes.
+            if ! systemctl stop \
+                    hw-management-bmc-boot-complete.service \
+                    hw-management-bmc-init.service \
+                    hw-management-bmc-early-i2c-init.service \
+                    hw-management-bmc-early-config.service \
+                    hw-management-bmc-plat-specific-preps.service \
+                    hw-management-bmc-health-monitor.service \
+                    hw-management-bmc-i2c-slave-setup.service \
+                    hw-management-bmc-recovery-handler.service \
+                    hw-management-bmc-reset-cause-logger.service \
+                    >/dev/null 2>&1; then
+                echo "WARNING: hw-management-bmc.prerm: failed to stop some BMC services; check systemctl status before removing package files" >&2
+            fi
+        fi
+        ;;
+    upgrade|deconfigure|failed-upgrade)
+        ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -130,15 +130,37 @@ ifeq ($(with_host),1)
 	dh_systemd_enable --no-enable --name=hw-management-sync
 endif
 ifeq ($(with_bmc),1)
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-plat-specific-preps
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-early-config
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-health-monitor
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-reset-cause-logger
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-boot-complete
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-init
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-early-i2c-init
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-i2c-slave-setup
-	dh_systemd_enable -phw-management-bmc --name=hw-management-bmc-recovery-handler
+	# IMPORTANT: do NOT use one `dh_systemd_enable --name=X` call per service
+	# here.  `dh_systemd_enable` does NOT use --name to filter which units to
+	# emit autoscript snippets for -- with no positional arg, every call walks
+	# the package's $tmpdir/lib/systemd/system/ and emits a postinst-systemd-
+	# enable snippet for EVERY unit it finds (debhelper 13 source:
+	# dh_systemd_enable line 211: `@args = @ARGV > 0 ? @ARGV : @installed_units`).
+	# With 9 BMC services, 9 explicit --name calls produced 9 x 9 = 81 enable
+	# snippets in the generated postinst.  Each `deb-systemd-helper enable`
+	# call takes ~0.8 s on this BMC, so the postinst blocked dpkg for ~65 s --
+	# verified by /var/log/dpkg.log showing `configure hw-management-bmc`
+	# spanning ~67 s (18:38:49 -> 18:39:56) for issue #4992267's reproduction.
+	#
+	# Instead, pass each service file as a POSITIONAL argument to a single
+	# `dh_systemd_enable -phw-management-bmc <files>` invocation.  With
+	# positional arguments dh_systemd_enable processes ONLY those units
+	# (line 211: `@args = @ARGV > 0 ? @ARGV : @installed_units`).  This:
+	#   - emits exactly 9 enable snippets (one per service), ~7 s of
+	#     postinst work instead of ~65 s,
+	#   - keeps the allow-list explicit, so a future BMC service file
+	#     added under bmc/usr/lib/systemd/system/ is NOT silently auto-
+	#     enabled -- adding it to this list is an intentional decision.
+	dh_systemd_enable -phw-management-bmc \
+		hw-management-bmc-plat-specific-preps.service \
+		hw-management-bmc-early-config.service \
+		hw-management-bmc-early-i2c-init.service \
+		hw-management-bmc-init.service \
+		hw-management-bmc-boot-complete.service \
+		hw-management-bmc-health-monitor.service \
+		hw-management-bmc-reset-cause-logger.service \
+		hw-management-bmc-i2c-slave-setup.service \
+		hw-management-bmc-recovery-handler.service
 endif
 
 override_dh_systemd_start:
@@ -152,15 +174,43 @@ ifeq ($(with_host),1)
 	dh_systemd_start --name=hw-management-blacklist-generator
 endif
 ifeq ($(with_bmc),1)
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-plat-specific-preps
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-early-config
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-health-monitor
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-reset-cause-logger
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-boot-complete
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-init
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-early-i2c-init
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-i2c-slave-setup
-	dh_systemd_start -phw-management-bmc --name=hw-management-bmc-recovery-handler
+	# BMC services are boot-order units (DefaultDependencies=no,
+	# WantedBy=sysinit.target / multi-user.target). They are designed to be
+	# activated by the boot itself in declared After=/Before= order. Starting
+	# them from a postinst that runs after both sysinit and multi-user are
+	# already active is what causes the install-time race and the ~40 s dpkg
+	# block on SONiC BMC first boot (see issue #4992267).  A custom postinst
+	# (debian/hw-management-bmc.postinst) triggers the chain non-blocking
+	# after #DEBHELPER# has run dh_systemd_enable's enable snippets.  A
+	# custom prerm (debian/hw-management-bmc.prerm) stops BMC services on
+	# `apt remove` — needed because with the flag combination below
+	# dh_systemd_start emits no prerm snippet either.
+	#
+	# Why both flags:
+	#   --no-start                 : suppress deb-systemd-invoke start on fresh install ($$1=configure, $$2 empty)
+	#   --no-restart-after-upgrade : suppress deb-systemd-invoke restart on upgrade  ($$1=configure, $$2 set)
+	# Without --no-restart-after-upgrade, `apt-get install hw-management-bmc=NEW`
+	# on a running system would restart hw-management-bmc-init.service from
+	# inside dpkg, blocking it for the full bmc_init_main (~40 s) — i.e.
+	# reproducing the original P1 bug in the upgrade scenario.
+	# Same allow-list / positional-args approach as override_dh_systemd_enable
+	# above (see the comment there for the debhelper line-211 details).
+	# Today with `--no-start --no-restart-after-upgrade` dh_systemd_start
+	# emits NO postinst / prerm snippet at all (debhelper 13 source:
+	# dh_systemd_start lines 247-260 + 264-270), so the multiplication
+	# problem does not manifest here right now -- but listing each service
+	# explicitly keeps this block in sync with the enable block above and
+	# protects a future maintainer who removes one of the flags.
+	dh_systemd_start --no-start --no-restart-after-upgrade -phw-management-bmc \
+		hw-management-bmc-plat-specific-preps.service \
+		hw-management-bmc-early-config.service \
+		hw-management-bmc-early-i2c-init.service \
+		hw-management-bmc-init.service \
+		hw-management-bmc-boot-complete.service \
+		hw-management-bmc-health-monitor.service \
+		hw-management-bmc-reset-cause-logger.service \
+		hw-management-bmc-i2c-slave-setup.service \
+		hw-management-bmc-recovery-handler.service
 endif
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
… postinst

On AST2700 SONiC BMC, serial-getty@ttyS12 is ordered After=rc-local.service. First-boot apt from rc.local therefore blocks the login prompt until hw-management-bmc postinst finishes. Two packaging defects compounded the delay:

- dh_systemd_start emitted synchronous deb-systemd-invoke start (~40 s bmc_init_main inside dpkg).
- Nine dh_systemd_enable --name=X calls each walked all nine BMC unit files and produced 81 enable snippets (~65 s on device).

Fix debian/rules: one dh_systemd_enable and one dh_systemd_start per BMC package with positional service allow-list; pass --no-start and --no-restart-after-upgrade to suppress blocking start/restart from debhelper.

Add debian/hw-management-bmc.postinst: daemon-reload on configure; on fresh install queue boot-complete, health-monitor, i2c-slave-setup, recovery-handler, and reset-cause-logger with systemctl start --no-block so dpkg returns immediately while the Requires= chain runs in the background.

Add debian/hw-management-bmc.prerm: stop BMC services on apt remove (debhelper emits no prerm stop when --no-start --no-restart-after-upgrade is set).

boot-complete.service: Requires= init (not Wants=) so init failure propagates. early-config and early-i2c-init

Upgrade path: postinst does not auto-restart the BMC chain; operator restarts hw-management-bmc-init.service or reboots after apt upgrade.


(cherry picked from commit 7511a9291a957a94c3439aa6131846895d24287a)