### PR TITLE
 Redfish curl stdin config instead of parameters

### DIFF
--- a/tests/offline/test_hw_management_redfish_client.py
+++ b/tests/offline/test_hw_management_redfish_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ########################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Comprehensive Test Suite for hw_management_redfish_client.py
 # Tests RedfishClient and BMCAccessor classes with simple, medium, and complex scenarios
@@ -22,6 +22,13 @@ from io import StringIO
 
 # Add the library path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'usr', 'usr', 'bin'))
+
+
+def mock_curl_stdout(body='', http_status=200):
+    '''Mimic curl stdout with -w "\\nHTTP Status Code: %{http_code}" trailer.'''
+    if isinstance(body, bytes):
+        body = body.decode('utf-8')
+    return f'{body}\nHTTP Status Code: {http_status}'.encode('utf-8')
 
 
 # =============================================================================
@@ -81,6 +88,10 @@ class TestRedfishClientInitialization:
         """Simple: Verify default timeout constant"""
         assert RedfishClient.DEFAULT_GET_TIMEOUT == 3
 
+    def test_simple_login_config_prefix(self):
+        """Login curl stdin configs are tagged for exec_curl_cmd detection."""
+        assert RedfishClient._CFG_LOGIN_PREFIX == '# hw-mgmt-redfish: login\n'
+
     def test_simple_error_codes(self):
         """Simple: Verify error code constants"""
         assert RedfishClient.ERR_CODE_OK == 0
@@ -130,37 +141,36 @@ class TestRedfishClientCommandBuilders:
     def test_simple_build_login_cmd(self, basic_redfish_client):
         """Simple: Build login command"""
         cmd = basic_redfish_client._RedfishClient__build_login_cmd('********')
-        assert '/usr/bin/curl' in cmd
-        assert '-X POST' in cmd
+        assert cmd.startswith(RedfishClient._CFG_LOGIN_PREFIX)
+        assert 'request = POST' in cmd
         assert 'https://10.0.1.1/login' in cmd
-        assert '"username" : "admin"' in cmd
-        assert '"password" : "********"' in cmd
+        assert 'username' in cmd and 'admin' in cmd
+        assert 'password' in cmd and '********' in cmd
 
     def test_medium_build_get_cmd(self, basic_redfish_client):
         """Medium: Build GET command"""
         basic_redfish_client._RedfishClient__token = 'test_token_123'
         cmd = basic_redfish_client._RedfishClient__build_get_cmd('/redfish/v1/test')
-        assert '/usr/bin/curl' in cmd
-        assert '--request GET' in cmd
-        assert 'X-Auth-Token: test_token_123' in cmd
+        assert 'request = GET' in cmd
+        assert 'header = "X-Auth-Token: test_token_123"' in cmd
         assert 'https://10.0.1.1/redfish/v1/test' in cmd
 
     def test_medium_build_fw_update_cmd(self, basic_redfish_client):
         """Medium: Build firmware update command"""
         basic_redfish_client._RedfishClient__token = 'test_token'
         cmd = basic_redfish_client._RedfishClient__build_fw_update_cmd('/path/to/firmware.bin')
-        assert '/usr/bin/curl' in cmd
-        assert '-X POST' in cmd
-        assert 'X-Auth-Token: test_token' in cmd
+        assert 'request = POST' in cmd
+        assert 'header = "X-Auth-Token: test_token"' in cmd
         assert '/redfish/v1/UpdateService' in cmd
-        assert '-T /path/to/firmware.bin' in cmd
+        assert 'upload-file = "/path/to/firmware.bin"' in cmd
 
     def test_medium_build_change_password_cmd(self, basic_redfish_client):
         """Medium: Build change password command"""
         basic_redfish_client._RedfishClient__token = 'test_token'
         cmd = basic_redfish_client._RedfishClient__build_change_password_cmd('********')
-        assert '-X PATCH' in cmd
-        assert '"Password" : "********"' in cmd
+        assert 'request = PATCH' in cmd
+        assert 'Password' in cmd
+        assert '********' in cmd
         assert '/redfish/v1/AccountService/Accounts/admin' in cmd
 
     def test_medium_build_post_cmd(self, basic_redfish_client):
@@ -168,21 +178,25 @@ class TestRedfishClientCommandBuilders:
         basic_redfish_client._RedfishClient__token = 'test_token'
         data = {'key1': 'value1', 'key2': 123}
         cmd = basic_redfish_client._RedfishClient__build_post_cmd('/test/uri', data)
-        assert '-X POST' in cmd
+        assert 'request = POST' in cmd
         assert 'https://10.0.1.1/test/uri' in cmd
-        assert '"key1": "value1"' in cmd or '"key1":"value1"' in cmd
+        assert 'key1' in cmd and 'value1' in cmd
 
     def test_complex_build_set_force_update_true(self, basic_redfish_client):
         """Complex: Build set force update command (true)"""
         basic_redfish_client._RedfishClient__token = 'test_token'
         cmd = basic_redfish_client._RedfishClient__build_set_force_update_cmd(True)
-        assert '"ForceUpdate":true' in cmd or '"ForceUpdate": true' in cmd
+        assert 'HttpPushUriOptions' in cmd
+        assert 'ForceUpdate' in cmd
+        assert 'true' in cmd
 
     def test_complex_build_set_force_update_false(self, basic_redfish_client):
         """Complex: Build set force update command (false)"""
         basic_redfish_client._RedfishClient__token = 'test_token'
         cmd = basic_redfish_client._RedfishClient__build_set_force_update_cmd(False)
-        assert '"ForceUpdate":false' in cmd or '"ForceUpdate": false' in cmd
+        assert 'HttpPushUriOptions' in cmd
+        assert 'ForceUpdate' in cmd
+        assert 'false' in cmd
 
 
 class TestRedfishClientObfuscation:
@@ -190,10 +204,10 @@ class TestRedfishClientObfuscation:
 
     def test_simple_obfuscate_user_password(self, basic_redfish_client):
         """Simple: Obfuscate username and password"""
