### PR TITLE
hw-mgmt: scripts: Centralize PSU I2C bus/addr in config for dummy PSUs

### DIFF
--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -400,7 +400,7 @@ Rev. 3.2
 
 | Revision | Date | Description |
 |----------|------|-------------|
-| 3.2 | March 2026 | Added SN6600_LD (SN66XX_LD family, SKU HI193) liquid-cooled platform support<br>• Hardware reference: `Documentation/SN6600_LD_Hardware_Interfaces.md`<br>• Validation: `tests/system_tree/hw-management-tree-SN6600_LD.txt`, `usr/etc/hw-management-sensors/sn66xxld_sensors.conf`<br>**Platform notes:**<br>• Single ASIC (`asic_num`=1), 4 CPLDs, `hotplug_pdbs`=2, `pdb_hotswap1/2` and `pdb_pwr_conv1/2`<br>• ASIC voltmons: 19 sysfs indexes (`voltmon1`-`14`, `voltmon16`-`20` on captured tree)<br>• SODIMM temp: JC42 at 0x52/0x53 on I2C bus 10<br>• Watchdog: `watchdog/main/` and `watchdog/aux/` hierarchy<br>• PDB hot-plug events: `events/pdb1`, `events/pdb2`<br>**Updated Sections:**<br>• Liquid-cooled applicability notes extended to SN66XX_LD across environment, alarms, thermal, and leakage-related text |
+| 3.2 | March 2026 | Added SN6600_LD (SN66XX_LD family, SKU HI193) liquid-cooled platform support<br>• Hardware reference: `Documentation/SN6600_LD_Hardware_Interfaces.md`<br>• Validation: `tests/system_tree/hw-management-tree-SN6600_LD.txt`, `usr/etc/hw-management-sensors/sn66xxld_sensors.conf`<br>**Platform notes:**<br>• Single ASIC (`asic_num`=1), 4 CPLDs, `hotplug_pdbs`=2, `pdb_hotswap1/2` and `pdb_pwr_conv1/2`<br>• ASIC voltmons: 19 sysfs indexes (`voltmon1`-`14`, `voltmon16`-`20` on captured tree)<br>• SODIMM temp: JC42 at 0x52/0x53 on I2C bus 10<br>• Watchdog: `watchdog/main/` and `watchdog/aux/` hierarchy<br>• PDB hot-plug events: `events/pdb1`, `events/pdb2`<br>**Updated Sections:**<br>• Liquid-cooled applicability notes extended to SN66XX_LD across environment, alarms, thermal, and leakage-related text<br>• Config: documented optional `psu<X>_i2c_bus` (hw-management internal; OS must not require it) |
 | 3.1 | January 2026 | Added N6100_LD (N61XX_LD family) liquid-cooled multi-ASIC platform support<br>**New Sections for N6100_LD:**<br>• Multi-ASIC Health (asic_health, asic2_health, asic3_health, asic4_health)<br>• MCU Reset Control (mcu1_reset, mcu2_reset)<br>• Cable Cartridge EEPROM (cable_cartridge1-4_eeprom)<br>• Cartridge Counter (config/cartridge_counter)<br>• Cartridge Status (cartridge1-4)<br>• eRoT Events (erot1_ap, erot1_error)<br>• Config: asic_num=4, erot_count=1<br>**Updated Sections:**<br>• Power Converters: Added pwr_conv naming (vs pdb_pwr_conv for SN58XX_LD)<br>• Updated all liquid-cooled references to include N61XX_LD family<br>• Extended voltmon support for 16 PMICs (voltmon1-16)<br>• SODIMM Temperature Sensors: Updated to include both SN58XX_LD and N61XX_LD |
 | 3.0 | September 2025 | Complete document alignment with Word document source<br>• Updated title and branding to NVIDIA<br>• Complete sysfs hierarchy coverage with 300+ attributes<br>• Professional markdown formatting throughout<br>• Added comprehensive examples for all attributes<br>• Updated all 22 major sections (3.1-3.22)<br>• Added Watchdog, JTAG, and BMC sections<br>• Complete thermal monitoring documentation<br>• Enterprise-grade documentation ready for production |
 | 2.8 | April 1st 2024 | Added temperature, BMC and power related attributes |
