### PR TITLE
hw-mgmt: bmc: netwroking: Add option to allow usb net IP address by NOS

### DIFF
--- a/bmc/DEVELOPER_GUIDE.md
+++ b/bmc/DEVELOPER_GUIDE.md
@@ -29,7 +29,7 @@ Create **`bmc/usr/etc/HINNN/`** and ship the same *kinds* of artifacts as **HI18
 | **`hw-management-bmc-boot-complete.conf`** | Optional | Minimum sysfs entry counts for **`hw-management-bmc-boot-complete.sh`**. |
 | **`hw-management-bmc-bom.json`** | Optional | SMBIOS BOM alternate maps for **`hw-management-bmc-devtree.sh`** when copied to **`/etc/hw-management-bmc-bom.json`**. |
 | **`hw-management-bmc-a2d-leakage-config.json`** | Optional | Only if the board uses the A2D leakage stack; otherwise omit or ship an empty / no-op policy per tooling expectations. |
-| **`hw-management-bmc-network.conf`** | Optional | **`USB0_ADDRESS=…`** for BMC↔host **`usb0`**; defaults exist in plat-specific-preps when this file is absent. |
+| **`hw-management-bmc-network.conf`** | Optional | **`USB0_ADDRESS=…`** for hw-management static **`usb0`**, or **`USB0_MANAGED_BY_NOS=1`** for SONiC/NOS-owned **`usb0`** (see **`hw-management-bmc-network-sonic.conf.example`**). Defaults exist in plat-specific-preps when this file is absent. |
 | **`99-hw-management-bmc-mctp.rules`** | Optional | IRoT MCTP (**`mctpirot*`**). Omit if the SKU has no such net devices. |
 
 All **`*.json`** files in the directory are **copied** to **`/etc/`** at boot (plat-specific-preps). All **`*.rules`** are **symlinked** into **`/lib/udev/rules.d/`**.

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -358,10 +358,10 @@ Static addressing for the BMC↔host **`usb0`** gadget interface (out-of-band li
 | Artifact | Location | Role |
 |----------|----------|------|
 | Template | **`usr/etc/systemd/network/00-hw-management-bmc-usb0.network`** | Shipped on the image as **`/usr/etc/systemd/network/…`**; contains **`Address=__USB0_ADDRESS__`**. Not read by networkd until rendered into **`/etc/systemd/network/`**. |
-| Platform params (optional) | **`usr/etc/<HID>/hw-management-bmc-network.conf`** | One line: **`USB0_ADDRESS=<addr>/<prefix>`** (e.g. **`169.254.0.1/16`**). Copied to **`/etc/hw-management-bmc-usb0.conf`** when present. |
+| Platform params (optional) | **`usr/etc/<HID>/hw-management-bmc-network.conf`** | **`USB0_ADDRESS=<addr>/<prefix>`** for hw-management-owned static addressing (e.g. **`169.254.0.1/16`**), or **`USB0_MANAGED_BY_NOS=1`** so SONiC/NOS owns **`usb0`** (see **`hw-management-bmc-network-sonic.conf.example`**). Copied to **`/etc/hw-management-bmc-usb0.conf`** when present. |
 | Runtime params | **`/etc/hw-management-bmc-usb0.conf`** | Effective source for substitution; may be written by plat-specific-preps (packaged copy, default fallback, or left as an operator-maintained file). |
-| Generated unit | **`/etc/systemd/network/00-hw-management-bmc-usb0.network`** | Written by **`hw-management-bmc-plat-specific-preps.sh`** before **`systemd-networkd`** starts. |
-| SONiC **`dhclient`** guard | **`/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf`** | When the generated **`.network`** file exists, **`sonic-usb-network-init`** is skipped so it does not run **`dhclient`** on **`usb0`**. That avoids fighting **`systemd-networkd`** (our unit sets **`DHCP=no`** and a static **`Address=`**) and avoids AppArmor denials on **`dhclient`**. If **`.network`** generation is skipped (invalid **`USB0_ADDRESS`**), SONiC’s service can still run. |
+| Generated unit | **`/etc/systemd/network/00-hw-management-bmc-usb0.network`** | Written by **`hw-management-bmc-plat-specific-preps.sh`** before **`systemd-networkd`** starts when **`USB0_MANAGED_BY_NOS`** is not set. |
+| SONiC **`dhclient`** guard | **`/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf`** | When the generated **`.network`** file exists, **`sonic-usb-network-init`** is skipped so it does not run **`dhclient`** on **`usb0`**. That avoids fighting **`systemd-networkd`** (our unit sets **`DHCP=no`** and a static **`Address=`**) and avoids AppArmor denials on **`dhclient`**. If **`.network`** generation is skipped (**`USB0_MANAGED_BY_NOS=1`**, invalid **`USB0_ADDRESS`**, etc.), SONiC’s service can run. |
 
 **Boot order:** **`hw-management-bmc-plat-specific-preps.service`** has **`Before=systemd-networkd.service`**, so the **`/etc/systemd/network/`** file exists before networkd loads configuration. No race on first boot for this unit.
 
@@ -371,8 +371,11 @@ Static addressing for the BMC↔host **`usb0`** gadget interface (out-of-band li
 
 **Defaults and overrides**
 
-- If **`hw-management-bmc-network.conf`** is **packaged** under **`/etc/<HID>/`**, it is copied to **`/etc/hw-management-bmc-usb0.conf`** and **`USB0_ADDRESS`** is read from there. If **`USB0_ADDRESS`** is missing or fails validation (conservative **`grep -E`** CIDR pattern, BusyBox-safe), **`.network`** generation is **skipped** for that boot (fix the platform file).
+- **`USB0_MANAGED_BY_NOS=1`** (values **`1`**, **`yes`**, **`true`**, case-insensitive): hw-management-bmc does **not** write **`00-hw-management-bmc-usb0.network`**, does **not** apply a static **`ip addr`**, and **`usb_net_config`** only loads **`g_ether`** and sets the link up. Use on **SONiC BMC** images so **`sonic-usb-network-init`** can configure **`usb0`**. Ship **`hw-management-bmc-network-sonic.conf.example`** as your platform **`hw-management-bmc-network.conf`** (or equivalent under **`/etc/<HID>/`**).
+- If **`hw-management-bmc-network.conf`** is **packaged** under **`/etc/<HID>/`** without **`USB0_MANAGED_BY_NOS`**, it is copied to **`/etc/hw-management-bmc-usb0.conf`** and **`USB0_ADDRESS`** is read from there. If **`USB0_ADDRESS`** is missing or fails validation (conservative **`grep -E`** CIDR pattern, BusyBox-safe), **`.network`** generation is **skipped** for that boot (fix the platform file).
 - If the packaged **`hw-management-bmc-network.conf`** is **absent**: use a valid **`USB0_ADDRESS`** from existing **`/etc/hw-management-bmc-usb0.conf`** if present; otherwise apply default **`169.254.0.1/16`** and write **`/etc/hw-management-bmc-usb0.conf`** with a comment so the active value is visible.
+
+**Host CPU (hw-management package):** On SONiC hosts (**`/etc/sonic/sonic_version.yml`**), **`hw-management-ifupdown.sh`** skips **`ifup usb0`** so the host NOS owns addressing (same pattern as BMC Redfish sync).
 
 **Changing address after install:** Edit **`/etc/hw-management-bmc-usb0.conf`** (when no packaged file overrides it each boot), or add **`hw-management-bmc-network.conf`** under the correct **`/etc/<HID>/`**. Then **`networkctl reload`** or restart **`systemd-networkd`** as usual for **`.network`** edits.
 

--- a/bmc/usr/etc/HI189/hw-management-bmc-network-sonic.conf.example
+++ b/bmc/usr/etc/HI189/hw-management-bmc-network-sonic.conf.example
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+#
+# Example for SONiC BMC images: copy to hw-management-bmc-network.conf in the
+# platform directory (or install as /etc/hw-management-bmc-usb0.conf) so
+# hw-management-bmc does not assign a static usb0 address. SONiC's
+# sonic-usb-network-init (or host NOS networking) owns the link instead.
+#
+# Do not set USB0_ADDRESS when USB0_MANAGED_BY_NOS is enabled.
+USB0_MANAGED_BY_NOS=1

--- a/bmc/usr/etc/HI189/hw-management-bmc-network.conf
+++ b/bmc/usr/etc/HI189/hw-management-bmc-network.conf
@@ -4,4 +4,7 @@
 # Installed as /etc/hw-management-bmc-usb0.conf by hw-management-bmc-plat-specific-preps.
 # Used to generate /etc/systemd/network/00-hw-management-bmc-usb0.network from
 # /usr/etc/systemd/network/00-hw-management-bmc-usb0.network (template with __USB0_ADDRESS__).
+#
+# For SONiC BMC images use USB0_MANAGED_BY_NOS=1 instead (see
+# hw-management-bmc-network-sonic.conf.example); do not set USB0_ADDRESS there.
 USB0_ADDRESS=169.254.0.1/16

--- a/bmc/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf
+++ b/bmc/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf
@@ -6,7 +6,9 @@
 # addressing; AppArmor may also block dhclient on this interface.
 #
 # When our .network file is present (rendered at boot by hw-management-bmc-plat-specific-preps),
-# skip the SONiC one-shot. If usb0 .network generation is skipped (invalid USB0_ADDRESS),
-# this condition passes and SONiC can still run dhclient.
+# this unit is skipped (ConditionPathExists=! fails). When USB0_MANAGED_BY_NOS=1,
+# plat-specific-preps does not write .network, so the condition passes and
+# sonic-usb-network-init may run. Same if .network generation is skipped
+# (invalid USB0_ADDRESS).
 [Unit]
 ConditionPathExists=!/etc/systemd/network/00-hw-management-bmc-usb0.network

--- a/bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh
@@ -176,13 +176,18 @@ deploy_hw_management_bmc_platform_files()
 	shopt -u nullglob
 
 	# USB0 (CPU ↔ BMC): copy platform network params and render systemd-networkd unit.
+	# shellcheck source=/usr/bin/hw-management-bmc-usb0-common.sh
+	. /usr/bin/hw-management-bmc-usb0-common.sh
 	default_usb0_addr="169.254.0.1/16"
 	if [ -f "$HID_SRC/hw-management-bmc-network.conf" ]; then
 		cp -f "$HID_SRC/hw-management-bmc-network.conf" /etc/hw-management-bmc-usb0.conf
 		chmod 0644 /etc/hw-management-bmc-usb0.conf
 	fi
 
-	if [ ! -f /usr/etc/systemd/network/00-hw-management-bmc-usb0.network ]; then
+	if hw_management_bmc_usb0_managed_by_nos; then
+		rm -f "$HW_MANAGEMENT_BMC_USB0_NETWORK_UNIT"
+		echo "plat-specific: USB0_MANAGED_BY_NOS set; NOS owns usb0 (no static .network)"
+	elif [ ! -f /usr/etc/systemd/network/00-hw-management-bmc-usb0.network ]; then
 		:
 	else
 		local usb0_addr

--- a/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
@@ -419,25 +419,31 @@ bmc_init_bootargs()
 #######################################
 # USB gadget Ethernet (usb0): load g_ether if needed, then either rely on
 # systemd-networkd (00-hw-management-bmc-usb0.network) or apply static
-# USB0_ADDRESS when networkd is not active (e.g. SONiC images).
+# USB0_ADDRESS when networkd is not active.
+# When USB0_MANAGED_BY_NOS=1, only bring up the link; addressing is NOS-owned.
 # Reads /etc/hw-management-bmc-usb0.conf and/or /etc/systemd/network/00-hw-management-bmc-usb0.network.
 # Never fails the caller; logs and returns 0.
 #######################################
 usb_net_config()
 {
-	local net_unit="/etc/systemd/network/00-hw-management-bmc-usb0.network"
-	local conf="/etc/hw-management-bmc-usb0.conf"
+	# shellcheck source=/usr/bin/hw-management-bmc-usb0-common.sh
+	. /usr/bin/hw-management-bmc-usb0-common.sh
+	local net_unit="$HW_MANAGEMENT_BMC_USB0_NETWORK_UNIT"
+	local conf="$HW_MANAGEMENT_BMC_USB0_CONF"
 	local addr=""
+	local nos_managed=0
 	local logtag="${LOG_TAG:-${_HW_MANAGEMENT_BMC_READY_COMMON_LOG_TAG}}"
 
-	if [ -f "$conf" ]; then
-		addr=$(sed -n 's/^[[:space:]]*USB0_ADDRESS=//p' "$conf" | head -1 | tr -d " '\"")
-	fi
-	if [ -z "$addr" ] && [ -f "$net_unit" ]; then
-		addr=$(sed -n 's/^[[:space:]]*Address=//p' "$net_unit" | head -1 | tr -d " '\"")
-	fi
-	if [ -z "$addr" ] || ! printf '%s' "$addr" | grep -qE '^[0-9a-fA-F.:/]+/[0-9]+$'; then
-		return 0
+	if hw_management_bmc_usb0_managed_by_nos; then
+		nos_managed=1
+	else
+		addr=$(_hw_management_bmc_usb0_conf_value USB0_ADDRESS "$conf")
+		if [ -z "$addr" ] && [ -f "$net_unit" ]; then
+			addr=$(sed -n 's/^[[:space:]]*Address=//p' "$net_unit" | head -1 | tr -d " '\"")
+		fi
+		if [ -z "$addr" ] || ! printf '%s' "$addr" | grep -qE '^[0-9a-fA-F.:/]+/[0-9]+$'; then
+			return 0
+		fi
 	fi
 
 	if [ ! -d /sys/module/g_ether ]; then
@@ -456,6 +462,12 @@ usb_net_config()
 	done
 	if [ ! -d /sys/class/net/usb0 ]; then
 		logger -t "$logtag" -p daemon.warning "usb_net_config: usb0 not present after g_ether"
+		return 0
+	fi
+
+	if [ "$nos_managed" -eq 1 ]; then
+		ip link set usb0 up 2>/dev/null || true
+		logger -t "$logtag" -p daemon.info "usb_net_config: USB0_MANAGED_BY_NOS; link up, NOS owns addressing"
 		return 0
 	fi
 

--- a/bmc/usr/usr/bin/hw-management-bmc-usb0-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-usb0-common.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+#
+# Shared usb0 (BMC <-> host CPU) helpers. Sourced by plat-specific-preps and
+# hw-management-bmc-ready-common (do not execute directly).
+
+HW_MANAGEMENT_BMC_USB0_CONF="/etc/hw-management-bmc-usb0.conf"
+HW_MANAGEMENT_BMC_USB0_NETWORK_UNIT="/etc/systemd/network/00-hw-management-bmc-usb0.network"
+
+# Read KEY=value from /etc/hw-management-bmc-usb0.conf (first match, strip quotes).
+_hw_management_bmc_usb0_conf_value()
+{
+	local key="$1"
+	local conf="${2:-$HW_MANAGEMENT_BMC_USB0_CONF}"
+
+	[ -n "$key" ] || return 1
+	[ -f "$conf" ] || return 1
+	sed -n "s/^[[:space:]]*${key}=//p" "$conf" | head -1 | tr -d " '\""
+}
+
+# True when the NOS (e.g. SONiC sonic-usb-network-init) owns usb0 addressing.
+hw_management_bmc_usb0_managed_by_nos()
+{
+	local v
+
+	v=$(_hw_management_bmc_usb0_conf_value USB0_MANAGED_BY_NOS)
+	v=$(printf '%s' "$v" | tr '[:upper:]' '[:lower:]')
+	case "$v" in
+	1 | yes | true) return 0 ;;
+	esac
+	return 1
+}

--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -38,26 +38,34 @@ source /usr/bin/hw-management-helpers.sh
 
 INTERFACE=$1
 
+# Check if interface parameter exists
 if [ -z "${INTERFACE}" ]; then
-	log_err "Missing interface parameter"
+	log_err "Interface parameter is missing"
 	exit 1
 fi
 
-if [ ! -e "/sys/class/net/${INTERFACE}" ]; then
-	log_info "Interface ${INTERFACE} is missing"
+# On SONiC hosts the NOS owns usb0 addressing (not ifup/static interfaces).
+if [ "${INTERFACE}" = "usb0" ] && check_host_os_is_sonic; then
+	log_info "SONiC host: skip ifup ${INTERFACE} (NOS-owned)"
 	exit 0
 fi
 
+# Check if /etc/network/interfaces exists
 if [ ! -e /etc/network/interfaces ]; then
-	log_info "/etc/network/interfaces is missing"
-	exit 0
+	log_err "/etc/network/interfaces is missing"
+	exit 1
 fi
 
-AUTO=$(ifquery -l 2>/dev/null)
-HOTPLUG=$(ifquery -l --allow=hotplug 2>/dev/null)
+# Check if interface exists
+if [ ! -d "/sys/class/net/$INTERFACE" ]; then
+	log_err "Interface $INTERFACE does not exist"
+	exit 1
+fi
 
-if ! echo "$AUTO" "$HOTPLUG" | grep -q "${INTERFACE}"; then
-	exit 0
+# Check if interface is defined in /etc/network/interfaces
+if ! ifquery "$INTERFACE" >/dev/null 2>&1; then
+	log_err "Interface $INTERFACE is not defined in /etc/network/interfaces"
+	exit 1
 fi
 
 # Retry ifup to work around locking conflicts with Debian networking service.
@@ -73,7 +81,7 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
 	fi
 
 	if [ "$i" -lt "$MAX_RETRIES" ]; then
-		log_info "Attempt $i to ifup ${INTERFACE} failed. Retrying in ${RETRY_DELAY} seconds..."
+		log_info "Unsuccessful attempt $i to ifup ${INTERFACE}. Retrying in ${RETRY_DELAY} seconds..."
 		sleep "${RETRY_DELAY}"
 	fi
 done


### PR DESCRIPTION
Add USB0_MANAGED_BY_NOS so BMC images can defer usb0 addressing to the NOS (e.g. SONiC sonic-usb-network-init) instead of hw-management-bmc static systemd-networkd configuration.

BMC:
- New hw-management-bmc-usb0-common.sh: read USB0_MANAGED_BY_NOS from /etc/hw-management-bmc-usb0.conf (1, yes, true; case-insensitive).
- plat-specific-preps: when set, remove static .network unit and skip Address= rendering; sonic-usb-network-init may run.
- usb_net_config: when set, load g_ether and bring link up only; no static ip addr or networkd reload for addressing.
- HI189 hw-management-bmc-network-sonic.conf.example for SONiC BMC image recipes; document flag in network.conf and README.

Host (hw-management):
- hw-management-ifupdown.sh: on SONiC hosts (sonic_version.yml), skip ifup usb0 so the host NOS owns the interface.

Backward compatible: without USB0_MANAGED_BY_NOS, behavior is unchanged (static USB0_ADDRESS / .network as before). HI189 default still ships USB0_ADDRESS only.

Clarify sonic-usb-network-init drop-in comments (NOS-managed mode allows the service to run when .network is not written).

Update bmc/README.md, DEVELOPER_GUIDE.md, and sonic-usb-network-init drop-in comments.