-        cmd = 'curl -d \'{"username" : "admin", "password" : "********"}\''
+        cmd = 'data-raw = "{\"username\": \"admin\", \"password\": \"secret123\"}"'
         obfuscated = basic_redfish_client._RedfishClient__obfuscate_user_password(cmd)
-        assert '"username" : "******"' in obfuscated
-        assert '"password" : "******"' in obfuscated
+        assert '"username": "******"' in obfuscated
+        assert '"password": "******"' in obfuscated
         assert 'admin' not in obfuscated
         assert 'secret123' not in obfuscated
 
@@ -214,9 +228,9 @@ class TestRedfishClientObfuscation:
 
     def test_medium_obfuscate_password(self, basic_redfish_client):
         """Medium: Obfuscate password in command"""
-        cmd = 'curl -d \'{"Password" : "********"}\''
+        cmd = '{"Password": "********"}'
         obfuscated = basic_redfish_client._RedfishClient__obfuscate_password(cmd)
-        assert '"Password" : "******"' in obfuscated
+        assert '"Password": "******"' in obfuscated
         assert '********' not in obfuscated
 
 
@@ -226,6 +240,12 @@ class TestRedfishClientHttpRequestType:
     def test_simple_get_request_type_post(self, basic_redfish_client):
         """Simple: Extract POST request type"""
         cmd = 'curl -X POST https://test.com'
+        req_type = basic_redfish_client._RedfishClient__get_http_request_type(cmd)
+        assert req_type == 'POST'
+
+    def test_simple_get_request_type_from_curl_config(self, basic_redfish_client):
+        """POST from curl -K stdin config."""
+        cmd = '# x\nrequest = POST\nurl = "https://t"'
         req_type = basic_redfish_client._RedfishClient__get_http_request_type(cmd)
         assert req_type == 'POST'
 
@@ -262,7 +282,7 @@ class TestRedfishClientLogin:
         # Mock subprocess response
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"token": "new_test_token"}',
+            mock_curl_stdout('{"token": "new_test_token"}'),
             b''
         )
         mock_process.returncode = 0
@@ -297,7 +317,10 @@ class TestRedfishClientLogin:
     def test_complex_login_invalid_json(self, basic_redfish_client, mock_subprocess):
         """Complex: Login with invalid JSON response"""
         mock_process = MagicMock()
-        mock_process.communicate.return_value = (b'invalid json {', b'')
+        mock_process.communicate.return_value = (
+            mock_curl_stdout('invalid json {'),
+            b''
+        )
         mock_process.returncode = 0
         mock_subprocess.Popen.return_value = mock_process
 
@@ -308,7 +331,7 @@ class TestRedfishClientLogin:
         """Complex: Login with error in JSON response"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"error": {"message": "Authentication failed"}}',
+            mock_curl_stdout('{"error": {"message": "Authentication failed"}}'),
             b''
         )
         mock_process.returncode = 0
@@ -321,7 +344,7 @@ class TestRedfishClientLogin:
         """Complex: Login response without token field"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"status": "ok", "data": "something"}',
+            mock_curl_stdout('{"status": "ok", "data": "something"}'),
             b''
         )
         mock_process.returncode = 0