@@ -1143,22 +1143,30 @@ cat $bsp_path/config/psu1_i2c_addr
 
 ### Read PSU I2C Bus
 
-**Node name:** `$bsp_path/config/psu<power supply module number>_i2c_bus`
+**Node name:** `$bsp_path/config/psu<X>_i2c_bus`
 
-**Description:** Get the I2C bus of PSU for direct connection
+Where `<X>` is the power supply module index (for example `psu1_i2c_bus`, `psu2_i2c_bus`).
+
+**Description:** Contains the I2C bus number of PSU<X> used for direct connection to that power supply module.
+
+This configuration parameter is **optional** and is **not mandatory** on all platforms. It is created and used by the hw-management package for internal purposes (for example dummy PSU detection and mapping on supported switch systems). The OS and user-space applications **must not** assume that `psu<X>_i2c_bus` is always present; check for the file before reading it.
 
 **Access:** Read only
 
-**Release version:** 1.0
+**Mandatory:** No
+
+**Release version:** 3.2
 
 **Arguments:**
 | Name | Data type | Values |
 |------|-----------|--------|
-| Status | Integer | X |
+| Bus index | Integer | Platform-specific I2C bus number (for example `3`, `4`) |
 
-**Example:** Get PSU1 I2C bus:
+**Example:** Get PSU1 I2C bus when the file exists:
 ```bash
-cat $bsp_path/config/psu1_i2c_bus
+if [ -f $bsp_path/config/psu1_i2c_bus ]; then
+	cat $bsp_path/config/psu1_i2c_bus
+fi
 ```
 
 ### Read Thermal Delay

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -673,36 +673,27 @@ function handle_hotplug_dpu_event()
     fi
 }
 
