### PR TITLE
hw-mgmt: kernel: Increase mlxsw I2C timeout 5000->10000ms for bug #49…

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -319,6 +319,7 @@ Kernel-5.10
 |0310-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp29502-.patch  |                    | Feature pending; os[sonic,opt,nvos,dvs]  |            | mp29502                                        |
 |0311-nvme-pci-try-function-level-reset-on-init-failure.patch     | 5b2c214a9594       | Bugfix upstream                          |            | NVME SSD fallback recovery                     |
 |0312-nvme-pci-try-flr-on-controller-disable-failure.patch        |                    | Downstream accepted                      |            | NVME SSD FLR additional flow                   |
+|0313-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch  |                    | Downstream accepted                      |            | Increase I2C timeout 5000->10000 (#4954530)    |
 |7001-mctp-Add-MCTP-base.patch                                    |                    | Downstream                               |            | MCTP                                           |
 |7002-mctp-Add-base-socket-protocol-definitions.patch             |                    | Downstream                               |            | MCTP                                           |
 |7003-mctp-Add-base-packet-definitions.patch                      |                    | Downstream                               |            | MCTP                                           |
@@ -745,6 +746,7 @@ Kernel-6.1
 |8011-mlxsw-minimal-Downstream-Disable-ethtool-interface.patch    |                    | Downstream accepted                      |            |                                                |
 |8012-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch  |                    | Downstream accepted                      |            |                                                |
 |8013-hwmon-pmbus-mp2975-Clear-interrupts-at-probe.patch          |                    | Downstream accepted                      |            |                                                |
+|8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch  |                    | Downstream accepted                      |            | Increase I2C timeout 5000->10000 (#4954530)    |
 |9000-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9001-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9002-regmap-debugfs-FT-Enable-writing-to-the-regmap-debug.patch  |                    | Downstream;skip[ALL];take[opt]           |            | BF3 (FT purpose)                               |
@@ -845,6 +847,7 @@ Kernel-6.12
 |8011-hwmon-pmbus-Downstream-Workaround-for-psu-attributes.patch  |                    | Downstream accepted                      |            |                                                |
 |8012-mlxsw-core-Downstream-Fix-uninitialized-variable.patch      |                    | Downstream accepted;skip[sonic]          |            |                                                |
 |8013-hwmon-pmbus-mp2975-Clear-interrupts-at-probe.patch          |                    | Downstream accepted                      |            |                                                |
+|8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch  |                    | Downstream accepted                      |            | Increase I2C timeout 5000->10000 (#4954530)    |
 |9001-platform-mellanox-Downstream-Add-dedicated-match-for.patch  |                    | Rejected                                 |            | Add dedicated match for QMB8700                |
 |9002-e1000e-OPT-skip-NVM-checksum.patch                          |                    | Downstream;skip[ALL];take[opt]           |            |                                                |
 |9003-iio-pressure-icp20100-OPT-add-driver-for-InvenSense-.patch  |                    | Downstream;skip[ALL];take[opt]           |            |                                                |

--- a/recipes-kernel/linux/linux-5.10/0313-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
+++ b/recipes-kernel/linux/linux-5.10/0313-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
@@ -4,13 +4,15 @@ Date: Mon, 25 May 2026 16:52:00 +0300
 Subject: [PATCH v5.10 1/1] mlxsw: i2c: Downstream: Increase I2C timeout for
  HW semaphore stability
 
-Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 milliseconds to
-reduce "HW semaphore is not released" errors observed under heavy system
-load or when the ASIC is handling large PCIe transaction volumes.
+When taking an IR core dump on SPC1 debug kernel, the firmware halts
+its IRISCs to capture a clean snapshot. This pause takes ~5 seconds
+and occasionally exceeds the driver's hardcoded 5-second I2C timeout,
+causing spurious "HW semaphore is not released" errors. The system
+recovers normally after the dump completes — this is not a real
+hardware failure.
 
-The current 5-second timeout has been shown to be insufficient in stress
-tests (bug #4954530), causing spurious I2C transaction failures not
-consistently covered by the existing retry mechanism.
+Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 to give the
+driver enough headroom to wait out the firmware pause.
 
 Signed-off-by: Nadav Hugi <nadavh@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-5.10/0313-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
+++ b/recipes-kernel/linux/linux-5.10/0313-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nadav Hugi <nadavh@nvidia.com>
+Date: Mon, 25 May 2026 16:52:00 +0300
+Subject: [PATCH v5.10 1/1] mlxsw: i2c: Downstream: Increase I2C timeout for
+ HW semaphore stability
+
+Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 milliseconds to
+reduce "HW semaphore is not released" errors observed under heavy system
+load or when the ASIC is handling large PCIe transaction volumes.
+
+The current 5-second timeout has been shown to be insufficient in stress
+tests (bug #4954530), causing spurious I2C transaction failures not
+consistently covered by the existing retry mechanism.
+
+Signed-off-by: Nadav Hugi <nadavh@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index XXXXXXX..YYYYYYY 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -50,7 +50,7 @@
+ #define MLXSW_I2C_BLK_DEF		32
+ #define MLXSW_I2C_BLK_MAX		100
+ #define MLXSW_I2C_RETRY			25
+-#define MLXSW_I2C_TIMEOUT_MSECS		5000
++#define MLXSW_I2C_TIMEOUT_MSECS		10000
+ #define MLXSW_I2C_CMD_RETRY_FW_ERR	3
+ #define MLXSW_I2C_MAX_DATA_SIZE		256
+ 
+-- 
+2.20.1

--- a/recipes-kernel/linux/linux-6.1/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
+++ b/recipes-kernel/linux/linux-6.1/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
@@ -4,13 +4,15 @@ Date: Mon, 25 May 2026 16:52:00 +0300
 Subject: [PATCH v6.1 1/1] mlxsw: i2c: Downstream: Increase I2C timeout for
  HW semaphore stability
 
-Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 milliseconds to
-reduce "HW semaphore is not released" errors observed under heavy system
-load or when the ASIC is handling large PCIe transaction volumes.
+When taking an IR core dump on SPC1 debug kernel, the firmware halts
+its IRISCs to capture a clean snapshot. This pause takes ~5 seconds
+and occasionally exceeds the driver's hardcoded 5-second I2C timeout,
+causing spurious "HW semaphore is not released" errors. The system
+recovers normally after the dump completes — this is not a real
+hardware failure.
 
-The current 5-second timeout has been shown to be insufficient in stress
-tests (bug #4954530), causing spurious I2C transaction failures not
-consistently covered by the existing retry mechanism.
+Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 to give the
+driver enough headroom to wait out the firmware pause.
 
 Signed-off-by: Nadav Hugi <nadavh@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.1/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
+++ b/recipes-kernel/linux/linux-6.1/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nadav Hugi <nadavh@nvidia.com>
+Date: Mon, 25 May 2026 16:52:00 +0300
+Subject: [PATCH v6.1 1/1] mlxsw: i2c: Downstream: Increase I2C timeout for
+ HW semaphore stability
+
+Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 milliseconds to
+reduce "HW semaphore is not released" errors observed under heavy system
+load or when the ASIC is handling large PCIe transaction volumes.
+
+The current 5-second timeout has been shown to be insufficient in stress
+tests (bug #4954530), causing spurious I2C transaction failures not
+consistently covered by the existing retry mechanism.
+
+Signed-off-by: Nadav Hugi <nadavh@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index XXXXXXX..YYYYYYY 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -50,7 +50,7 @@
+ #define MLXSW_I2C_BLK_DEF		32
+ #define MLXSW_I2C_BLK_MAX		100
+ #define MLXSW_I2C_RETRY			5
+-#define MLXSW_I2C_TIMEOUT_MSECS		5000
++#define MLXSW_I2C_TIMEOUT_MSECS		10000
+ #define MLXSW_I2C_CMD_RETRY_FW_ERR	3
+ #define MLXSW_I2C_MAX_DATA_SIZE		256
+ 
+-- 
+2.20.1

--- a/recipes-kernel/linux/linux-6.12/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
+++ b/recipes-kernel/linux/linux-6.12/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
@@ -4,13 +4,15 @@ Date: Mon, 25 May 2026 16:52:00 +0300
 Subject: [PATCH v6.12 1/1] mlxsw: i2c: Downstream: Increase I2C timeout for
  HW semaphore stability
 
-Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 milliseconds to
-reduce "HW semaphore is not released" errors observed under heavy system
-load or when the ASIC is handling large PCIe transaction volumes.
+When taking an IR core dump on SPC1 debug kernel, the firmware halts
+its IRISCs to capture a clean snapshot. This pause takes ~5 seconds
+and occasionally exceeds the driver's hardcoded 5-second I2C timeout,
+causing spurious "HW semaphore is not released" errors. The system
+recovers normally after the dump completes — this is not a real
+hardware failure.
 
-The current 5-second timeout has been shown to be insufficient in stress
-tests (bug #4954530), causing spurious I2C transaction failures not
-consistently covered by the existing retry mechanism.
+Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 to give the
+driver enough headroom to wait out the firmware pause.
 
 Signed-off-by: Nadav Hugi <nadavh@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
+++ b/recipes-kernel/linux/linux-6.12/8014-mlxsw-i2c-Downstream-Increase-I2C-timeout-for-HW-sem.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nadav Hugi <nadavh@nvidia.com>
+Date: Mon, 25 May 2026 16:52:00 +0300
+Subject: [PATCH v6.12 1/1] mlxsw: i2c: Downstream: Increase I2C timeout for
+ HW semaphore stability
+
+Increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 milliseconds to
+reduce "HW semaphore is not released" errors observed under heavy system
+load or when the ASIC is handling large PCIe transaction volumes.
+
+The current 5-second timeout has been shown to be insufficient in stress
+tests (bug #4954530), causing spurious I2C transaction failures not
+consistently covered by the existing retry mechanism.
+
+Signed-off-by: Nadav Hugi <nadavh@nvidia.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/i2c.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/i2c.c b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+index XXXXXXX..YYYYYYY 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/i2c.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/i2c.c
+@@ -50,7 +50,7 @@
+ #define MLXSW_I2C_BLK_DEF		32
+ #define MLXSW_I2C_BLK_MAX		100
+ #define MLXSW_I2C_RETRY			5
+-#define MLXSW_I2C_TIMEOUT_MSECS		5000
++#define MLXSW_I2C_TIMEOUT_MSECS		10000
+ #define MLXSW_I2C_CMD_RETRY_FW_ERR	3
+ #define MLXSW_I2C_MAX_DATA_SIZE		256
+ 
+-- 
+2.20.1


### PR DESCRIPTION
On SPC1 debug kernel, taking an IR core dump causes the firmware to halt 
its IRISCs for ~5 seconds. This occasionally exceeds the driver's hardcoded 
5-second I2C timeout, producing spurious "HW semaphore is not released" errors.
The system recovers normally — this is not a real hardware failure.

Fix: increase MLXSW_I2C_TIMEOUT_MSECS from 5000 to 10000 in
drivers/net/ethernet/mellanox/mlxsw/i2c.c

Patched for linux-5.10, linux-6.1, linux-6.12.

Bug: #4954530