@@ -334,7 +357,7 @@ class TestRedfishClientLogin:
         """Complex: Login response with null token"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"token": null}',
+            mock_curl_stdout('{"token": null}'),
             b''
         )
         mock_process.returncode = 0
@@ -342,6 +365,59 @@ class TestRedfishClientLogin:
 
         ret = basic_redfish_client.login()
         assert ret == RedfishClient.ERR_CODE_UNEXPECTED_RESPONSE
+
+
+class TestParseCurlOutput:
+    """Tests for __parse_curl_output() trailer handling."""
+
+    def test_parse_strips_trailer(self, basic_redfish_client):
+        raw = '{"token": "x"}\nHTTP Status Code: 200'
+        body, code = basic_redfish_client._RedfishClient__parse_curl_output(raw)
+        assert body == '{"token": "x"}'
+        assert code == '200'
+
+    def test_parse_body_with_embedded_status_text(self, basic_redfish_client):
+        raw = (
+            '{"error": {"message": "line ends with HTTP Status Code: 401"}}\n'
+            'HTTP Status Code: 403'
+        )
+        body, code = basic_redfish_client._RedfishClient__parse_curl_output(raw)
+        assert 'HTTP Status Code: 401' in body
+        assert code == '403'
+
+    def test_parse_no_trailer_returns_full_output(self, basic_redfish_client):
+        raw = '{"token": "x"}'
+        body, code = basic_redfish_client._RedfishClient__parse_curl_output(raw)
+        assert body == raw
+        assert code is None
+
+
+class TestUpdateTokenInCurlConfig:
+    """Tests for __update_token_in_curl_config()."""
+
+    def test_substitutes_auth_header(self, basic_redfish_client):
+        basic_redfish_client._RedfishClient__token = 'new-token-456'
+        cfg = (
+            '# hw-mgmt-redfish: GET\n'
+            'insecure\n'
+            'header = "X-Auth-Token: old-token"\n'
+            'request = GET\n'
+            'url = "https://10.0.1.1/redfish/v1/test"\n'
+        )
+        updated = basic_redfish_client._RedfishClient__update_token_in_curl_config(cfg)
+        assert 'header = "X-Auth-Token: old-token"' not in updated
+        assert 'header = "X-Auth-Token: new-token-456"' in updated
+
+    def test_token_none_leaves_config_unchanged(self, basic_redfish_client):
+        cfg = 'header = "X-Auth-Token: old-token"\n'
+        basic_redfish_client._RedfishClient__token = None
+        assert basic_redfish_client._RedfishClient__update_token_in_curl_config(cfg) == cfg
+
+    def test_escapes_special_chars_in_token(self, basic_redfish_client):
+        basic_redfish_client._RedfishClient__token = 'tok"en\\here'
+        cfg = 'header = "X-Auth-Token: stale"\n'
+        updated = basic_redfish_client._RedfishClient__update_token_in_curl_config(cfg)
+        assert 'header = "X-Auth-Token: tok\\"en\\here"' in updated
 
 
 class TestRedfishClientExecCurl:
@@ -356,7 +432,10 @@ class TestRedfishClientExecCurl:
     def test_medium_exec_login_command(self, basic_redfish_client, mock_subprocess):
         """Medium: Execute login command"""
         mock_process = MagicMock()
-        mock_process.communicate.return_value = (b'{"token": "test"}', b'')
+        mock_process.communicate.return_value = (
+            mock_curl_stdout('{"token": "test"}'),
+            b''
+        )
         mock_process.returncode = 0
         mock_subprocess.Popen.return_value = mock_process
 
@@ -372,17 +451,17 @@ class TestRedfishClientExecCurl:
         # First call returns empty (invalid token), second call after re-login succeeds
         call_count = [0]
 
-        def mock_communicate():
+        def mock_communicate(*_a, **_kw):
             call_count[0] += 1
             if call_count[0] == 1:
                 # First call - empty response (invalid token)
                 return (b'', b'')
             elif call_count[0] == 2:
                 # Re-login call
-                return (b'{"token": "new_token"}', b'')
+                return (mock_curl_stdout('{"token": "new_token"}'), b'')
             else:
                 # Retry with new token
-                return (b'{"data": "success"}', b'')
+                return (mock_curl_stdout('{"data": "success"}'), b'')
 
         mock_process = MagicMock()
         mock_process.communicate.side_effect = mock_communicate
@@ -395,6 +474,38 @@ class TestRedfishClientExecCurl:
         # Should succeed after re-login
         assert ret == 0
         assert basic_redfish_client.get_token() == 'new_token'
+
+    def test_task_monitor_skips_stderr_logging(
+            self, basic_redfish_client, mock_subprocess, capsys):
+        """Task status polling must not flood stderr with curl debug lines."""
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (mock_curl_stdout('{}'), b'')
+        mock_process.returncode = 0
+        mock_subprocess.Popen.return_value = mock_process
+
+        basic_redfish_client._RedfishClient__token = 'test_token'
+        task_uri = f'{RedfishClient.REDFISH_URI_TASKS}/task-1'
+        cfg = basic_redfish_client._RedfishClient__build_get_cmd(task_uri)
+        basic_redfish_client.exec_curl_cmd(cfg)
+
+        captured = capsys.readouterr()
+        assert 'Execute cURL command:' not in captured.err
+
+    def test_non_task_request_logs_to_stderr(
+            self, basic_redfish_client, mock_subprocess, capsys):
+        """Non-task Redfish calls still log redacted curl config to stderr."""
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (mock_curl_stdout('{}'), b'')
+        mock_process.returncode = 0
+        mock_subprocess.Popen.return_value = mock_process
+
+        basic_redfish_client._RedfishClient__token = 'test_token'
+        cfg = basic_redfish_client._RedfishClient__build_get_cmd('/redfish/v1/test')
+        basic_redfish_client.exec_curl_cmd(cfg)
+
+        captured = capsys.readouterr()
+        assert 'Execute cURL command:' in captured.err
+        assert 'test_token' not in captured.err
 
 
 # =============================================================================
@@ -519,7 +630,7 @@ class TestBMCAccessorUserManagement:
     def test_simple_create_user(self, mock_bmc_accessor, mock_subprocess):
         """Simple: Create new user"""
         mock_process = MagicMock()
-        mock_process.communicate.return_value = (b'{}', b'')
+        mock_process.communicate.return_value = (mock_curl_stdout('{}'), b'')
         mock_process.returncode = 0
         mock_subprocess.Popen.return_value = mock_process
 
@@ -552,7 +663,10 @@ class TestBMCAccessorLogin:
         """Medium: Login with TPM-generated password"""
         # Mock successful login
         mock_process = MagicMock()
-        mock_process.communicate.return_value = (b'{"token": "test_token"}', b'')
+        mock_process.communicate.return_value = (
+            mock_curl_stdout('{"token": "test_token"}'),
+            b''
+        )
         mock_process.returncode = 0
         mock_subprocess.Popen.return_value = mock_process
 
@@ -613,7 +727,7 @@ class TestComplexScenarios:
                 return (b'', b'')
             else:
                 # Third attempt succeeds
-                return (b'{"token": "final_token"}', b'')
+                return (mock_curl_stdout('{"token": "final_token"}'), b'')
 
         mock_process = MagicMock()
         mock_process.communicate.side_effect = mock_communicate
@@ -641,7 +755,10 @@ class TestComplexScenarios:
     def test_complex_concurrent_operations(self, basic_redfish_client, mock_subprocess):
         """Complex: Multiple operations with same client"""
         mock_process = MagicMock()
-        mock_process.communicate.return_value = (b'{"token": "test"}', b'')
+        mock_process.communicate.return_value = (
+            mock_curl_stdout('{"token": "test"}'),
+            b''
+        )
         mock_process.returncode = 0
         mock_subprocess.Popen.return_value = mock_process
 
@@ -660,7 +777,7 @@ class TestComplexScenarios:
         """Complex: Error recovery and retry logic"""
         responses = [
             (b'', b'curl: (28) Timeout'),  # First call times out
-            (b'{"token": "new_token"}', b''),  # Retry succeeds
+            (mock_curl_stdout('{"token": "new_token"}'), b''),  # Retry succeeds
         ]
 
         mock_process = MagicMock()
@@ -740,7 +857,9 @@ class TestEdgeCases:
         """Edge: Null values in JSON response"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"token": "test", "extra": null, "nested": {"value": null}}',
+            mock_curl_stdout(
+                '{"token": "test", "extra": null, "nested": {"value": null}}'
+            ),
             b''
         )
         mock_process.returncode = 0
@@ -758,8 +877,8 @@ class TestMissingCoverageLines:
         cmd = basic_redfish_client._build_change_user_password_after_factory_cmd(
             'admin', '********', '********'
         )
