### PR TITLE
hw-mgmt: bmc: leakage: Update json config file for system HI189

### DIFF
--- a/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
+++ b/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
@@ -10,7 +10,7 @@
             {
                 "DeviceType": "MAX1363",
                 "Bus": 27,
-                "Address": "0x49",
+                "Address": "0x34",
                 "Probe": true,
                 "Type": "embedded",
                 "Scale": 0.000244140625,
@@ -33,9 +33,10 @@
                 "WarningMax": 0.8,
                 "CriticalMax": 0.7,
                 "CfgReg": "0x01",
-                "CfgRegVal": "0xc4 0x90",
+                "CfgRegVal": "0xc4 0x94",
+                "CfgRegVal_comment": "Interrupt mode (window comparator, ALERT enabled). For polling-only with no hardware ALERT, change CfgRegVal to 0xc4 0x93 (COMP_QUE=11 disables comparator); Lo/Hi threshold registers are optional then.",
                 "LoThreshReg": "0x02",
-                "LoThreshRegVal": "0x38 0x40",
+                "LoThreshRegVal": "0x20 0x00",
                 "HiThreshReg": "0x03",
                 "HiThreshRegVal": "0x7f 0xf0"
             }
@@ -52,7 +53,7 @@
             {
                 "DeviceType": "MAX1363",
                 "Bus": 28,
-                "Address": "0x48",
+                "Address": "0x35",
                 "Probe": true,
                 "Type": "embedded",
                 "Scale": 0.000244140625,
@@ -75,9 +76,10 @@
                 "WarningMax": 0.8,
                 "CriticalMax": 0.7,
                 "CfgReg": "0x01",
-                "CfgRegVal": "0xc4 0x90",
+                "CfgRegVal": "0xc4 0x94",
+                "CfgRegVal_comment": "Interrupt mode (window comparator, ALERT enabled). For polling-only with no hardware ALERT, change CfgRegVal to 0xc4 0x93 (COMP_QUE=11 disables comparator); Lo/Hi threshold registers are optional then.",
                 "LoThreshReg": "0x02",
-                "LoThreshRegVal": "0x4b 0x00",
+                "LoThreshRegVal": "0x20 0x00",
                 "HiThreshReg": "0x03",
                 "HiThreshRegVal": "0x7f 0xf0"
             }

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
@@ -95,8 +95,9 @@ check_config_file()
 	return 0
 }
 
-# Optional JSON field "Probe": true — bind kernel driver (new_device) before register writes so
-# the driver does not later overwrite programmed thresholds/configuration.
+# Optional JSON field "Probe": true — bind kernel driver (new_device) before register programming,
+# briefly unbind for raw i2ctransfer, then rebind for IIO sysfs so driver probe does not run after
+# our final register values are written.
 # JSON booleans are unquoted (true/false); json_get_string only sees quoted values — use json_get_bool.
 json_probe_true()
 {
@@ -148,13 +149,56 @@ bind_kernel_driver()
 		log_message "info" "I2C device $dev_id already present — assuming driver or early init"
 		return 0
 	fi
-	log_message "info" "Binding $driver at $address on bus $bus (new_device before register config)"
+	log_message "info" "Binding $driver at $address on bus $bus (new_device before register config, then unbind/program/rebind)"
 	if ! echo "$driver $address" > "${adapter}/new_device" 2>/dev/null; then
 		log_message "warning" "new_device failed for $driver $address on i2c-$bus (driver missing or device conflict) — continuing with raw I2C config"
 		return 1
 	fi
 	sleep 0.2
 	return 0
+}
+
+# Release driver so i2ctransfer can program device registers (I2C client node remains).
+unbind_kernel_driver()
+{
+	local bus="$1" address="$2"
+	local suf devpath driver_name unbind_file dev_id
+
+	suf=$(i2c_addr_sysfs_suffix "$address") || return 1
+	devpath="/sys/bus/i2c/devices/${bus}-${suf}"
+	[ -L "$devpath/driver" ] || return 0
+	driver_name=$(basename "$(readlink "$devpath/driver" 2>/dev/null)" 2>/dev/null) || return 1
+	unbind_file="/sys/bus/i2c/drivers/${driver_name}/unbind"
+	[ -f "$unbind_file" ] || return 1
+	dev_id=$(basename "$devpath")
+	if ! echo "$dev_id" >"$unbind_file" 2>/dev/null; then
+		log_message "warning" "Failed to unbind $driver_name from $dev_id (Bus $bus, Addr $address) — cannot program registers via raw I2C"
+		return 1
+	fi
+	log_message "info" "Unbound $driver_name from $dev_id for raw register programming"
+	sleep 0.2
+	return 0
+}
+
+# Re-attach driver after raw I2C programming (uses bind, not new_device).
+rebind_kernel_driver()
+{
+	local bus="$1" address="$2" device_type="$3"
+	local driver suf dev_id bind_file
+
+	driver=$(kernel_driver_for_type "$device_type")
+	[ -n "$driver" ] || return 1
+	suf=$(i2c_addr_sysfs_suffix "$address") || return 1
+	dev_id="${bus}-${suf}"
+	bind_file="/sys/bus/i2c/drivers/${driver}/bind"
+	[ -f "$bind_file" ] || return 1
+	if echo "$dev_id" >"$bind_file" 2>/dev/null; then
+		log_message "info" "Rebound $driver to $dev_id after register programming"
+		sleep 0.2
+		return 0
+	fi
+	log_message "warning" "Rebind $driver to $dev_id failed"
+	return 1
 }
 
 # sysfs name for /sys/bus/i2c/devices/<bus>-<addr> (4-digit hex address).
