### PR TITLE
hw-mgmt: ifupdown: Restore ifquery guard and retry log wording

### DIFF
--- a/bmc/SONIC_USB0_INTEGRATION.md
+++ b/bmc/SONIC_USB0_INTEGRATION.md
@@ -125,7 +125,7 @@ ip -4 addr show dev usb0
 - On SONiC **with** **`/etc/bmc-network-sonic.conf`** (or alt): **does not** call
   **`ifup usb0`**. Without that file, **ifup** runs (misaligned / static-BMC case).
 - Other interfaces / missing **`/etc/network/interfaces`**: unchanged defensive behavior
-  (silent **exit 0**, auto/hotplug class guard via **`ifquery -l`**).
+  (**`log_err`** and **exit 1** when **`ifquery`** does not define the interface).
 - Does **not** assign a host **usb0** IP when the NOS contract file is present (SONiC owns it).
 
 ### Host verification

--- a/usr/usr/bin/hw-management-ifupdown.sh
+++ b/usr/usr/bin/hw-management-ifupdown.sh
@@ -61,23 +61,9 @@ if [ ! -e /etc/network/interfaces ]; then
 	exit 0
 fi
 
-# Exact name match per list (avoid substring false positives, e.g. usb0 vs usb01).
-_hw_mgmt_ifupdown_iface_auto_or_hotplug()
-{
-	local iface="$1"
-	local entry
-
-	for entry in $(ifquery -l 2>/dev/null); do
-		[ "$entry" = "$iface" ] && return 0
-	done
-	for entry in $(ifquery -l --allow=hotplug 2>/dev/null); do
-		[ "$entry" = "$iface" ] && return 0
-	done
-	return 1
-}
-
-if ! _hw_mgmt_ifupdown_iface_auto_or_hotplug "${INTERFACE}"; then
-	exit 0
+if ! ifquery "$INTERFACE" >/dev/null 2>&1; then
+	log_err "Interface $INTERFACE is not defined in /etc/network/interfaces"
+	exit 1
 fi
 
 # Retry ifup to work around locking conflicts with Debian networking service.
@@ -93,7 +79,7 @@ for ((i=1; i<=MAX_RETRIES; i++)); do
 	fi
 
 	if [ "$i" -lt "$MAX_RETRIES" ]; then
-		log_info "Attempt $i to ifup ${INTERFACE} failed. Retrying in ${RETRY_DELAY} seconds..."
+		log_info "Unsuccessful attempt $i to ifup ${INTERFACE}. Retrying in ${RETRY_DELAY} seconds..."
 		sleep "${RETRY_DELAY}"
 	fi
 done


### PR DESCRIPTION
Drop auto/hotplug ifquery -l check so usb0 stanzas without those keywords still get ifup. Revert retry log text to avoid log analyzer false positives.