-        assert 'curl' in cmd
-        assert '-X PATCH' in cmd
+        assert '# hw-mgmt-redfish: PATCH account-factory' in cmd
+        assert 'request = PATCH' in cmd
         assert 'Password' in cmd
         assert '********' in cmd
 
@@ -768,8 +887,8 @@ class TestMissingCoverageLines:
         # Set token using the property
         basic_redfish_client._RedfishClient__token = 'test_token'
         cmd = basic_redfish_client._build_delete_cmd('admin_user')
-        assert 'curl' in cmd
-        assert '-X DELETE' in cmd
+        assert '# hw-mgmt-redfish: DELETE account' in cmd
+        assert 'request = DELETE' in cmd
         assert 'admin_user' in cmd
         assert 'test_token' in cmd
 
@@ -790,7 +909,7 @@ class TestMissingCoverageLines:
         """Test login with password=None (uses default)"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"token": "test_token"}',
+            mock_curl_stdout('{"token": "test_token"}'),
             b''
         )
         mock_process.returncode = 0
@@ -812,10 +931,10 @@ class TestMissingCoverageLines:
         """Test _build_change_user_password_cmd"""
         basic_redfish_client._RedfishClient__token = 'test_token'
         cmd = basic_redfish_client._build_change_user_password_cmd('testuser', '********')
-        assert 'curl' in cmd
+        assert '# hw-mgmt-redfish: PATCH account-user' in cmd
         assert 'testuser' in cmd
         assert '********' in cmd
-        assert '-X PATCH' in cmd
+        assert 'request = PATCH' in cmd
 
     def test_get_http_request_type(self, basic_redfish_client):
         """Test __get_http_request_type with different patterns"""
@@ -827,6 +946,10 @@ class TestMissingCoverageLines:
         req_type = basic_redfish_client._RedfishClient__get_http_request_type('curl --request POST ...')
         assert req_type == 'POST'
 
+        # Test curl -K stdin config
+        req_type = basic_redfish_client._RedfishClient__get_http_request_type('x\nrequest = DELETE\n')
+        assert req_type == 'DELETE'
+
         # Test default (no explicit method)
         req_type = basic_redfish_client._RedfishClient__get_http_request_type('curl ...')
         assert req_type is None  # No match
@@ -836,10 +959,75 @@ class TestMissingCoverageLines:
         basic_redfish_client._RedfishClient__token = 'test_token'
         data = {'key': 'value', 'nested': {'inner': 123}}
         cmd = basic_redfish_client._RedfishClient__build_post_cmd('/test/endpoint', data)
-        assert 'curl' in cmd
-        assert '-X POST' in cmd
+        assert '# hw-mgmt-redfish: POST json' in cmd
+        assert 'request = POST' in cmd
         assert '/test/endpoint' in cmd
         assert 'test_token' in cmd
+
+    def test_build_post_cmd_without_body(self, basic_redfish_client):
+        """POST config keeps JSON body in data-raw, not in url."""
+        basic_redfish_client._RedfishClient__token = 'test_token'
+        cmd = basic_redfish_client._RedfishClient__build_post_cmd('/test/endpoint')
+        url_line = next(line for line in cmd.splitlines() if line.startswith('url = '))
+        assert 'data-raw' not in cmd
+        assert ' -d ' not in url_line
+
+    def test_format_curl_command_for_logging(self, basic_redfish_client):
+        """Debug log includes argv and redacted stdin config."""
+        basic_redfish_client._RedfishClient__token = 'secret-token'
+        cfg = basic_redfish_client._RedfishClient__build_login_cmd('my-pass')
+        log_line = basic_redfish_client._RedfishClient__format_curl_command_for_logging(cfg)
+        assert '/usr/bin/curl' in log_line
+        assert '-K -' in log_line
+        assert 'HW_MGMT_CURL_CFG' in log_line
+        assert 'secret-token' not in log_line
+        assert 'my-pass' not in log_line
+
+    def test_redact_json_field_plain_value(self):
+        cfg = '{"username": "admin", "password": "secret"}'
+        redacted = RedfishClient._RedfishClient__redact_json_field_in_curl_config(
+            cfg, 'password')
+        assert '"password": "******"' in redacted
+        assert 'secret' not in redacted
+
+    def test_redact_json_field_escaped_curl_config_value(self):
+        cfg = (
+            'data-raw = "{\\"username\\": \\"admin\\", '
+            '\\"password\\": \\"secret\\"}"'
+        )
+        redacted = RedfishClient._RedfishClient__redact_json_field_in_curl_config(
+            cfg, 'password')
+        assert 'secret' not in redacted
+        assert '******' in redacted
+
+    def test_redact_json_field_value_with_embedded_quotes(self):
+        cfg = r'"password": "ab\"cd"'
+        redacted = RedfishClient._RedfishClient__redact_json_field_in_curl_config(
+            cfg, 'password')
+        assert redacted == r'"password": "******"'
+        assert 'ab' not in redacted
+
+    def test_redact_json_field_value_with_backslashes(self):
+        cfg = r'"password": "ab\\cd"'
+        redacted = RedfishClient._RedfishClient__redact_json_field_in_curl_config(
+            cfg, 'password')
+        assert redacted == r'"password": "******"'
+        assert 'ab' not in redacted
+
+    def test_curl_config_for_logging_redacts_escaped_login(self, basic_redfish_client):
+        login_cfg = basic_redfish_client._RedfishClient__build_login_cmd('secret')
+        redacted = basic_redfish_client._RedfishClient__curl_config_for_logging(login_cfg)
+        assert 'secret' not in redacted
+        assert 'admin' not in redacted
+        assert '******' in redacted
+        assert '\\"password\\"' in redacted
+        assert redacted.count('******') >= 2
+
+    def test_curl_config_for_logging_keeps_json_structure(self, basic_redfish_client):
+        login_cfg = basic_redfish_client._RedfishClient__build_login_cmd('secret')
+        redacted = basic_redfish_client._RedfishClient__curl_config_for_logging(login_cfg)
+        assert '\\"password\\":' in redacted
+        assert redacted.rstrip().endswith('}"')
 
     def test_has_login_false(self, basic_redfish_client):
         """Test has_login when not logged in"""
@@ -868,7 +1056,7 @@ class TestMissingCoverageLines:
         """Test login with explicit password parameter"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"token": "new_token"}',
