### PR TITLE
hw-mgmt: bmc: netwroking: Add option to allow usb net IP address by NOS

### DIFF
--- a/bmc/DEVELOPER_GUIDE.md
+++ b/bmc/DEVELOPER_GUIDE.md
@@ -29,7 +29,7 @@ Create **`bmc/usr/etc/HINNN/`** and ship the same *kinds* of artifacts as **HI18
 | **`hw-management-bmc-boot-complete.conf`** | Optional | Minimum sysfs entry counts for **`hw-management-bmc-boot-complete.sh`**. |
 | **`hw-management-bmc-bom.json`** | Optional | SMBIOS BOM alternate maps for **`hw-management-bmc-devtree.sh`** when copied to **`/etc/hw-management-bmc-bom.json`**. |
 | **`hw-management-bmc-a2d-leakage-config.json`** | Optional | Only if the board uses the A2D leakage stack; otherwise omit or ship an empty / no-op policy per tooling expectations. |
-| **`hw-management-bmc-network.conf`** | Optional | **`USB0_ADDRESS=…`** for BMC↔host **`usb0`**; defaults exist in plat-specific-preps when this file is absent. |
+| **`hw-management-bmc-network.conf`** | Optional | **`USB0_ADDRESS=…`** for hw-management static **`usb0`**, or **`USB0_MANAGED_BY_NOS=1`** for SONiC/NOS-owned **`usb0`** (see **`hw-management-bmc-network-sonic.conf.example`**). Defaults exist in plat-specific-preps when this file is absent. |
 | **`99-hw-management-bmc-mctp.rules`** | Optional | IRoT MCTP (**`mctpirot*`**). Omit if the SKU has no such net devices. |
 
 All **`*.json`** files in the directory are **copied** to **`/etc/`** at boot (plat-specific-preps). All **`*.rules`** are **symlinked** into **`/lib/udev/rules.d/`**.

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -371,10 +371,10 @@ Static addressing for the BMC↔host **`usb0`** gadget interface (out-of-band li
 | Artifact | Location | Role |
 |----------|----------|------|
 | Template | **`usr/etc/systemd/network/00-hw-management-bmc-usb0.network`** | Shipped on the image as **`/usr/etc/systemd/network/…`**; contains **`Address=__USB0_ADDRESS__`**. Not read by networkd until rendered into **`/etc/systemd/network/`**. |
-| Platform params (optional) | **`usr/etc/<HID>/hw-management-bmc-network.conf`** | One line: **`USB0_ADDRESS=<addr>/<prefix>`** (e.g. **`169.254.0.1/16`**). Copied to **`/etc/hw-management-bmc-usb0.conf`** when present. |
+| Platform params (optional) | **`usr/etc/<HID>/hw-management-bmc-network.conf`** | Non-SONiC: **`USB0_ADDRESS=…`**. SONiC/NOS: install **`/etc/bmc-network-sonic.conf`** (see **`SONIC_USB0_INTEGRATION.md`**). Copied to **`/etc/hw-management-bmc-usb0.conf`** at boot. |
 | Runtime params | **`/etc/hw-management-bmc-usb0.conf`** | Effective source for substitution; may be written by plat-specific-preps (packaged copy, default fallback, or left as an operator-maintained file). |
-| Generated unit | **`/etc/systemd/network/00-hw-management-bmc-usb0.network`** | Written by **`hw-management-bmc-plat-specific-preps.sh`** before **`systemd-networkd`** starts. |
-| SONiC **`dhclient`** guard | **`/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf`** | When the generated **`.network`** file exists, **`sonic-usb-network-init`** is skipped so it does not run **`dhclient`** on **`usb0`**. That avoids fighting **`systemd-networkd`** (our unit sets **`DHCP=no`** and a static **`Address=`**) and avoids AppArmor denials on **`dhclient`**. If **`.network`** generation is skipped (invalid **`USB0_ADDRESS`**), SONiC’s service can still run. |
+| Generated unit | **`/etc/systemd/network/00-hw-management-bmc-usb0.network`** | Written by **`hw-management-bmc-plat-specific-preps.sh`** before **`systemd-networkd`** starts when **`USB0_MANAGED_BY_NOS`** is not set. |
+| SONiC **`dhclient`** guard | **`/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf`** | When the generated **`.network`** file exists, **`sonic-usb-network-init`** is skipped so it does not run **`dhclient`** on **`usb0`**. That avoids fighting **`systemd-networkd`** (our unit sets **`DHCP=no`** and a static **`Address=`**) and avoids AppArmor denials on **`dhclient`**. If **`.network`** generation is skipped (**`USB0_MANAGED_BY_NOS=1`**, invalid **`USB0_ADDRESS`**, etc.), SONiC’s service can run. |
 
 **Boot order:** **`hw-management-bmc-plat-specific-preps.service`** has **`Before=systemd-networkd.service`**, so the **`/etc/systemd/network/`** file exists before networkd loads configuration. No race on first boot for this unit.
 
@@ -384,8 +384,11 @@ Static addressing for the BMC↔host **`usb0`** gadget interface (out-of-band li
 
 **Defaults and overrides**
 
-- If **`hw-management-bmc-network.conf`** is **packaged** under **`/etc/<HID>/`**, it is copied to **`/etc/hw-management-bmc-usb0.conf`** and **`USB0_ADDRESS`** is read from there. If **`USB0_ADDRESS`** is missing or fails validation (conservative **`grep -E`** CIDR pattern, BusyBox-safe), **`.network`** generation is **skipped** for that boot (fix the platform file).
+- **`USB0_MANAGED_BY_NOS=1`** (values **`1`**, **`yes`**, **`true`**, case-insensitive): hw-management-bmc does **not** write **`00-hw-management-bmc-usb0.network`**, does **not** apply a static **`ip addr`**, and **`usb_net_config`** only loads **`g_ether`** and sets the link up. On **SONiC BMC** images, SONiC installs **`/etc/bmc-network-sonic.conf`** (or **`/etc/bmc-usb-network.conf`**) so **`sonic-usb-network-init`** can configure **`usb0`**. See **`bmc/SONIC_USB0_INTEGRATION.md`**.
+- If **`hw-management-bmc-network.conf`** is **packaged** under **`/etc/<HID>/`** without **`USB0_MANAGED_BY_NOS`**, it is copied to **`/etc/hw-management-bmc-usb0.conf`** and **`USB0_ADDRESS`** is read from there. If **`USB0_ADDRESS`** is missing or fails validation (conservative **`grep -E`** CIDR pattern, BusyBox-safe), **`.network`** generation is **skipped** for that boot (fix the platform file).
 - If the packaged **`hw-management-bmc-network.conf`** is **absent**: use a valid **`USB0_ADDRESS`** from existing **`/etc/hw-management-bmc-usb0.conf`** if present; otherwise apply default **`169.254.0.1/16`** and write **`/etc/hw-management-bmc-usb0.conf`** with a comment so the active value is visible.
+
+**Host CPU (hw-management package):** On SONiC hosts (**`/etc/sonic/sonic_version.yml`**), **`hw-management-ifupdown.sh`** skips **`ifup usb0`** so the host NOS owns addressing (same pattern as BMC Redfish sync).
 
 **Changing address after install:** Edit **`/etc/hw-management-bmc-usb0.conf`** (when no packaged file overrides it each boot), or add **`hw-management-bmc-network.conf`** under the correct **`/etc/<HID>/`**. Then **`networkctl reload`** or restart **`systemd-networkd`** as usual for **`.network`** edits.
 

--- a/bmc/SONIC_USB0_INTEGRATION.md
+++ b/bmc/SONIC_USB0_INTEGRATION.md
@@ -1,0 +1,178 @@
+# SONiC integration: usb0 (BMC ↔ host CPU)
+
+This document describes what **SONiC** must provide on the **host CPU** and **BMC**
+so the NOS owns **usb0** IP assignment. **hw-management-bmc** and **hw-management**
+stay out of addressing when the opt-in flag (BMC) or SONiC detection (host) apply.
+
+For implementation details in this package, see **`bmc/README.md`** (section *BMC usb0 /
+systemd-networkd*).
+
+### Config file naming
+
+| Where | Path | Notes |
+|-------|------|--------|
+| **SONiC BMC image (runtime)** | **`/etc/bmc-network-sonic.conf`** | **Preferred** well-known path; SONiC installs content here. |
+| **SONiC BMC image (runtime, alt)** | **`/etc/bmc-usb-network.conf`** | Optional alias if SONiC prefers a shorter name (checked if primary is absent). |
+| **hw-management runtime** | **`/etc/hw-management-bmc-usb0.conf`** | Written at boot by plat-specific-preps (copy of NOS file or HID platform file). |
+| **Non-SONiC BMC (HID platform)** | **`/etc/<HID>/hw-management-bmc-network.conf`** | Legacy static **`USB0_ADDRESS`** path when no NOS file is present. |
+| **hw-mgmt repo (reference)** | **`usr/etc/<HID>/hw-management-bmc-network-sonic.conf.example`** | Example content only; not read from the package path at runtime. |
+
+**To agree with SONiC:** source filename and recipe layout in the SONiC tree are
+**SONiC’s choice**. The **runtime contract** is: install **`USB0_MANAGED_BY_NOS=1`** at
+**`/etc/bmc-network-sonic.conf`** (or **`/etc/bmc-usb-network.conf`**). No rename into
+**`/etc/<HID>/`** is required.
+
+**SONiC deliverable:** ship a file on the BMC rootfs with:
+
+```bash
+USB0_MANAGED_BY_NOS=1
+```
+
+at **`/etc/bmc-network-sonic.conf`** (preferred). Do **not** set **`USB0_ADDRESS`** there.
+
+---
+
+## Overview
+
+| Side | hw-management role | SONiC role |
+|------|------------------|------------|
+| **BMC** | Link up (`g_ether`); no static IP, no `.network` unit | Configure **usb0** (e.g. `sonic-usb-network-init`) |
+| **Host CPU** | No `ifup usb0` on SONiC | Configure **usb0** via SONiC networking |
+
+**Rule:** Only one stack must assign **usb0** on each side. Do not combine hw-management
+static **`USB0_ADDRESS`** / **systemd-networkd** with SONiC **`dhclient`** on the same
+interface.
+
+---
+
+## BMC (SONiC BMC image)
+
+### Image / BSP requirements
+
+1. **Release usb0 to SONiC** — install **`/etc/bmc-network-sonic.conf`** on the SONiC BMC
+   image (see [Config file naming](#config-file-naming)). Source name in the SONiC git tree
+   is flexible; only the **runtime path** on the BMC must match the contract.
+
+   ```bash
+   # /etc/bmc-network-sonic.conf (on BMC rootfs)
+   USB0_MANAGED_BY_NOS=1
+   ```
+
+   At boot, **hw-management-bmc-plat-specific-preps** copies that file to
+   **`/etc/hw-management-bmc-usb0.conf`** only when **`USB0_MANAGED_BY_NOS=1`** is set
+   there.    A NOS path without the flag is ignored and the HID static config is used
+   instead. Stale **`/etc/hw-management-bmc-usb0.conf`** from an earlier SONiC boot
+   is not honored unless a live NOS or HID source sets the flag again this boot.
+   Do **not** set **`USB0_ADDRESS=…`** on SONiC BMC images.
+
+   Reference content in hw-mgmt:
+   **`usr/etc/<HID>/hw-management-bmc-network-sonic.conf.example`**.
+
+2. **SONiC BMC usb0 init** — **`sonic-usb-network-init.service`** must be present and
+   allowed to run:
+   - With **`USB0_MANAGED_BY_NOS=1`**, hw-management does **not** create
+     **`/etc/systemd/network/00-hw-management-bmc-usb0.network`**.
+   - Without that file, the hw-management drop-in
+     (**`sonic-usb-network-init.service.d/10-hw-management-bmc.conf`**) does **not**
+     block SONiC; **`sonic-usb-network-init`** may run (typically **`dhclient usb0`**).
+
+3. **Addressing policy** — SONiC defines how **usb0** gets an address on the BMC
+   (DHCP, static from CONFIG_DB / template / script, etc.). Agree with platform/BSP on
+   BMC vs host addresses (e.g. link-local **`169.254.0.0/16`**, who is **`.1`** / **`.2`**).
+
+### What hw-management-bmc still does
+
+- Loads **`g_ether`** and brings **usb0** up (no static **`ip addr`**, no static
+  **systemd-networkd** unit for addressing).
+- Does **not** assign an IP when **`USB0_MANAGED_BY_NOS=1`**.
+
+### BMC verification
+
+```bash
+grep USB0 /etc/hw-management-bmc-usb0.conf
+test ! -f /etc/systemd/network/00-hw-management-bmc-usb0.network
+systemctl status sonic-usb-network-init
+ip -4 addr show dev usb0
+```
+
+---
+
+## Host CPU (SONiC switch / NOS)
+
+### Image / recipe requirements
+
+1. **SONiC identity** — host image includes **`/etc/sonic/sonic_version.yml`**.
+
+2. **Host NOS contract (aligned with BMC)** — when both sides use NOS-owned **usb0**,
+   the **SONiC host** image must also ship **`/etc/bmc-network-sonic.conf`** (or
+   **`/etc/bmc-usb-network.conf`**). **`hw-management-ifupdown.sh`** skips **`ifup
+   usb0`** only when SONiC **and** that file exists. If the host is SONiC but the
+   file is missing (BMC still on static **usb0**), the host keeps the normal **ifup**
+   path so **usb0** can be configured on both sides.
+
+3. **Host usb0 configuration** — when the contract file is present, SONiC must
+   configure **usb0** (platform recipe,
+   networkd, init script, CONFIG_DB, etc.). Do **not** rely on **`/etc/network/interfaces`**
+   + hw-management udev **`ifup`** on SONiC.
+
+4. **BMC communication** — on SONiC, hw-management does **not** drive CPU↔BMC Redfish /
+   password sync; SONiC owns that path. **usb0** must be reachable using SONiC’s
+   addressing plan.
+
+### What hw-management does on the host
+
+- May rename the USB NIC to **usb0** (udev), where applicable.
+- On SONiC **with** **`/etc/bmc-network-sonic.conf`** (or alt): **does not** call
+  **`ifup usb0`**. Without that file, **ifup** runs (misaligned / static-BMC case).
+- Other interfaces / missing **`/etc/network/interfaces`**: unchanged defensive behavior
+  (silent **exit 0**, auto/hotplug class guard via **`ifquery -l`**).
+- Does **not** assign a host **usb0** IP when the NOS contract file is present (SONiC owns it).
+
+### Host verification
+
+```bash
+test -f /etc/sonic/sonic_version.yml
+test -f /etc/bmc-network-sonic.conf || test -f /etc/bmc-usb-network.conf
+ip link show usb0
+ip -4 addr show dev usb0
+```
+
+---
+
+## Integrator checklist
+
+| Item | BMC SONiC image | Host SONiC image |
+|------|-----------------|------------------|
+| **`/etc/bmc-network-sonic.conf`** (or **`/etc/bmc-usb-network.conf`**) on BMC image | Required | N/A |
+| **`USB0_MANAGED_BY_NOS=1`** in that config | Required | N/A (auto via **`sonic_version.yml`**) |
+| No **`USB0_ADDRESS`** in hw-mgmt BMC config | Required | N/A |
+| No **`00-hw-management-bmc-usb0.network`** at boot | Expected | N/A |
+| **`sonic-usb-network-init`** (or equivalent) runs on BMC | Required | N/A |
+| SONiC configures **usb0** IP | Required | Required (when contract file present) |
+| **`/etc/bmc-network-sonic.conf`** (or alt) on **host** when using NOS mode | N/A | Required |
+| No static **usb0** for hw-mgmt **`ifup`** on host | N/A | Only when host contract file present |
+| Agreed BMC / host IP plan | Required | Required |
+
+---
+
+## Non-SONiC (unchanged)
+
+Without **`USB0_MANAGED_BY_NOS=1`** on the BMC and without SONiC on the host,
+hw-management keeps the legacy path: **`USB0_ADDRESS`** + **systemd-networkd** on the
+BMC, **`ifup`** on the host where **`/etc/network/interfaces`** defines **usb0**.
+
+---
+
+## Related files in this repository
+
+| Path | Purpose |
+|------|---------|
+| **`bmc/usr/etc/<HID>/hw-management-bmc-network-sonic.conf.example`** | Example content for **`/etc/bmc-network-sonic.conf`** |
+| **`bmc/usr/usr/bin/hw-management-bmc-usb0-common.sh`** | NOS well-known paths + **`USB0_MANAGED_BY_NOS`** parser |
+| **`bmc/usr/etc/<HID>/hw-management-bmc-network.conf`** | Default non-SONiC platform config (**`USB0_ADDRESS`**) |
+| **`bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh`** | Renders or skips **`.network`** unit |
+| **`bmc/usr/usr/bin/hw-management-bmc-ready-common.sh`** | **`usb_net_config()`** |
+| **`usr/usr/bin/hw-management-ifupdown.sh`** | Host udev **`ifup`** (skips **usb0** when SONiC + contract file) |
+| **`usr/usr/bin/hw-management-helpers.sh`** | **`check_host_usb0_managed_by_nos()`** |
+| **`usr/usr/bin/hw_management_sonic_check.py`** | SONiC host detection |
+| **`bmc/README.md`** | Full BMC package and **usb0** documentation |

--- a/bmc/usr/etc/HI189/hw-management-bmc-network-sonic.conf.example
+++ b/bmc/usr/etc/HI189/hw-management-bmc-network-sonic.conf.example
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+#
+# hw-mgmt reference template. SONiC installs the same content at a well-known path:
+#   /etc/bmc-network-sonic.conf   (preferred)
+#   /etc/bmc-usb-network.conf     (optional alias)
+# See bmc/SONIC_USB0_INTEGRATION.md. Do not assign USB0_ADDRESS here.
+#
+# Do not set USB0_ADDRESS when USB0_MANAGED_BY_NOS is enabled.
+USB0_MANAGED_BY_NOS=1

--- a/bmc/usr/etc/HI189/hw-management-bmc-network.conf
+++ b/bmc/usr/etc/HI189/hw-management-bmc-network.conf
@@ -4,4 +4,7 @@
 # Installed as /etc/hw-management-bmc-usb0.conf by hw-management-bmc-plat-specific-preps.
 # Used to generate /etc/systemd/network/00-hw-management-bmc-usb0.network from
 # /usr/etc/systemd/network/00-hw-management-bmc-usb0.network (template with __USB0_ADDRESS__).
+#
+# For SONiC BMC images install /etc/bmc-network-sonic.conf instead (see
+# bmc/SONIC_USB0_INTEGRATION.md); this file is for non-SONiC static usb0.
 USB0_ADDRESS=169.254.0.1/16

--- a/bmc/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf
+++ b/bmc/usr/lib/systemd/system/sonic-usb-network-init.service.d/10-hw-management-bmc.conf
@@ -6,7 +6,9 @@
 # addressing; AppArmor may also block dhclient on this interface.
 #
 # When our .network file is present (rendered at boot by hw-management-bmc-plat-specific-preps),
-# skip the SONiC one-shot. If usb0 .network generation is skipped (invalid USB0_ADDRESS),
-# this condition passes and SONiC can still run dhclient.
+# this unit is skipped (ConditionPathExists=! fails). When USB0_MANAGED_BY_NOS=1,
+# plat-specific-preps does not write .network, so the condition passes and
+# sonic-usb-network-init may run. Same if .network generation is skipped
+# (invalid USB0_ADDRESS).
 [Unit]
 ConditionPathExists=!/etc/systemd/network/00-hw-management-bmc-usb0.network

--- a/bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh
@@ -176,20 +176,48 @@ deploy_hw_management_bmc_platform_files()
 	shopt -u nullglob
 
 	# USB0 (CPU ↔ BMC): copy platform network params and render systemd-networkd unit.
+	# shellcheck source=/usr/bin/hw-management-bmc-usb0-common.sh
+	. /usr/bin/hw-management-bmc-usb0-common.sh
 	default_usb0_addr="169.254.0.1/16"
-	if [ -f "$HID_SRC/hw-management-bmc-network.conf" ]; then
+	usb0_nos_managed=0
+	nos_conf=""
+	nos_conf=$(hw_management_bmc_usb0_nos_conf_path 2>/dev/null) || nos_conf=""
+	if [ -n "$nos_conf" ] && hw_management_bmc_usb0_managed_by_nos_from "$nos_conf"; then
+		usb0_nos_managed=1
+		cp -f "$nos_conf" /etc/hw-management-bmc-usb0.conf
+		chmod 0644 /etc/hw-management-bmc-usb0.conf
+		echo "plat-specific: usb0 config from NOS file ${nos_conf}"
+	elif [ -f "$HID_SRC/hw-management-bmc-network.conf" ]; then
+		if [ -n "$nos_conf" ]; then
+			echo "plat-specific: ${nos_conf} ignored (USB0_MANAGED_BY_NOS not set); use HID platform usb0 config"
+		fi
 		cp -f "$HID_SRC/hw-management-bmc-network.conf" /etc/hw-management-bmc-usb0.conf
 		chmod 0644 /etc/hw-management-bmc-usb0.conf
+		if hw_management_bmc_usb0_managed_by_nos_from "$HID_SRC/hw-management-bmc-network.conf"; then
+			usb0_nos_managed=1
+		fi
+	elif [ -n "$nos_conf" ]; then
+		echo "plat-specific: ${nos_conf} ignored (USB0_MANAGED_BY_NOS not set); using default/static usb0 config"
 	fi
 
-	if [ ! -f /usr/etc/systemd/network/00-hw-management-bmc-usb0.network ]; then
+	if [ "$usb0_nos_managed" -eq 0 ] && [ -f /etc/hw-management-bmc-usb0.conf ] && \
+		hw_management_bmc_usb0_managed_by_nos; then
+		echo "plat-specific: clearing stale USB0_MANAGED_BY_NOS (no live NOS/HID source this boot)"
+		rm -f /etc/hw-management-bmc-usb0.conf
+	fi
+
+	# Only NOS mode when a live conf source set the flag this boot (not stale runtime).
+	if [ "$usb0_nos_managed" -eq 1 ]; then
+		rm -f "$HW_MANAGEMENT_BMC_USB0_NETWORK_UNIT"
+		echo "plat-specific: USB0_MANAGED_BY_NOS set; NOS owns usb0 (no static .network)"
+	elif [ ! -f /usr/etc/systemd/network/00-hw-management-bmc-usb0.network ]; then
 		:
 	else
 		local usb0_addr
 		usb0_addr=""
-		if [ -f "$HID_SRC/hw-management-bmc-network.conf" ] && [ -f /etc/hw-management-bmc-usb0.conf ]; then
-			usb0_addr=$(sed -n 's/^[[:space:]]*USB0_ADDRESS=//p' /etc/hw-management-bmc-usb0.conf | head -1 | tr -d " '\"")
-		elif [ ! -f "$HID_SRC/hw-management-bmc-network.conf" ]; then
+		if [ -f "$HID_SRC/hw-management-bmc-network.conf" ]; then
+			usb0_addr=$(sed -n 's/^[[:space:]]*USB0_ADDRESS=//p' "$HID_SRC/hw-management-bmc-network.conf" | head -1 | tr -d " '\"")
+		else
 			# No packaged hw-management-bmc-network.conf: use /etc if valid, else default.
 			if [ -f /etc/hw-management-bmc-usb0.conf ]; then
 				usb0_addr=$(sed -n 's/^[[:space:]]*USB0_ADDRESS=//p' /etc/hw-management-bmc-usb0.conf | head -1 | tr -d " '\"")

--- a/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
@@ -419,25 +419,31 @@ bmc_init_bootargs()
 #######################################
 # USB gadget Ethernet (usb0): load g_ether if needed, then either rely on
 # systemd-networkd (00-hw-management-bmc-usb0.network) or apply static
-# USB0_ADDRESS when networkd is not active (e.g. SONiC images).
+# USB0_ADDRESS when networkd is not active.
+# When USB0_MANAGED_BY_NOS=1, only bring up the link; addressing is NOS-owned.
 # Reads /etc/hw-management-bmc-usb0.conf and/or /etc/systemd/network/00-hw-management-bmc-usb0.network.
 # Never fails the caller; logs and returns 0.
 #######################################
 usb_net_config()
 {
-	local net_unit="/etc/systemd/network/00-hw-management-bmc-usb0.network"
-	local conf="/etc/hw-management-bmc-usb0.conf"
+	# shellcheck source=/usr/bin/hw-management-bmc-usb0-common.sh
+	. /usr/bin/hw-management-bmc-usb0-common.sh
+	local net_unit="$HW_MANAGEMENT_BMC_USB0_NETWORK_UNIT"
+	local conf="$HW_MANAGEMENT_BMC_USB0_CONF"
 	local addr=""
+	local nos_managed=0
 	local logtag="${LOG_TAG:-${_HW_MANAGEMENT_BMC_READY_COMMON_LOG_TAG}}"
 
-	if [ -f "$conf" ]; then
-		addr=$(sed -n 's/^[[:space:]]*USB0_ADDRESS=//p' "$conf" | head -1 | tr -d " '\"")
-	fi
-	if [ -z "$addr" ] && [ -f "$net_unit" ]; then
-		addr=$(sed -n 's/^[[:space:]]*Address=//p' "$net_unit" | head -1 | tr -d " '\"")
-	fi
-	if [ -z "$addr" ] || ! printf '%s' "$addr" | grep -qE '^[0-9a-fA-F.:/]+/[0-9]+$'; then
-		return 0
+	if hw_management_bmc_usb0_managed_by_nos; then
+		nos_managed=1
+	else
+		addr=$(_hw_management_bmc_usb0_conf_value USB0_ADDRESS "$conf")
+		if [ -z "$addr" ] && [ -f "$net_unit" ]; then
+			addr=$(sed -n 's/^[[:space:]]*Address=//p' "$net_unit" | head -1 | tr -d " '\"")
+		fi
+		if [ -z "$addr" ] || ! printf '%s' "$addr" | grep -qE '^[0-9a-fA-F.:/]+/[0-9]+$'; then
+			return 0
+		fi
 	fi
 
 	if [ ! -d /sys/module/g_ether ]; then
@@ -456,6 +462,12 @@ usb_net_config()
 	done
 	if [ ! -d /sys/class/net/usb0 ]; then
 		logger -t "$logtag" -p daemon.warning "usb_net_config: usb0 not present after g_ether"
+		return 0
+	fi
+
+	if [ "$nos_managed" -eq 1 ]; then
+		ip link set usb0 up 2>/dev/null || true
+		logger -t "$logtag" -p daemon.info "usb_net_config: USB0_MANAGED_BY_NOS; link up, NOS owns addressing"
 		return 0
 	fi
 

--- a/bmc/usr/usr/bin/hw-management-bmc-usb0-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-usb0-common.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Shared usb0 (BMC <-> host CPU) helpers. Sourced by plat-specific-preps and
+# hw-management-bmc-ready-common (do not execute directly).
+
+HW_MANAGEMENT_BMC_USB0_CONF="/etc/hw-management-bmc-usb0.conf"
+HW_MANAGEMENT_BMC_USB0_NETWORK_UNIT="/etc/systemd/network/00-hw-management-bmc-usb0.network"
+# Well-known paths for SONiC (or other NOS) to own usb0; checked before HID platform file.
+HW_MANAGEMENT_BMC_USB0_NOS_CONF="/etc/bmc-network-sonic.conf"
+HW_MANAGEMENT_BMC_USB0_NOS_CONF_ALT="/etc/bmc-usb-network.conf"
+
+# Print path to installed NOS usb0 config, or return 1 if absent.
+hw_management_bmc_usb0_nos_conf_path()
+{
+	if [ -f "$HW_MANAGEMENT_BMC_USB0_NOS_CONF" ]; then
+		printf '%s\n' "$HW_MANAGEMENT_BMC_USB0_NOS_CONF"
+		return 0
+	fi
+	if [ -f "$HW_MANAGEMENT_BMC_USB0_NOS_CONF_ALT" ]; then
+		printf '%s\n' "$HW_MANAGEMENT_BMC_USB0_NOS_CONF_ALT"
+		return 0
+	fi
+	return 1
+}
+
+# Read KEY=value from /etc/hw-management-bmc-usb0.conf (first match, strip quotes).
+# key must be a fixed literal (no sed metacharacters); callers use USB0_* names only.
+_hw_management_bmc_usb0_conf_value()
+{
+	local key="$1"
+	local conf="${2:-$HW_MANAGEMENT_BMC_USB0_CONF}"
+
+	[ -n "$key" ] || return 1
+	[ -f "$conf" ] || return 1
+	sed -n "s|^[[:space:]]*${key}=||p" "$conf" | head -1 | sed 's/[[:space:]]*#.*//' | tr -d " '\""
+}
+
+# True when USB0_MANAGED_BY_NOS is set in the given conf (default: runtime usb0.conf).
+hw_management_bmc_usb0_managed_by_nos_from()
+{
+	local v
+	local conf="${1:-$HW_MANAGEMENT_BMC_USB0_CONF}"
+
+	v=$(_hw_management_bmc_usb0_conf_value USB0_MANAGED_BY_NOS "$conf")
+	v=$(printf '%s' "$v" | tr '[:upper:]' '[:lower:]')
+	case "$v" in
+	1 | yes | true) return 0 ;;
+	esac
+	return 1
+}
+
+# True when the NOS (e.g. SONiC sonic-usb-network-init) owns usb0 addressing.
+hw_management_bmc_usb0_managed_by_nos()
+{
+	hw_management_bmc_usb0_managed_by_nos_from "$HW_MANAGEMENT_BMC_USB0_CONF"
+}

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -378,6 +378,14 @@ check_host_os_is_sonic()
 	/usr/bin/hw_management_sonic_check.py >/dev/null 2>&1
 }
 
+# Returns 0 when the SONiC host defers usb0 to the NOS (aligned with BMC NOS mode).
+# Requires SONiC plus a host-side contract file (same well-known paths as on the BMC).
+check_host_usb0_managed_by_nos()
+{
+	check_host_os_is_sonic || return 1
+	[ -f /etc/bmc-network-sonic.conf ] || [ -f /etc/bmc-usb-network.conf ]
+}
+
 # This function create or cleans sysfs monitor helper files.
 init_sysfs_monitor_timestamp_files()
 {

--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -38,28 +38,46 @@ source /usr/bin/hw-management-helpers.sh
 
 INTERFACE=$1
 
-# Check if interface parameter exists
 if [ -z "${INTERFACE}" ]; then
-	log_err "Interface parameter is missing"
+	log_err "Missing interface parameter"
 	exit 1
 fi
 
-# Check if /etc/network/interfaces exists
+# Skip ifup only when SONiC host and BMC/host images agree (NOS contract file present).
+# If the host is SONiC but the contract file is absent, BMC may still use static
+# usb0 and the host must run ifup as on non-SONiC images.
+if [ "${INTERFACE}" = "usb0" ] && check_host_usb0_managed_by_nos; then
+	log_info "SONiC host: skip ifup ${INTERFACE} (NOS-owned, contract file present)"
+	exit 0
+fi
+
+if [ ! -e "/sys/class/net/${INTERFACE}" ]; then
+	log_info "Interface ${INTERFACE} is missing"
+	exit 0
+fi
+
 if [ ! -e /etc/network/interfaces ]; then
-	log_err "/etc/network/interfaces is missing"
-	exit 1
+	log_info "/etc/network/interfaces is missing"
+	exit 0
 fi
 
-# Check if interface exists
-if [ ! -d "/sys/class/net/$INTERFACE" ]; then
-	log_err "Interface $INTERFACE does not exist"
-	exit 1
-fi
+# Exact name match per list (avoid substring false positives, e.g. usb0 vs usb01).
+_hw_mgmt_ifupdown_iface_auto_or_hotplug()
+{
+	local iface="$1"
+	local entry
 
-# Check if interface is defined in /etc/network/interfaces
-if ! ifquery "$INTERFACE" >/dev/null 2>&1; then
-	log_err "Interface $INTERFACE is not defined in /etc/network/interfaces"
-	exit 1
+	for entry in $(ifquery -l 2>/dev/null); do
+		[ "$entry" = "$iface" ] && return 0
+	done
+	for entry in $(ifquery -l --allow=hotplug 2>/dev/null); do
+		[ "$entry" = "$iface" ] && return 0
+	done
+	return 1
+}
+
+if ! _hw_mgmt_ifupdown_iface_auto_or_hotplug "${INTERFACE}"; then
+	exit 0
 fi
 
 # Retry ifup to work around locking conflicts with Debian networking service.
@@ -75,11 +93,10 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
 	fi
 
 	if [ "$i" -lt "$MAX_RETRIES" ]; then
-		log_info "Unsuccessful attempt $i to ifup ${INTERFACE}. Retrying in ${RETRY_DELAY} seconds..."
+		log_info "Attempt $i to ifup ${INTERFACE} failed. Retrying in ${RETRY_DELAY} seconds..."
 		sleep "${RETRY_DELAY}"
 	fi
 done
 
 log_err "Failed to ifup interface ${INTERFACE}"
 exit 1
-


### PR DESCRIPTION
Add USB0_MANAGED_BY_NOS so BMC images can defer usb0 addressing to the NOS (e.g. SONiC sonic-usb-network-init) instead of hw-management-bmc static systemd-networkd configuration.

BMC:
- New hw-management-bmc-usb0-common.sh: read USB0_MANAGED_BY_NOS from /etc/hw-management-bmc-usb0.conf (1, yes, true; case-insensitive).
- plat-specific-preps: when set, remove static .network unit and skip Address= rendering; sonic-usb-network-init may run.
- usb_net_config: when set, load g_ether and bring link up only; no static ip addr or networkd reload for addressing.
- HI189 hw-management-bmc-network-sonic.conf.example; SONiC ships bmc-network-sonic.conf as hw-management-bmc-network.conf on image.
- bmc/SONIC_USB0_INTEGRATION.md for SONiC/BSP integrators.

Host (hw-management):
- hw-management-ifupdown.sh: on SONiC hosts, skip ifup usb0 only; keep auto/hotplug ifquery guard and silent exit when ifupdown unused.

Backward compatible: without USB0_MANAGED_BY_NOS, behavior is unchanged (static USB0_ADDRESS / .network as before). HI189 default still ships USB0_ADDRESS only.

Update bmc/README.md, DEVELOPER_GUIDE.md, and sonic-usb-network-init drop-in comments.