### PR TITLE
hw-mgmt: scripts: Add JSON-driven hw-management exec helpers

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -52,6 +52,17 @@ endif
 	cp -a usr/etc/hw-management-virtual/* debian/$(pname)/etc/hw-management-virtual
 	dh_installdirs -p$(pname) etc/hw-management-fast-sysfs-monitor
 	cp -a usr/etc/hw-management-fast-sysfs-monitor/* debian/$(pname)/etc/hw-management-fast-sysfs-monitor
+	@if [ -d usr/etc/hw-management-exec ] && [ -n "$$(find usr/etc/hw-management-exec -maxdepth 1 -type f 2>/dev/null | head -n1)" ]; then \
+		dh_installdirs -p$(pname) etc/hw-management-exec; \
+		cp -a usr/etc/hw-management-exec/* debian/$(pname)/etc/hw-management-exec/; \
+	fi
+	@for d in usr/etc/HI*; do \
+		if [ -d "$$d" ] && [ -n "$$(find "$$d" -maxdepth 1 -type f 2>/dev/null | head -n1)" ]; then \
+			hid=$$(basename "$$d"); \
+			dh_installdirs -p$(pname) etc/$$hid; \
+			cp -a "$$d"/* debian/$(pname)/etc/$$hid/; \
+		fi; \
+	done
 
 override_dh_installinit:
 	dh_installinit --name=hw-management

--- a/examples/hw-management-exec-example.json
+++ b/examples/hw-management-exec-example.json
@@ -1,0 +1,33 @@
+{
+    "hids": ["HI162", "HI166", "HI167", "HI169", "HI170"],
+    "bus": 12,
+    "attributes": [
+        {
+            "AttributeName": "hotplug_irq_mask_set",
+            "bus": 12,
+            "address": "0x16",
+            "offset": "0xd7",
+            "size": 1,
+            "mask": "0x20",
+            "retry": 5,
+            "action": "attempt=0; while [ $attempt -lt $retry ]; do val=$(i2cget -f -y $bus $address $offset); new=$(( (val & ~mask) | mask )); i2cset -f -y $bus $address $offset $new; rb=$(i2cget -f -y $bus $address $offset); if [ $(( rb & mask )) -eq $(( new & mask )) ]; then exit 0; fi; attempt=$((attempt + 1)); done; exit 1",
+            "description": "Set masked bits in device interrupt register with readback verify"
+        },
+        {
+            "AttributeName": "hotplug_irq_mask_clear",
+            "bus": 12,
+            "address": "0x16",
+            "offset": "0xd7",
+            "size": 1,
+            "mask": "0x20",
+            "retry": 5,
+            "action": "attempt=0; while [ $attempt -lt $retry ]; do val=$(i2cget -f -y $bus $address $offset); new=$(( val & ~mask )); i2cset -f -y $bus $address $offset $new; rb=$(i2cget -f -y $bus $address $offset); if [ $(( rb & mask )) -eq 0 ]; then exit 0; fi; attempt=$((attempt + 1)); done; exit 1",
+            "description": "Clear masked bits in device interrupt register with readback verify"
+        },
+        {
+            "AttributeName": "aux_pwr_cycle",
+            "action": "echo 1 > /var/run/hw-management/system/aux_pwr_cycle",
+            "description": "Trigger auxiliary power cycle via hw-management sysfs"
+        }
+    ]
+}

--- a/examples/hw-management-exec.md
+++ b/examples/hw-management-exec.md
@@ -1,0 +1,183 @@
+<!-- SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES -->
+<!-- Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!--
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the names of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+Alternatively, this software may be distributed under the terms of the
+GNU General Public License ("GPL") version 2 as published by the Free
+Software Foundation.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+
+# Host hw-management executable attributes
+
+Platform-specific helpers are defined in JSON and exposed at runtime in
+**BusyBox applet style**: one dispatcher script and symlinks per attribute
+(I2C bit set/clear, CPLD/sysfs actions, GPIO, and so on) without hard-coding
+those commands in **`hw-management.sh`**.
+
+This document describes the **host CPU** package only (`hw-management`, not BMC).
+
+## Components
+
+| Item | Installed path | Role |
+|------|----------------|------|
+| [hw-management-exec](../usr/usr/bin/hw-management-exec) | `/usr/bin/hw-management-exec` | Dispatcher (symlink target; must not live under `/var/run` if that mount is `noexec`) |
+| [hw-management-exec-parser.sh](../usr/usr/bin/hw-management-exec-parser.sh) | `/usr/bin/hw-management-exec-parser.sh` | Reads JSON, creates symlinks + `.env` fragments |
+| [hw-management-json-parser.sh](../usr/usr/bin/hw-management-json-parser.sh) | `/usr/bin/hw-management-json-parser.sh` | BusyBox-safe JSON helpers (AWK, no `jq`) |
+| Shared config | `/etc/hw-management-exec/*.json` | One file can list many HIDs in a `"hids"` array |
+| Per-HID override | `/etc/<HID>/hw-management-exec.json` | Optional; wins over shared configs |
+| Example JSON | [hw-management-exec-example.json](hw-management-exec-example.json) | Full schema example (I2C + sysfs) |
+| GB200 platforms | [hw-management-exec-gb200.json](../usr/etc/hw-management-exec/hw-management-exec-gb200.json) | Shipped for HI162, HI166, HI167, HI169, HI170 |
+
+## Lifecycle
+
+- **`hw-management start`** — at the end of **`do_start()`**, runs **`hw-management-exec-parser.sh`** after **`/var/run/hw-management`** exists.
+- **`hw-management stop`** — at the start of **`do_stop()`**, removes **`/var/run/hw-management/exec.d/`** (and any legacy **`/var/run/hw-management/exec`** copy); the full **`/var/run/hw-management`** tree is removed afterward.
+
+If no config matches the system HID, the parser exits silently (no error).
+
+## Runtime layout (BusyBox-style)
+
+After **`hw-management start`**:
+
+```text
+/usr/bin/hw-management-exec                 # dispatcher (installed by package)
+/var/run/hw-management/exec.d/
+    hotplug_irq_mask_set -> /usr/bin/hw-management-exec
+    hotplug_irq_mask_set.env                # variables + action (sourced by dispatcher)
+    hotplug_irq_mask_clear -> /usr/bin/hw-management-exec
+    hotplug_irq_mask_clear.env
+```
+
+Invoking a symlink runs **`hw-management-exec`**; the attribute name is taken from **`basename "$0"`** (like **`cp`** → **`busybox`**). Symlinks must not point at a binary under **`/var/run`**: many systems mount **`/run`** or **`/var`** with **`noexec`**, which yields **Permission denied** even for root.
+
+After upgrading, re-run **`hw-management restart`** (or **`hw-management-exec-parser.sh`**) so symlinks are recreated.
+
+## Config resolution (first match wins)
+
+1. **`/etc/<HID>/hw-management-exec.json`** (or **`/usr/etc/<HID>/...`**)
+2. Any **`/etc/hw-management-exec/*.json`** (or **`/usr/etc/hw-management-exec/*.json`**) whose **`"hids"`** array contains the current HID
+
+HID is taken from, in order: environment variable **`HID`**, **`/var/run/hw-management/config/hid`**, then DMI **`product_sku`**.
+
+## JSON schema
+
+Top-level object:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `hids` | For shared files | List of SKUs (e.g. `"HI162"`) that use this file |
+| `bus` | No | Default I2C bus for attributes that define I2C fields but omit `bus` |
+| `attributes` | Yes | Array of attribute objects |
+
+Each **attribute** object:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `AttributeName` | Yes | Symlink name under `exec.d/` (also `attribute_name`) |
+| `action` | Yes | Shell snippet executed when the helper is run (may use variables below) |
+| `description` | No | Comment in the `.env` fragment |
+| `bus` | No | I2C bus number |
+| `address` | No | I2C address (hex, e.g. `0x16`) |
+| `offset` | No | Register offset (hex) |
+| `size` | No | Register size in bytes |
+| `mask` | No | Bit(s) to change (hex); **set** forces them to 1, **clear** forces them to 0 |
+| `retry` | No | Max attempts for I2C write + readback verify (`retry=N` in `.env`) |
+
+**Only `AttributeName` and `action` are required.** Omit all I2C fields for pure shell/sysfs/CPLD actions.
+
+### I2C attributes
+
+When any of `address`, `offset`, or `mask` is set, the parser may apply the top-level default **`bus`** if the attribute does not define **`bus`**. It writes optional variables into the **`.env`** fragment before **`action`**:
+
+```sh
+bus=12
+address=0x16
+offset=0xd7
+mask=0x20
+```
+
+The **`action`** field should reference those variables (see the example file). For GB200 hotplug IRQ, **`mask`** is **`0x20`** (one interrupt bit), not a register-wide value like **`0xdf`**.
+
+### I2C write with readback and retry
+
+Set **`retry`** (e.g. `5`) and use a loop in **`action`** that:
+
+1. Reads the register (`i2cget`)
+2. Computes the new value and writes it (`i2cset`)
+3. Reads back (`i2cget`) and compares masked bits
+4. Exits `0` on match, otherwise increments **`attempt`** until **`retry`** is reached, then exits `1`
+
+GB200 hotplug IRQ helpers use masked compare: **set** checks `(rb & mask) == (new & mask)`; **clear** checks `(rb & mask) == 0`. See [hw-management-exec-gb200.json](../usr/etc/hw-management-exec/hw-management-exec-gb200.json).
+
+### Non-I2C attributes (CPLD, sysfs, GPIO)
+
+Define only **`AttributeName`**, **`action`**, and optionally **`description`**. No `bus`/`address`/`offset`/`mask` lines are emitted.
+
+Example:
+
+```json
+{
+    "AttributeName": "aux_pwr_cycle",
+    "action": "echo 1 > /var/run/hw-management/system/aux_pwr_cycle",
+    "description": "Trigger auxiliary power cycle via hw-management sysfs"
+}
+```
+
+## Usage
+
+After **`hw-management start`**:
+
+```sh
+/var/run/hw-management/exec.d/hotplug_irq_mask_set
+/var/run/hw-management/exec.d/aux_pwr_cycle
+```
+
+Symlinks and `.env` fragments are recreated on each start; do not edit them by hand.
+
+## Adding a new platform
+
+**Same behavior as an existing group (e.g. GB200):** add the HID to the **`"hids"`** array in the appropriate file under **`usr/etc/hw-management-exec/`**.
+
+**Different behavior:**
+
+- Add **`usr/etc/hw-management-exec/hw-management-exec-<name>.json`** with its own **`hids`** list, or
+- Ship **`/etc/<HID>/hw-management-exec.json`** for a single-SKU override.
+
+Rebuild/install the **`hw-management`** package; **`debian/rules`** installs **`etc/hw-management-exec/`** from **`usr/etc/hw-management-exec/`**.
+
+## Safety and portability
+
+- **`address`**, **`offset`**, and **`mask`** are sanitized to hex digits (and `x`) before being written into `.env` fragments.
+- **`bus`** and **`size`** must be numeric.
+- **`AttributeName`** is restricted to alphanumeric characters, `_`, and `-`.
+- **`description`** is stripped to safe comment characters.
+- Parser and library use **`#!/bin/sh`** and BusyBox AWK; load the JSON library with **`. /usr/bin/hw-management-json-parser.sh`**.
+- Simple string fields use **`json_get_string`**; **`action`** and **`description`** use **`json_get_escaped_string`** (supports `\"` and common escapes).
+
+## See also
+
+- [hw-management-exec-example.json](hw-management-exec-example.json) — copy/paste starting point
+- [hw-management.sh](../usr/usr/bin/hw-management.sh) — **`do_start()`** / **`do_stop()`** integration

--- a/usr/etc/hw-management-exec/hw-management-exec-gb200.json
+++ b/usr/etc/hw-management-exec/hw-management-exec-gb200.json
@@ -1,0 +1,28 @@
+{
+    "hids": ["HI162", "HI166", "HI167", "HI169", "HI170"],
+    "bus": 12,
+    "attributes": [
+        {
+            "AttributeName": "hotplug_irq_mask_set",
+            "bus": 12,
+            "address": "0x16",
+            "offset": "0xd7",
+            "size": 1,
+            "mask": "0x20",
+            "retry": 5,
+            "action": "attempt=0; while [ $attempt -lt $retry ]; do val=$(i2cget -f -y $bus $address $offset); new=$(( (val & ~mask) | mask )); i2cset -f -y $bus $address $offset $new; rb=$(i2cget -f -y $bus $address $offset); if [ $(( rb & mask )) -eq $(( new & mask )) ]; then exit 0; fi; attempt=$((attempt + 1)); done; exit 1",
+            "description": "Set hotplug IRQ mask bit (0x20) in interrupt register 0xd7"
+        },
+        {
+            "AttributeName": "hotplug_irq_mask_clear",
+            "bus": 12,
+            "address": "0x16",
+            "offset": "0xd7",
+            "size": 1,
+            "mask": "0x20",
+            "retry": 5,
+            "action": "attempt=0; while [ $attempt -lt $retry ]; do val=$(i2cget -f -y $bus $address $offset); new=$(( val & ~mask )); i2cset -f -y $bus $address $offset $new; rb=$(i2cget -f -y $bus $address $offset); if [ $(( rb & mask )) -eq 0 ]; then exit 0; fi; attempt=$((attempt + 1)); done; exit 1",
+            "description": "Clear hotplug IRQ mask bit (0x20) in interrupt register 0xd7"
+        }
+    ]
+}

--- a/usr/usr/bin/hw-management-exec
+++ b/usr/usr/bin/hw-management-exec
@@ -1,0 +1,58 @@
+#!/bin/sh
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# BusyBox-style multiplexer: symlinks in exec.d/<AttributeName> point here.
+# Attribute name is taken from argv[0] (basename of the invoked path).
+################################################################################
+
+EXEC_LINK_DIR="/var/run/hw-management/exec.d"
+
+attr=$(basename "$0")
+case "$attr" in
+exec|hw-management-exec)
+	echo "Run /var/run/hw-management/exec.d/<AttributeName> (symlink to hw-management-exec)." >&2
+	exit 1
+	;;
+esac
+
+frag="${EXEC_LINK_DIR}/${attr}.env"
+if [ ! -f "$frag" ]; then
+	if command -v logger >/dev/null 2>&1; then
+		logger -t hw-management-exec -p daemon.err "unknown attribute: ${attr}"
+	fi
+	exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$frag"
+exit $?

--- a/usr/usr/bin/hw-management-exec-parser.sh
+++ b/usr/usr/bin/hw-management-exec-parser.sh
@@ -1,0 +1,343 @@
+#!/bin/sh
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Parse per-platform hw-management-exec.json and install BusyBox-style helpers:
+#   /usr/bin/hw-management-exec                - dispatcher (not under /var/run; noexec-safe)
+#   /var/run/hw-management/exec.d/<name>     - symlink -> hw-management-exec
+#   /var/run/hw-management/exec.d/<name>.env - variables and action body
+#
+# Config (first match wins):
+#   1. /etc/<HID>/hw-management-exec.json - per-platform override
+#   2. /etc/hw-management-exec/*.json - shared file whose "hids" array contains <HID>
+################################################################################
+
+EXEC_DISPATCHER="/usr/bin/hw-management-exec"
+EXEC_LINK_DIR="/var/run/hw-management/exec.d"
+LOG_TAG="hw-management-exec-parser"
+
+log_info()
+{
+	if command -v logger >/dev/null 2>&1; then
+		logger -t "$LOG_TAG" -p daemon.info "$@"
+	fi
+}
+
+log_err()
+{
+	if command -v logger >/dev/null 2>&1; then
+		logger -t "$LOG_TAG" -p daemon.err "$@"
+	fi
+}
+
+# shellcheck source=/dev/null
+source_hw_json_parser()
+{
+	if [ -f /usr/bin/hw-management-json-parser.sh ]; then
+		# shellcheck source=/dev/null
+		. /usr/bin/hw-management-json-parser.sh
+		return 0
+	fi
+	return 1
+}
+
+get_system_hid()
+{
+	if [ -n "${HID:-}" ]; then
+		echo "$HID"
+		return 0
+	fi
+	if [ -f /var/run/hw-management/config/hid ]; then
+		cat /var/run/hw-management/config/hid
+		return 0
+	fi
+	if [ -f /sys/devices/virtual/dmi/id/product_sku ]; then
+		cat /sys/devices/virtual/dmi/id/product_sku
+		return 0
+	fi
+	echo ""
+}
+
+config_lists_hid()
+{
+	local hid="$1"
+	local config="$2"
+	awk -v hid="$hid" '
+	BEGIN { in_hids = 0; found = 0 }
+	$0 ~ "\"hids\"" && index($0, "[") > 0 { in_hids = 1 }
+	in_hids && index($0, "\"" hid "\"") > 0 { found = 1 }
+	in_hids && index($0, "]") > 0 { in_hids = 0 }
+	END { exit found ? 0 : 1 }
+	' "$config"
+}
+
+find_exec_config()
+{
+	local hid="$1"
+	local f d
+	for f in "/etc/${hid}/hw-management-exec.json" "/usr/etc/${hid}/hw-management-exec.json"; do
+		if [ -f "$f" ]; then
+			echo "$f"
+			return 0
+		fi
+	done
+	for d in /etc/hw-management-exec /usr/etc/hw-management-exec; do
+		[ -d "$d" ] || continue
+		for f in "$d"/*.json; do
+			[ -f "$f" ] || continue
+			if config_lists_hid "$hid" "$f"; then
+				echo "$f"
+				return 0
+			fi
+		done
+	done
+	return 1
+}
+
+json_get_attr_name()
+{
+	local block="$1"
+	local name
+	name=$(printf '%s\n' "$block" | json_get_string "AttributeName")
+	if [ -n "$name" ]; then
+		echo "$name"
+		return 0
+	fi
+	printf '%s\n' "$block" | json_get_string "attribute_name"
+}
+
+sanitize_attr_name()
+{
+	printf '%s' "$1" | tr -cd 'a-zA-Z0-9_-'
+}
+
+sanitize_i2c_hex_value()
+{
+	local v
+	v=$(printf '%s' "$1" | tr -cd '0-9a-fA-Fx')
+	[ -n "$v" ] || return 1
+	printf '%s' "$v"
+}
+
+sanitize_bus_number()
+{
+	local v
+	v=$(printf '%s' "$1" | tr -cd '0-9')
+	[ -n "$v" ] || return 1
+	printf '%s' "$v"
+}
+
+sanitize_comment_text()
+{
+	printf '%s' "$1" | tr -cd 'a-zA-Z0-9 _.,/-'
+}
+
+install_exec_dispatcher()
+{
+	if [ ! -x "$EXEC_DISPATCHER" ]; then
+		log_err "dispatcher missing or not executable: ${EXEC_DISPATCHER}"
+		return 1
+	fi
+	return 0
+}
+
+create_exec_attribute()
+{
+	local attr_json="$1"
+	local default_bus="$2"
+	local attr_name safe_name bus address offset size mask retry action description
+	local frag_path link_path
+	attr_name=$(json_get_attr_name "$attr_json")
+	safe_name=$(sanitize_attr_name "$attr_name")
+	if [ -z "$safe_name" ]; then
+		log_err "skip entry: missing or invalid AttributeName"
+		return 1
+	fi
+	case "$safe_name" in
+	exec|hw-management-exec)
+		log_err "skip ${safe_name}: reserved dispatcher name"
+		return 1
+		;;
+	esac
+
+	address=$(printf '%s\n' "$attr_json" | json_get_string "address")
+	offset=$(printf '%s\n' "$attr_json" | json_get_string "offset")
+	size=$(printf '%s\n' "$attr_json" | json_get_number "size")
+	mask=$(printf '%s\n' "$attr_json" | json_get_string "mask")
+	[ -z "$mask" ] && mask=$(printf '%s\n' "$attr_json" | json_get_string "Mask")
+
+	bus=$(printf '%s\n' "$attr_json" | json_get_number "bus")
+	if [ -z "$bus" ] && [ -n "$default_bus" ]; then
+		if [ -n "$address" ] || [ -n "$offset" ] || [ -n "$mask" ]; then
+			bus="$default_bus"
+		fi
+	fi
+	if [ -n "$bus" ]; then
+		bus=$(sanitize_bus_number "$bus") || bus=""
+		if [ -z "$bus" ]; then
+			log_err "skip ${safe_name}: invalid bus"
+			return 1
+		fi
+	fi
+	retry=$(printf '%s\n' "$attr_json" | json_get_number "retry")
+	action=$(printf '%s\n' "$attr_json" | json_get_escaped_string "action")
+	description=$(printf '%s\n' "$attr_json" | json_get_escaped_string "description")
+
+	if [ -n "$address" ]; then
+		address=$(sanitize_i2c_hex_value "$address") || address=""
+		if [ -z "$address" ]; then
+			log_err "skip ${safe_name}: invalid address"
+			return 1
+		fi
+	fi
+	if [ -n "$offset" ]; then
+		offset=$(sanitize_i2c_hex_value "$offset") || offset=""
+		if [ -z "$offset" ]; then
+			log_err "skip ${safe_name}: invalid offset"
+			return 1
+		fi
+	fi
+	if [ -n "$mask" ]; then
+		mask=$(sanitize_i2c_hex_value "$mask") || mask=""
+		if [ -z "$mask" ]; then
+			log_err "skip ${safe_name}: invalid mask"
+			return 1
+		fi
+	fi
+	if [ -n "$size" ]; then
+		size=$(sanitize_bus_number "$size") || size=""
+		if [ -z "$size" ]; then
+			log_err "skip ${safe_name}: invalid size"
+			return 1
+		fi
+	fi
+	if [ -n "$retry" ]; then
+		retry=$(sanitize_bus_number "$retry") || retry=""
+		if [ -z "$retry" ]; then
+			log_err "skip ${safe_name}: invalid retry"
+			return 1
+		fi
+	fi
+	if [ -n "$description" ]; then
+		description=$(sanitize_comment_text "$description")
+	fi
+
+	if [ -z "$action" ]; then
+		log_err "skip ${safe_name}: missing action"
+		return 1
+	fi
+
+	frag_path="${EXEC_LINK_DIR}/${safe_name}.env"
+	link_path="${EXEC_LINK_DIR}/${safe_name}"
+	{
+		printf '%s\n' "# Attribute: ${safe_name}"
+		if [ -n "$description" ]; then
+			printf '%s\n' "# ${description}"
+		fi
+		[ -n "$bus" ] && printf 'bus=%s\n' "$bus"
+		[ -n "$address" ] && printf 'address=%s\n' "$address"
+		[ -n "$offset" ] && printf 'offset=%s\n' "$offset"
+		[ -n "$size" ] && printf 'size=%s\n' "$size"
+		[ -n "$mask" ] && printf 'mask=%s\n' "$mask"
+		[ -n "$retry" ] && printf 'retry=%s\n' "$retry"
+		printf '%s\n' "$action"
+	} > "$frag_path"
+	chmod 0640 "$frag_path"
+	ln -sf "$EXEC_DISPATCHER" "$link_path"
+	log_info "created exec attribute ${safe_name}"
+	return 0
+}
+
+cleanup_exec_tree()
+{
+	# Legacy: dispatcher was copied here; /var/run is often mounted noexec.
+	rm -f /var/run/hw-management/exec
+	rm -f "${EXEC_LINK_DIR}/"*.env
+	find "$EXEC_LINK_DIR" -maxdepth 1 -type l -delete 2>/dev/null
+}
+
+main()
+{
+	local hid config_file default_bus i attr_json created
+	if ! source_hw_json_parser; then
+		log_err "JSON parser not found, skip exec attributes"
+		exit 0
+	fi
+
+	hid=$(get_system_hid)
+	if [ -z "$hid" ] || [ "$hid" = "Unknown" ]; then
+		exit 0
+	fi
+
+	if ! config_file=$(find_exec_config "$hid"); then
+		exit 0
+	fi
+
+	if ! json_validate "$config_file"; then
+		log_err "invalid JSON: $config_file"
+		exit 0
+	fi
+
+	if [ ! -d /var/run/hw-management ]; then
+		log_info "/var/run/hw-management missing, skip exec attributes"
+		exit 0
+	fi
+
+	cleanup_exec_tree
+	mkdir -p -m 0755 "$EXEC_LINK_DIR"
+	if ! install_exec_dispatcher; then
+		exit 0
+	fi
+
+	default_bus=$(json_get_number "bus" < "$config_file")
+	if [ -n "$default_bus" ]; then
+		default_bus=$(sanitize_bus_number "$default_bus") || default_bus=""
+	fi
+
+	created=0
+	i=0
+	while attr_json=$(json_get_nested_array_element "attributes" "$i" < "$config_file"); [ -n "$attr_json" ]; do
+		if create_exec_attribute "$attr_json" "$default_bus"; then
+			created=$((created + 1))
+		fi
+		i=$((i + 1))
+	done
+
+	if [ "$created" -eq 0 ]; then
+		cleanup_exec_tree
+		exit 0
+	fi
+
+	log_info "HID=${hid} config=${config_file} exec attributes=${created}"
+}
+
+main "$@"

--- a/usr/usr/bin/hw-management-json-parser.sh
+++ b/usr/usr/bin/hw-management-json-parser.sh
@@ -1,0 +1,548 @@
+#!/bin/sh
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# BusyBox-Compatible JSON Parser Library
+#
+# This library provides JSON parsing functions using only AWK and standard
+# BusyBox utilities (no jq or Python required).
+#
+# Upstream name in OpenBMC: switch_json_parser.sh (bmc-post-boot-cfg).
+# Packaged as hw-management-json-parser.sh for host hw-management.
+#
+# Usage:
+#   source /usr/bin/hw-management-json-parser.sh
+################################################################################
+
+# Function to extract a top-level object block from JSON array by index
+# Usage: json_get_array_element <json_file> <index>
+# Returns: The complete JSON object at the specified index
+# Ignores "{" and "}" inside JSON string values (same rule as json_get_nested_array_element).
+json_get_array_element()
+{
+    local json_file="$1"
+    local index="$2"
+    awk -v idx="$index" '
+    BEGIN {
+        block_count = -1
+        in_block = 0
+        brace_count = 0
+        depth = 0
+        in_string = 0
+        escape = 0
+    }
+
+    function update_string_state(c) {
+        if (in_string) {
+            if (escape) {
+                escape = 0
+                return
+            }
+            if (c == "\\") {
+                escape = 1
+                return
+            }
+            if (c == "\"") {
+                in_string = 0
+            }
+            return
+        }
+        if (c == "\"") {
+            in_string = 1
+        }
+    }
+
+    {
+        line = $0
+        for (i = 1; i <= length(line); i++) {
+            c = substr(line, i, 1)
+            if (in_string) {
+                update_string_state(c)
+                continue
+            }
+            if (c == "\"") {
+                in_string = 1
+                continue
+            }
+            if (c == "{") {
+                if (depth == 0 && !in_block) {
+                    block_count++
+                    if (block_count == idx) {
+                        in_block = 1
+                        brace_count = 0
+                    }
+                }
+                if (in_block) {
+                    brace_count++
+                }
+                depth++
+            } else if (c == "}") {
+                if (in_block) {
+                    brace_count--
+                }
+                depth--
+            }
+        }
+        if (in_block) {
+            print $0
+        }
+        if (in_block && brace_count == 0 && depth == 0) {
+            exit
+        }
+    }
+    ' "$json_file"
+}
+
+# Function to extract a nested object from a JSON block by array name and index
+# Usage: echo "$json_block" | json_get_nested_array_element <array_name> <index>
+# <index> is 0-based (first element is 0). Matches callers: early-i2c-init, devtree, gpio-set, a2d-leakage.
+# A new array element is recognized only when "{" appears at brace depth 0 inside the named array
+# (nested objects like "config": { ... } do not start a new element). Lines inside the element are
+# printed in full and brace-balanced so nested "{" lines are not dropped.
+# Returns: The JSON object at the specified index within the named array
+json_get_nested_array_element()
+{
+    local array_name="$1"
+    local index="$2"
+    awk -v array="$array_name" -v idx="$index" '
+    BEGIN {
+        in_target_array = 0
+        element_count = -1
+        in_element = 0
+        brace_count = 0
+        depth = 0
+        in_string = 0
+        escape = 0
+    }
+
+    function update_string_state(c) {
+        if (in_string) {
+            if (escape) {
+                escape = 0
+                return
+            }
+            if (c == "\\") {
+                escape = 1
+                return
+            }
+            if (c == "\"") {
+                in_string = 0
+            }
+            return
+        }
+        if (c == "\"") {
+            in_string = 1
+        }
+    }
+
+    function count_element_braces(line, from,    i, c) {
+        for (i = from; i <= length(line); i++) {
+            c = substr(line, i, 1)
+            update_string_state(c)
+            if (in_string) {
+                continue
+            }
+            if (c == "{") {
+                brace_count++
+            } else if (c == "}") {
+                brace_count--
+            }
+        }
+    }
+
+    function scan_array_depth(line,    i, c) {
+        for (i = 1; i <= length(line); i++) {
+            c = substr(line, i, 1)
+            update_string_state(c)
+            if (in_string) {
+                continue
+            }
+            if (c == "{") {
+                if (depth == 0) {
+                    element_count++
+                    if (element_count == idx) {
+                        in_element = 1
+                        print substr(line, i)
+                        brace_count = 0
+                        count_element_braces(line, i)
+                        if (brace_count == 0) {
+                            exit
+                        }
+                        depth++
+                        return
+                    }
+                }
+                depth++
+            } else if (c == "}") {
+                depth--
+            }
+        }
+    }
+
+    {
+        has_array = index($0, "\"" array "\"")
+        if (has_array > 0 && index($0, "[") > 0) {
+            in_target_array = 1
+            next
+        }
+
+        if (in_target_array && !in_element && !in_string && depth == 0 && index($0, "]") > 0) {
+            in_target_array = 0
+            next
+        }
+
+        if (in_target_array && !in_element) {
+            scan_array_depth($0)
+            next
+        }
+
+        if (in_element) {
+            print $0
+            count_element_braces($0, 1)
+            if (brace_count == 0) {
+                exit
+            }
+        }
+    }
+    '
+}
+
+# Function to extract a simple string value by key from JSON
+# Usage: echo "$json" | json_get_string <key>
+# Returns: The string value (without quotes)
+# Use only for tokens without embedded quotes (hex address, AttributeName, etc.).
+# For "action", "description", or any value that may contain \" use
+# json_get_escaped_string instead.
+json_get_string()
+{
+    local key="$1"
+    awk -v k="$key" '
+    {
+        p = "\"" k "\""
+        i = index($0, p)
+        if (i == 0) next
+        j = i + length(p)
+        while (j <= length($0) && substr($0, j, 1) ~ /[[:space:]]/) j++
+        if (substr($0, j, 1) != ":") next
+        j++
+        while (j <= length($0) && substr($0, j, 1) ~ /[[:space:]]/) j++
+        if (substr($0, j, 1) != "\"") next
+        j++
+        start = j
+        while (j <= length($0) && substr($0, j, 1) != "\"") j++
+        if (j > start) print substr($0, start, j - start)
+        exit
+    }'
+}
+
+# Function to extract a JSON string value with backslash escapes (multi-line safe)
+# Usage: echo "$json" | json_get_escaped_string <key>
+json_get_escaped_string()
+{
+	local key="$1"
+	awk -v k="$key" '
+	BEGIN { buf = "" }
+	{ buf = buf $0 }
+	END {
+		p = "\"" k "\""
+		i = index(buf, p)
+		if (i == 0) exit
+		j = i + length(p)
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
+		if (substr(buf, j, 1) != ":") exit
+		j++
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
+		if (substr(buf, j, 1) != "\"") exit
+		j++
+		out = ""
+		while (j <= length(buf)) {
+			c = substr(buf, j, 1)
+			if (c == "\\" && j < length(buf)) {
+				n = substr(buf, j + 1, 1)
+				if (n == "n") { out = out "\n"; j += 2; continue }
+				if (n == "t") { out = out "\t"; j += 2; continue }
+				if (n == "r") { out = out "\r"; j += 2; continue }
+				out = out n
+				j += 2
+				continue
+			}
+			if (c == "\"") break
+			out = out c
+			j++
+		}
+		print out
+	}'
+}
+
+# Function to extract a numeric value by key from JSON
+# Usage: echo "$json" | json_get_number <key>
+# Returns: The numeric value (integer or decimal). Reads full stdin (multi-line safe).
+# Note: The old implementation split on : , and took the *first* integer field on
+# any line containing the key — wrong when another number (e.g. NumChnl, Scale)
+# appeared before "Bus" on the same logical object.
+json_get_number()
+{
+	local key="$1"
+	awk -v k="$key" '
+	BEGIN { buf = "" }
+	{ buf = buf $0 }
+	END {
+		p = "\"" k "\""
+		i = index(buf, p)
+		if (i == 0) exit
+		j = i + length(p)
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
+		if (substr(buf, j, 1) != ":") exit
+		j++
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
+		if (j > length(buf)) exit
+		start = j
+		if (substr(buf, j, 1) == "-") j++
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[0-9]/) j++
+		if (substr(buf, j, 1) == ".") {
+			j++
+			while (j <= length(buf) && substr(buf, j, 1) ~ /[0-9]/) j++
+		}
+		if (j > start) print substr(buf, start, j - start)
+	}'
+}
+
+# Function to extract a JSON boolean or string that looks like a boolean
+# Usage: echo "$json" | json_get_bool <key>
+# Prints: true, false, or a quoted string value (e.g. true from "true"); empty if absent/invalid.
+# RFC 8259 booleans are lowercase true/false without quotes — json_get_string cannot read those.
+json_get_bool()
+{
+	local key="$1"
+	awk -v k="$key" '
+	BEGIN { buf = "" }
+	{ buf = buf $0 }
+	END {
+		p = "\"" k "\""
+		i = index(buf, p)
+		if (i == 0) exit 2
+		j = i + length(p)
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
+		if (substr(buf, j, 1) != ":") exit 2
+		j++
+		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
+		if (j > length(buf)) exit 2
+		rest = substr(buf, j)
+		if (match(rest, /^true([^a-zA-Z0-9_]|$)/)) { print "true"; exit 0 }
+		if (match(rest, /^false([^a-zA-Z0-9_]|$)/)) { print "false"; exit 0 }
+		if (substr(buf, j, 1) == "\"") {
+			j++
+			start = j
+			while (j <= length(buf) && substr(buf, j, 1) != "\"") j++
+			if (j > start) {
+				print substr(buf, start, j - start)
+				exit 0
+			}
+		}
+		exit 2
+	}'
+}
+
+# Function to extract array elements (strings) from a JSON array
+# Usage: echo "$json" | json_get_array <array_name>
+# Returns: Array elements, one per line
+json_get_array()
+{
+    local array_name="$1"
+    awk -v arr="$array_name" '
+    BEGIN { in_array = 0 }
+    $0 ~ "\"" arr "\".*\\[" { in_array = 1; next }
+    in_array && /\]/ { exit }
+    in_array && /"/ {
+        gsub(/^[ \t]*"/, "")
+        gsub(/"[ \t,]*$/, "")
+        print
+    }
+    '
+}
+
+# Function to count top-level elements in a JSON array
+# Usage: json_count_array_elements <json_file>
+# Returns: Number of top-level elements
+# Note: Do not use grep on lines starting with "{" — nested Device objects also start
+# lines with "{" and would inflate the count (e.g. 6 instead of 2).
+json_count_array_elements()
+{
+	local json_file="$1"
+	local idx=0
+	local block
+	while block=$(json_get_array_element "$json_file" "$idx"); [ -n "$block" ]; do
+		idx=$((idx + 1))
+	done
+	echo "$idx"
+}
+
+# Function to count elements in a named array within a JSON block
+# Usage: echo "$json_block" | json_count_nested_array <array_name>
+# Returns: Number of elements in the named array
+# Counts only top-level "{" openings at brace depth 0 inside the array (same rule as
+# json_get_nested_array_element). Ignores "{" inside JSON string values.
+json_count_nested_array()
+{
+    local array_name="$1"
+    awk -v array="$array_name" '
+    BEGIN {
+        in_target_array = 0
+        count = 0
+        depth = 0
+        in_string = 0
+        escape = 0
+    }
+    {
+        has_array = index($0, "\"" array "\"")
+        if (has_array > 0 && index($0, "[") > 0) {
+            in_target_array = 1
+            next
+        }
+
+        if (in_target_array && !in_string && depth == 0 && index($0, "]") > 0) {
+            in_target_array = 0
+            next
+        }
+
+        if (!in_target_array) {
+            next
+        }
+
+        line = $0
+        for (i = 1; i <= length(line); i++) {
+            c = substr(line, i, 1)
+            if (in_string) {
+                if (escape) {
+                    escape = 0
+                    continue
+                }
+                if (c == "\\") {
+                    escape = 1
+                    continue
+                }
+                if (c == "\"") {
+                    in_string = 0
+                }
+                continue
+            }
+            if (c == "\"") {
+                in_string = 1
+                continue
+            }
+            if (c == "{") {
+                if (depth == 0) {
+                    count++
+                }
+                depth++
+            } else if (c == "}") {
+                depth--
+            }
+        }
+    }
+    END { print count }
+    '
+}
+
+# Function to validate JSON file (basic check)
+# Usage: json_validate <json_file>
+# Returns: 0 if valid, 1 if invalid
+json_validate()
+{
+    local json_file="$1"
+    if [ ! -f "$json_file" ]; then
+        return 1
+    fi
+
+    # Brace/bracket balance outside JSON string values (grep would count { inside strings).
+    awk '
+    BEGIN { depth_brace = 0; depth_bracket = 0; in_string = 0; escape = 0; ok = 1 }
+    {
+        for (i = 1; i <= length($0); i++) {
+            c = substr($0, i, 1)
+            if (in_string) {
+                if (escape) {
+                    escape = 0
+                    continue
+                }
+                if (c == "\\") {
+                    escape = 1
+                    continue
+                }
+                if (c == "\"") {
+                    in_string = 0
+                }
+                continue
+            }
+            if (c == "\"") {
+                in_string = 1
+                continue
+            }
+            if (c == "{") {
+                depth_brace++
+            } else if (c == "}") {
+                depth_brace--
+                if (depth_brace < 0) {
+                    ok = 0
+                }
+            } else if (c == "[") {
+                depth_bracket++
+            } else if (c == "]") {
+                depth_bracket--
+                if (depth_bracket < 0) {
+                    ok = 0
+                }
+            }
+        }
+    }
+    END {
+        if (depth_brace != 0 || depth_bracket != 0) {
+            ok = 0
+        }
+        exit ok ? 0 : 1
+    }
+    ' "$json_file"
+}
+
+# BusyBox ash has no export -f; load with ". /usr/bin/hw-management-json-parser.sh".
+if [ -n "${BASH_VERSION:-}" ]; then
+	export -f json_get_array_element
+	export -f json_get_nested_array_element
+	export -f json_get_string
+	export -f json_get_escaped_string
+	export -f json_get_number
+	export -f json_get_bool
+	export -f json_get_array
+	export -f json_count_array_elements
+	export -f json_count_nested_array
+	export -f json_validate
+fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2018-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2018-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -3418,11 +3418,14 @@ do_start()
 	else
 		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
+	[ -x /usr/bin/hw-management-exec-parser.sh ] && /usr/bin/hw-management-exec-parser.sh
 	log_info "Init completed."
 }
 
 do_stop()
 {
+	rm -f /var/run/hw-management/exec 2>/dev/null
+	rm -rf /var/run/hw-management/exec.d 2>/dev/null
 	check_cpu_type
 	# There is no need to perform extra work of check_system during
 	# hw-management stop in case of devtree exist. Directly init connect_table.


### PR DESCRIPTION
Add a JSON-based executable attribute framework for host hw-management:

- hw-management-json-parser.sh: BusyBox-safe AWK JSON library
- hw-management-exec-parser.sh: materialize helpers under /var/run/hw-management/exec/ from platform JSON
- hw-management-exec-gb200.json for HI162/HI166/HI167/HI169/HI170 (I2C hotplug IRQ mask set/clear with readback and retry)
- examples/hw-management-exec-example.json and examples/hw-management-exec.md
- debian/rules: install etc/hw-management-exec/; optional per-HID overrides (empty-directory safe)
- hw-management.sh: run parser after do_start(); remove exec/ on do_stop()

Each attribute requires AttributeName and action only; I2C fields and retry are optional. Shell-only actions (sysfs, CPLD, GPIO) need no bus/address/offset/mask.

Motivation for this commit: provide executable files for simple flows as user APIs.