### PR TITLE
hw-mgmt: bmc: Add leakage debug scripts for ADS7924 and ADS1015

### DIFF
--- a/bmc/README.md
+++ b/bmc/README.md
@@ -143,6 +143,10 @@ bmc/
         ├── hw-management-bmc-i2c-slave-setup.sh
         ├── hw-management-bmc-json-parser.sh
         ├── hw-management-bmc-leakage-handler.sh
+        ├── hw-management-bmc-ads1015-force-alarm.sh
+        ├── hw-management-bmc-ads1015-read-status.sh
+        ├── hw-management-bmc-ads7924-force-alarm.sh
+        ├── hw-management-bmc-ads7924-read-status.sh
         ├── hw-management-bmc-max1363-force-alarm.sh
         ├── hw-management-bmc-max1363-read-status.sh
         ├── hw-management-bmc-plat-specific-preps.sh
@@ -190,7 +194,11 @@ Documentation and sample data only. Nothing here is required at runtime unless y
 | **`hw-management-bmc-json-parser.sh`** | From OpenBMC **`switch_json_parser.sh`**: **`json_validate`**, **`json_get_nested_array_element`**, etc. (awk/BusyBox). Sourced by **`hw-management-bmc-a2d-leakage-config.sh`**, **`hw-management-bmc-early-i2c-init.sh`**, **`hw-management-bmc-gpio-set.sh`** (**`bmc_init_sysfs_gpio`**). |
 | **`hw-management-bmc-copy-cartridge-data.sh`** | **Cartridge SKUs:** sources **`/usr/bin/switch_json_parser.sh`** when **`/etc/hw-mgmt-bmc-copy-cartridge-data.json`** exists; reads cartridge FRU over I2C and programs SWB CPLD registers. See **`README-hw-management-bmc-copy-cartridge-data.md`**. |
 | **`hw-management-bmc-helpers.sh`** | Platform / ASIC helpers; sources **`hw-management-bmc-helpers-common.sh`** by absolute path. |