+            mock_curl_stdout('{"token": "new_token"}'),
             b''
         )
         mock_process.returncode = 0
@@ -881,7 +1069,7 @@ class TestMissingCoverageLines:
         """Test login uses default password when None passed"""
         mock_process = MagicMock()
         mock_process.communicate.return_value = (
-            b'{"token": "default_token"}',
+            mock_curl_stdout('{"token": "default_token"}'),
             b''
         )
         mock_process.returncode = 0

--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -43,7 +43,6 @@ import subprocess
 import json
 import time
 import re
-import shlex
 import os
 import sys
 import base64
@@ -54,13 +53,15 @@ import fcntl
 
 
 '''
-cURL wrapper for Redfish client access
+cURL wrapper for Redfish client access (curl -K stdin; secrets off argv).
 '''
 
 
 class RedfishClient:
 
     DEFAULT_GET_TIMEOUT = 3
+    _CFG_LOGIN_PREFIX = '# hw-mgmt-redfish: login\n'
+    _CURL_HTTP_TRAILER_RE = re.compile(r'\nHTTP Status Code: (\d+)\Z')
 
     # Redfish URIs
     REDFISH_URI_FW_INVENTORY = '/redfish/v1/UpdateService/FirmwareInventory'
@@ -97,184 +98,337 @@ class RedfishClient:
         self.__token = None
         self.__password = password
 
+    @staticmethod
+    def __curl_config_escape_double_quoted_value(val):
+        '''Escape content for curl -K \"...\" quoted strings (\\ and ").'''
+        if val is None:
+            return ''
+        if not isinstance(val, str):
+            val = os.fspath(val)
+        return val.replace('\\', '\\\\').replace('"', '\\"')
+
+    def __curl_redfish_url(self, path_without_scheme):
+        return f'https://{self.__svr_ip}{path_without_scheme}'
+
+    def __curl_config_auth_header_line(self):
+        return (
+            'header = "X-Auth-Token: '
+            + self.__curl_config_escape_double_quoted_value(self.__token) + '"'
+        )
+
     '''
-    Build the POST command to get bearer token
+    Build curl stdin config for POST /login (credentials in config only, never argv).
     '''
     def __build_login_cmd(self, password, timeout=DEFAULT_GET_TIMEOUT):
-        cmd = f'{self.__curl_path} -m {timeout} -k ' \
-            f'-H "Content-Type: application/json" ' \
-            f'-X POST https://{self.__svr_ip}/login ' \
-            f'-d \'{{"username" : "{self.__user}", "password" : "{password}"}}\''
-        return cmd
+        body = json.dumps({'username': self.__user, 'password': password})
+        cred_escape = self.__curl_config_escape_double_quoted_value(body)
+        login_url_escape = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url('/login'))
+        return '\n'.join([
+            self._CFG_LOGIN_PREFIX.rstrip('\n'),
+            'insecure',
+            f'max-time = {timeout}',
+            'header = "Content-Type: application/json"',
+            'request = POST',
+            f'url = "{login_url_escape}"',
+            f'data-raw = "{cred_escape}"',
+        ])
 
     '''
-    Build the GET command
+    Build curl stdin config for GET (token off argv).
     '''
     def __build_get_cmd(self, uri, timeout=DEFAULT_GET_TIMEOUT):
-        cmd = f'{self.__curl_path} -m {timeout} -k ' \
-            f'-H "X-Auth-Token: {self.__token}" --request GET ' \
-            f'--location https://{self.__svr_ip}{uri}'
-        return cmd
+        full_url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(uri))
+        return '\n'.join([
+            '# hw-mgmt-redfish: GET',
+            'insecure',
+            f'max-time = {timeout}',
+            'location',
+            self.__curl_config_auth_header_line(),
+            'request = GET',
+            f'url = "{full_url_esc}"',
+        ])
 
     '''
-    Build the POST command to do firmware update
+    Build curl stdin config for firmware upload POST (token off argv).
     '''
     def __build_fw_update_cmd(self, fw_image):
-        cmd = f'{self.__curl_path} -k -H "X-Auth-Token: {self.__token}" ' \
-            f'-H "Content-Type: application/octet-stream" -X POST ' \
-            f'https://{self.__svr_ip}' \
-            f'{RedfishClient.REDFISH_URI_UPDATE_SERVICE} -T {fw_image}'
-        return cmd
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(RedfishClient.REDFISH_URI_UPDATE_SERVICE))
+        up_esc = self.__curl_config_escape_double_quoted_value(fw_image)
+        return '\n'.join([
+            '# hw-mgmt-redfish: fw-post-upload',
+            'insecure',
+            self.__curl_config_auth_header_line(),
+            'header = "Content-Type: application/octet-stream"',
+            'request = POST',
+            f'upload-file = "{up_esc}"',
+            f'url = "{url_esc}"',
+        ])
 
     '''
-    Build the PATCH command to change login password
+    Build curl stdin config for PATCH account password (token off argv).
     '''
     def __build_change_password_cmd(self, new_password):
