### PR TITLE
hw-mgmt: thermal: TC fix attention_fans config for Q3200/Q3400

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_q3200.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3200.json
@@ -21,6 +21,8 @@
 			"1" : {"rpm_min":5650, "rpm_max":20500, "slope": 200.4, "pwm_min" : 30, "pwm_max_reduction" : 10}
 			}
 	},
+	"general_config" : {"attention_fans" : ["drwr1", "drwr2", "drwr3", "drwr4", "drwr5"],
+						"fan_steady_state_delay" : 15, "fan_steady_state_pwm" : 40},
 	"dev_parameters" : {
 		"asic\\d*":       {"pwm_min": 30, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":100}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3, "sensor_read_error":100},

--- a/usr/etc/hw-management-thermal/tc_config_q3400.json
+++ b/usr/etc/hw-management-thermal/tc_config_q3400.json
@@ -22,7 +22,7 @@
 			}
 	}, 
 	"general_config" : {"attention_fans" : ["drwr1", "drwr2", "drwr3", "drwr4", "drwr5", "drwr6", "drwr7", "drwr8", "drwr9", "drwr10"],
-											 "fan_steady_state_delay" : 10, "fan_steady_state_pwm" : 50},
+											 "fan_steady_state_delay" : 15, "fan_steady_state_pwm" : 40},
 	"dev_parameters" : {
 		"asic\\d*":       {"pwm_min": 30, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":100}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3, "sensor_read_error":100},


### PR DESCRIPTION
Fix attention_fans config for Q3200/Q3400.

fan_steady_state_delay =15 sec
fan_steady_state_pwm = 40%

FR:  4902558
Bug: 5032054, 5942294

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