-| **`hw-management-bmc-a2d-leakage-read.sh`** | From OpenBMC **`a2d_leakage_read.sh`**: walks **`/var/run/hw-management/leakage/<idx>/<bus>-<addr>/`** (after **`hw-management-bmc-a2d-leakage-config.sh`**), reads **ADS1015** / **ADS7924** (IIO symlink or **`i2ctransfer`**) and writes per-channel **`value`** (volts); **MAX1363** path is still a placeholder. Requires **`bash`**, **`bc`**, **`i2ctransfer`**. |
+| **`hw-management-bmc-a2d-leakage-read.sh`** | From OpenBMC **`a2d_leakage_read.sh`**: walks **`/var/run/hw-management/leakage/<idx>/<bus>-<addr>/`** (after **`hw-management-bmc-a2d-leakage-config.sh`**), reads **ADS1015** / **ADS7924** (IIO symlink or **`i2ctransfer`**) and writes per-channel **`value`** (volts); **MAX1363** path is still a placeholder. Requires **`bash`**, **`bc`** or **`busybox bc`**, **`i2ctransfer`**. |
+| **`hw-management-bmc-ads1015-force-alarm.sh`** | Debug — per MUX channel **0–3**, programs tight or wide comparator thresholds (**`LoThresh`/`HiThresh`**) and config (**`i2ctransfer`**). **`#!/bin/sh`**. |
+| **`hw-management-bmc-ads1015-read-status.sh`** | Debug — reads ADS1015 config (0x01) and conversion (0x00) via **`i2ctransfer`**; optional MUX channel **0–3** (same numbering as **`ads1015-force-alarm`**). **`#!/bin/sh`**. |
+| **`hw-management-bmc-ads7924-force-alarm.sh`** | Debug — programs per-channel **ULR/LLR**, enables **INTCNTRL** alarm bits, and starts auto-scan (same sequence as **`hw-management-bmc-a2d-leakage-config.sh`**). **`#!/bin/sh`**. |
+| **`hw-management-bmc-ads7924-read-status.sh`** | Debug — reads ADS7924 **MODECNTRL**, **INTCNTRL** (alarm status/enable), and all four channel data registers (**`i2ctransfer`**, optional **scale**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-max1363-force-alarm.sh`** | From OpenBMC **`max1363_force_alarm.sh`**: debug — programs tight/safe per-channel thresholds so selected channels hit alarm (**`i2ctransfer`**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-max1363-read-status.sh`** | From OpenBMC **`max1363_read_status.sh`**: debug — prints first read bytes / decoded status flags (**`i2ctransfer`**, **`awk`**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-bios-recovery-flash.sh`** | From OpenBMC **`bios-recovery-flash.sh`**: BMC-side host BIOS recovery — writes CPLD **`spi_chnl_select`** then **`flashcp`** to **`spidev`** (default **`/dev/spidev1.0`**). Requires **`mtd-utils`**, hw-management runtime (**`/var/run/hw-management/system/spi_chnl_select`**). **`#!/bin/bash`**. |
@@ -270,8 +278,8 @@ SONiC BMC images often ship **BusyBox** (`/bin/sh` → **ash**) and may also inc
 | Script | BusyBox `ash` | Notes |
 |--------|---------------|--------|
 | **`hw-management-bmc-a2d-leakage-config.sh`** | Yes | **`#!/bin/sh`** — POSIX-style, no bash arrays / `[[ ]]`. |
-| **`hw-management-bmc-a2d-leakage-read.sh`** | **bash** | Associative arrays, **`[[`**, **`declare -A`**; requires **`bc`** for voltage math. |
-| **`hw-management-bmc-max1363-force-alarm.sh`**, **`hw-management-bmc-max1363-read-status.sh`** | Yes | **`#!/bin/sh`** — POSIX **`[`** and **`i2ctransfer`**. |
+| **`hw-management-bmc-a2d-leakage-read.sh`** | **bash** | Associative arrays, **`[[`**, **`declare -A`**; requires **`bc`** or **`busybox bc`** for voltage math (via **`hw_mgmt_bc`** in helpers-common). |
+| **`hw-management-bmc-ads1015-force-alarm.sh`**, **`hw-management-bmc-ads1015-read-status.sh`**, **`hw-management-bmc-ads7924-force-alarm.sh`**, **`hw-management-bmc-ads7924-read-status.sh`**, **`hw-management-bmc-max1363-force-alarm.sh`**, **`hw-management-bmc-max1363-read-status.sh`** | Yes | **`#!/bin/sh`** — POSIX **`[`** and **`i2ctransfer`**. |
 | **`hw-management-bmc-leakage-handler.sh`** | Yes | Uses `[`, `awk`; **`shopt -s nullglob`** is supported by BusyBox ash. |
 | **`hw-management-bmc-early-config.sh`**, **`hw-management-bmc-plat-specific-preps.sh`**, **`hw-management-bmc-early-i2c-init.sh`**, **`hw-management-bmc-recovery-handler.sh`**, and most other **`usr/usr/bin/*.sh`** helpers | Parse OK under ash | Shebang may still say **`#!/bin/bash`**; runtime is fine on ash-heavy systems if invoked via **`sh`** or **`ash`**. |
 | **`hw-management-bmc-devtree.sh`**, **`hw-management-bmc-devtree-check.sh`**, **`hw-management-bmc.sh`** | **bash** | Associative arrays / bash-only syntax; require **`bash`**. |

--- a/bmc/tests/hw-management-bmc-services-validation.sh
+++ b/bmc/tests/hw-management-bmc-services-validation.sh
@@ -17,6 +17,9 @@ set +e
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/../usr/usr/bin/hw-management-bmc-helpers-common.sh"
+
 UNITS_DEFAULT=(
 	hw-management-bmc-reset-cause-logger.service
 	hw-management-bmc-plat-specific-preps.service
@@ -122,8 +125,8 @@ main()
 	done
 
 	t1=$(date +%s.%N 2>/dev/null || date +%s)
-	if command -v bc >/dev/null 2>&1 && [[ "$t0" == *.* ]]; then
-		wall=$(echo "scale=3; $t1 - $t0" | bc)
+	if hw_mgmt_bc_available && [[ "$t0" == *.* ]]; then
+		wall=$(echo "scale=3; $t1 - $t0" | hw_mgmt_bc)
 	else
 		wall=$((t1 - t0))
 		wall="${wall}s (approx)"

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-read.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-read.sh
@@ -42,6 +42,9 @@
 LEAKAGE_BASE="/var/run/hw-management/leakage"
 LOG_TAG="a2d_read"
 
+# shellcheck source=/dev/null
+source /usr/bin/hw-management-bmc-helpers-common.sh
+
 # Function to log messages
 log_message()
 {
@@ -87,7 +90,7 @@ ads1015_read_channel()
 
     # Convert to voltage: (read_val / 16) * 0.002
     local result
-    result=$(echo "scale=6; ($read_val/16)*0.002" | bc 2>/dev/null)
+    result=$(echo "scale=6; ($read_val/16)*0.002" | hw_mgmt_bc)
 
     if [[ -z "$result" ]]; then
         log_message "warning" "Failed to calculate voltage for channel $channel"
@@ -207,7 +210,7 @@ ads7924_read_channel_volts()
     lo=$((lo))
     val=$(( (hi << 8) | lo ))
     raw12=$(( val >> 4 ))
-    echo "scale=10; ($raw12 * $scale) / 1" | bc 2>/dev/null
+    echo "scale=10; ($raw12 * $scale) / 1" | hw_mgmt_bc
 }
 
 # Read all ADS7924 channels under device_dir (uses ch_dir/input + scale when present, else I2C).
@@ -267,7 +270,7 @@ ads7924_read_channels()
             raw_input="${raw_input//$'\r'/}"
             raw_input="${raw_input// /}"
             if [ -n "$raw_input" ] && ads7924_is_decimal_int "$raw_input"; then
-                result=$(echo "scale=10; ($raw_input * $scale_f) / 1" | bc 2>/dev/null)
+                result=$(echo "scale=10; ($raw_input * $scale_f) / 1" | hw_mgmt_bc)
             fi
         fi
         if [ -z "$result" ]; then
@@ -403,9 +406,9 @@ main()
 {
     log_message "info" "A2D Leakage Channel Reader"
 
-    # Check for bc (needed for floating point calculations)
-    if ! command -v bc >/dev/null 2>&1; then
-        log_message "err" "bc is not installed. Cannot perform voltage calculations."
+    # Check for bc or busybox bc (floating point voltage calculations)
+    if ! hw_mgmt_bc_available; then
+        log_message "err" "Neither bc nor busybox bc is available. Cannot perform voltage calculations."
         exit 1
     fi
 

--- a/bmc/usr/usr/bin/hw-management-bmc-ads1015-force-alarm.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads1015-force-alarm.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# ADS1015: force comparator window so selected MUX channels assert ALERT (debug).
+# Threshold / MUX bytes match hw-management-bmc-a2d-leakage-config.sh example JSON.
+################################################################################
+
+# Usage:
+#   hw-management-bmc-ads1015-force-alarm.sh <bus> <addr> <channels>
+#
+# Examples:
+#   hw-management-bmc-ads1015-force-alarm.sh 12 0x49 all
+#   hw-management-bmc-ads1015-force-alarm.sh 12 0x49 0,1
+
+BUS="$1"
+ADDR="$2"
+CHS="$3"
+
+# Config register low byte: comparator enabled (see example CfgRegVal 0xc4 0x90).
+CFG_LO=0x90
+
+# Tight window → alarm (example LoThreshRegVal / HiThreshRegVal).
+ALARM_LO_MSB=0x38
+ALARM_LO_LSB=0x40
+ALARM_HI_MSB=0x7f
+ALARM_HI_LSB=0xf0
+
+# Wide window → no alarm (12-bit comparator value in bits 15:4; 0x7ff0 = max).
+# Do not use 0xffff — interpreted as signed 12-bit that is −1 and asserts ALERT.
+SAFE_LO_MSB=0x00
+SAFE_LO_LSB=0x00
+SAFE_HI_MSB=0x7f
+SAFE_HI_LSB=0xf0
+
+usage() {
+    echo "Usage: $0 <bus> <i2c_addr> <channels>"
+    echo "Channels: 0,1,2,3 | 0 | 1,3 | all"
+    exit 1
+}
+
+if [ -z "$BUS" ] || [ -z "$ADDR" ] || [ -z "$CHS" ]; then
+    usage
+fi
+
+# MUX high byte per channel (same as hw-management-bmc-a2d-leakage-read.sh).
+ads1015_mux_byte() {
+    case "$1" in
+    0) printf '%s' 0xc2 ;;
+    1) printf '%s' 0xd2 ;;
+    2) printf '%s' 0xe2 ;;
+    3) printf '%s' 0xf2 ;;
+    *) return 1 ;;
+    esac
+}
+
+CH0="safe"
+CH1="safe"
+CH2="safe"
+CH3="safe"
+
+if [ "$CHS" = "all" ]; then
+    CH0=alarm
+    CH1=alarm
+    CH2=alarm
+    CH3=alarm
+else
+    for c in $(echo "$CHS" | tr ',' ' '); do
+        case "$c" in
+        0) CH0=alarm ;;
+        1) CH1=alarm ;;
+        2) CH2=alarm ;;
+        3) CH3=alarm ;;
+        *)
+            echo "Invalid channel: $c"
+            exit 1
+            ;;
+        esac
+    done
+fi
+
+program_channel() {
+    local ch="$1"
+    local mode="$2"
+    local mux lo_msb lo_lsb hi_msb hi_lsb
+
+    mux=$(ads1015_mux_byte "$ch") || return 1
+    case "$mode" in
+    alarm)
+        lo_msb=$ALARM_LO_MSB
+        lo_lsb=$ALARM_LO_LSB
+        hi_msb=$ALARM_HI_MSB
+        hi_lsb=$ALARM_HI_LSB
+        ;;
+    safe)
+        lo_msb=$SAFE_LO_MSB
+        lo_lsb=$SAFE_LO_LSB
+        hi_msb=$SAFE_HI_MSB
+        hi_lsb=$SAFE_HI_LSB
+        ;;
+    *)
+        return 1
+        ;;
+    esac
+
+    if ! i2ctransfer -f -y "$BUS" w3@"$ADDR" 0x01 "$mux" "$CFG_LO" >/dev/null 2>&1; then
+        echo "Failed to write ADS1015 config for channel $ch"
+        return 1
+    fi
+    if ! i2ctransfer -f -y "$BUS" w3@"$ADDR" 0x02 "$lo_msb" "$lo_lsb" >/dev/null 2>&1; then
+        echo "Failed to write ADS1015 low threshold for channel $ch"
+        return 1
+    fi
+    if ! i2ctransfer -f -y "$BUS" w3@"$ADDR" 0x03 "$hi_msb" "$hi_lsb" >/dev/null 2>&1; then
+        echo "Failed to write ADS1015 high threshold for channel $ch"
+        return 1
+    fi
+    return 0
+}
+
+ch=0
+while [ "$ch" -lt 4 ]; do
+    eval mode=\$CH${ch}
+    if ! program_channel "$ch" "$mode"; then
+        exit 1
+    fi
+    ch=$((ch + 1))
+done
+
+echo "Forced alarm configured"
+echo "Bus=$BUS Addr=$ADDR Channels=$CHS"
+echo "Note: ADS1015 MUX is per-channel; last programmed MUX (channel 3) remains selected."

