### PR TITLE
hw-mgmt: thermal: Preserve FAN relax period on small PWM jumps

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2605,7 +2605,7 @@ class fan_sensor(system_device):
                 relax_time = self.rpm_relax_timeout * 2
         else:
             relax_time = 0
-        self.rpm_relax_timestamp = current_milli_time() + relax_time
+        self.rpm_relax_timestamp = max(current_milli_time() + relax_time, self.rpm_relax_timestamp)
         self.log.debug("{} pwm jump by:{} relax_time:{} timestamp {}".format(self.name, pwm_jump, relax_time, self.rpm_relax_timestamp))
 
         self.pwm_set = pwm_val

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2953,7 +2953,7 @@ class fan_sensor(system_device):
                 relax_time = self.rpm_relax_timeout * 2
         else:
             relax_time = 0
-        self.rpm_relax_timestamp = current_milli_time() + relax_time
+        self.rpm_relax_timestamp = max(current_milli_time() + relax_time, self.rpm_relax_timestamp)
         self.log.debug("{} pwm jump by:{} relax_time:{} timestamp {}".format(self.name, pwm_jump, relax_time, self.rpm_relax_timestamp))
 
         self.pwm_set = pwm_val


### PR DESCRIPTION
Small PWM changes (below FAN_RELAX_PWM_JUMP_MIN) set relax_time to 0
and overwrote rpm_relax_timestamp with current_milli_time(), cancelling
an active relax window from a prior large jump. The trend check then ran
too early against unstabilized RPM and could raise a spurious TACHO
fault.
Use max(current_milli_time() + relax_time, rpm_relax_timestamp) so small
steps do not shorten stabilization started by a larger PWM change.

Bug: 5001186

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