@@ -506,6 +550,100 @@ ads7924_hex_byte_to_uint()
 	printf '%d' "$((16#$x))"
 }
 
+# ADS1015 config register MUX high byte (AINn single-ended vs GND); channel 0..3.
+ads1015_mux_high_byte()
+{
+	case "$1" in
+	0) printf '%s' 0xc2 ;;
+	1) printf '%s' 0xd2 ;;
+	2) printf '%s' 0xe2 ;;
+	3) printf '%s' 0xf2 ;;
+	*) return 1 ;;
+	esac
+}
+
+# Program ADS1015 window comparator per MUX channel (TI SBAS173; one Lo/Hi pair per rotation).
+configure_ads1015_raw_i2c()
+{
+	local device_json="$1"
+	local device_name="$2"
+	local bus="$3"
+	local address="$4"
+	local num_channels="$5"
+
+	local cfg_lo lo_val hi_val lo_reg hi_reg mux ch nch failed
+	local t
+
+	cfg_lo="0x94"
+	t=$(echo "$device_json" | json_get_string "CfgRegVal" 2>/dev/null) || true
+	t=$(echo "$t" | tr -d '"')
+	if [ -n "$t" ] && [ "$t" != "null" ]; then
+		set -- $t
+		shift
+		[ -n "$1" ] && cfg_lo="$1"
+	fi
+
+	local default_lo default_hi
+	default_lo="0x20 0x00"
+	default_hi="0x7f 0xf0"
+	t=$(echo "$device_json" | json_get_string "LoThreshRegVal" 2>/dev/null) || true
+	t=$(echo "$t" | tr -d '"')
+	[ -n "$t" ] && [ "$t" != "null" ] && default_lo="$t"
+	t=$(echo "$device_json" | json_get_string "HiThreshRegVal" 2>/dev/null) || true
+	t=$(echo "$t" | tr -d '"')
+	[ -n "$t" ] && [ "$t" != "null" ] && default_hi="$t"
+
+	lo_reg="0x02"
+	hi_reg="0x03"
+	t=$(echo "$device_json" | json_get_string "LoThreshReg" 2>/dev/null) || true
+	t=$(echo "$t" | tr -d '"')
+	[ -n "$t" ] && [ "$t" != "null" ] && lo_reg="$t"
+	t=$(echo "$device_json" | json_get_string "HiThreshReg" 2>/dev/null) || true
+	t=$(echo "$t" | tr -d '"')
+	[ -n "$t" ] && [ "$t" != "null" ] && hi_reg="$t"
+
+	nch=4
+	if [ -n "$num_channels" ] && [ "$num_channels" -ge 1 ] 2>/dev/null; then
+		nch="$num_channels"
+		[ "$nch" -gt 4 ] && nch=4
+	fi
+
+	log_message "info" "ADS1015 $device_name: per-channel init (window comparator, cfg_lo=$cfg_lo, channels=0..$((nch - 1)))"
+	failed=0
+	ch=0
+	while [ "$ch" -lt "$nch" ]; do
+		mux=$(ads1015_mux_high_byte "$ch") || {
+			failed=1
+			break
+		}
+		lo_val="$default_lo"
+		hi_val="$default_hi"
+		t=$(json_optional_scalar "$device_json" "Ads1015LoThreshCh$((ch + 1))") && lo_val="$t"
+		t=$(json_optional_scalar "$device_json" "Ads1015HiThreshCh$((ch + 1))") && hi_val="$t"
+
+		if ! write_and_verify_register "$bus" "$address" 0x01 \
+			"$mux $cfg_lo" "ADS1015 Config ch $ch" "$device_name"; then
+			failed=1
+		fi
+		if ! write_and_verify_register "$bus" "$address" "$lo_reg" \
+			"$lo_val" "ADS1015 Lo_thresh ch $ch" "$device_name"; then
+			failed=1
+		fi
+		if ! write_and_verify_register "$bus" "$address" "$hi_reg" \
+			"$hi_val" "ADS1015 Hi_thresh ch $ch" "$device_name"; then
+			failed=1
+		fi
+		ch=$((ch + 1))
+	done
+
+	if [ "$failed" -ne 0 ]; then
+		log_message "warning" "ADS1015 $device_name: one or more channel programs failed"
+		return 1
+	fi
+	log_message "info" "ADS1015 $device_name: raw I2C configuration complete (last MUX channel $((nch - 1)) selected)"
+	return 0
+}
+
 # Program ADS7924 when no kernel driver is bound (TI SBAS482 register map).
 configure_ads7924_raw_i2c()
 {
@@ -801,15 +939,18 @@ populate_leakage_channel_dir()
 	lo_hex=$(echo "$lo_hex" | tr -d '"')
 	hi_hex=$(echo "$hi_hex" | tr -d '"')
 
-	if [ -n "$lo_hex" ] && [ "$lo_hex" != "null" ]; then
-		local lo_u
-		lo_u=$(hex_bytes_to_uint_be "$lo_hex")
-		awk -v u="$lo_u" -v s="$sc_num" 'BEGIN { printf "%.12g\n", u * s }' >"$ch_dir/min"
-	fi
-	if [ -n "$hi_hex" ] && [ "$hi_hex" != "null" ]; then
-		local hi_u
-		hi_u=$(hex_bytes_to_uint_be "$hi_hex")
-		awk -v u="$hi_u" -v s="$sc_num" 'BEGIN { printf "%.12g\n", u * s }' >"$ch_dir/max"
+	# ADS1015 Lo/Hi registers are hardware-only; sysfs min/max align with MAX1363 via Warning*.
+	if [ "$device_type" != "ADS1015" ]; then
+		if [ -n "$lo_hex" ] && [ "$lo_hex" != "null" ]; then
+			local lo_u
+			lo_u=$(hex_bytes_to_uint_be "$lo_hex")
+			awk -v u="$lo_u" -v s="$sc_num" 'BEGIN { printf "%.12g\n", u * s }' >"$ch_dir/min"
+		fi
+		if [ -n "$hi_hex" ] && [ "$hi_hex" != "null" ]; then
+			local hi_u
+			hi_u=$(hex_bytes_to_uint_be "$hi_hex")
+			awk -v u="$hi_u" -v s="$sc_num" 'BEGIN { printf "%.12g\n", u * s }' >"$ch_dir/max"
+		fi
 	fi
 
 	# min/max when Lo/Hi register hex absent (e.g. MAX1363): optional NormalMin/NormalMax scalars, else WarningMin/WarningMax
@@ -902,6 +1043,66 @@ create_channel_infrastructure()
 	return 0
 }
 