--- a/bmc/usr/usr/bin/hw-management-bmc-ads1015-read-status.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads1015-read-status.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# ADS1015: read config / conversion registers via i2ctransfer (debug).
+# Register map: TI SBAS173 (pointer 0x00 conversion, 0x01 config).
+################################################################################
+
+# Usage:
+#   hw-management-bmc-ads1015-read-status.sh <bus> <addr> [channel]
+# Examples:
+#   hw-management-bmc-ads1015-read-status.sh 12 0x49
+#   hw-management-bmc-ads1015-read-status.sh 12 0x49 1
+#
+# Channel numbering matches hw-management-bmc-ads1015-force-alarm.sh (0–3).
+
+BUS="$1"
+ADDR="$2"
+CHANNEL="$3"
+
+# Config register low byte: comparator enabled (same as force-alarm).
+CFG_LO=0x90
+
+usage() {
+    echo "Usage: $0 <bus> <i2c_addr> [channel]"
+    echo "  channel: 0-3 optional — program MUX then read conversion"
+    echo "  (same numbering as hw-management-bmc-ads1015-force-alarm.sh)"
+    exit 1
+}
+
+# MUX high byte per channel (same as hw-management-bmc-ads1015-force-alarm.sh).
+ads1015_mux_byte() {
+    case "$1" in
+    0) printf '%s' 0xc2 ;;
+    1) printf '%s' 0xd2 ;;
+    2) printf '%s' 0xe2 ;;
+    3) printf '%s' 0xf2 ;;
+    *) return 1 ;;
+    esac
+}
+
+if [ -z "$BUS" ] || [ -z "$ADDR" ]; then
+    usage
+fi
+
+if [ -n "$CHANNEL" ]; then
+    case "$CHANNEL" in
+    0|1|2|3) ;;
+    *)
+        echo "Invalid channel: $CHANNEL (use 0-3)"
+        exit 1
+        ;;
+    esac
+    CH_OFF=$(ads1015_mux_byte "$CHANNEL") || exit 1
+    if ! i2ctransfer -f -y "$BUS" w3@"$ADDR" 0x01 "$CH_OFF" "$CFG_LO" >/dev/null 2>&1; then
+        echo "Failed to select ADS1015 channel $CHANNEL"
+        exit 1
+    fi
+    sleep 0.1
+fi
+
+CFG_DATA=$(i2ctransfer -f -y "$BUS" w1@"$ADDR" 0x01 r2 2>/dev/null) || true
+CONV_DATA=$(i2ctransfer -f -y "$BUS" w1@"$ADDR" 0x00 r2 2>/dev/null) || true
+
+CFG_B0=$(echo "$CFG_DATA" | awk '{print $1}')
+CFG_B1=$(echo "$CFG_DATA" | awk '{print $2}')
+CONV_B0=$(echo "$CONV_DATA" | awk '{print $1}')
+CONV_B1=$(echo "$CONV_DATA" | awk '{print $2}')
+
+if [ -z "$CFG_B0" ] || [ -z "$CFG_B1" ]; then
+    echo "Failed to read ADS1015 config register (pointer 0x01)"
+    exit 1
+fi
+
+if [ -z "$CONV_B0" ] || [ -z "$CONV_B1" ]; then
+    echo "Failed to read ADS1015 conversion register (pointer 0x00)"
+    exit 1
+fi
+
+CFG_HI=$((${CFG_B0}))
+CFG_LO=$((${CFG_B1}))
+CONV_HI=$((${CONV_B0}))
+CONV_LO=$((${CONV_B1}))
+CFG=$(( (CFG_HI << 8) | CFG_LO ))
+CONV=$(( (CONV_HI << 8) | CONV_LO ))
+CONV_RAW=$CONV
+# Sign-extend 16-bit two's complement for voltage display only.
+[ "$CONV" -ge 32768 ] && CONV=$((CONV - 65536))
+
+# Default ±4.096 V, single-ended — same scaling as leakage reader.
+VOLTS=$(awk -v v="$CONV" 'BEGIN { printf "%.6f", (v / 16) * 0.002 }')
+
+OS=$(( (CFG >> 15) & 1 ))
+MUX=$(( (CFG >> 12) & 7 ))
+PGA=$(( (CFG >> 9) & 7 ))
+MODE=$(( (CFG >> 8) & 1 ))
+DR=$(( (CFG >> 5) & 7 ))
+COMP_MODE=$(( (CFG >> 4) & 1 ))
+COMP_POL=$(( (CFG >> 3) & 1 ))
+COMP_LAT=$(( (CFG >> 2) & 1 ))
+COMP_QUE=$(( CFG & 3 ))
+
+echo "I2C bus       : $BUS"
+echo "I2C address   : $ADDR"
+[ -n "$CHANNEL" ] && echo "Channel select: $CHANNEL (config high byte 0x$(printf '%02x' "$CH_OFF"))"
+echo ""
+echo "Config register (0x01): 0x$(printf '%04x' "$CFG")  bytes $CFG_B0 $CFG_B1"
+echo "  OS (bit 15)       : $OS  (1 = idle / not converting)"
+echo "  MUX [14:12]       : $MUX"
+echo "  PGA [11:9]        : $PGA"
+echo "  MODE (bit 8)      : $MODE  (0=continuous, 1=single-shot)"
+echo "  DR [7:5]          : $DR"
+echo "  COMP_MODE (bit 4) : $COMP_MODE"
+echo "  COMP_POL (bit 3)  : $COMP_POL"
+echo "  COMP_LAT (bit 2)  : $COMP_LAT"
+echo "  COMP_QUE [1:0]    : $COMP_QUE"
+echo ""
+echo "Conversion register (0x00): 0x$(printf '%04x' "$CONV_RAW")  bytes $CONV_B0 $CONV_B1"
+echo "  Raw ADC code      : $CONV_RAW"
+echo "  Voltage (approx)  : ${VOLTS} V  ((code/16)*0.002, ±4.096 V assumption)"

