### PR TITLE
hw-mgmt: scripts: Restrict udev event log size

### DIFF
--- a/usr/etc/logrotate.d/udev
+++ b/usr/etc/logrotate.d/udev
@@ -1,9 +1,10 @@
 "/var/log/udev_events.log" {
-    size 1M
+    size 4M
     rotate 3
     olddir /var/log/
     copytruncate
     compress
+    compressext .gz
     delaycompress
     dateext
     dateformat -%Y%m%d%H%M%S

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -77,6 +77,7 @@ l1_power_events=("power_button graceful_pwr_off")
 ui_tree_sku=`cat $sku_file`
 ui_tree_archive=
 udev_event_log="/var/log/udev_events.log"
+udev_event_log_max_size=4194304
 vm_sku=`cat $sku_file`
 vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
 cpldreg_log_file=/var/log/hw-mgmt-cpldreg.log
@@ -178,6 +179,12 @@ log_info()
 
 trace_udev_events()
 {
+	log_size=$(stat -c %s "$udev_event_log" 2>/dev/null || echo 0)
+	if [ "$log_size" -ge "$udev_event_log_max_size" ]; then
+		if ! pgrep -x logrotate > /dev/null 2>&1; then
+			/usr/sbin/logrotate --state /var/lib/logrotate/status /etc/logrotate.d/udev 2>/dev/null
+		fi
+	fi
 	echo "[$(date '+%Y-%m-%d %H:%M:%S.%3N')] $@" >> $udev_event_log
 	return 0
 }


### PR DESCRIPTION
In most of the operating systems, logrotate runs daily once via cron. If there is a faulty hardware, there can be many number of udev events and size of the udev_events.log can exceed the maximum configured size very fast. This will have an impact on the disk size. To prevent this, adding an explicit logrotate call in the udev event tracing function.  When the log size reaches 4M, an explicit logrotate call is made.

Bug #5040812