### PR TITLE
hw-mgmt: config: Add support for generic system configuration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Architecture: any
 Build-Profiles: <!pkg.hw-mgmt.bmc-only>
 Depends: ${misc:Depends}, ${shlibs:Depends}, ${dist:Depends}, lsb-base (>= 3.0-6),
  python2.7 | python3, python3-psutil, xxd, libiio-utils, dmidecode, i2c-tools, tpm2-tools,
- awk, gzip, logrotate
+ awk, gzip, logrotate, jq
 Description: Thermal control and chassis management for Nvidia systems (host)
  This package supports Nvidia switches family for chassis
  management and thermal control on the host CPU.

--- a/debian/rules
+++ b/debian/rules
@@ -68,6 +68,13 @@ endif
 		dh_installdirs -p$(pname) etc/hw-management-exec; \
 		cp -a usr/etc/hw-management-exec/* debian/$(pname)/etc/hw-management-exec/; \
 	fi
+	@for d in usr/etc/hw-management-cfg/HI*; do \
+		if [ -d "$$d" ] && [ -n "$$(find "$$d" -maxdepth 1 -type f 2>/dev/null | head -n1)" ]; then \
+			hid=$$(basename "$$d"); \
+			dh_installdirs -p$(pname) etc/hw-management-cfg/$$hid; \
+			cp -a "$$d"/* debian/$(pname)/etc/hw-management-cfg/$$hid/; \
+		fi; \
+	done
 	@for d in usr/etc/HI*; do \
 		if [ -d "$$d" ] && [ -n "$$(find "$$d" -maxdepth 1 -type f 2>/dev/null | head -n1)" ]; then \
 			hid=$$(basename "$$d"); \

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,46 @@
+<!-- SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES -->
+
+# `examples/`
+
+Reference material for host CPU **hw-management** tooling: sample JSON,
+schema notes, and small source examples. These files are **not** installed
+automatically by the scripts under **`usr/`** unless your packaging explicitly
+copies them.
+
+| File | Purpose |
+|------|---------|
+| [hw-management-platform-example.json](hw-management-platform-example.json) | Platform bring-up JSON for **`check_system_json()`**: **`system`**, **`variables`**, **`board`**, **`pci`**, **`config`**, **`connection`**, **`psu_i2c`**, **`asic_i2c_buses`**, **`actions`** → deploy as **`/etc/hw-management-cfg/<HID>/platform.json`** (from **`usr/etc/hw-management-cfg/<HID>/`** on the image). Used by new platforms instead of a new **`*_specific()`** function in **`hw-management.sh`**. Parsed by **`hw-management-platform-json.sh`**. |
+| [hw-management-exec-example.json](hw-management-exec-example.json) | Per-platform exec attributes (I2C/sysfs actions) for **`hw-management-exec-parser.sh`**: shared **`hids`** list or per-HID override → **`/etc/<HID>/hw-management-exec.json`** or **`/etc/hw-management-exec/*.json`**. |
+| [hw-management-exec.md](hw-management-exec.md) | Host exec-attribute schema, config lookup order, dispatcher layout, and bring-up notes for **`hw-management-exec`**. |
+| [vr_dpc_update_example.json](vr_dpc_update_example.json) | VR DPC bulk-update config for **`hw-management-vr-dpc-update-all.sh`**: **`System HID`**, **`Devices`** array (type, bus, addr, config files). |
+| [vr_dpc_update_nn5500ld.json](vr_dpc_update_nn5500ld.json) | Platform-specific VR DPC update example (N5110 LD). |
+| [pmbus_devices_example.json](pmbus_devices_example.json) | PMBus device list schema (**`devices`**: name, bus, slave address, pages). |
+| [src/iorw/](src/iorw/) | Sample **iorw** userspace tool sources (LPC/I2C access). |
+| [src/ev_hndl/](src/ev_hndl/) | Sample line-card / event-handler sources (C and Python). |
+
+## Platform JSON quick reference
+
+For a **new HID**, ship **`usr/etc/hw-management-cfg/<HID>/platform.json`**. At
+runtime **`check_system()`** applies it when the file exists under
+**`/etc/hw-management-cfg/<HID>/`**; otherwise the legacy **`check_system_internal()`** path
+runs. Invalid JSON aborts **`do_start()`**.
+
+See **`hw-management-platform-example.json`** for all supported sections and
+field names. The optional **`system`** section describes platform traits
+(**`bmc`**, **`cooling`**, **`power_supply`**, **`power_source`**, **`ssd`**,
+**`tpm`**, **`security`**, **`type`**, etc.) and writes validated values under
+**`/var/run/hw-management/config/`**. Use **`_comment_<field>`** keys in the
+example JSON to document allowed values; they are ignored at runtime. The optional
+**`pci`** section sets **`asic_pci_id`**, **`dpu_pci_id`**, and **`dpu_pci_addr`**
+for **`set_asic_pci_id()`** / **`set_dpu_pci_id()`** on JSON platforms (replacing
+per-SKU PCI ID variables in **`hw-management.sh`**). The optional **`board`**
+section writes devtree topology keys (**`cpu_brd_bus_offset`**, **`swb_brd_num`**,
+**`pwr_brd_num`**, offsets, VR/hotswap counts, etc.) and replaces
+**`pre_devtr_init()`** SKU dispatch when platform JSON is present.
+
+On new platforms the I2C connection table is built from **devtree**; the
+**`connection`** section supplies **`named_busses`** (inline name/bus pairs) and
+optional COMEx named-bus offsets. Use **`base_tables`**, **`dynamic_tables`**, or
+inline **`base_connect`** / **`dynamic_connect`** only when devtree is absent.
+**`named_busses_table`** (shell-array reference) and inline **`named_busses`**
+are mutually exclusive. Mistyped values abort boot.

--- a/examples/hw-management-exec.md
+++ b/examples/hw-management-exec.md
@@ -45,7 +45,7 @@ This document describes the **host CPU** package only (`hw-management`, not BMC)
 |------|----------------|------|
 | [hw-management-exec](../usr/usr/bin/hw-management-exec) | `/usr/bin/hw-management-exec` | Dispatcher (symlink target; must not live under `/var/run` if that mount is `noexec`) |
 | [hw-management-exec-parser.sh](../usr/usr/bin/hw-management-exec-parser.sh) | `/usr/bin/hw-management-exec-parser.sh` | Reads JSON, creates symlinks + `.env` fragments |
-| [hw-management-json-parser.sh](../usr/usr/bin/hw-management-json-parser.sh) | `/usr/bin/hw-management-json-parser.sh` | BusyBox-safe JSON helpers (AWK, no `jq`) |
+| [hw-management-json-parser.sh](../usr/usr/bin/hw-management-json-parser.sh) | `/usr/bin/hw-management-json-parser.sh` | JSON helpers using **`jq`** (host CPU) |
 | Shared config | `/etc/hw-management-exec/*.json` | One file can list many HIDs in a `"hids"` array |
 | Per-HID override | `/etc/<HID>/hw-management-exec.json` | Optional; wins over shared configs |
 | Example JSON | [hw-management-exec-example.json](hw-management-exec-example.json) | Full schema example (I2C + sysfs) |
@@ -174,7 +174,7 @@ Rebuild/install the **`hw-management`** package; **`debian/rules`** installs **`
 - **`bus`** and **`size`** must be numeric.
 - **`AttributeName`** is restricted to alphanumeric characters, `_`, and `-`.
 - **`description`** is stripped to safe comment characters.
-- Parser and library use **`#!/bin/sh`** and BusyBox AWK; load the JSON library with **`. /usr/bin/hw-management-json-parser.sh`**.
+- Parser and library use **`#!/bin/sh`** and **`jq`**; load the JSON library with **`. /usr/bin/hw-management-json-parser.sh`**.
 - Simple string fields use **`json_get_string`**; **`action`** and **`description`** use **`json_get_escaped_string`** (supports `\"` and common escapes).
 
 ## See also

--- a/examples/hw-management-platform-example.json
+++ b/examples/hw-management-platform-example.json
@@ -1,0 +1,115 @@
+{
+    "_comment": "Example platform config for /etc/hw-management-cfg/<HID>/platform.json. Remove _comment before deploy.",
+    "system": {
+        "_comment_bmc": "yes | no",
+        "bmc": "yes",
+        "_comment_cooling": "liquid | air | hybrid",
+        "cooling": "air",
+        "_comment_power_supply": "AC | DC",
+        "power_supply": "AC",
+        "_comment_power_source": "busbar | replaceable_unit",
+        "power_source": "replaceable_unit",
+        "_comment_power_supply_replaceable": "yes | no | na",
+        "power_supply_replaceable": "yes",
+        "_comment_fan_replaceable": "yes | no | na",
+        "fan_replaceable": "yes",
+        "_comment_ssd": "sata | nvme",
+        "ssd": "nvme",
+        "_comment_tpm": "yes | no",
+        "tpm": "yes",
+        "_comment_security": "PQC",
+        "security": "PQC",
+        "_comment_type": "Ethernet | IB | NvLink",
+        "type": "Ethernet"
+    },
+    "variables": {
+        "hotplug_fans": 4,
+        "max_tachos": 8,
+        "hotplug_pwrs": 0,
+        "hotplug_psus": 0,
+        "hotplug_pdbs": 0,
+        "hotplug_linecards": 0,
+        "erot_count": 0,
+        "vrot_count": 0,
+        "mcu_count": 0,
+        "cartridge_count": 0,
+        "cpld_num": 4,
+        "asic_control": 1,
+        "asic_num": 2,
+        "health_events_count": 0,
+        "pwr_events_count": 0,
+        "dpu_count": 0,
+        "psu_count": 2,
+        "minimal_unsupported": 0,
+        "dummy_psus_supported": 0,
+        "leakage_count": 0,
+        "leakage_rope_count": 0,
+        "i2c_comex_mon_bus_default": 23,
+        "i2c_bus_def_off_eeprom_cpu": 24,
+        "lm_sensors_config": "/etc/hw-management-sensors/example_sensors.conf",
+        "lm_sensors_labels": "/etc/hw-management-sensors/example_sensors_labels.json",
+        "thermal_control_config": "/etc/hw-management-thermal/tc_config_not_supported.json",
+        "mctp_bus": "",
+        "mctp_addr": ""
+    },
+    "pci": {
+        "_comment_asic_pci_id": "lspci grep -E pattern: 4-digit hex; use | for multiple IDs",
+        "asic_pci_id": "22a3",
+        "_comment_dpu": "optional; omit dpu_pci_id and dpu_pci_addr when no DPUs",
+        "dpu_pci_id": "a2dc",
+        "dpu_pci_addr": [
+            "06:00.0",
+            "05:00.0",
+            "01:00.0",
+            "02:00.0"
+        ]
+    },
+    "board": {
+        "_comment_board": "Devtree board topology; replaces pre_devtr_init() for JSON platforms",
+        "cpu_brd_bus_offset": 55,
+        "swb_brd_num": 4,
+        "pwr_brd_num": 4,
+        "swb_brd_bus_offset": 16,
+        "pwr_brd_bus_offset": 16,
+        "swb_brd_vr_num": 11,
+        "pwr_brd_pwr_conv_num": 1,
+        "pwr_brd_hotswap_num": 1,
+        "pwr_brd_temp_sens_num": 1
+    },
+    "config": {
+        "fan_max_speed": "21000",
+        "fan_min_speed": "5400",
+        "psu_fan_max": "18000",
+        "psu_fan_min": "2000",
+        "fan_inversed": "7 8 5 6 3 4 1 2",
+        "psu_eeprom_type": "24c02",
+        "reset_attr_num": "8",
+        "global_wp_wait_step": "1",
+        "global_wp_timeout": "20",
+        "system_flow_capability": "C2P"
+    },
+    "psu_i2c": {
+        "psu1_i2c_bus": 4,
+        "psu1_i2c_addr": "0x59",
+        "psu2_i2c_bus": 4,
+        "psu2_i2c_addr": "0x58"
+    },
+    "asic_i2c_buses": [
+        2,
+        18
+    ],
+    "connection": {
+        "_comment_connection": "I2C topology comes from devtree; list named busses here",
+        "named_busses": [
+            { "name": "ts", "bus": 7 },
+            { "name": "vpd", "bus": 8 },
+            { "name": "erot1", "bus": 15 },
+            { "name": "vr1", "bus": 26 },
+            { "name": "vr2", "bus": 29 }
+        ],
+        "add_come_named_busses_offset": 18
+    },
+    "actions": [
+        "get_i2c_bus_frequency_default"
+    ]
+}

--- a/usr/usr/bin/hw-management-json-parser.sh
+++ b/usr/usr/bin/hw-management-json-parser.sh
@@ -31,10 +31,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# BusyBox-Compatible JSON Parser Library
+# JSON Parser Library (host CPU)
 #
-# This library provides JSON parsing functions using only AWK and standard
-# BusyBox utilities (no jq or Python required).
+# Uses jq (available on host CPU images). BMC-side scripts continue to use
+# hw-management-bmc-json-parser.sh until jq is present there as well.
 #
 # Upstream name in OpenBMC: switch_json_parser.sh (bmc-post-boot-cfg).
 # Packaged as hw-management-json-parser.sh for host hw-management.
@@ -43,225 +43,48 @@
 #   source /usr/bin/hw-management-json-parser.sh
 ################################################################################
 
+_json_parser_require_jq()
+{
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "hw-management-json-parser: jq is required but not installed" >&2
+		return 1
+	fi
+}
+
 # Function to extract a top-level object block from JSON array by index
 # Usage: json_get_array_element <json_file> <index>
 # Returns: The complete JSON object at the specified index
-# Ignores "{" and "}" inside JSON string values (same rule as json_get_nested_array_element).
 json_get_array_element()
 {
-    local json_file="$1"
-    local index="$2"
-    awk -v idx="$index" '
-    BEGIN {
-        block_count = -1
-        in_block = 0
-        brace_count = 0
-        depth = 0
-        in_string = 0
-        escape = 0
-    }
+	local json_file="$1"
+	local index="$2"
 
-    function update_string_state(c) {
-        if (in_string) {
-            if (escape) {
-                escape = 0
-                return
-            }
-            if (c == "\\") {
-                escape = 1
-                return
-            }
-            if (c == "\"") {
-                in_string = 0
-            }
-            return
-        }
-        if (c == "\"") {
-            in_string = 1
-        }
-    }
-
-    {
-        line = $0
-        for (i = 1; i <= length(line); i++) {
-            c = substr(line, i, 1)
-            if (in_string) {
-                update_string_state(c)
-                continue
-            }
-            if (c == "\"") {
-                in_string = 1
-                continue
-            }
-            if (c == "{") {
-                if (depth == 0 && !in_block) {
-                    block_count++
-                    if (block_count == idx) {
-                        in_block = 1
-                        brace_count = 0
-                    }
-                }
-                if (in_block) {
-                    brace_count++
-                }
-                depth++
-            } else if (c == "}") {
-                if (in_block) {
-                    brace_count--
-                }
-                depth--
-            }
-        }
-        if (in_block) {
-            print $0
-        }
-        if (in_block && brace_count == 0 && depth == 0) {
-            exit
-        }
-    }
-    ' "$json_file"
+	_json_parser_require_jq || return 1
+	jq -c --argjson idx "$index" '.[$idx] // empty' "$json_file"
 }
 
 # Function to extract a nested object from a JSON block by array name and index
 # Usage: echo "$json_block" | json_get_nested_array_element <array_name> <index>
-# <index> is 0-based (first element is 0). Matches callers: early-i2c-init, devtree, gpio-set, a2d-leakage.
-# A new array element is recognized only when "{" appears at brace depth 0 inside the named array
-# (nested objects like "config": { ... } do not start a new element). Lines inside the element are
-# printed in full and brace-balanced so nested "{" lines are not dropped.
+# <index> is 0-based (first element is 0).
 # Returns: The JSON object at the specified index within the named array
 json_get_nested_array_element()
 {
-    local array_name="$1"
-    local index="$2"
-    awk -v array="$array_name" -v idx="$index" '
-    BEGIN {
-        in_target_array = 0
-        element_count = -1
-        in_element = 0
-        brace_count = 0
-        depth = 0
-        in_string = 0
-        escape = 0
-    }
+	local array_name="$1"
+	local index="$2"
 
-    function update_string_state(c) {
-        if (in_string) {
-            if (escape) {
-                escape = 0
-                return
-            }
-            if (c == "\\") {
-                escape = 1
-                return
-            }
-            if (c == "\"") {
-                in_string = 0
-            }
-            return
-        }
-        if (c == "\"") {
-            in_string = 1
-        }
-    }
-
-    function count_element_braces(line, from,    i, c) {
-        for (i = from; i <= length(line); i++) {
-            c = substr(line, i, 1)
-            update_string_state(c)
-            if (in_string) {
-                continue
-            }
-            if (c == "{") {
-                brace_count++
-            } else if (c == "}") {
-                brace_count--
-            }
-        }
-    }
-
-    function scan_array_depth(line,    i, c) {
-        for (i = 1; i <= length(line); i++) {
-            c = substr(line, i, 1)
-            update_string_state(c)
-            if (in_string) {
-                continue
-            }
-            if (c == "{") {
-                if (depth == 0) {
-                    element_count++
-                    if (element_count == idx) {
-                        in_element = 1
-                        print substr(line, i)
-                        brace_count = 0
-                        count_element_braces(line, i)
-                        if (brace_count == 0) {
-                            exit
-                        }
-                        depth++
-                        return
-                    }
-                }
-                depth++
-            } else if (c == "}") {
-                depth--
-            }
-        }
-    }
-
-    {
-        has_array = index($0, "\"" array "\"")
-        if (has_array > 0 && index($0, "[") > 0) {
-            in_target_array = 1
-            next
-        }
-
-        if (in_target_array && !in_element && !in_string && depth == 0 && index($0, "]") > 0) {
-            in_target_array = 0
-            next
-        }
-
-        if (in_target_array && !in_element) {
-            scan_array_depth($0)
-            next
-        }
-
-        if (in_element) {
-            print $0
-            count_element_braces($0, 1)
-            if (brace_count == 0) {
-                exit
-            }
-        }
-    }
-    '
+	_json_parser_require_jq || return 1
+	jq -c --arg a "$array_name" --argjson idx "$index" '.[$a][$idx] // empty'
 }
 
 # Function to extract a simple string value by key from JSON
 # Usage: echo "$json" | json_get_string <key>
 # Returns: The string value (without quotes)
-# Use only for tokens without embedded quotes (hex address, AttributeName, etc.).
-# For "action", "description", or any value that may contain \" use
-# json_get_escaped_string instead.
 json_get_string()
 {
-    local key="$1"
-    awk -v k="$key" '
-    {
-        p = "\"" k "\""
-        i = index($0, p)
-        if (i == 0) next
-        j = i + length(p)
-        while (j <= length($0) && substr($0, j, 1) ~ /[[:space:]]/) j++
-        if (substr($0, j, 1) != ":") next
-        j++
-        while (j <= length($0) && substr($0, j, 1) ~ /[[:space:]]/) j++
-        if (substr($0, j, 1) != "\"") next
-        j++
-        start = j
-        while (j <= length($0) && substr($0, j, 1) != "\"") j++
-        if (j > start) print substr($0, start, j - start)
-        exit
-    }'
+	local key="$1"
+
+	_json_parser_require_jq || return 1
+	jq -r --arg k "$key" '(.[$k] // empty) | if type == "string" then . else empty end'
 }
 
 # Function to extract a JSON string value with backslash escapes (multi-line safe)
@@ -269,272 +92,107 @@ json_get_string()
 json_get_escaped_string()
 {
 	local key="$1"
-	awk -v k="$key" '
-	BEGIN { buf = "" }
-	{ buf = buf $0 }
-	END {
-		p = "\"" k "\""
-		i = index(buf, p)
-		if (i == 0) exit
-		j = i + length(p)
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
-		if (substr(buf, j, 1) != ":") exit
-		j++
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
-		if (substr(buf, j, 1) != "\"") exit
-		j++
-		out = ""
-		while (j <= length(buf)) {
-			c = substr(buf, j, 1)
-			if (c == "\\" && j < length(buf)) {
-				n = substr(buf, j + 1, 1)
-				if (n == "n") { out = out "\n"; j += 2; continue }
-				if (n == "t") { out = out "\t"; j += 2; continue }
-				if (n == "r") { out = out "\r"; j += 2; continue }
-				out = out n
-				j += 2
-				continue
-			}
-			if (c == "\"") break
-			out = out c
-			j++
-		}
-		print out
-	}'
+
+	_json_parser_require_jq || return 1
+	jq -r --arg k "$key" '(.[$k] // empty) | if type == "string" then . else empty end'
 }
 
 # Function to extract a numeric value by key from JSON
 # Usage: echo "$json" | json_get_number <key>
-# Returns: The numeric value (integer or decimal). Reads full stdin (multi-line safe).
-# Note: The old implementation split on : , and took the *first* integer field on
-# any line containing the key — wrong when another number (e.g. NumChnl, Scale)
-# appeared before "Bus" on the same logical object.
+# Returns: The numeric value (integer or decimal)
 json_get_number()
 {
 	local key="$1"
-	awk -v k="$key" '
-	BEGIN { buf = "" }
-	{ buf = buf $0 }
-	END {
-		p = "\"" k "\""
-		i = index(buf, p)
-		if (i == 0) exit
-		j = i + length(p)
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
-		if (substr(buf, j, 1) != ":") exit
-		j++
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
-		if (j > length(buf)) exit
-		start = j
-		if (substr(buf, j, 1) == "-") j++
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[0-9]/) j++
-		if (substr(buf, j, 1) == ".") {
-			j++
-			while (j <= length(buf) && substr(buf, j, 1) ~ /[0-9]/) j++
-		}
-		if (j > start) print substr(buf, start, j - start)
-	}'
+
+	_json_parser_require_jq || return 1
+	jq -r --arg k "$key" '
+		(.[$k] // empty) |
+		if type == "number" then tostring
+		elif type == "string" and test("^-?[0-9]+(\\.[0-9]+)?$") then .
+		else empty end
+	'
 }
 
 # Function to extract a JSON boolean or string that looks like a boolean
 # Usage: echo "$json" | json_get_bool <key>
-# Prints: true, false, or a quoted string value (e.g. true from "true"); empty if absent/invalid.
-# RFC 8259 booleans are lowercase true/false without quotes — json_get_string cannot read those.
+# Prints: true, false, or a quoted string value; empty if absent/invalid.
+# Returns: 2 when absent or invalid (matches legacy awk parser contract).
 json_get_bool()
 {
 	local key="$1"
-	awk -v k="$key" '
-	BEGIN { buf = "" }
-	{ buf = buf $0 }
-	END {
-		p = "\"" k "\""
-		i = index(buf, p)
-		if (i == 0) exit 2
-		j = i + length(p)
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
-		if (substr(buf, j, 1) != ":") exit 2
-		j++
-		while (j <= length(buf) && substr(buf, j, 1) ~ /[[:space:]]/) j++
-		if (j > length(buf)) exit 2
-		rest = substr(buf, j)
-		if (match(rest, /^true([^a-zA-Z0-9_]|$)/)) { print "true"; exit 0 }
-		if (match(rest, /^false([^a-zA-Z0-9_]|$)/)) { print "false"; exit 0 }
-		if (substr(buf, j, 1) == "\"") {
-			j++
-			start = j
-			while (j <= length(buf) && substr(buf, j, 1) != "\"") j++
-			if (j > start) {
-				print substr(buf, start, j - start)
-				exit 0
-			}
-		}
-		exit 2
-	}'
+	local val
+
+	_json_parser_require_jq || return 2
+	val=$(jq -r --arg k "$key" '
+		(.[$k] // empty) |
+		if type == "boolean" then tostring
+		elif type == "string" then .
+		else empty end
+	' 2>/dev/null) || return 2
+	if [ -z "$val" ]; then
+		return 2
+	fi
+	printf '%s\n' "$val"
 }
 
-# Function to extract array elements (strings) from a JSON array
+# Function to extract array elements from a JSON array
 # Usage: echo "$json" | json_get_array <array_name>
 # Returns: Array elements, one per line
 json_get_array()
 {
-    local array_name="$1"
-    awk -v arr="$array_name" '
-    BEGIN { in_array = 0 }
-    $0 ~ "\"" arr "\".*\\[" { in_array = 1; next }
-    in_array && /\]/ { exit }
-    in_array && /"/ {
-        gsub(/^[ \t]*"/, "")
-        gsub(/"[ \t,]*$/, "")
-        print
-    }
-    '
+	local array_name="$1"
+
+	_json_parser_require_jq || return 1
+	jq -r --arg a "$array_name" '
+		(.[$a] // []) |
+		if type != "array" then empty else .[] end |
+		if type == "string" then .
+		elif type == "number" then tostring
+		elif type == "boolean" then tostring
+		else empty end
+	'
 }
 
 # Function to count top-level elements in a JSON array
 # Usage: json_count_array_elements <json_file>
 # Returns: Number of top-level elements
-# Note: Do not use grep on lines starting with "{" — nested Device objects also start
-# lines with "{" and would inflate the count (e.g. 6 instead of 2).
 json_count_array_elements()
 {
 	local json_file="$1"
-	local idx=0
-	local block
-	while block=$(json_get_array_element "$json_file" "$idx"); [ -n "$block" ]; do
-		idx=$((idx + 1))
-	done
-	echo "$idx"
+
+	_json_parser_require_jq || return 1
+	jq -r 'if type == "array" then length else 0 end' "$json_file"
 }
 
 # Function to count elements in a named array within a JSON block
 # Usage: echo "$json_block" | json_count_nested_array <array_name>
 # Returns: Number of elements in the named array
-# Counts only top-level "{" openings at brace depth 0 inside the array (same rule as
-# json_get_nested_array_element). Ignores "{" inside JSON string values.
 json_count_nested_array()
 {
-    local array_name="$1"
-    awk -v array="$array_name" '
-    BEGIN {
-        in_target_array = 0
-        count = 0
-        depth = 0
-        in_string = 0
-        escape = 0
-    }
-    {
-        has_array = index($0, "\"" array "\"")
-        if (has_array > 0 && index($0, "[") > 0) {
-            in_target_array = 1
-            next
-        }
+	local array_name="$1"
 
-        if (in_target_array && !in_string && depth == 0 && index($0, "]") > 0) {
-            in_target_array = 0
-            next
-        }
-
-        if (!in_target_array) {
-            next
-        }
-
-        line = $0
-        for (i = 1; i <= length(line); i++) {
-            c = substr(line, i, 1)
-            if (in_string) {
-                if (escape) {
-                    escape = 0
-                    continue
-                }
-                if (c == "\\") {
-                    escape = 1
-                    continue
-                }
-                if (c == "\"") {
-                    in_string = 0
-                }
-                continue
-            }
-            if (c == "\"") {
-                in_string = 1
-                continue
-            }
-            if (c == "{") {
-                if (depth == 0) {
-                    count++
-                }
-                depth++
-            } else if (c == "}") {
-                depth--
-            }
-        }
-    }
-    END { print count }
-    '
+	_json_parser_require_jq || return 1
+	jq -r --arg a "$array_name" '
+		(.[$a] // []) |
+		if type == "array" then length else 0 end
+	'
 }
 
-# Function to validate JSON file (basic check)
+# Function to validate JSON file
 # Usage: json_validate <json_file>
 # Returns: 0 if valid, 1 if invalid
 json_validate()
 {
-    local json_file="$1"
-    if [ ! -f "$json_file" ]; then
-        return 1
-    fi
+	local json_file="$1"
 
-    # Brace/bracket balance outside JSON string values (grep would count { inside strings).
-    awk '
-    BEGIN { depth_brace = 0; depth_bracket = 0; in_string = 0; escape = 0; ok = 1 }
-    {
-        for (i = 1; i <= length($0); i++) {
-            c = substr($0, i, 1)
-            if (in_string) {
-                if (escape) {
-                    escape = 0
-                    continue
-                }
-                if (c == "\\") {
-                    escape = 1
-                    continue
-                }
-                if (c == "\"") {
-                    in_string = 0
-                }
-                continue
-            }
-            if (c == "\"") {
-                in_string = 1
-                continue
-            }
-            if (c == "{") {
-                depth_brace++
-            } else if (c == "}") {
-                depth_brace--
-                if (depth_brace < 0) {
-                    ok = 0
-                }
-            } else if (c == "[") {
-                depth_bracket++
-            } else if (c == "]") {
-                depth_bracket--
-                if (depth_bracket < 0) {
-                    ok = 0
-                }
-            }
-        }
-    }
-    END {
-        if (depth_brace != 0 || depth_bracket != 0) {
-            ok = 0
-        }
-        exit ok ? 0 : 1
-    }
-    ' "$json_file"
+	_json_parser_require_jq || return 1
+	[ -f "$json_file" ] || return 1
+	jq empty "$json_file" >/dev/null 2>&1
 }
 
 # BusyBox ash has no export -f; load with ". /usr/bin/hw-management-json-parser.sh".
 if [ -n "${BASH_VERSION:-}" ]; then
+	export -f _json_parser_require_jq
 	export -f json_get_array_element
 	export -f json_get_nested_array_element
 	export -f json_get_string

--- a/usr/usr/bin/hw-management-platform-json.sh
+++ b/usr/usr/bin/hw-management-platform-json.sh
@@ -1,0 +1,907 @@
+#!/bin/bash
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Apply per-platform hw-management settings from
+# /etc/hw-management-cfg/<HID>/platform.json
+# (packaged under usr/etc/hw-management-cfg/<HID>/).
+# Parsed with hw-management-json-parser.sh (jq).
+################################################################################
+
+PLATFORM_JSON_CFG_DIR="hw-management-cfg"
+PLATFORM_JSON_FILENAME="platform.json"
+
+platform_json_asic_pci_id=""
+platform_json_dpu_pci_id=""
+platform_json_dpu_pci_addr=()
+
+PLATFORM_JSON_NUMERIC_VARS=(
+	asic_control
+	asic_chipup_retry
+	asic_num
+	cartridge_count
+	chipup_delay_default
+	chipup_log_size
+	chipup_retry_count
+	cpld_num
+	device_connect_retry
+	dpu_count
+	dummy_psus_supported
+	erot_count
+	fan_speed_tolerance
+	health_events_count
+	hotplug_fans
+	hotplug_linecards
+	hotplug_pdbs
+	hotplug_psus
+	hotplug_pwrs
+	i2c_bus_def_off_eeprom_cpu
+	i2c_comex_mon_bus_default
+	leakage_count
+	leakage_rope_count
+	max_tachos
+	mcu_count
+	minimal_unsupported
+	psu_count
+	pwr_events_count
+	vrot_count
+)
+
+PLATFORM_JSON_STRING_VARS=(
+	lm_sensors_config
+	lm_sensors_config_lc
+	lm_sensors_labels
+	mctp_addr
+	mctp_bus
+	thermal_control_config
+)
+
+PLATFORM_JSON_CONFIG_KEYS=(
+	asic_control
+	core1_temp_id
+	cpld_port
+	cx_default_i2c_bus
+	default_i2c_freq
+	fan_dir_eeprom
+	fan_drwr_num
+	fan_front_max_speed
+	fan_front_min_speed
+	fan_inversed
+	fan_max_speed
+	fan_min_speed
+	fan_rear_max_speed
+	fan_rear_min_speed
+	fixed_fans_system
+	global_wp_timeout
+	global_wp_wait_step
+	jtag_bridge_offset
+	jtag_ro_reg
+	jtag_rw_reg
+	max_tachos
+	psu_eeprom_type
+	psu_fan_max
+	psu_fan_min
+	reset_attr_num
+	system_flow_capability
+)
+
+PLATFORM_JSON_ACTIONS=(
+	get_i2c_bus_frequency_default
+)
+
+PLATFORM_JSON_SYSTEM_KEYS=(
+	bmc
+	cooling
+	fan_replaceable
+	power_source
+	power_supply
+	power_supply_replaceable
+	security
+	ssd
+	tpm
+	type
+)
+
+PLATFORM_JSON_BOARD_NUMERIC_KEYS=(
+	clk_brd_num
+	cpu_brd_bus_offset
+	dpu_brd_bus_offset
+	dpu_num
+	pwr_brd_bus_offset
+	pwr_brd_hotswap_num
+	pwr_brd_num
+	pwr_brd_pwr_conv_num
+	pwr_brd_temp_sens_num
+	swb_brd_bus_offset
+	swb_brd_num
+	swb_brd_pdb_bus_offset
+	swb_brd_vr_num
+)
+
+PLATFORM_JSON_BOARD_STRING_KEYS=(
+	dpu_board_type
+)
+
+source_hw_platform_json_parser()
+{
+	if [ -f /usr/bin/hw-management-json-parser.sh ]; then
+		# shellcheck source=/dev/null
+		. /usr/bin/hw-management-json-parser.sh
+		return 0
+	fi
+	return 1
+}
+
+find_platform_json_config()
+{
+	local hid="$1"
+	local f
+
+	[ -n "$hid" ] || return 1
+	[ "$hid" != "Unknown" ] || return 1
+	case "$hid" in
+	HI[0-9]*) ;;
+	*) return 1 ;;
+	esac
+
+	for f in "/etc/${PLATFORM_JSON_CFG_DIR}/${hid}/${PLATFORM_JSON_FILENAME}" \
+		"/usr/etc/${PLATFORM_JSON_CFG_DIR}/${hid}/${PLATFORM_JSON_FILENAME}"; do
+		if [ -f "$f" ]; then
+			echo "$f"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Extract a top-level JSON object by key from a file (multi-line safe).
+# Matches only keys at brace depth 1 (root object), not string values.
+platform_json_extract_object()
+{
+	local key="$1"
+	local json_file="$2"
+	awk -v k="$key" '
+	BEGIN {
+		buf = ""
+		in_string = 0
+		escape = 0
+		depth = 0
+	}
+	{ buf = buf $0 "\n" }
+	END {
+		i = 1
+		n = length(buf)
+		while (i <= n) {
+			c = substr(buf, i, 1)
+			if (in_string) {
+				if (escape) {
+					escape = 0
+				} else if (c == "\\") {
+					escape = 1
+				} else if (c == "\"") {
+					in_string = 0
+				}
+				i++
+				continue
+			}
+			if (c == "\"") {
+				key_start = i + 1
+				i++
+				while (i <= n) {
+					c = substr(buf, i, 1)
+					if (c == "\\") {
+						i += 2
+						continue
+					}
+					if (c == "\"") {
+						break
+					}
+					i++
+				}
+				if (i > n) {
+					exit
+				}
+				key_name = substr(buf, key_start, i - key_start)
+				i++
+				while (i <= n && substr(buf, i, 1) ~ /[[:space:]]/) {
+					i++
+				}
+				if (depth == 1 && key_name == k && substr(buf, i, 1) == ":") {
+					i++
+					while (i <= n && substr(buf, i, 1) ~ /[[:space:]]/) {
+						i++
+					}
+					if (substr(buf, i, 1) == "{") {
+						start = i
+						obj_depth = 1
+						in_obj_string = 0
+						obj_escape = 0
+						i++
+						while (i <= n && obj_depth > 0) {
+							c = substr(buf, i, 1)
+							if (in_obj_string) {
+								if (obj_escape) {
+									obj_escape = 0
+								} else if (c == "\\") {
+									obj_escape = 1
+								} else if (c == "\"") {
+									in_obj_string = 0
+								}
+								i++
+								continue
+							}
+							if (c == "\"") {
+								in_obj_string = 1
+								i++
+								continue
+							}
+							if (c == "{") {
+								obj_depth++
+							} else if (c == "}") {
+								obj_depth--
+							}
+							i++
+						}
+						if (obj_depth == 0) {
+							print substr(buf, start, i - start)
+							exit
+						}
+					}
+				}
+				continue
+			}
+			if (c == "{") {
+				depth++
+			} else if (c == "}") {
+				depth--
+			}
+			i++
+		}
+	}
+	' "$json_file"
+}
+
+# Return 0 when a top-level JSON array key is present in the file.
+platform_json_has_top_level_array()
+{
+	local key="$1"
+	local json_file="$2"
+	awk -v k="$key" '
+	BEGIN { buf = ""; in_string = 0; escape = 0; depth = 0 }
+	{ buf = buf $0 "\n" }
+	END {
+		i = 1
+		n = length(buf)
+		while (i <= n) {
+			c = substr(buf, i, 1)
+			if (in_string) {
+				if (escape) {
+					escape = 0
+				} else if (c == "\\") {
+					escape = 1
+				} else if (c == "\"") {
+					in_string = 0
+				}
+				i++
+				continue
+			}
+			if (c == "\"") {
+				key_start = i + 1
+				i++
+				while (i <= n) {
+					c = substr(buf, i, 1)
+					if (c == "\\") {
+						i += 2
+						continue
+					}
+					if (c == "\"") {
+						break
+					}
+					i++
+				}
+				if (i > n) {
+					exit 1
+				}
+				key_name = substr(buf, key_start, i - key_start)
+				i++
+				while (i <= n && substr(buf, i, 1) ~ /[[:space:]]/) {
+					i++
+				}
+				if (depth == 1 && key_name == k && substr(buf, i, 1) == ":") {
+					i++
+					while (i <= n && substr(buf, i, 1) ~ /[[:space:]]/) {
+						i++
+					}
+					if (substr(buf, i, 1) == "[") {
+						exit 0
+					}
+				}
+				continue
+			}
+			if (c == "{") {
+				depth++
+			} else if (c == "}") {
+				depth--
+			}
+			i++
+		}
+		exit 1
+	}
+	' "$json_file"
+}
+
+platform_json_action_allowed()
+{
+	local name="$1"
+	local key
+
+	for key in "${PLATFORM_JSON_ACTIONS[@]}"; do
+		[ "$key" = "$name" ] && return 0
+	done
+	return 1
+}
+
+platform_json_valid_shell_array_name()
+{
+	[[ "$1" =~ ^[a-z][a-z0-9_]+$ ]]
+}
+
+platform_json_write_config_key()
+{
+	local key="$1"
+	local val="$2"
+
+	if ! echo "$val" > "$config_path/$key"; then
+		log_err "platform JSON: failed to write config/${key}"
+		return 1
+	fi
+}
+
+platform_json_valid_number()
+{
+	[[ "$1" =~ ^[0-9]+$ ]]
+}
+
+platform_json_valid_named_bus_name()
+{
+	[[ "$1" =~ ^[a-zA-Z0-9_-]+$ ]]
+}
+
+platform_json_valid_i2c_addr()
+{
+	[[ "$1" =~ ^0x[0-9a-fA-F]{1,2}$ ]]
+}
+
+platform_json_valid_pci_id()
+{
+	[[ "$1" =~ ^[0-9a-fA-F]{4}(\|[0-9a-fA-F]{4})*$ ]]
+}
+
+platform_json_valid_pci_bdf()
+{
+	[[ "$1" =~ ^[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$ ]]
+}
+
+platform_json_append_shell_array_ref()
+{
+	local table_name="$1"
+
+	if platform_json_valid_shell_array_name "$table_name"; then
+		if eval "[ \${#${table_name}[@]} -gt 0 ]" 2>/dev/null; then
+			# shellcheck disable=SC1087,SC2086
+			eval "connect_table+=(\"\${${table_name}[@]}\")"
+			return 0
+		fi
+	fi
+	log_err "platform JSON: unknown or empty connect table '${table_name}'"
+	return 1
+}
+
+platform_json_append_named_busses_ref()
+{
+	local table_name="$1"
+
+	if platform_json_valid_shell_array_name "$table_name"; then
+		if eval "[ \${#${table_name}[@]} -gt 0 ]" 2>/dev/null; then
+			# shellcheck disable=SC1087,SC2086
+			eval "named_busses+=(\"\${${table_name}[@]}\")"
+			return 0
+		fi
+	fi
+	log_err "platform JSON: unknown or empty named busses table '${table_name}'"
+	return 1
+}
+
+platform_json_append_dynamic_shell_array_ref()
+{
+	local table_name="$1"
+
+	if platform_json_valid_shell_array_name "$table_name"; then
+		if eval "[ \${#${table_name}[@]} -gt 0 ]" 2>/dev/null; then
+			# shellcheck disable=SC1087,SC2086
+			eval "add_i2c_dynamic_bus_dev_connection_table \"\${${table_name}[@]}\"" || return 1
+			return 0
+		fi
+	fi
+	log_err "platform JSON: unknown or empty dynamic connect table '${table_name}'"
+	return 1
+}
+
+platform_json_apply_inline_base_connect()
+{
+	local conn_obj="$1"
+	local i block chip addr bus
+
+	i=0
+	while block=$(printf '%s\n' "$conn_obj" | json_get_nested_array_element "base_connect" "$i"); [ -n "$block" ]; do
+		chip=$(printf '%s\n' "$block" | json_get_string "chip")
+		addr=$(printf '%s\n' "$block" | json_get_string "addr")
+		bus=$(printf '%s\n' "$block" | json_get_number "bus")
+		if [ -n "$chip" ] && [ -n "$addr" ] && [ -n "$bus" ]; then
+			connect_table+=("$chip" "$addr" "$bus")
+		else
+			log_err "platform JSON: incomplete base_connect entry"
+			return 1
+		fi
+		i=$((i + 1))
+	done
+}
+
+platform_json_apply_inline_dynamic_connect()
+{
+	local conn_obj="$1"
+	local i block chip addr bus name
+
+	i=0
+	while block=$(printf '%s\n' "$conn_obj" | json_get_nested_array_element "dynamic_connect" "$i"); [ -n "$block" ]; do
+		chip=$(printf '%s\n' "$block" | json_get_string "chip")
+		addr=$(printf '%s\n' "$block" | json_get_string "addr")
+		bus=$(printf '%s\n' "$block" | json_get_number "bus")
+		name=$(printf '%s\n' "$block" | json_get_string "name")
+		if [ -n "$chip" ] && [ -n "$addr" ] && [ -n "$bus" ] && [ -n "$name" ]; then
+			add_i2c_dynamic_bus_dev_connection_table "$chip" "$addr" "$bus" "$name" || return 1
+		else
+			log_err "platform JSON: incomplete dynamic_connect entry"
+			return 1
+		fi
+		i=$((i + 1))
+	done
+}
+
+platform_json_apply_connection()
+{
+	local json_file="$1"
+	local conn_obj cpu_offset table_name nb_count j nb_name nb_bus add_come
+
+	conn_obj=$(platform_json_extract_object "connection" "$json_file")
+	[ -n "$conn_obj" ] || return 0
+
+	table_name=$(printf '%s\n' "$conn_obj" | json_get_string "named_busses_table")
+	nb_count=$(printf '%s\n' "$conn_obj" | json_count_nested_array "named_busses")
+	[ -z "$nb_count" ] && nb_count=0
+	if [ -n "$table_name" ] && [ "$nb_count" -gt 0 ]; then
+		log_err "platform JSON: use named_busses_table or named_busses, not both"
+		return 1
+	fi
+
+	# New platforms use devtree for I2C topology; JSON supplies extras only.
+	if [ ! -e "$devtree_file" ]; then
+		while read -r table_name; do
+			[ -n "$table_name" ] || continue
+			platform_json_append_shell_array_ref "$table_name" || return 1
+		done < <(printf '%s\n' "$conn_obj" | json_get_array "base_tables")
+
+		cpu_offset=$(printf '%s\n' "$conn_obj" | json_get_number "cpu_board_offset")
+		if [ -n "$cpu_offset" ]; then
+			if ! platform_json_valid_number "$cpu_offset"; then
+				log_err "platform JSON: invalid cpu_board_offset '${cpu_offset}'"
+				return 1
+			fi
+			add_cpu_board_to_connection_table "$cpu_offset" || return 1
+		fi
+
+		while read -r table_name; do
+			[ -n "$table_name" ] || continue
+			platform_json_append_dynamic_shell_array_ref "$table_name" || return 1
+		done < <(printf '%s\n' "$conn_obj" | json_get_array "dynamic_tables")
+
+		platform_json_apply_inline_base_connect "$conn_obj" || return 1
+		platform_json_apply_inline_dynamic_connect "$conn_obj" || return 1
+	fi
+
+	table_name=$(printf '%s\n' "$conn_obj" | json_get_string "named_busses_table")
+	if [ -n "$table_name" ]; then
+		platform_json_append_named_busses_ref "$table_name" || return 1
+	fi
+
+	if [ "$nb_count" -gt 0 ]; then
+		j=0
+		while [ "$j" -lt "$nb_count" ]; do
+			nb_name=$(printf '%s\n' "$conn_obj" | json_get_nested_array_element "named_busses" "$j" | json_get_string "name")
+			nb_bus=$(printf '%s\n' "$conn_obj" | json_get_nested_array_element "named_busses" "$j" | json_get_number "bus")
+			if [ -z "$nb_name" ] || [ -z "$nb_bus" ]; then
+				log_err "platform JSON: incomplete named_busses entry"
+				return 1
+			fi
+			if ! platform_json_valid_named_bus_name "$nb_name"; then
+				log_err "platform JSON: invalid named_busses name '${nb_name}'"
+				return 1
+			fi
+			if ! platform_json_valid_number "$nb_bus"; then
+				log_err "platform JSON: invalid named_busses bus '${nb_bus}'"
+				return 1
+			fi
+			named_busses+=("$nb_name" "$nb_bus")
+			j=$((j + 1))
+		done
+	fi
+
+	cpu_offset=$(printf '%s\n' "$conn_obj" | json_get_number "add_come_named_busses_offset")
+	if [ -n "$cpu_offset" ]; then
+		if ! platform_json_valid_number "$cpu_offset"; then
+			log_err "platform JSON: invalid add_come_named_busses_offset '${cpu_offset}'"
+			return 1
+		fi
+		add_come_named_busses "$cpu_offset" || return 1
+	else
+		add_come=$(printf '%s\n' "$conn_obj" | json_get_bool "add_come_named_busses")
+		if [ "$add_come" = "true" ]; then
+			add_come_named_busses || return 1
+		fi
+	fi
+
+	if [ ${#named_busses[@]} -gt 0 ]; then
+		if ! echo -n "${named_busses[@]}" > "$config_path/named_busses"; then
+			log_err "platform JSON: failed to write config/named_busses"
+			return 1
+		fi
+	fi
+}
+
+platform_json_validate_system_value()
+{
+	local key="$1"
+	local val="$2"
+
+	case "$key" in
+	bmc)
+		case "$val" in
+		yes|no) return 0 ;;
+		esac
+		;;
+	cooling)
+		case "$val" in
+		liquid|air|hybrid) return 0 ;;
+		esac
+		;;
+	power_supply)
+		case "$val" in
+		AC|DC) return 0 ;;
+		esac
+		;;
+	power_source)
+		case "$val" in
+		busbar|replaceable_unit) return 0 ;;
+		esac
+		;;
+	power_supply_replaceable|fan_replaceable|tpm)
+		case "$val" in
+		yes|no|na) return 0 ;;
+		esac
+		;;
+	ssd)
+		case "$val" in
+		sata|nvme) return 0 ;;
+		esac
+		;;
+	security)
+		case "$val" in
+		PQC) return 0 ;;
+		esac
+		;;
+	type)
+		case "$val" in
+		Ethernet|IB|NvLink) return 0 ;;
+		esac
+		;;
+	esac
+	log_err "platform JSON: invalid system.${key} value '${val}'"
+	return 1
+}
+
+platform_json_apply_system()
+{
+	local json_file="$1"
+	local sys_obj key val
+
+	sys_obj=$(platform_json_extract_object "system" "$json_file")
+	[ -n "$sys_obj" ] || return 0
+
+	for key in "${PLATFORM_JSON_SYSTEM_KEYS[@]}"; do
+		val=$(printf '%s\n' "$sys_obj" | json_get_string "$key")
+		[ -n "$val" ] || continue
+		platform_json_validate_system_value "$key" "$val" || return 1
+		platform_json_write_config_key "$key" "$val" || return 1
+	done
+}
+
+platform_json_apply_variables()
+{
+	local json_file="$1"
+	local var_obj key val
+
+	var_obj=$(platform_json_extract_object "variables" "$json_file")
+	[ -n "$var_obj" ] || return 0
+
+	for key in "${PLATFORM_JSON_NUMERIC_VARS[@]}"; do
+		val=$(printf '%s\n' "$var_obj" | json_get_number "$key")
+		if [ -n "$val" ]; then
+			if ! platform_json_valid_number "$val"; then
+				log_err "platform JSON: non-numeric value for ${key}: '${val}'"
+				return 1
+			fi
+			eval "$key=$val" || return 1
+			if [ "$key" = "asic_num" ]; then
+				platform_json_write_config_key "asic_num" "$val" || return 1
+			fi
+			if [ "$key" = "cartridge_count" ]; then
+				platform_json_write_config_key "cartridge_counter" "$val" || return 1
+			fi
+			if [ "$key" = "cpld_num" ]; then
+				platform_json_write_config_key "cpld_num" "$val" || return 1
+			fi
+		fi
+	done
+
+	for key in "${PLATFORM_JSON_STRING_VARS[@]}"; do
+		val=$(printf '%s\n' "$var_obj" | json_get_escaped_string "$key")
+		if [ -n "$val" ]; then
+			eval "$key=\"\$val\"" || return 1
+		fi
+	done
+}
+
+platform_json_apply_config_files()
+{
+	local json_file="$1"
+	local cfg_obj key val
+
+	cfg_obj=$(platform_json_extract_object "config" "$json_file")
+	[ -n "$cfg_obj" ] || return 0
+
+	for key in "${PLATFORM_JSON_CONFIG_KEYS[@]}"; do
+		val=$(printf '%s\n' "$cfg_obj" | json_get_escaped_string "$key")
+		if [ -z "$val" ]; then
+			val=$(printf '%s\n' "$cfg_obj" | json_get_number "$key")
+		fi
+		if [ -n "$val" ]; then
+			platform_json_write_config_key "$key" "$val" || return 1
+		fi
+	done
+}
+
+platform_json_apply_board()
+{
+	local json_file="$1"
+	local board_obj key val
+
+	board_obj=$(platform_json_extract_object "board" "$json_file")
+	[ -n "$board_obj" ] || return 0
+
+	for key in "${PLATFORM_JSON_BOARD_NUMERIC_KEYS[@]}"; do
+		val=$(printf '%s\n' "$board_obj" | json_get_number "$key")
+		if [ -n "$val" ]; then
+			if ! platform_json_valid_number "$val"; then
+				log_err "platform JSON: non-numeric board.${key}: '${val}'"
+				return 1
+			fi
+			platform_json_write_config_key "$key" "$val" || return 1
+		fi
+	done
+
+	for key in "${PLATFORM_JSON_BOARD_STRING_KEYS[@]}"; do
+		val=$(printf '%s\n' "$board_obj" | json_get_escaped_string "$key")
+		if [ -n "$val" ]; then
+			if ! platform_json_valid_named_bus_name "$val"; then
+				log_err "platform JSON: invalid board.${key}: '${val}'"
+				return 1
+			fi
+			platform_json_write_config_key "$key" "$val" || return 1
+		fi
+	done
+}
+
+platform_json_apply_psu_i2c_map()
+{
+	local json_file="$1"
+	local psu_obj i bus addr
+
+	psu_obj=$(platform_json_extract_object "psu_i2c" "$json_file")
+	[ -n "$psu_obj" ] || return 0
+
+	for i in 1 2 3 4 5 6 7 8; do
+		bus=$(printf '%s\n' "$psu_obj" | json_get_number "psu${i}_i2c_bus")
+		addr=$(printf '%s\n' "$psu_obj" | json_get_string "psu${i}_i2c_addr")
+		if [ -n "$bus" ]; then
+			if ! platform_json_valid_number "$bus"; then
+				log_err "platform JSON: invalid psu${i}_i2c_bus '${bus}'"
+				return 1
+			fi
+			eval "psu${i}_i2c_bus=$bus" || return 1
+		fi
+		if [ -n "$addr" ]; then
+			if ! platform_json_valid_i2c_addr "$addr"; then
+				log_err "platform JSON: invalid psu${i}_i2c_addr '${addr}'"
+				return 1
+			fi
+			eval "psu${i}_i2c_addr=\"\$addr\"" || return 1
+		fi
+	done
+}
+
+platform_json_apply_asic_i2c_buses()
+{
+	local json_file="$1"
+	local buses=()
+
+	platform_json_has_top_level_array "asic_i2c_buses" "$json_file" || return 0
+
+	while read -r line; do
+		[ -n "$line" ] || continue
+		if ! platform_json_valid_number "$line"; then
+			log_err "platform JSON: invalid asic_i2c_buses entry '${line}'"
+			return 1
+		fi
+		buses+=("$line")
+	done < <(json_get_array "asic_i2c_buses" < "$json_file")
+
+	if [ ${#buses[@]} -eq 0 ]; then
+		log_err "platform JSON: asic_i2c_buses is empty; omit key to keep default"
+		return 1
+	fi
+
+	asic_i2c_buses=("${buses[@]}")
+}
+
+platform_json_apply_pci()
+{
+	local json_file="$1"
+	local pci_obj val line
+
+	platform_json_asic_pci_id=""
+	platform_json_dpu_pci_id=""
+	platform_json_dpu_pci_addr=()
+
+	pci_obj=$(platform_json_extract_object "pci" "$json_file")
+	[ -n "$pci_obj" ] || return 0
+
+	val=$(printf '%s\n' "$pci_obj" | json_get_string "asic_pci_id")
+	if [ -n "$val" ]; then
+		if ! platform_json_valid_pci_id "$val"; then
+			log_err "platform JSON: invalid pci.asic_pci_id '${val}'"
+			return 1
+		fi
+		platform_json_asic_pci_id=$val
+	fi
+
+	val=$(printf '%s\n' "$pci_obj" | json_get_string "dpu_pci_id")
+	if [ -n "$val" ]; then
+		if ! platform_json_valid_pci_id "$val"; then
+			log_err "platform JSON: invalid pci.dpu_pci_id '${val}'"
+			return 1
+		fi
+		platform_json_dpu_pci_id=$val
+	fi
+
+	while read -r line; do
+		[ -n "$line" ] || continue
+		if ! platform_json_valid_pci_bdf "$line"; then
+			log_err "platform JSON: invalid pci.dpu_pci_addr entry '${line}'"
+			return 1
+		fi
+		platform_json_dpu_pci_addr+=("$line")
+	done < <(printf '%s\n' "$pci_obj" | json_get_array "dpu_pci_addr")
+
+	if [ -n "$platform_json_dpu_pci_id" ] && \
+	   [ ${#platform_json_dpu_pci_addr[@]} -eq 0 ]; then
+		log_err "platform JSON: dpu_pci_id requires non-empty dpu_pci_addr"
+		return 1
+	fi
+	if [ ${#platform_json_dpu_pci_addr[@]} -gt 0 ] && \
+	   [ -z "$platform_json_dpu_pci_id" ]; then
+		log_err "platform JSON: dpu_pci_addr requires dpu_pci_id"
+		return 1
+	fi
+}
+
+set_asic_pci_id_from_json()
+{
+	local asic_num i=0 asic_pci
+
+	asic_pci_id=$platform_json_asic_pci_id
+
+	if [ -f "$config_path/asic_num" ]; then
+		asic_num=$(< "$config_path/asic_num")
+	else
+		asic_num=0
+		while read -r asic_pci; do
+			[ -n "$asic_pci" ] || continue
+			asic_num=$((asic_num + 1))
+		done < <(lspci -nn | grep -E "$asic_pci_id" | awk '{print $1}')
+		echo "$asic_num" > "$config_path/asic_num"
+	fi
+
+	while read -r asic_pci; do
+		[ -n "$asic_pci" ] || continue
+		i=$((i + 1))
+		if [ "$i" -gt "$asic_num" ]; then
+			break
+		fi
+		echo "$asic_pci" > "$config_path/asic${i}_pci_bus_id"
+	done < <(lspci -nn | grep -E "$asic_pci_id" | awk '{print $1}')
+}
+
+set_dpu_pci_id_from_json()
+{
+	local dpus total_dpu_num idx element dpu_detected_num=0
+
+	dpu_pci_id=$platform_json_dpu_pci_id
+	dpus=$(lspci -nn | grep -E "$dpu_pci_id" | awk '{print $1}')
+	total_dpu_num=${#platform_json_dpu_pci_addr[@]}
+
+	for ((idx=0; idx<total_dpu_num; idx++)); do
+		element="${platform_json_dpu_pci_addr[$idx]}"
+		if echo "$dpus" | grep -q -w "$element"; then
+			echo "$element" > "$config_path/dpu$((idx+1))_pci_bus_id"
+			dpu_detected_num=$((dpu_detected_num + 1))
+		else
+			echo "" > "$config_path/dpu$((idx+1))_pci_bus_id"
+		fi
+	done
+	echo "$dpu_detected_num" > "$config_path/dpu_detected_num"
+}
+
+platform_json_apply_actions()
+{
+	local json_file="$1"
+	local action
+
+	while read -r action; do
+		[ -n "$action" ] || continue
+		if ! platform_json_action_allowed "$action"; then
+			log_err "platform JSON: unsupported action '${action}'"
+			return 1
+		fi
+		if ! "$action"; then
+			log_err "platform JSON: action '${action}' failed"
+			return 1
+		fi
+	done < <(json_get_array "actions" < "$json_file")
+}
+
+platform_json_apply_config()
+{
+	local json_file="$1"
+
+	if ! source_hw_platform_json_parser; then
+		log_err "platform JSON parser not found, cannot apply ${json_file}"
+		return 1
+	fi
+
+	if ! json_validate "$json_file"; then
+		log_err "platform JSON invalid: ${json_file}"
+		return 1
+	fi
+
+	platform_json_apply_system "$json_file" || return 1
+	platform_json_apply_variables "$json_file" || return 1
+	# board section is applied in pre_devtr_init() before devtree init
+	platform_json_apply_pci "$json_file" || return 1
+	platform_json_apply_config_files "$json_file" || return 1
+	platform_json_apply_psu_i2c_map "$json_file" || return 1
+	platform_json_apply_asic_i2c_buses "$json_file" || return 1
+	platform_json_apply_connection "$json_file" || return 1
+	platform_json_apply_actions "$json_file" || return 1
+	return 0
+}

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -62,6 +62,8 @@ source hw-management-helpers.sh
 [ -f "$board_type_file" ] && board_type=$(< $board_type_file) || board_type="Unknown"
 [ -f "$sku_file" ] && sku=$(< $sku_file) || sku="Unknown"
 source hw-management-devtree.sh
+# shellcheck source=/dev/null
+[ -f /usr/bin/hw-management-platform-json.sh ] && . /usr/bin/hw-management-platform-json.sh
 # Local constants and variables
 
 asic_control=1
@@ -87,6 +89,9 @@ hotplug_pwrs=2
 hotplug_pdbs=0
 hotplug_linecards=0
 erot_count=0
+vrot_count=0
+mcu_count=0
+cartridge_count=0
 health_events_count=0
 pwr_events_count=0
 dpu_count=0
@@ -1047,7 +1052,7 @@ add_cpu_board_to_connection_table()
 			;;
 		*)
 			log_err "$product is not supported"
-			exit 0
+			return 1
 			;;
 	esac
 
@@ -1063,7 +1068,7 @@ add_cpu_board_to_connection_table()
 	fi
 
 	connect_table+=(${cpu_connection_table[@]})
-	add_i2c_dynamic_bus_dev_connection_table "${cpu_voltmon_connection_table[@]}"
+	add_i2c_dynamic_bus_dev_connection_table "${cpu_voltmon_connection_table[@]}" || return 1
 }
 
 add_i2c_dynamic_bus_dev_connection_table()
@@ -1071,7 +1076,9 @@ add_i2c_dynamic_bus_dev_connection_table()
 	connection_table=("$@")
 	dynamic_i2cbus_connection_table=()
 
-	echo -n "${connection_table[@]} " >> $config_path/i2c_bus_connect_devices
+	if ! echo -n "${connection_table[@]} " >> $config_path/i2c_bus_connect_devices; then
+		return 1
+	fi
 	for ((i=0; i<${#connection_table[@]}; i+=4)); do
 		dynamic_i2cbus_connection_table[$i]="${connection_table[i]}"
 		dynamic_i2cbus_connection_table[$i+1]="${connection_table[i+1]}"
@@ -1093,7 +1100,8 @@ add_come_named_busses()
 		come_named_busses+=( ${amd_snw_named_busses[@]} )
 		;;
 	*)
-		return
+		log_err "unsupported cpu_type '${cpu_type}' for add_come_named_busses"
+		return 1
 		;;
 	esac
 
@@ -2867,12 +2875,56 @@ system_cleanup_specific()
 	esac
 }
 
-check_system()
+check_system_reset_attr_num()
 {
-	# Reset reset_attr_num if it exists.
 	if [ -f "$config_path/reset_attr_num" ]; then
 		rm -f "$config_path"/reset_attr_num
 	fi
+}
+
+check_system_write_i2c_defaults()
+{
+	echo ${i2c_comex_mon_bus_default} > $config_path/i2c_comex_mon_bus_default || return 1
+	echo ${i2c_bus_def_off_eeprom_cpu} > $config_path/i2c_bus_def_off_eeprom_cpu || return 1
+}
+
+check_system_bmc_redfish_login()
+{
+	# Obtain/rotate the BMC password and log in over Redfish only on platforms
+	# with a BMC AND when the host NOS is not SONiC. On SONiC, SONiC owns
+	# CPU<->BMC communication, so hw-management must not drive this flow.
+	if check_bmc_is_supported && ! check_host_os_is_sonic; then
+		pushd /usr/bin
+		for ((i=1; i<=5; i++)); do
+			local bmc_ip_addr=$(ip addr show usb0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
+			if [ -n "${bmc_ip_addr}" ] && ping -c 1 "${bmc_ip_addr}" >& /dev/null; then
+				python -c "from hw_management_redfish_client import BMCAccessor; print(BMCAccessor().login())" || true
+				break
+			fi
+			echo "Pinging BMC failed, i=$i"
+			sleep 3
+		done
+		popd
+	fi
+}
+
+check_system_json()
+{
+	local json_file="$1"
+
+	[ -n "$json_file" ] || return 1
+	if [ ! -f "$json_file" ]; then
+		log_err "platform JSON missing: ${json_file}"
+		return 1
+	fi
+	check_system_reset_attr_num
+	platform_json_apply_config "$json_file" || return 1
+	check_system_write_i2c_defaults || return 1
+}
+
+check_system_internal()
+{
+	check_system_reset_attr_num
 	# Check ODM
 	case $board_type in
 		VMOD0001)
@@ -3009,7 +3061,7 @@ check_system()
 								;;
 							*)
 								log_err "$product is not supported"
-								exit 0
+								return 1
 								;;
 						esac
 					else
@@ -3020,7 +3072,7 @@ check_system()
 								;;
 							*)
 								log_err "$product is not supported"
-								exit 0
+								return 1
 								;;
 						esac
 					fi
@@ -3028,24 +3080,19 @@ check_system()
 			esac
 			;;
 	esac
-	echo ${i2c_comex_mon_bus_default} > $config_path/i2c_comex_mon_bus_default
-	echo ${i2c_bus_def_off_eeprom_cpu} > $config_path/i2c_bus_def_off_eeprom_cpu
-	# Obtain/rotate the BMC password and log in over Redfish only on platforms
-	# with a BMC AND when the host NOS is not SONiC. On SONiC, SONiC owns
-	# CPU<->BMC communication, so hw-management must not drive this flow.
-	if check_bmc_is_supported && ! check_host_os_is_sonic; then
-		pushd /usr/bin
-		for ((i=1; i<=5; i++)); do
-			local bmc_ip_addr=$(ip addr show usb0 | grep 'inet ' | awk '{print $2}' | cut -d/ -f1)
-			if [ -n "${bmc_ip_addr}" ] && ping -c 1 "${bmc_ip_addr}" >& /dev/null; then
-				python -c "from hw_management_redfish_client import BMCAccessor; print(BMCAccessor().login())" || true
-				break
-			fi
-			echo "Pinging BMC failed, i=$i"
-			sleep 3
-		done
-		popd
+	check_system_write_i2c_defaults || return 1
+}
+
+check_system()
+{
+	local json_file
+
+	if json_file=$(find_platform_json_config "$sku"); then
+		check_system_json "$json_file" || return 1
+	else
+		check_system_internal || return 1
 	fi
+	check_system_bmc_redfish_login || true
 }
 
 create_event_files()
@@ -3387,6 +3434,12 @@ set_asic_pci_id()
 		echo $minimal_unsupported > "$config_path"/minimal_unsupported
 	fi
 
+	if find_platform_json_config "$sku" >/dev/null && \
+	   [ -n "$platform_json_asic_pci_id" ]; then
+		set_asic_pci_id_from_json
+		return
+	fi
+
 	# Get ASIC PCI Ids.
 	case $sku in
 	HI122|HI123|HI124|HI126|HI156|HI160|HI184)
@@ -3553,6 +3606,12 @@ set_dpu_pci_id()
 	local element
 	local dpu_detected_num=0
 
+	if find_platform_json_config "$sku" >/dev/null && \
+	   [ -n "$platform_json_dpu_pci_id" ]; then
+		set_dpu_pci_id_from_json
+		return
+	fi
+
 	# Get DPU PCI Ids.
 	case $sku in
 	HI160)
@@ -3641,6 +3700,21 @@ set_sodimms()
 
 pre_devtr_init()
 {
+	local json_file
+
+	if json_file=$(find_platform_json_config "$sku"); then
+		if ! source_hw_platform_json_parser; then
+			log_err "platform JSON parser not found, cannot apply board config"
+			return 1
+		fi
+		if ! json_validate "$json_file"; then
+			log_err "platform JSON invalid: ${json_file}"
+			return 1
+		fi
+		platform_json_apply_board "$json_file" || return 1
+		return 0
+	fi
+
 	case $board_type in
 	VMOD0009)
 		case $sku in
@@ -3855,11 +3929,12 @@ do_start()
 	create_symbolic_links
 	run_fixup_script pre
 	check_cpu_type
-	pre_devtr_init
+	pre_devtr_init || exit 1
 	load_modules
 	devtr_check_smbios_device_description
-	check_system
+	check_system || exit 1
 	set_asic_pci_id
+	set_dpu_pci_id
 	set_sodimms
 	set_config_data
 


### PR DESCRIPTION
Allow new platforms to describe hw-management settings in /etc/<HID>/hw-management-platform.json instead of adding a new *_specific() function in hw-management.sh.

Split check_system() into:
- check_system_internal() for legacy board/product dispatch
- check_system_json() to load and apply the platform JSON
- check_system_bmc_redfish_login() for BMC Redfish login

Add hw-management-platform-json.sh to parse JSON using the existing BusyBox-safe hw-management-json-parser.sh. JSON can set system traits, shell variables, config files, I2C connection tables, named busses, PSU/ASIC maps, and whitelisted actions. Invalid connection table names and JSON apply errors abort boot.

Add examples/hw-management-platform-example.json as schema reference for new platform bring-up, including system section option comments and variables such as erot_count, vrot_count, mcu_count, and cartridge_count.

Add examples/README.md cataloging host-side example files.