--- a/bmc/usr/usr/bin/hw-management-bmc-ads7924-force-alarm.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads7924-force-alarm.sh
@@ -1,0 +1,168 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# ADS7924: force ULR/LLR window so selected channels assert alarm (debug).
+# Register sequence aligned with hw-management-bmc-a2d-leakage-config.sh.
+################################################################################
+
+# Usage:
+#   hw-management-bmc-ads7924-force-alarm.sh <bus> <addr> <channels>
+#
+# Examples:
+#   hw-management-bmc-ads7924-force-alarm.sh 12 0x48 all
+#   hw-management-bmc-ads7924-force-alarm.sh 12 0x48 0,2
+
+BUS="$1"
+ADDR="$2"
+CHS="$3"
+
+# Narrow ULR/LLR window → alarm; wide window → safe.
+ALARM_UL=0x10
+ALARM_LL=0x0f
+SAFE_UL=0xff
+SAFE_LL=0x00
+
+# Defaults from hw-management-bmc-a2d-leakage-config.sh (raw I2C path).
+INT_B=0xe0
+SLP_B=0x00
+ACQ_B=0x00
+PWR_B=0x00
+AWAKE_B=0x20
+MODE_B=0x33
+
+usage() {
+    echo "Usage: $0 <bus> <i2c_addr> <channels>"
+    echo "Channels: 0,1,2,3 | 0 | 1,3 | all"
+    exit 1
+}
+
+if [ -z "$BUS" ] || [ -z "$ADDR" ] || [ -z "$CHS" ]; then
+    usage
+fi
+
+build_ch() {
+    case "$1" in
+    alarm) echo "$ALARM_UL $ALARM_LL" ;;
+    safe) echo "$SAFE_UL $SAFE_LL" ;;
+    esac
+}
+
+CH0="safe"
+CH1="safe"
+CH2="safe"
+CH3="safe"
+
+if [ "$CHS" = "all" ]; then
+    CH0=alarm
+    CH1=alarm
+    CH2=alarm
+    CH3=alarm
+else
+    for c in $(echo "$CHS" | tr ',' ' '); do
+        case "$c" in
+        0) CH0=alarm ;;
+        1) CH1=alarm ;;
+        2) CH2=alarm ;;
+        3) CH3=alarm ;;
+        *)
+            echo "Invalid channel: $c"
+            exit 1
+            ;;
+        esac
+    done
+fi
+
+set -- $(build_ch "$CH0")
+ul0=$1
+ll0=$2
+set -- $(build_ch "$CH1")
+ul1=$1
+ll1=$2
+set -- $(build_ch "$CH2")
+ul2=$1
+ll2=$2
+set -- $(build_ch "$CH3")
+ul3=$1
+ll3=$2
+
+aen=0
+ch=0
+while [ "$ch" -lt 4 ]; do
+    eval mode=\$CH${ch}
+    if [ "$mode" = "alarm" ]; then
+        aen=$((aen | (1 << ch)))
+    fi
+    ch=$((ch + 1))
+done
+
+# Software reset, IDLE, thresholds, INT block, alarm enable, AWAKE + auto-scan.
+if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x16 0xaa >/dev/null 2>&1; then
+    echo "ADS7924 soft reset failed (continuing)"
+fi
+sleep 0.05
+
+if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x00 0x00 >/dev/null 2>&1; then
+    echo "ADS7924 IDLE mode write failed"
+    exit 1
+fi
+
+if ! i2ctransfer -f -y "$BUS" w9@"$ADDR" 0x8a \
+    "$ul0" "$ll0" "$ul1" "$ll1" "$ul2" "$ll2" "$ul3" "$ll3" >/dev/null 2>&1; then
+    echo "ADS7924 ULR/LLR burst write failed"
+    exit 1
+fi
+
+if ! i2ctransfer -f -y "$BUS" w5@"$ADDR" 0x92 "$INT_B" "$SLP_B" "$ACQ_B" "$PWR_B" >/dev/null 2>&1; then
+    echo "ADS7924 INT/SLP/ACQ/PWR write failed"
+    exit 1
+fi
+
+if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x01 "$aen" >/dev/null 2>&1; then
+    echo "ADS7924 INTCNTRL (alarm enable) write failed"
+    exit 1
+fi
+
+if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x00 "$AWAKE_B" >/dev/null 2>&1; then
+    echo "ADS7924 AWAKE mode write failed"
+    exit 1
+fi
+sleep 0.002
+if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x00 "$MODE_B" >/dev/null 2>&1; then
+    echo "ADS7924 MODE write failed"
+    exit 1
+fi
+
+echo "Forced alarm configured"
+echo "Bus=$BUS Addr=$ADDR Channels=$CHS AlarmEnable=0x$(printf '%02x' "$aen")"

