### PR TITLE
hw-mgmt: bmc: HI189: align A2D leakage config with new naming and thresholds

### DIFF
--- a/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
+++ b/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
@@ -1,10 +1,10 @@
 [
     {
-        "Name": "Chassis_0_LeakDetector_0_Mgmt",
+        "Name": "Mngm_ADC0",
         "NumChnl": 2,
         "ChnlNames": [
-            "Chassis_0_LeakDetector_0_A",
-            "Chassis_0_LeakDetector_0_B"
+            "Mngm_ADC0_Ch0_Embedded_0",
+            "Mngm_ADC0_Ch1_Embedded_1"
         ],
         "Device": [
             {
@@ -12,12 +12,12 @@
                 "Bus": 27,
                 "Address": "0x49",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x00",
                 "CfgRegVal": "0x01 0x00 0x11 0x1f 0x13 0x14 0x15"
             },
@@ -26,12 +26,12 @@
                 "Bus": 27,
                 "Address": "0x49",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x01",
                 "CfgRegVal": "0xc4 0x90",
                 "LoThreshReg": "0x02",
@@ -42,11 +42,11 @@
         ]
     },
     {
-        "Name": "Chassis_0_LeakDetector_1_Swb",
+        "Name": "Swb_ADC0",
         "NumChnl": 2,
         "ChnlNames": [
-            "Chassis_0_LeakDetector_1_A",
-            "Chassis_0_LeakDetector_1_B"
+            "Swb_ADC0_Ch0_Embedded_0",
+            "Swb_ADC0_Ch1_Embedded_1"
         ],
         "Device": [
             {
@@ -54,12 +54,12 @@
                 "Bus": 28,
                 "Address": "0x48",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x00",
                 "CfgRegVal": "0x01 0x00 0x11 0x1f 0x13 0x14 0x15"
             },
@@ -68,12 +68,12 @@
                 "Bus": 28,
                 "Address": "0x48",
                 "Probe": true,
-                "Type": "rop",
+                "Type": "embedded",
                 "Scale": 0.000244140625,
-                "WarningMin": 0.05,
-                "CriticalMin": 0.02,
-                "WarningMax": 0.85,
-                "CriticalMax": 0.95,
+                "WarningMin": 0.7,
+                "CriticalMin": 0.1,
+                "WarningMax": 0.8,
+                "CriticalMax": 0.7,
                 "CfgReg": "0x01",
                 "CfgRegVal": "0xc4 0x90",
                 "LoThreshReg": "0x02",


### PR DESCRIPTION
Update /etc/HI189/hw-management-bmc-a2d-leakage-config.json to follow the latest leakage architecture:

- Rename detectors: Chassis_0_LeakDetector_0_Mgmt -> Mngm_ADC0, Chassis_0_LeakDetector_1_Swb -> Swb_ADC0.
- Rename per-channel ChnlNames to <detector>_Ch<j>_Embedded_<n> to match the new example convention.
- Switch per-device Type from "rop" to "embedded" on all four Device entries (MAX1363 + ADS1015 alternatives for both detectors).
- Update engineering-unit thresholds on all four Device entries: WarningMin 0.05 -> 0.7, CriticalMin 0.02 -> 0.1, WarningMax 0.85 -> 0.8, CriticalMax 0.95 -> 0.7.

Register-derived thresholds (LoThreshReg/RegVal, HiThreshReg/RegVal), Scale, CfgReg/CfgRegVal, Bus, Address and Probe are unchanged.

(cherry picked from commit c1856b5c32e6b7ff157132369511a54c05f3520e)