### PR TITLE
leakage: ignore ADS1015 Config OS bit on readback verify

### DIFF
--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
@@ -424,7 +424,33 @@ i2c_readback_hex_concat()
 	printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | grep -oE '0x[0-9a-f]{1,2}' | sed 's/^0x//' | tr -d '\n'
 }
 
+# AND a concatenated hex string (2 chars per byte) with a space-separated 0xNN mask list.
+# Used to ignore volatile/status bits during readback verify (e.g. ADS1015 Config OS bit).
+# Mask shorter than data: trailing bytes pass through unmasked.
+hex_concat_apply_mask()
+{
+	local data="$1"
+	local byte mb pos=0 out="" n=${#data}
+
+	set -- $2
+	while [ "$pos" -lt "$n" ]; do
+		byte="${data:$pos:2}"
+		if [ -n "$1" ]; then
+			mb="${1#0x}"
+			mb="${mb#0X}"
+			out="$out$(printf '%02x' $((16#$byte & 16#$mb)))"
+			shift
+		else
+			out="$out$byte"
+		fi
+		pos=$((pos + 2))
+	done
+	printf '%s' "$out"
+}
+
 # Function to write and verify register
+# Optional 7th arg: per-byte verify mask (space-separated 0xNN). Bits cleared in the mask
+# are ignored on readback compare — needed for registers with volatile/read-only bits.
 write_and_verify_register()
 {
 	local bus="$1"
@@ -433,6 +459,7 @@ write_and_verify_register()
 	local reg_val="$4"
 	local reg_name="$5"
 	local device_name="$6"
+	local verify_mask="${7:-}"
 
 	# Count number of bytes in reg_val (word-split; reg_val is space-separated hex bytes)
 	set -- $reg_val
@@ -463,6 +490,11 @@ write_and_verify_register()
 	local read_n exp_n
 	read_n=$(i2c_readback_hex_concat "$readback")
 	exp_n=$(i2c_readback_hex_concat "$reg_val")
+
+	if [ -n "$verify_mask" ]; then
+		read_n=$(hex_concat_apply_mask "$read_n" "$verify_mask")
+		exp_n=$(hex_concat_apply_mask "$exp_n" "$verify_mask")
+	fi
 
 	if [ "$read_n" != "$exp_n" ]; then
 		log_message "warning" "$reg_name mismatch on $device_name (Bus $bus, Addr $addr): expected hex [$exp_n] from [$reg_val], readback hex [$read_n] from i2ctransfer — continuing"
@@ -621,8 +653,11 @@ configure_ads1015_raw_i2c()
 		t=$(json_optional_scalar "$device_json" "Ads1015LoThreshCh$((ch + 1))") && lo_val="$t"
 		t=$(json_optional_scalar "$device_json" "Ads1015HiThreshCh$((ch + 1))") && hi_val="$t"
 
+		# Config high byte bit 15 (OS) is a volatile single-shot/status bit, not stored config:
+		# write 1 starts a conversion, read returns 0 while converting (continuous mode reads 0).
+		# Mask it off (0x7f) so verify checks MUX/PGA/MODE/comparator bits without false-failing.
 		if ! write_and_verify_register "$bus" "$address" 0x01 \
-			"$mux $cfg_lo" "ADS1015 Config ch $ch" "$device_name"; then
+			"$mux $cfg_lo" "ADS1015 Config ch $ch" "$device_name" "0x7f 0xff"; then
 			failed=1
 		fi
 		if ! write_and_verify_register "$bus" "$address" "$lo_reg" \

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
@@ -432,7 +432,9 @@ hex_concat_apply_mask()
 	local data="$1"
 	local byte mb pos=0 out="" n=${#data}
 
+	set -f
 	set -- $2
+	set +f
 	while [ "$pos" -lt "$n" ]; do
 		byte="${data:$pos:2}"
 		if [ -n "$1" ]; then

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
@@ -432,6 +432,14 @@ hex_concat_apply_mask()
 	local data="$1"
 	local byte mb pos=0 out="" n=${#data}
 
+	# Expect whole bytes (2 hex chars each). On malformed odd-length input, return the data
+	# unmasked so the caller's compare stays byte-exact and still flags a mismatch (fail-safe:
+	# never hide a real difference behind a partial-byte mask).
+	if [ $((n % 2)) -ne 0 ]; then
+		printf '%s' "$data"
+		return
+	fi
+
 	set -f
 	set -- $2
 	set +f

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -367,6 +367,17 @@ check_bmc_is_supported()
 	esac
 }
 
+# This function checks if the host NOS is SONiC.
+# On SONiC, SONiC itself owns CPU<->BMC communication, so hw-management must
+# skip the BMC sync flow (Redfish login / BMC password rotation / BMC temp
+# polling). On any other host OS the behavior is unchanged.
+# Returns 0 if the host runs SONiC, 1 otherwise (single source of truth:
+# hw_management_sonic_check.py).
+check_host_os_is_sonic()
+{
+	/usr/bin/hw_management_sonic_check.py >/dev/null 2>&1
+}
+
 # This function create or cleans sysfs monitor helper files.
 init_sysfs_monitor_timestamp_files()
 {

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2982,7 +2982,10 @@ check_system()
 	esac
 	echo ${i2c_comex_mon_bus_default} > $config_path/i2c_comex_mon_bus_default
 	echo ${i2c_bus_def_off_eeprom_cpu} > $config_path/i2c_bus_def_off_eeprom_cpu
-	if check_bmc_is_supported; then
+	# Obtain/rotate the BMC password and log in over Redfish only on platforms
+	# with a BMC AND when the host NOS is not SONiC. On SONiC, SONiC owns
+	# CPU<->BMC communication, so hw-management must not drive this flow.
+	if check_bmc_is_supported && ! check_host_os_is_sonic; then
 		pushd /usr/bin
 		for ((i=1; i<=5; i++)); do
 			local bmc_ip_addr=$(ip addr show usb0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)

--- a/usr/usr/bin/hw_management_peripheral_updater.py
+++ b/usr/usr/bin/hw_management_peripheral_updater.py
@@ -52,6 +52,7 @@ try:
     from collections import Counter
 
     from hw_management_redfish_client import RedfishClient, BMCAccessor
+    from hw_management_sonic_check import is_sonic_os
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
@@ -648,6 +649,13 @@ def main():
         if re.match(key, product_sku):
             sys_attr.extend(val)
             break
+
+    # On SONiC hosts, SONiC owns CPU<->BMC communication. Drop the BMC Redfish
+    # entries so this daemon never logs in to the BMC or polls BMC sensors over
+    # Redfish. On any other host OS the configuration is left unchanged.
+    if is_sonic_os():
+        sys_attr = [attr for attr in sys_attr if attr.get("fn") != "redfish_get_sensor"]
+        LOGGER.notice("hw-management-peripheral-updater: SONiC host detected, BMC Redfish sync disabled")
 
     # Write module_counter for other services (must be done before they start)
     # This is done here in peripheral_updater to ensure it's written even if

--- a/usr/usr/bin/hw_management_sonic_check.py
+++ b/usr/usr/bin/hw_management_sonic_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# pylint: disable=line-too-long
+# pylint: disable=C0103
+########################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+"""
+@summary:
+    Detect whether the host NOS is SONiC.
+
+    SONiC ships a version manifest at /etc/sonic/sonic_version.yml that is not
+    present on other network operating systems (e.g. Cumulus Linux). Its
+    presence is used as the single source of truth for "host is running SONiC".
+
+    When the host runs SONiC, hw-management must NOT drive the CPU<->BMC sync
+    flow (Redfish login / BMC password rotation / BMC temperature polling),
+    because SONiC owns BMC communication on those platforms. On any other host
+    OS the existing behavior is unchanged.
+
+Usage:
+    As a module:
+        from hw_management_sonic_check import is_sonic_os
+        if is_sonic_os():
+            ...
+
+    As a command (for shell callers, exit code based):
+        hw_management_sonic_check.py   # exit 0 if SONiC, 1 otherwise
+"""
+
+import os
+import sys
+
+# SONiC version manifest. Present only on SONiC hosts.
+SONIC_VERSION_FILE = "/etc/sonic/sonic_version.yml"
+
+
+def is_sonic_os():
+    """
+    @summary: Check whether the host is running SONiC.
+    @return: True if the SONiC version manifest exists, False otherwise.
+    """
+    return os.path.isfile(SONIC_VERSION_FILE)
+
+
+def main():
+    """
+    @summary: CLI entry point.
+
+    Prints the boolean result and returns a shell-friendly exit code:
+    0 when the host runs SONiC, 1 otherwise.
+    """
+    sonic = is_sonic_os()
+    print(sonic)
+    return 0 if sonic else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The ADS1015/ADS1115 Config register bit 15 (OS) is a volatile single-shot/status bit, not stored configuration: writing 1 starts a conversion and it reads back 0 while a conversion is in progress (and in continuous-conversion mode it reads 0). The previous byte-exact readback verify of the Config register therefore always mismatched (e.g. wrote 0xc2 0x94, read 0x42 0x94), which marked every channel program as failed, skipped the detector, and left /var/run/hw-management/leakage/ empty even though the device was present and correctly programmed.

Add an optional per-byte verify mask to write_and_verify_register (via a new hex_concat_apply_mask helper) and use 0x7f 0xff for the ADS1015 Config write so the OS bit is ignored while MUX/PGA/MODE/comparator bits are still verified. The Lo/Hi threshold registers remain fully verified. This mirrors the existing ADS7924 path that skips verify on volatile bits.