--- a/bmc/usr/usr/bin/hw-management-bmc-ads7924-read-status.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads7924-read-status.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# ADS7924: read mode, interrupt/alarm, and channel data via i2ctransfer (debug).
+# Register map: TI SBAS482 (same layout as hw-management-bmc-a2d-leakage-config.sh).
+################################################################################
+
+# Usage:
+#   hw-management-bmc-ads7924-read-status.sh <bus> <addr> [scale]
+# Example:
+#   hw-management-bmc-ads7924-read-status.sh 12 0x48
+#   hw-management-bmc-ads7924-read-status.sh 12 0x48 0.000244140625
+
+BUS="$1"
+ADDR="$2"
+SCALE="${3:-0.000244140625}"
+
+usage() {
+    echo "Usage: $0 <bus> <i2c_addr> [scale]"
+    echo "  scale: volts per LSB (default 0.000244140625)"
+    exit 1
+}
+
+if [ -z "$BUS" ] || [ -z "$ADDR" ]; then
+    usage
+fi
+
+MODE_DATA=$(i2ctransfer -f -y "$BUS" w1@"$ADDR" 0x00 r1 2>/dev/null) || true
+INT_DATA=$(i2ctransfer -f -y "$BUS" w1@"$ADDR" 0x01 r1 2>/dev/null) || true
+# Auto-increment from DATA0_U (0x02): pointer 0x82, read 8 bytes (4 channels × 2).
+CHAN_DATA=$(i2ctransfer -f -y "$BUS" w1@"$ADDR" 0x82 r8 2>/dev/null) || true
+
+MODE_B=$(echo "$MODE_DATA" | awk '{print $1}')
+INT_B=$(echo "$INT_DATA" | awk '{print $1}')
+
+if [ -z "$MODE_B" ]; then
+    echo "Failed to read ADS7924 MODECNTRL (0x00)"
+    exit 1
+fi
+if [ -z "$INT_B" ]; then
+    echo "Failed to read ADS7924 INTCNTRL (0x01)"
+    exit 1
+fi
+
+MODE=$((${MODE_B}))
+INT=$((${INT_B}))
+
+MODE_FIELD=$(( (MODE >> 2) & 0x3f ))
+SEL=$(( MODE & 3 ))
+AEN=$(( INT & 15 ))
+ALRM=$(( (INT >> 4) & 15 ))
+
+echo "I2C bus     : $BUS"
+echo "I2C address : $ADDR"
+echo "Scale       : $SCALE V/LSB"
+echo ""
+printf 'MODECNTRL (0x00): 0x%02x\n' "$MODE"
+echo "  MODE [7:2]  : $MODE_FIELD"
+echo "  SEL [1:0]   : $SEL"
+echo ""
+printf 'INTCNTRL (0x01): 0x%02x\n' "$INT"
+echo "  Alarm status (ALRM_ST3..0, bits 7:4):"
+i=0
+while [ "$i" -lt 4 ]; do
+    bit=$(( (ALRM >> i) & 1 ))
+    if [ "$bit" -ne 0 ]; then
+        echo "    Channel $i alarm active"
+    fi
+    i=$((i + 1))
+done
+if [ "$ALRM" -eq 0 ]; then
+    echo "    (none)"
+fi
+echo "  Alarm enable (AEN3..0, bits 3:0): $(printf '0x%x' "$AEN")"
+echo ""
+echo "Channel data (DATAx_U/L, pointer 0x82 + INC):"
+
+if [ -z "$CHAN_DATA" ]; then
+    echo "  (read failed)"
+    exit 0
+fi
+
+# shellcheck disable=SC2086
+set -- $CHAN_DATA
+ch=0
+while [ "$ch" -lt 4 ]; do
+    case $ch in
+    0) b_hi=$1; b_lo=$2 ;;
+    1) b_hi=$3; b_lo=$4 ;;
+    2) b_hi=$5; b_lo=$6 ;;
+    3) b_hi=$7; b_lo=$8 ;;
+    esac
+    if [ -z "$b_hi" ] || [ -z "$b_lo" ]; then
+        echo "  Channel $ch: (missing bytes)"
+        ch=$((ch + 1))
+        continue
+    fi
+    hi=$((${b_hi}))
+    lo=$((${b_lo}))
+    raw=$(( (hi << 8) | lo ))
+    raw12=$(( raw >> 4 ))
+    volts=$(awk -v r="$raw12" -v s="$SCALE" 'BEGIN { printf "%.10f", r * s }')
+    echo "  Channel $ch: raw=0x$(printf '%03x' "$raw12")  ${volts} V  ($b_hi $b_lo)"
+    ch=$((ch + 1))
+done