+# Program device registers over raw I2C (caller must have unbound any kernel driver).
+configure_a2d_registers_raw()
+{
+	local device_json="$1"
+	local device_name="$2"
+	local bus="$3"
+	local address="$4"
+	local device_type="$5"
+	local num_channels="$6"
+
+	local cfg_reg cfg_reg_val lo_thresh_reg lo_thresh_val hi_thresh_reg hi_thresh_val
+	local success failed
+
+	cfg_reg=$(echo "$device_json" | json_get_string "CfgReg")
+	cfg_reg_val=$(echo "$device_json" | json_get_string "CfgRegVal")
+	lo_thresh_reg=$(echo "$device_json" | json_get_string "LoThreshReg")
+	lo_thresh_val=$(echo "$device_json" | json_get_string "LoThreshRegVal")
+	hi_thresh_reg=$(echo "$device_json" | json_get_string "HiThreshReg")
+	hi_thresh_val=$(echo "$device_json" | json_get_string "HiThreshRegVal")
+
+	if [ "$device_type" = "ADS7924" ]; then
+		configure_ads7924_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels"
+		return $?
+	fi
+	if [ "$device_type" = "ADS1015" ]; then
+		configure_ads1015_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels"
+		return $?
+	fi
+
+	success=0
+	failed=0
+
+	if [ -n "$cfg_reg" ] && [ -n "$cfg_reg_val" ] && [ "$cfg_reg" != "null" ] && [ "$cfg_reg_val" != "null" ]; then
+		if write_and_verify_register "$bus" "$address" "$cfg_reg" "$cfg_reg_val" "Configuration Register" "$device_name"; then
+			success=$((success + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	fi
+
+	if [ -n "$lo_thresh_reg" ] && [ -n "$lo_thresh_val" ] && [ "$lo_thresh_reg" != "null" ] && [ "$lo_thresh_val" != "null" ]; then
+		if write_and_verify_register "$bus" "$address" "$lo_thresh_reg" "$lo_thresh_val" "Low Threshold Register" "$device_name"; then
+			success=$((success + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	fi
+
+	if [ -n "$hi_thresh_reg" ] && [ -n "$hi_thresh_val" ] && [ "$hi_thresh_reg" != "null" ] && [ "$hi_thresh_val" != "null" ]; then
+		if write_and_verify_register "$bus" "$address" "$hi_thresh_reg" "$hi_thresh_val" "High Threshold Register" "$device_name"; then
+			success=$((success + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	fi
+
+	log_message "info" "Device configuration for $device_name: $success successful, $failed failed"
+	[ "$failed" -eq 0 ]
+}
+
 # Args: device_json, device_name, num_channels, chnames (space-separated words from ChnlNames)
 configure_device()
 {
@@ -910,17 +1111,12 @@ configure_device()
 	local num_channels="$3"
 	local chnames="$4"
 
-	# Extract device parameters using library functions
-	local device_type bus address cfg_reg cfg_reg_val lo_thresh_reg lo_thresh_val hi_thresh_reg hi_thresh_val
+	local device_type bus address need_rebind
+
 	device_type=$(echo "$device_json" | json_get_string "DeviceType")
 	bus=$(echo "$device_json" | json_get_number "Bus")
 	address=$(echo "$device_json" | json_get_string "Address")
-	cfg_reg=$(echo "$device_json" | json_get_string "CfgReg")
-	cfg_reg_val=$(echo "$device_json" | json_get_string "CfgRegVal")
-	lo_thresh_reg=$(echo "$device_json" | json_get_string "LoThreshReg")
-	lo_thresh_val=$(echo "$device_json" | json_get_string "LoThreshRegVal")
-	hi_thresh_reg=$(echo "$device_json" | json_get_string "HiThreshReg")
-	hi_thresh_val=$(echo "$device_json" | json_get_string "HiThreshRegVal")
+	need_rebind=0
 
 	log_message "info" "Checking $device_type device at Bus $bus, Address $address for $device_name"
 
@@ -933,70 +1129,49 @@ configure_device()
 
 	log_message "info" "Configuring $device_type for $device_name..."
 
-	# 2) Optional kernel driver bind before register access (JSON Probe)
+	# 2) Bind kernel driver first when Probe is true (instantiates client; driver probe may run once).
 	if json_probe_true "$device_json"; then
-		if ! bind_kernel_driver "$bus" "$address" "$device_type"; then
-			if ! probe_i2c_sysfs_present "$bus" "$address"; then
-				log_message "info" "Bind failed and no I2C client in sysfs — try next alternative"
-				return 1
+		bind_kernel_driver "$bus" "$address" "$device_type"
+	fi
+
+	# 3) Unbind so i2ctransfer can program registers (MAX1363 / ADS1015 / ADS7924).
+	if i2c_client_has_bound_driver "$bus" "$address"; then
+		if ! unbind_kernel_driver "$bus" "$address"; then
+			log_message "info" "Leak detector $device_name: driver unbind failed — try next Device alternative"
+			return 1
+		fi
+		need_rebind=1
+	fi
+
+	# 4) Raw register programming — final values for all supported A2D types.
+	if ! configure_a2d_registers_raw "$device_json" "$device_name" "$bus" "$address" "$device_type" "$num_channels"; then
+		log_message "info" "Register programming failed — try next Device alternative"
+		if [ "$need_rebind" -eq 1 ] && json_probe_true "$device_json"; then
+			rebind_kernel_driver "$bus" "$address" "$device_type"
+		fi
+		return 1
+	fi
+
+	# 5) Rebind for IIO sysfs when Probe is true and we unbound for step 4.
+	if json_probe_true "$device_json"; then
+		if [ "$need_rebind" -eq 1 ]; then
+			if ! rebind_kernel_driver "$bus" "$address" "$device_type"; then
+				if ! probe_i2c_sysfs_present "$bus" "$address"; then
+					log_message "info" "Rebind failed and no I2C client in sysfs — try next alternative"
+					return 1
+				fi
+			fi
+		elif ! i2c_client_has_bound_driver "$bus" "$address"; then
+			if ! bind_kernel_driver "$bus" "$address" "$device_type"; then
+				if ! probe_i2c_sysfs_present "$bus" "$address"; then
+					log_message "info" "Bind failed and no I2C client in sysfs — try next alternative"
+					return 1
+				fi
 			fi
 		fi
 	fi
 
-	# 3) Register writes via i2ctransfer only when no kernel driver owns the client — otherwise
-	#    userspace gets "No such device or address"; configuration is expected from the driver / IIO.
-	if i2c_client_has_bound_driver "$bus" "$address"; then
-		log_message "info" "Kernel driver bound — skipping raw i2ctransfer register writes for $device_name (Bus $bus, Addr $address); use driver sysfs or program before bind if needed"
-		log_message "info" "Device configuration complete for $device_name: register writes skipped (driver active)"
-		return 0
-	fi
-
-	if [ "$device_type" = "ADS7924" ]; then
-		if ! configure_ads7924_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels"; then
-			log_message "info" "ADS7924 programming failed — try next Device alternative"
-			return 1
-		fi
-		log_message "info" "Device configuration complete for $device_name: ADS7924 raw I2C done"
-		return 0
-	fi
-
-	local success=0
-	local failed=0
-
-	# Write and verify configuration register (if provided)
-	if [ -n "$cfg_reg" ] && [ -n "$cfg_reg_val" ] && [ "$cfg_reg" != "null" ] && [ "$cfg_reg_val" != "null" ]; then
-		if write_and_verify_register "$bus" "$address" "$cfg_reg" "$cfg_reg_val" "Configuration Register" "$device_name"; then
-			success=$((success + 1))
-		else
-			failed=$((failed + 1))
-		fi
-	fi
-
-	# Write and verify low threshold register (if provided)
-	if [ -n "$lo_thresh_reg" ] && [ -n "$lo_thresh_val" ] && [ "$lo_thresh_reg" != "null" ] && [ "$lo_thresh_val" != "null" ]; then
-		if write_and_verify_register "$bus" "$address" "$lo_thresh_reg" "$lo_thresh_val" "Low Threshold Register" "$device_name"; then
-			success=$((success + 1))
-		else
-			failed=$((failed + 1))
-		fi
-	fi
-
-	# Write and verify high threshold register (if provided)
-	if [ -n "$hi_thresh_reg" ] && [ -n "$hi_thresh_val" ] && [ "$hi_thresh_reg" != "null" ] && [ "$hi_thresh_val" != "null" ]; then
-		if write_and_verify_register "$bus" "$address" "$hi_thresh_reg" "$hi_thresh_val" "High Threshold Register" "$device_name"; then
-			success=$((success + 1))
-		else
-			failed=$((failed + 1))
-		fi
-	fi
-
-	log_message "info" "Device configuration complete for $device_name: $success successful, $failed failed"
-
-	if [ "$failed" -gt 0 ]; then
-		log_message "info" "Register programming had failures — try next Device alternative"
-		return 1
-	fi
-
+	log_message "info" "Device configuration complete for $device_name"
 	return 0
 }
 

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-read.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-read.sh
@@ -63,8 +63,8 @@ ads1015_read_channel()
     local channel="$3"
     local offset="$4"
 
-    # Write channel selection (register 0x01, offset, 0x90)
-    if ! i2ctransfer -f -y "$bus" w3@"$addr" 0x01 "$offset" 0x90 >/dev/null 2>&1; then
+    # Write channel selection (register 0x01, MUX high byte, cfg low 0x94 — matches leakage-config init)
+    if ! i2ctransfer -f -y "$bus" w3@"$addr" 0x01 "$offset" 0x94 >/dev/null 2>&1; then
         log_message "warning" "Failed to select ADS1015 channel $channel on bus $bus addr $addr"
         return 1
     fi

--- a/bmc/usr/usr/bin/hw-management-bmc-ads1015-force-alarm.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads1015-force-alarm.sh
@@ -48,8 +48,8 @@ BUS="$1"
 ADDR="$2"
 CHS="$3"
 
-# Config register low byte: comparator enabled (see example CfgRegVal 0xc4 0x90).
-CFG_LO=0x90
+# Config register low byte: window comparator + latched ALERT (see CfgRegVal 0xc4 0x94).
+CFG_LO=0x94
 
 # Tight window → alarm (example LoThreshRegVal / HiThreshRegVal).
 ALARM_LO_MSB=0x38

--- a/bmc/usr/usr/bin/hw-management-bmc-ads1015-read-status.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads1015-read-status.sh
@@ -47,7 +47,8 @@ BUS="$1"
 ADDR="$2"
 CHANNEL="$3"
 
-# Legacy MUX/config high bytes (same as hw-management-bmc-a2d-leakage-read.sh).
+# Legacy MUX high bytes (same as hw-management-bmc-a2d-leakage-read.sh); cfg low 0x94.
+ADS1015_CFG_LO=0x94
 ADS1015_CH_OFFSET_1=0xc2
 ADS1015_CH_OFFSET_2=0xd2
 ADS1015_CH_OFFSET_3=0xe2
@@ -71,7 +72,7 @@ if [ -n "$CHANNEL" ]; then
     4) CH_OFF=$ADS1015_CH_OFFSET_4 ;;
     *) echo "Invalid channel: $CHANNEL (use 1-4)"; exit 1 ;;
     esac
-    if ! i2ctransfer -f -y "$BUS" w3@"$ADDR" 0x01 "$CH_OFF" 0x90 >/dev/null 2>&1; then
+    if ! i2ctransfer -f -y "$BUS" w3@"$ADDR" 0x01 "$CH_OFF" "$ADS1015_CFG_LO" >/dev/null 2>&1; then
         echo "Failed to select ADS1015 channel $CHANNEL"
         exit 1
     fi


### PR DESCRIPTION
Align HI189 A2D leakage configuration and BMC init with the leak- detection design (ADS1015 window comparator, MAX1363 fallback).

HI189 JSON (hw-management-bmc-a2d-leakage-config.json):
- Keep Mngm_ADC0 / Swb_ADC0 channel names per platform convention
- MAX1363 at 0x34; ADS1015 at 0x49 / 0x48 (mutually exclusive BOM)
- ADS1015: CfgRegVal 0xc4 0x94 (latched window comparator, ALERT)
- ADS1015: Lo/Hi 0x20 0x00 / 0x7f 0xf0; same Warning* limits as MAX1363
- Add CfgRegVal_comment for polling mode (use 0xc4 0x93 to disable ALERT)
- Probe remains true for kernel IIO after register programming

hw-management-bmc-a2d-leakage-config.sh:
- Add per-channel ADS1015 init (MUX + config + Lo/Hi per channel)
- sysfs min/max for ADS1015 from WarningMin/Max, not comparator regs
- A2D init order: bind -> unbind -> i2ctransfer -> rebind (Probe true)
- Shared configure_a2d_registers_raw() for MAX1363/ADS1015/ADS7924

Debug/read scripts: use config low byte 0x94 (was 0x90) consistently. On hw-mgmt-sonic-bmc, ads1015-read-status.sh keeps channel IDs 1-4.