+# Handle PSU hotplug event.
+# $1 - PSU name (e.g. psu1, psu2, psu3, psu4, psu5, psu6, psu7, psu8)
+# $2 - Event (0 or 1)
 function handle_hotplug_psu_event()
 {
 	local psu_name=$1
 	local event=$2
-	local psu_num
-	local psu_i2c_bus
-	local psu_i2c_addr
+	local psu_bus
+	local psu_addr
 	local psu_is_dummy
 	local dummy_psus_supported=$(< ${config_path}/dummy_psus_supported)
 
+	psu_name=$(echo ${psu_name} | awk '{print tolower($0)}')
 	if [ ${dummy_psus_supported} -eq 1 ]; then
-		case ${dmi_sku} in
-		HI157)
-			psu_i2c_bus=(4 4 4 4)
-			psu_i2c_addr=(59 58 5b 5a)
-			;;
-		HI158)
-			psu_i2c_bus=(4 4 3 3 3 3 4 4)
-			psu_i2c_addr=(59 58 5b 5a 5d 5c 5e 5f)
-			;;
-		*)
-			;;
-		esac
-
-		psu_name=$(echo ${psu_name} | awk '{print tolower($0)}')
-		psu_num=${psu_name#psu}
-
 		if [ $event -eq 1 ]; then
-			psu_bus=${psu_i2c_bus[$((psu_num-1))]}
-			psu_addr=${psu_i2c_addr[$((psu_num-1))]}
+			# Bus/addr from set_config_data() in hw-management.sh
+			psu_addr=$(< "${config_path}/${psu_name}_i2c_addr")
+			psu_bus=$(< "${config_path}/${psu_name}_i2c_bus")
+			if [ -z "$psu_bus" ] || [ -z "$psu_addr" ]; then
+				return
+			fi
 			psu_is_dummy=1
 			for ((i=0; i<5; i++)); do
 				if [ -d "/sys/bus/i2c/devices/${psu_bus}-00${psu_addr}" ]; then

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2336,7 +2336,14 @@ qm3xxx_specific()
 		thermal_control_config="$thermal_control_configs_path/tc_config_q3200.json"
 		named_busses+=(${q3200_named_busses[@]})
 		asic_i2c_buses=(2 18)
-		psu_i2c_map=(4 59 4 58 4 5b 4 5a)
+		psu1_i2c_bus=4
+		psu1_i2c_addr=59
+		psu2_i2c_bus=4
+		psu2_i2c_addr=58
+		psu3_i2c_bus=4
+		psu3_i2c_addr=5b
+		psu4_i2c_bus=4
+		psu4_i2c_addr=5a
 		dummy_psus_supported=1
 	elif [ "$sku" == "HI158" ]; then
 		# Set according to front fan max.
@@ -2359,7 +2366,25 @@ qm3xxx_specific()
 		thermal_control_config="$thermal_control_configs_path/tc_config_q3400.json"
 		named_busses+=(${q3400_named_busses[@]})
 		asic_i2c_buses=(2 18 34 50)
-		psu_i2c_map=(4 59 4 58 3 5b 3 5a 4 5d 4 5c 3 5e 3 5f)
+
+		# Map I2C bus and address to psu number
+		psu1_i2c_bus=4
+		psu1_i2c_addr=59
+		psu2_i2c_bus=4
+		psu2_i2c_addr=58
+		psu3_i2c_bus=3
+		psu3_i2c_addr=5b
+		psu4_i2c_bus=3
+		psu4_i2c_addr=5a
+		psu5_i2c_bus=4
+		psu5_i2c_addr=5d
+		psu6_i2c_bus=4
+		psu6_i2c_addr=5c
+		psu7_i2c_bus=3
+		psu7_i2c_addr=5e
+		psu8_i2c_bus=3
+		psu8_i2c_addr=5f
+
 		dummy_psus_supported=1
 	elif [ "$sku" == "HI175" ] || [ "$sku" == "HI178" ]; then
 		# Set according to front fan max.
@@ -3130,6 +3155,11 @@ set_config_data()
 {
 	local asic_num=0
 	for ((idx=1; idx<=psu_count; idx+=1)); do
+		# if psuX_i2c_bus variable is set - add file psuX_i2c_bus to config_path
+		local psu_i2c_bus=psu"$idx"_i2c_bus
+		if [ ${!psu_i2c_bus} ]; then
+			echo ${!psu_i2c_bus} > $config_path/psu"$idx"_i2c_bus
+		fi
 		psu_i2c_addr=psu"$idx"_i2c_addr
 		echo ${!psu_i2c_addr} > $config_path/psu"$idx"_i2c_addr
 	done
@@ -3765,14 +3795,20 @@ map_dummy_psus()
 		return
 	fi
 
-	for ((i=0; i < "${#psu_i2c_map[@]}"; i+=2)); do
-		psu_bus=${psu_i2c_map[$i]}
-		psu_addr=${psu_i2c_map[$i+1]}
-		psu_num=$(((i/2)+1))
-		psu_present=$(< $thermal_path/psu${psu_num}_status)
+	for ((psu_idx=1; psu_idx <= psu_count; psu_idx+=1)); do
+		# Bus/addr from set_config_data() in hw-management.sh
+		psu_bus=$(< "${config_path}/psu${psu_idx}_i2c_bus")
+		psu_addr=$(< "${config_path}/psu${psu_idx}_i2c_addr")
+
+		# psuX_i2c_bus is optional; set_config_data() writes it only when set
+		if [ -z "$psu_bus" ] || [ -z "$psu_addr" ]; then
+			continue
+		fi
+
+		psu_present=$(< $thermal_path/psu${psu_idx}_status)
 		psu_dev_path="/sys/bus/i2c/devices/${psu_bus}-00${psu_addr}"
 		if [ ${psu_present} -eq 1 ] && [ ! -d ${psu_dev_path} ]; then
-			touch ${config_path}/psu${psu_num}_is_dummy
+			touch ${config_path}/psu${psu_idx}_is_dummy
 		fi
 	done
 }


### PR DESCRIPTION
Replace psu_i2c_map and per-SKU tables in chassis-events with per-PSU
psuX_i2c_bus/psuX_i2c_addr on QM3xxx (HI157/Q3200, HI158/Q3400).
set_config_data() writes optional config/psuX_i2c_bus and
map_dummy_psus()
and handle_hotplug_psu_event() read bus/addr from config.
Document optional psu<X>_i2c_bus in Chassis Management sysfs rev. 3.2
(hw-management internal; OS must not assume the file is present).

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