--- a/bmc/usr/usr/bin/hw-management-bmc-devtree.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-devtree.sh
@@ -33,6 +33,11 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+if ! declare -f hw_mgmt_bc >/dev/null 2>&1; then
+	# shellcheck source=/dev/null
+	source /usr/bin/hw-management-bmc-helpers-common.sh
+fi
+
 devtr_verb_display=0
 devtree_codes_file=
 # Deployed per platform to /etc by hw-management-bmc-plat-specific-preps (usr/etc/<HID>/).
@@ -384,7 +389,7 @@ devtr_check_board_components()
 #					fi
 					if [ $board_bus_offset -ne 0 ]; then
 						curr_component[2]=$((curr_component[2]+board_bus_offset*brd))
-						curr_component[2]=0x$(echo "obase=16; ${curr_component[2]}"|bc)
+						curr_component[2]=0x$(echo "obase=16; ${curr_component[2]}"|hw_mgmt_bc)
 					fi
 					# Check if component from SMBIOS BOM string is defined in layout
 					if [ -z "${curr_component[0]}" ]; then

--- a/bmc/usr/usr/bin/hw-management-bmc-helpers-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-helpers-common.sh
@@ -376,3 +376,37 @@ leak_detection_on_init() {
 	done
 	return 1
 }
+
+# Cached bc backend: "bc", "busybox", or "none".
+_HW_MGMT_BC_BACKEND=""
+
+_hw_mgmt_bc_resolve() {
+	case "$_HW_MGMT_BC_BACKEND" in
+	bc|busybox) return 0 ;;
+	none) return 1 ;;
+	esac
+	if command -v bc >/dev/null 2>&1 && echo "1+1" | bc >/dev/null 2>&1; then
+		_HW_MGMT_BC_BACKEND=bc
+		return 0
+	fi
+	if command -v busybox >/dev/null 2>&1 && echo "1+1" | busybox bc >/dev/null 2>&1; then
+		_HW_MGMT_BC_BACKEND=busybox
+		return 0
+	fi
+	_HW_MGMT_BC_BACKEND=none
+	return 1
+}
+
+# Pipe calculator expressions on stdin; prefer bc(1), else busybox bc on BMC images.
+hw_mgmt_bc() {
+	_hw_mgmt_bc_resolve || return 127
+	case "$_HW_MGMT_BC_BACKEND" in
+	bc) bc 2>/dev/null ;;
+	busybox) busybox bc 2>/dev/null ;;
+	*) return 127 ;;
+	esac
+}
+
+hw_mgmt_bc_available() {
+	_hw_mgmt_bc_resolve
+}


### PR DESCRIPTION
Add four POSIX /bin/sh debug helpers under bmc/usr/usr/bin/, in the same style as the existing MAX1363 tools:

- hw-management-bmc-ads1015-read-status.sh — config and conversion registers; optional MUX channel 1–4
- hw-management-bmc-ads1015-force-alarm.sh — tight/wide comparator thresholds per MUX channel 0–3
- hw-management-bmc-ads7924-read-status.sh — MODECNTRL, INTCNTRL, and four channel data registers
- hw-management-bmc-ads7924-force-alarm.sh — ULR/LLR, alarm enable, and auto-scan (aligned with a2d-leakage-config)

Introduce hw_mgmt_bc() in hw-management-bmc-helpers-common.sh: prefer standalone bc(1), fall back to busybox bc on BMC images. Use it from a2d-leakage-read, devtree hex formatting, and the services validation test.

Document the new scripts in bmc/README.md.