-        cmd = f'{self.__curl_path} -k -H "X-Auth-Token: {self.__token}" ' \
-            f'-H "Content-Type: application/json" -X PATCH ' \
-            f'https://{self.__svr_ip}' \
-            f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{self.__user} ' \
-            f'-d \'{{"Password" : "{new_password}"}}\''
-        return cmd
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(
+                f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{self.__user}'))
+        body = json.dumps({'Password': new_password})
+        data_esc = self.__curl_config_escape_double_quoted_value(body)
+        return '\n'.join([
+            '# hw-mgmt-redfish: PATCH account-self',
+            'insecure',
+            self.__curl_config_auth_header_line(),
+            'header = "Content-Type: application/json"',
+            'request = PATCH',
+            f'url = "{url_esc}"',
+            f'data-raw = "{data_esc}"',
+        ])
 
     def _build_change_user_password_cmd(self, user, new_password):
-        cmd = f'{self.__curl_path} -k -H "X-Auth-Token: {self.__token}" ' \
-            f'-H "Content-Type: application/json" -X PATCH ' \
-            f'https://{self.__svr_ip}' \
-            f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{user} ' \
-            f'-d \'{{"Password" : "{new_password}"}}\''  # Change password for the specific user
-        return cmd
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(
+                f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{user}'))
+        body = json.dumps({'Password': new_password})
+        data_esc = self.__curl_config_escape_double_quoted_value(body)
+        return '\n'.join([
+            '# hw-mgmt-redfish: PATCH account-user',
+            'insecure',
+            self.__curl_config_auth_header_line(),
+            'header = "Content-Type: application/json"',
+            'request = PATCH',
+            f'url = "{url_esc}"',
+            f'data-raw = "{data_esc}"',
+        ])
 
     def _build_change_user_password_after_factory_cmd(self, user, user_pwd, new_password):
-        cmd = f'{self.__curl_path} -k -u {user}:{user_pwd} ' \
-            f'-H "Content-Type: application/json" -X PATCH ' \
-            f'https://{self.__svr_ip}' \
-            f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{user} ' \
-            f'-d \'{{"Password" : "{new_password}"}}\''  # Change password for the specific user
-        return cmd
+        user_esc = self.__curl_config_escape_double_quoted_value(
+            f'{user}:{user_pwd}')
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(
+                f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{user}'))
+        body = json.dumps({'Password': new_password})
+        data_esc = self.__curl_config_escape_double_quoted_value(body)
+        return '\n'.join([
+            '# hw-mgmt-redfish: PATCH account-factory',
+            'insecure',
+            f'user = "{user_esc}"',
+            'header = "Content-Type: application/json"',
+            'request = PATCH',
+            f'url = "{url_esc}"',
+            f'data-raw = "{data_esc}"',
+        ])
 
     def _build_delete_cmd(self, user_to_delete):
-        # curl -k -H "X-Auth-Token: $bmc_token" -X DELETE https://${bmc}/redfish/v1/AccountService/Accounts/admin_user
-        cmd = f'{self.__curl_path} -k -H "X-Auth-Token: {self.__token}" ' \
-            f'-X DELETE ' \
-            f'https://{self.__svr_ip}' \
-            f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{user_to_delete} '
-        return cmd
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(
+                f'{RedfishClient.REDFISH_URI_ACCOUNTS}/{user_to_delete}'))
+        return '\n'.join([
+            '# hw-mgmt-redfish: DELETE account',
+            'insecure',
+            self.__curl_config_auth_header_line(),
+            'request = DELETE',
+            f'url = "{url_esc}"',
+        ])
 
     '''
-    Build the PATCH command to set 'ForceUpdate' attribute
+    Build curl stdin config for PATCH ForceUpdate (token off argv).
     '''
     def __build_set_force_update_cmd(self, force):
-        value = 'true' if force else 'false'
-        cmd = f'{self.__curl_path} -k -H "X-Auth-Token: {self.__token}" ' \
-            f'-X PATCH -d \'{{"HttpPushUriOptions":{{"ForceUpdate":{value}}}}}\' ' \
-            f'https://{self.__svr_ip}' \
-            f'{RedfishClient.REDFISH_URI_UPDATE_SERVICE}'
-        return cmd
+        body = json.dumps({'HttpPushUriOptions': {'ForceUpdate': bool(force)}})
+        data_esc = self.__curl_config_escape_double_quoted_value(body)
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(RedfishClient.REDFISH_URI_UPDATE_SERVICE))
+        return '\n'.join([
+            '# hw-mgmt-redfish: PATCH force-update',
+            'insecure',
+            self.__curl_config_auth_header_line(),
+            'header = "Content-Type: application/json"',
+            'request = PATCH',
+            f'url = "{url_esc}"',
+            f'data-raw = "{data_esc}"',
+        ])
 
     '''
-    Build generic POST command
+    Build curl stdin config for generic JSON POST (token off argv).
     '''
-    def __build_post_cmd(self, uri, data_dict, timeout=DEFAULT_GET_TIMEOUT):
-        data_str = json.dumps(data_dict)
-        cmd = f'{self.__curl_path} -m {timeout} -k -H "X-Auth-Token: {self.__token}" ' \
-            f'-H "Content-Type: application/json" ' \
-            f'-X POST https://{self.__svr_ip}{uri} ' \
-            f'-d \'{data_str}\''
-        return cmd
+    def __build_post_cmd(self, uri, data_dict=None, timeout=DEFAULT_GET_TIMEOUT):
+        url_esc = self.__curl_config_escape_double_quoted_value(
+            self.__curl_redfish_url(uri))
+        lines = [
+            '# hw-mgmt-redfish: POST json',
+            'insecure',
+            f'max-time = {timeout}',
+            self.__curl_config_auth_header_line(),
+            'header = "Content-Type: application/json"',
+            'request = POST',
+            f'url = "{url_esc}"',
+        ]
+        if data_dict is not None:
+            data_str = json.dumps(data_dict)
+            data_esc = self.__curl_config_escape_double_quoted_value(data_str)
+            lines.append(f'data-raw = "{data_esc}"')
+        return '\n'.join(lines)
+
+    @staticmethod
+    def __redact_json_field_in_curl_config(cfg, field_name):
+        '''
+        Redact JSON field values in curl -K config (plain or backslash-escaped).
+        '''
+        key = re.escape(field_name)
+        escaped_comma = (
+            rf'(\\"{key}\\"\s*:\s*\\")((?:\\.[^"\\]|[^"\\])*)(\\")(?=,)'
+        )
+        escaped_end = (
+            rf'(\\"{key}\\"\s*:\s*\\")((?:\\.[^"\\]|[^"\\])*)(\\")(?=}})'
+        )
+        plain = rf'("{key}"\s*:\s*")((?:\\.[^"\\]|[^"\\])*)(")'
+        redacted, count = re.subn(
+            escaped_comma, r'\1******\3', cfg, count=1, flags=re.IGNORECASE)
+        if count:
+            return redacted
+        redacted, count = re.subn(
+            escaped_end, r'\1******\3', cfg, count=1, flags=re.IGNORECASE)
+        if count:
+            return redacted
+        return re.sub(plain, r'\1******\3', cfg, count=1, flags=re.IGNORECASE)
 
     '''
-    Obfuscate username and password while asking for bearer token
+    Redact secrets from curl --config stdin for syslog / debug logs.
     '''
-    def __obfuscate_user_password(self, cmd):
-        pattern = r'"username" : "[^"]*", "password" : "[^"]*"'
-        replacement = '"username" : "******", "password" : "******"'
-        obfuscation_cmd = re.sub(pattern, replacement, cmd)
-        return obfuscation_cmd
+    def __curl_config_for_logging(self, curl_config):
+
+        cfg = curl_config
+
+        for field in ('username', 'password', 'Password'):
+            cfg = self.__redact_json_field_in_curl_config(cfg, field)
+
+        cfg = re.sub(
+            r'header = "X-Auth-Token:[^"]*"',
+            'header = "X-Auth-Token: ******"',
+            cfg)
+
+        cfg = re.sub(
+            r'user = "[^"]*"',
+            'user = "******:******"',
+            cfg)
+
+        cfg = re.sub(
+            r'/AccountService/Accounts/[^"/\s]+',
+            '/AccountService/Accounts/******',
+            cfg)
+
+        return cfg
+
+    def __format_curl_command_for_logging(self, curl_config):
+        '''
+        Log argv plus redacted -K stdin config for copy-paste debugging.
+        '''
+        redacted_cfg = self.__curl_config_for_logging(curl_config)
+        return (
+            f'{self.__curl_path} -w "\\nHTTP Status Code: %{{http_code}}" -K - '
+            f'<<\'HW_MGMT_CURL_CFG\'\n{redacted_cfg}\nHW_MGMT_CURL_CFG'
+        )
 
     '''
-    Obfuscate bearer token in the response string
+    Obfuscate username and password in curl config (delegates to __curl_config_for_logging).
+    '''
+    def __obfuscate_user_password(self, curl_config):
+        return self.__curl_config_for_logging(curl_config)
+
+    '''
+    Obfuscate bearer token in a Redfish login response string (logging helpers/tests).
     '''
     def __obfuscate_token_response(self, response):
-        # Credential obfuscation
         pattern = r'"token": "[^"]*"'
         replacement = '"token": "******"'
-        obfuscation_response = re.sub(pattern,
-                                      replacement,
-                                      response)
-        return obfuscation_response
+        return re.sub(pattern, replacement, response)
 
     '''
-    Obfuscate bearer token passed to cURL
+    Obfuscate bearer token passed to cURL (stdin config or legacy argv string).
     '''
     def __obfuscate_auth_token(self, cmd):
-        pattern = r'X-Auth-Token: [^"]+'
-        replacement = 'X-Auth-Token: ******'
-
-        obfuscation_cmd = re.sub(pattern, replacement, cmd)
-        return obfuscation_cmd
+        obfuscated = self.__curl_config_for_logging(cmd)
+        return re.sub(
+            r'X-Auth-Token:\s*[^\s"]+',
+            'X-Auth-Token: ******',
+            obfuscated)
 
     '''
-    Obfuscate password while aksing for password change
+    Obfuscate password in curl config (delegates to __curl_config_for_logging).
     '''
     def __obfuscate_password(self, cmd):
-        pattern = r'"Password" : "[^"]*"'
-        replacement = '"Password" : "******"'
-        obfuscation_cmd = re.sub(pattern, replacement, cmd)
+        return self.__curl_config_for_logging(cmd)
 
-        return obfuscation_cmd
+    def __parse_curl_output(self, curl_output):
+        '''
+        Split curl -w trailer from body. Trailer must be at end of stdout only.
+        '''
+        match = RedfishClient._CURL_HTTP_TRAILER_RE.search(curl_output)
+        if match:
+            return (curl_output[:match.start()], match.group(1))
+        return (curl_output, None)
 
     '''
     Execute cURL command and return the output and error messages
     '''
-    def __exec_curl_cmd_internal(self, cmd):
+    def __exec_curl_cmd_internal(self, curl_config):
 
-        # Will not print task monitor to syslog
-        task_mon = (RedfishClient.REDFISH_URI_TASKS in cmd)
-        login_cmd = ('/login ' in cmd)
-        password_change = (RedfishClient.REDFISH_URI_ACCOUNTS in cmd)
+        task_mon = RedfishClient.REDFISH_URI_TASKS in curl_config
+        if not task_mon:
+            cmd_str = self.__format_curl_command_for_logging(curl_config)
+            print(f'Execute cURL command: {cmd_str}', file=sys.stderr)
 
-        # Credential obfuscation
-        if login_cmd:
-            obfuscation_cmd = self.__obfuscate_user_password(cmd)
-        else:
-            obfuscation_cmd = self.__obfuscate_auth_token(cmd)
-
-        if password_change:
-            obfuscation_cmd = self.__obfuscate_password(obfuscation_cmd)
-
-        process = subprocess.Popen(shlex.split(cmd),
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        output, error = process.communicate()
-        output_str = output.decode('utf-8')
+        curl_argv = [
+            self.__curl_path,
+            '-w', '\nHTTP Status Code: %{http_code}',
+            '-K', '-',
+        ]
+        process = subprocess.Popen(
+            curl_argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdin_bytes = curl_config.encode('utf-8')
+        output, error = process.communicate(input=stdin_bytes)
+        output_decoded = output.decode('utf-8')
         error_str = error.decode('utf-8')
         ret = process.returncode
-        # print ("Curl send:{}\n".format(cmd))
-        # print ("Curl rcv: err:{}\nout:{}".format(error_str, output_str))
 
-        if (ret > 0):
+        if ret > 0:
             ret = RedfishClient.ERR_CODE_CURL_FAILURE
 
-        if (ret == 0):  # cURL retuns ok
-            if login_cmd:
-                obfuscation_output_str = \
-                    self.__obfuscate_token_response(output_str)
-            else:
-                obfuscation_output_str = output_str
+        output_str, _http = self.__parse_curl_output(output_decoded)
+        output_str = output_str.rstrip('\n')
 
-        else:  # cURL returns error
-            # Extract cURL command failure reason
+        if ret != 0:
             match = re.search(r'curl: \([0-9]+\) (.*)', error_str)
             if match:
                 error_str = match.group(1)
 
         return (ret, output_str, error_str)
 
+    def __update_token_in_curl_config(self, curl_config):
+        if self.__token is None:
+            return curl_config
+        hdr = (
+            'header = "X-Auth-Token: '
+            + self.__curl_config_escape_double_quoted_value(self.__token) + '"')
+        return re.sub(
+            r'^header = "X-Auth-Token:[^"]*"',
+            hdr,
+            curl_config,
+            count=1,
+            flags=re.MULTILINE)
+
     def __get_http_request_type(self, cmd):
+        m = re.search(r'^request = (\w+)', cmd, re.MULTILINE | re.I)
+        if m:
+            return m.group(1).upper()
 
         patterns = (r'-X[ \t]+([A-Z]+)', r'--request[ \t]+([A-Z]+)')
-
         for pattern in patterns:
             match = re.search(pattern, cmd)
             if match:
@@ -286,17 +440,17 @@ class RedfishClient:
     Wrapper function to execute the given cURL command which can deal with
     invalid bearer token case.
     '''
-    def exec_curl_cmd(self, cmd):
-        is_login_cmd = ('/login ' in cmd)
+    def exec_curl_cmd(self, curl_config):
+        is_login_cmd = curl_config.startswith(RedfishClient._CFG_LOGIN_PREFIX)
 
-        req_type = self.__get_http_request_type(cmd)
+        req_type = self.__get_http_request_type(curl_config)
         is_patch_req = (req_type == 'PATCH')
 
         # Not login, return
         if (not self.has_login()) and (not is_login_cmd):
             return (RedfishClient.ERR_CODE_NOT_LOGIN, 'Not login', 'Not login')
 
-        ret, output_str, error_str = self.__exec_curl_cmd_internal(cmd)
+        ret, output_str, error_str = self.__exec_curl_cmd_internal(curl_config)
 
         is_empty_response = ((ret == 0) and (len(output_str) == 0))
 
@@ -304,17 +458,16 @@ class RedfishClient:
         # GET & POST.
         # Need to re-generate token
         if (is_empty_response and (not is_login_cmd) and (not is_patch_req)):
-            # print(f'need to regenerate token..')
             self.__token = None
             ret = self.login()
             if ret == RedfishClient.ERR_CODE_OK:
-                ret, output_str, error_str = self.__exec_curl_cmd_internal(cmd)
+                curl_retry = self.__update_token_in_curl_config(curl_config)
+                ret, output_str, error_str = self.__exec_curl_cmd_internal(
+                    curl_retry)
             elif ret == RedfishClient.ERR_CODE_BAD_CREDENTIAL:
-                # Login fails, invalidate token.
                 self.__token = None
                 return (ret, 'Bad credential', 'Bad credential')
             else:
-                # Login fails, invalidate token.
                 self.__token = None
                 return (ret, 'Login failure', 'Login failure')
 
@@ -336,9 +489,8 @@ class RedfishClient:
         if not password:
             password = self.__password
 
-        cmd = self.__build_login_cmd(password)
-        # print(f'cmd:{cmd}')
-        ret, response, error = self.exec_curl_cmd(cmd)
+        curl_cfg = self.__build_login_cmd(password)
+        ret, response, error = self.exec_curl_cmd(curl_cfg)
 
         if (ret != 0):  # cURL execution error
             ret = RedfishClient.ERR_CODE_CURL_FAILURE
@@ -375,7 +527,7 @@ class RedfishClient:
     def build_get_cmd(self, uri):
         return self.__build_get_cmd(uri)
 
-    def build_post_cmd(self, uri, data_dict):
+    def build_post_cmd(self, uri, data_dict=None):
         return self.__build_post_cmd(uri, data_dict)
 
 


### PR DESCRIPTION

Refactor BMC Redfish curl usage in `sonic_platform/redfish_client.py` to pass request options via stdin (`curl -K -`) instead of long command-line argument lists. Login, GET/POST/PATCH, logout, firmware upload, and login-failure probe share one config-builder path; subprocess supplies the config on stdin.
Improve debug logging: redacted curl config in logs (including escaped `data-raw` JSON), consistent with the new invocation style.
Simplify login-failure probe setup by removing temporary netrc; probe uses the same stdin curl config as other Redfish calls.
Bump `platform/mellanox/hw-management/hw-mgmt` to `f1bf0b37` so `hw_management_redfish_client.py` follows the same curl stdin pattern and stays aligned with platform-api.
Fix curl config escaping for non-string values on BMC status paths; extend unit tests for config build, probe flows, and log redaction.
**Evidence:** `platform/mellanox/mlnx-platform-api/sonic_platform/redfish_client.py`, `tests/test_redfish_client.py`, `platform/mellanox/hw-management/hw-mgmt` @ `f1bf0b37` (`hw_management_redfish_client.py`, `tests/offline/test_hw_management_redfish_client.py`).
## Test plan

- Review diff: `redfish_client.py`, `test_redfish_client.py`, hw-mgmt submodule pointer (if included)
- Run mlnx-platform-api Redfish unit tests (`test_redfish_client.py`)
- Run hw-mgmt offline tests (`test_hw_management_redfish_client.py`) after submodule bump
- On a BMC platform: exercise login, status query, logout — confirm Redfish behavior unchanged
- Confirm login-failure probe still returns expected error JSON
- Confirm log output uses redacted curl config where applicable