### PR TITLE
hw-mgmt: bmc: HI189: align A2D leakage config with new naming and thresholds

### DIFF
--- a/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
+++ b/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
@@ -1,10 +1,10 @@
 [
     {
-        "Name": "Chassis_0_LeakDetector_0_Mgmt",
+        "Name": "Mngm_ADC0",
         "NumChnl": 2,
         "ChnlNames": [
-            "Chassis_0_LeakDetector_0_A",
-            "Chassis_0_LeakDetector_0_B"
+            "Mngm_ADC0_Ch0_Embedded_0",
+            "Mngm_ADC0_Ch1_Embedded_1"
         ],
         "Device": [
             {
@@ -12,12 +12,12 @@
                 "Bus": 27,
                 "Address": "0x49",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x00",
                 "CfgRegVal": "0x01 0x00 0x11 0x1f 0x13 0x14 0x15"
             },
@@ -26,12 +26,12 @@
                 "Bus": 27,
                 "Address": "0x49",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x01",
                 "CfgRegVal": "0xc4 0x90",
                 "LoThreshReg": "0x02",
@@ -42,11 +42,11 @@
         ]
     },
     {
-        "Name": "Chassis_0_LeakDetector_1_Swb",
+        "Name": "Swb_ADC0",
         "NumChnl": 2,
         "ChnlNames": [
-            "Chassis_0_LeakDetector_1_A",
-            "Chassis_0_LeakDetector_1_B"
+            "Swb_ADC0_Ch0_Embedded_0",
+            "Swb_ADC0_Ch1_Embedded_1"
         ],
         "Device": [
             {
@@ -54,12 +54,12 @@
                 "Bus": 28,
                 "Address": "0x48",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x00",
                 "CfgRegVal": "0x01 0x00 0x11 0x1f 0x13 0x14 0x15"
             },
@@ -68,12 +68,12 @@
                 "Bus": 28,
                 "Address": "0x48",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x01",
                 "CfgRegVal": "0xc4 0x90",
                 "LoThreshReg": "0x02",


### PR DESCRIPTION
## Summary

Aligns `bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json` (installed as `/etc/hw-management-bmc-a2d-leakage-config.json`) with the new leakage architecture described in `bmc/examples/hw-management-bmc-a2d-leakage-config-example.json`:

- **Detector rename**
  - `Chassis_0_LeakDetector_0_Mgmt` -> `Mngm_ADC0`
  - `Chassis_0_LeakDetector_1_Swb`  -> `Swb_ADC0`
- **ChnlNames rename** (per the new `<detector>_Ch<j>_Embedded_<n>` convention)
  - Mgmt: `Mngm_ADC0_Ch0_Embedded_0`, `Mngm_ADC0_Ch1_Embedded_1`
  - Swb:  `Swb_ADC0_Ch0_Embedded_0`,  `Swb_ADC0_Ch1_Embedded_1`
- **Per-device `Type`** (all 4 Device entries: MAX1363 + ADS1015 in both detectors)
  - `"rop"` -> `"embedded"`
- **Engineering-unit thresholds** (all 4 Device entries)
  - `WarningMin`:  0.05 -> 0.7
  - `CriticalMin`: 0.02 -> 0.1
  - `WarningMax`:  0.85 -> 0.8
  - `CriticalMax`: 0.95 -> 0.7

**Unchanged on purpose:** `Bus`, `Address`, `Probe: true`, `Scale`, `CfgReg`/`CfgRegVal`, ADS1015 `LoThreshReg`/`LoThreshRegVal` (per-detector: `0x38 0x40` Mgmt, `0x4b 0x00` Swb), `HiThreshReg`/`HiThreshRegVal` (`0x7f 0xf0`). No new optional fields added (e.g. `NormalMin`/`NormalMax` were intentionally **not** added).

## Runtime impact (per `bmc/README.md` runtime layout and `bmc/examples/hw-management-bmc-leakage-sysfs.txt`)

- `/var/run/hw-management/leakage/1/device_name` -> `Mngm_ADC0`
- `/var/run/hw-management/leakage/2/device_name` -> `Swb_ADC0`
- `/var/run/hw-management/leakage/<n>/<j>/type` -> `embedded` (was `rop`)
- `/var/run/hw-management/leakage/<n>/<j>/{lwarn,lcrit,warn,crit}` updated to the new threshold values.
- `min` / `max` are still derived from the (unchanged) register values: ~0.22 V / 0.5 V for Mgmt, ~0.29 V / 0.5 V for Swb.

## Notes / review points

- `WarningMax (0.8) > CriticalMax (0.7)` was applied verbatim from the new example. Reviewers should confirm this is the intended ordering for downstream alarm rules (Warning is normally expected to trip before Critical on the high side).
- The new register-derived `min`/`max` band sits below the new user `WarningMax`/`CriticalMax`; flagging in case the registers also need a parallel update.

## Test plan

- [ ] On an HI189 BMC, install the updated package and verify `/etc/hw-management-bmc-a2d-leakage-config.json` matches.
- [ ] After `hw-management-bmc-a2d-leakage-config.sh` runs, check `/var/run/hw-management/leakage/{1,2}/device_name` and per-channel `type`, `channel_name`, `warn`, `crit`, `lwarn`, `lcrit`.
- [ ] Confirm `LEAKAGE1` / `LEAKAGE2` udev events still trigger `hw-management-bmc-leakage-handler.sh` correctly with the new thresholds.
