### PR TITLE
hw-mgmt: service: Improve hw-mgmt trace log rotation

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: any
 Build-Profiles: <!pkg.hw-mgmt.bmc-only>
 Depends: ${misc:Depends}, ${shlibs:Depends}, ${dist:Depends}, lsb-base (>= 3.0-6),
  python2.7 | python3, python3-psutil, xxd, libiio-utils, dmidecode, i2c-tools, tpm2-tools,
- awk
+ awk, gzip, logrotate
 Description: Thermal control and chassis management for Nvidia systems (host)
  This package supports Nvidia switches family for chassis
  management and thermal control on the host CPU.

--- a/debian/hw-management.hw-management.service
+++ b/debian/hw-management.hw-management.service
@@ -8,6 +8,7 @@ Wants=hw-management-fast-sysfs-monitor.service
 Type=oneshot
 RemainAfterExit=true
 ExecStartPre=-/bin/sh -c "/usr/bin/hw-management-ready.sh"
+ExecStartPre=-/usr/sbin/logrotate --state /var/lib/logrotate/status /etc/logrotate.d/hw-mgmt-trace
 ExecStart=/bin/sh -c "/usr/bin/hw-management.sh start"
 ExecStop=/bin/sh -c "/usr/bin/hw-management.sh stop"
 ExecStopPost=/bin/sleep 3

--- a/usr/etc/logrotate.d/hw-mgmt-trace
+++ b/usr/etc/logrotate.d/hw-mgmt-trace
@@ -10,12 +10,14 @@
     notifempty
 }
 
-# Active log + rotate 2 => three files total (1 active + 2 rotated, compressed after delaycompress).
+# Active log + rotate 2 => three files total (1 active + 2 rotated, .gz after delaycompress).
 "/var/log/hw-mgmt-i2c-trace.log" {
     size 4M
     rotate 2
     copytruncate
     compress
+    compresscmd /usr/bin/gzip
+    compressext .gz
     delaycompress
     missingok
     notifempty


### PR DESCRIPTION
Some log files can grow beyond 10 MB despite the existing size-based log
rotation policy. This occurs because logrotate is triggered only once
per day.

Fixes:

- Invoke logrotate for hw-mgmt logs on every hw-management service
startup.
- Enable gzip compression for rotated log files.

Bug: 5027944

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
