### PR TITLE
hw-mgmt: scripts: JSON-driven devtree BOM loading

### DIFF
--- a/examples/hw-management-devtree-json-example.md
+++ b/examples/hw-management-devtree-json-example.md
@@ -1,0 +1,215 @@
+<!-- SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES -->
+<!-- Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!--
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the names of the copyright holders nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+Alternatively, this software may be distributed under the terms of the
+GNU General Public License ("GPL") version 2 as published by the Free
+Software Foundation.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+-->
+
+# hw-management devtree BOM JSON
+
+Per-SKU device-tree BOM data can be supplied as a JSON config file instead
+of hard-coding a new `case` branch in `hw-management-devtree.sh`.  The JSON
+file is parsed by `hw-management-devtree-json-parser.py`, which populates the
+`*_alternatives` associative arrays that the rest of `hw-management-devtree.sh`
+already uses.
+
+## Components
+
+| Item | Installed path | Role |
+|------|----------------|------|
+| [hw-management-devtree-json-parser.py](../usr/usr/bin/hw-management-devtree-json-parser.py) | `/usr/bin/hw-management-devtree-json-parser.py` | Reads, validates and prints `<section> <key> <spec>` lines |
+| [hw-management-devtree.sh](../usr/usr/bin/hw-management-devtree.sh) | `/usr/bin/hw-management-devtree.sh` | Consumes parser output; populates `*_alternatives` arrays |
+| Per-SKU config | `/etc/hw-management-cfg/<SKU>/devtree.json` | One file per SKU; contains all board sections |
+
+## Design
+
+```
+  SMBIOS board SKU
+       │
+       ▼
+  devtr_check_supported_system_init_alternatives()
+       │
+       ├─ case $cpu_type ─► populate comex_alternatives (CPU sensors)
+       │
+       ├─ /etc/hw-management-cfg/<SKU>/devtree.json exists?
+       │       YES ──► devtr_bom_load_from_json()
+       │                   │
+       │                   ├─ hw-management-devtree-json-parser.py <file>
+       │                   │       validates JSON, prints: section key spec
+       │                   │
+       │                   └─ while read section key spec
+       │                           <section>_alternatives["$key"]="$spec"
+       │                           (undeclared sections are skipped with a log)
+       │               return 0 ◄──────────────────────────────────────────┘
+       │
+       └─ NO ──► case $board_type (legacy hard-coded alternatives)
+```
+
+The JSON path is evaluated **after** the `cpu_type` block so that CPU-side
+sensors (comex VRs, DIMMs, etc.) are always initialised regardless of which
+loading path is taken.
+
+If the JSON file exists but is invalid the function logs an error and returns
+non-zero, which causes `hw-management-devtree.sh` to abort BOM loading for
+that SKU.
+
+## JSON format
+
+```json
+{
+    "<section>": [
+        { "key": "<key>", "spec": "<spec>" },
+        ...
+    ],
+    ...
+}
+```
+
+### Sections
+
+A section name maps 1-to-1 to an `*_alternatives` associative array that is
+**already declared** in `hw-management-devtree.sh`.  The runtime arrays are:
+
+| Section name | Bash array | Covers |
+|--------------|------------|--------|
+| `swb` | `swb_alternatives` | Switch-board VRs, EEPROMs |
+| `port` | `port_alternatives` | Port-card VRs |
+| `pwr` | `pwr_alternatives` | Power-board converters, temp sensors |
+| `platform` | `platform_alternatives` | Main-board EEPROMs, SODIMMs, VRs |
+| `comex` | `comex_alternatives` | CPU-complex VRs (usually set by cpu_type) |
+| `fan` | `fan_alternatives` | Fan controllers |
+| `clk` | `clk_alternatives` | Clock generators |
+| `dpu` | `dpu_alternatives` | DPU board devices |
+| `board` | `board_alternatives` | Miscellaneous board-level devices |
+
+A section present in the JSON but with no corresponding `declare -A` in
+`hw-management-devtree.sh` is silently skipped with a `log_info` message.
+
+### Keys and specs
+
+Each entry has exactly two string fields:
+
+| Field | Constraints | Example |
+|-------|-------------|---------|
+| `key` | Non-empty; no whitespace | `"mp29816_0"` |
+| `spec` | Non-empty; no `\n` or `\r` | `"mp29816 0x61 15 voltmon1"` |
+
+The `spec` value is passed verbatim as the value of `<section>_alternatives["$key"]`
+and is later consumed by the I²C device-tree instantiation logic in
+`hw-management-devtree.sh`.
+
+## Annotated example
+
+The example below shows the structure used for a typical platform with a
+switch board, port card, power board, and main-board components.
+
+```json
+{
+    "swb": [
+        { "key": "mp29816_0",    "spec": "mp29816 0x61 15 voltmon1"  },
+        { "key": "mp29816_1",    "spec": "mp29816 0x62 15 voltmon2"  },
+        { "key": "xdpe1a2g7_0", "spec": "xdpe1a2g7b 0x61 15 voltmon1" },
+        { "key": "24c512_0",    "spec": "24c512 0x51 24 swb_info"    }
+    ],
+    "port": [
+        { "key": "mp29816_0",    "spec": "mp29816 0x68 15 voltmon19"    },
+        { "key": "xdpe1a2g7_0", "spec": "xdpe1a2g7b 0x68 15 voltmon19" }
+    ],
+    "pwr": [
+        { "key": "raa228004_0", "spec": "raa228004 0x60 6 pdb_pwr_conv1" },
+        { "key": "mp29502_0",   "spec": "mp29502 0x2e 6 pdb_pwr_conv1"  },
+        { "key": "tmp451_0",    "spec": "tmp451 0x4c 6 pdb_temp1"       }
+    ],
+    "platform": [
+        { "key": "24c512_1",  "spec": "24c512 0x51 1 vpd_info"        },
+        { "key": "jc42_0",    "spec": "jc42 0x52 10 somdimm_temp1"    },
+        { "key": "mp2845_0",  "spec": "mp2845 0x69 5 comex_voltmon1"  }
+    ]
+}
+```
+
+## Adding a new platform
+
+1. **Identify the SKU string** reported by SMBIOS (field used as `$sku` in
+   `hw-management-devtree.sh`, typically the board product name, e.g. `HI195`).
+
+2. **Create the config directory and JSON file**:
+   ```
+   usr/etc/hw-management-cfg/<SKU>/devtree.json
+   ```
+
+3. **Populate the JSON** with one entry per I²C device alternative, grouping
+   them under the appropriate section (`swb`, `port`, `pwr`, `platform`, etc.).
+
+4. **No changes to `hw-management-devtree.sh` are required** — the JSON loader
+   runs automatically for any SKU whose `devtree.json` exists.
+
+5. **If a brand-new section name is needed** (not in the table above), declare
+   the corresponding `declare -A <section>_alternatives` in
+   `hw-management-devtree.sh` and add it to the `devtr_check_supported_system_init_alternatives`
+   selection logic.
+
+## Validation rules enforced by the parser
+
+The parser exits non-zero and prints a message to stderr if any of the
+following conditions are violated:
+
+| Rule | Reason |
+|------|--------|
+| Top-level value must be a JSON object | bash loop expects `section key spec` triples |
+| Each section value must be a JSON array | structural requirement |
+| Each array element must be a JSON object | structural requirement |
+| `key` and `spec` fields must be present and non-empty strings | required for device instantiation |
+| Section name must not contain whitespace | a space would shift `read -r` fields |
+| `key` must not contain whitespace | a space in the key shifts bash `read -r` fields, corrupting the alternatives array |
+| `spec` must not contain `\n` or `\r` | a newline causes `print()` to emit two physical lines; bash `read -r` then misparses the second fragment as an independent entry |
+
+## Running the tests
+
+The offline test suite for the parser lives in
+`tests/offline/test_hw_management_devtree_json_parser.py`.
+
+```bash
+# Run all parser tests
+python3 -m pytest tests/offline/test_hw_management_devtree_json_parser.py -v
+
+# Print the populated *_alternatives dicts from the inline TEST_BOM
+python3 -m pytest tests/offline/test_hw_management_devtree_json_parser.py::TestParserWithDevtreeJson::test_print_alternatives -v -s
+```
+
+The test file defines an inline `TEST_BOM` dictionary that mirrors the JSON
+format above.  The `devtree_json` pytest fixture writes this dict to a
+temporary file, which is then passed to the parser subprocess exactly as
+`hw-management-devtree.sh` does at runtime.
+
+Two test classes are provided:
+
+| Class | What it covers |
+|-------|---------------|
+| `TestParserWithDevtreeJson` | Happy-path: exit code, section/key presence, spec values, line format |
+| `TestParserErrorHandling` | Error paths: missing file, bad JSON, wrong types, whitespace in key/section, newline in spec |

--- a/tests/offline/test_hw_management_devtree_json_parser.py
+++ b/tests/offline/test_hw_management_devtree_json_parser.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms and conditions of the GNU General Public License,
+# version 2, as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+# more details.
+#
+
+"""
+Tests for hw-management-devtree-json-parser.py
+
+Mirrors the invocation used in hw-management-devtree.sh:
+
+    devtree_json_parser=/usr/bin/hw-management-devtree-json-parser.py
+
+    output=$($devtree_json_parser "$json_file")
+    while read -r section key spec; do
+        local -n _arr="${section}_alternatives"
+        _arr["$key"]="$spec"
+        unset -n _arr
+    done <<< "$output"
+
+The parser is invoked via subprocess with a JSON file path; its stdout is
+parsed line-by-line into <section>_alternatives dicts.  A simplified
+devtree.json defined inline in this file (TEST_BOM) is used as the test
+input, written to a temporary file by the devtree_json fixture.
+
+To print the populated <section>_alternatives contents, run:
+    python3 -m pytest tests/offline/test_hw_management_devtree_json_parser.py::TestParserWithDevtreeJson::test_print_alternatives -v -s
+"""
+
+import json
+import subprocess
+import pytest
+from pathlib import Path
+
+
+TESTS_DIR = Path(__file__).parent
+PROJECT_ROOT = (TESTS_DIR / ".." / "..").resolve()
+PARSER = PROJECT_ROOT / "usr" / "usr" / "bin" / "hw-management-devtree-json-parser.py"
+
+# Simplified devtree BOM used as the test input.
+# Mirrors the structure of usr/etc/hw-management-cfg/HI195/devtree.json
+# with a representative subset of entries for each section.
+TEST_BOM = {
+    "swb": [
+        {"key": "mp29816_0", "spec": "mp29816 0x61 15 voltmon1"},
+        {"key": "mp29816_1", "spec": "mp29816 0x62 15 voltmon2"},
+        {"key": "xdpe1a2g7_0", "spec": "xdpe1a2g7b 0x61 15 voltmon1"},
+        {"key": "24c512_0", "spec": "24c512 0x51 24 swb_info"},
+    ],
+    "port": [
+        {"key": "mp29816_0", "spec": "mp29816 0x68 15 voltmon19"},
+        {"key": "xdpe1a2g7_0", "spec": "xdpe1a2g7b 0x68 15 voltmon19"},
+    ],
+    "pwr": [
+        {"key": "raa228004_0", "spec": "raa228004 0x60 6 pdb_pwr_conv1"},
+        {"key": "mp29502_0", "spec": "mp29502 0x2e 6 pdb_pwr_conv1"},
+        {"key": "tmp451_0", "spec": "tmp451 0x4c 6 pdb_temp1"},
+    ],
+    "platform": [
+        {"key": "24c512_1", "spec": "24c512 0x51 1 vpd_info"},
+        {"key": "jc42_0", "spec": "jc42 0x52 10 sodimm_temp1"},
+        {"key": "mp2845_0", "spec": "mp2845 0x69 5 comex_voltmon1"},
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def devtree_json(tmp_path_factory):
+    """Write TEST_BOM to a temporary JSON file and return its path."""
+    path = tmp_path_factory.mktemp("devtree") / "devtree.json"
+    path.write_text(json.dumps(TEST_BOM, indent=4))
+    return path
+
+
+def run_parser(json_file):
+    """
+    Invoke the parser the same way hw-management-devtree.sh does:
+        output=$($devtree_json_parser "$json_file")
+    Returns (stdout, stderr, returncode).
+    """
+    result = subprocess.run(
+        [str(PARSER), str(json_file)],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def parse_into_alternatives(output):
+    """
+    Mirror the bash while-read loop in devtr_bom_load_from_json():
+        while read -r section key spec; do
+            _arr["$key"]="$spec"
+        done
+    Returns a dict of dicts: { section: { key: spec, ... }, ... }
+    """
+    alternatives = {}
+    for line in output.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) != 3:
+            continue
+        section, key, spec = parts
+        alternatives.setdefault(section, {})[key] = spec
+    return alternatives
+
+
+class TestParserWithDevtreeJson:
+    """Tests using the inline TEST_BOM devtree.json as input."""
+
+    @pytest.fixture(autouse=True)
+    def check_parser(self):
+        if not PARSER.exists():
+            pytest.skip(f"Parser not found: {PARSER}")
+
+    def test_parser_exits_zero(self, devtree_json):
+        """Parser must exit 0 on a valid JSON file."""
+        _, _, rc = run_parser(devtree_json)
+        assert rc == 0
+
+    def test_output_matches_json_sections(self, devtree_json):
+        """All sections present in the JSON must appear in the parser output."""
+        stdout, _, rc = run_parser(devtree_json)
+        assert rc == 0
+        alternatives = parse_into_alternatives(stdout)
+        for section in TEST_BOM:
+            assert section in alternatives, f"Section '{section}' missing from parser output"
+
+    def test_all_keys_present(self, devtree_json):
+        """Every key defined in TEST_BOM must appear in the parsed alternatives."""
+        stdout, _, _ = run_parser(devtree_json)
+        alternatives = parse_into_alternatives(stdout)
+        for section, entries in TEST_BOM.items():
+            for entry in entries:
+                key = entry["key"]
+                assert key in alternatives.get(section, {}), (
+                    f"Key '{key}' missing from {section}_alternatives"
+                )
+
+    def test_spec_values_match(self, devtree_json):
+        """The spec value for every key must match TEST_BOM exactly."""
+        stdout, _, _ = run_parser(devtree_json)
+        alternatives = parse_into_alternatives(stdout)
+        for section, entries in TEST_BOM.items():
+            for entry in entries:
+                key, expected_spec = entry["key"], entry["spec"]
+                actual_spec = alternatives.get(section, {}).get(key)
+                assert actual_spec == expected_spec, (
+                    f"{section}['{key}']: expected '{expected_spec}', got '{actual_spec}'"
+                )
+
+    def test_output_line_format(self, devtree_json):
+        """Every output line must have exactly three whitespace-separated fields."""
+        stdout, _, rc = run_parser(devtree_json)
+        assert rc == 0
+        for line in stdout.splitlines():
+            parts = line.split(None, 2)
+            assert len(parts) == 3, f"Unexpected line format: {line!r}"
+
+    def test_expected_sections_present(self, devtree_json):
+        """TEST_BOM must produce swb, port, pwr and platform alternatives."""
+        stdout, _, rc = run_parser(devtree_json)
+        assert rc == 0
+        alternatives = parse_into_alternatives(stdout)
+        for section in ("swb", "port", "pwr", "platform"):
+            assert section in alternatives, f"Expected section '{section}' not found"
+
+    def test_print_alternatives(self, devtree_json):
+        """Print the contents of each <section>_alternatives dict."""
+        stdout, _, rc = run_parser(devtree_json)
+        assert rc == 0
+        alternatives = parse_into_alternatives(stdout)
+        for section, entries in sorted(alternatives.items()):
+            print(f"\n{section}_alternatives:")
+            for key, spec in sorted(entries.items()):
+                print(f"  [{key}] = {spec}")
+
+
+class TestParserErrorHandling:
+    """Tests that the parser rejects invalid inputs."""
+
+    @pytest.fixture(autouse=True)
+    def check_parser(self):
+        if not PARSER.exists():
+            pytest.skip(f"Parser not found: {PARSER}")
+
+    def test_missing_file(self, tmp_path):
+        """Parser must exit non-zero when the file does not exist."""
+        _, _, rc = run_parser(tmp_path / "nonexistent.json")
+        assert rc != 0
+
+    def test_syntax_error(self, tmp_path):
+        """Parser must exit non-zero on malformed JSON."""
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ not valid json }")
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_wrong_top_level_type(self, tmp_path):
+        """Parser must exit non-zero when top-level value is not an object."""
+        bad = tmp_path / "bad.json"
+        bad.write_text('["not", "an", "object"]')
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_section_not_a_list(self, tmp_path):
+        """Parser must exit non-zero when a section value is not an array."""
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"swb": "should be a list"}')
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_entry_missing_key_field(self, tmp_path):
+        """Parser must exit non-zero when an entry is missing the 'key' field."""
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"swb": [{"spec": "mp29816 0x61 15 voltmon1"}]}')
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_entry_missing_spec_field(self, tmp_path):
+        """Parser must exit non-zero when an entry is missing the 'spec' field."""
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"swb": [{"key": "mp29816_0"}]}')
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_no_arguments(self):
+        """Parser must exit non-zero when called with no arguments."""
+        result = subprocess.run(
+            [str(PARSER)],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+
+    def test_error_output_goes_to_stderr(self, tmp_path):
+        """Error messages must be printed to stderr, not stdout."""
+        bad = tmp_path / "bad.json"
+        bad.write_text("{ invalid }")
+        stdout, stderr, rc = run_parser(bad)
+        assert rc != 0
+        assert stdout == ""
+        assert stderr != ""
+
+    def test_key_with_embedded_whitespace_rejected(self, tmp_path):
+        """Parser must exit non-zero when a key contains embedded whitespace.
+        A space in the key shifts bash read -r fields: key='mp29816', spec='extra ...'
+        instead of the correct key='mp29816 extra'."""
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"swb": [{"key": "mp29816 extra", "spec": "mp29816 0x61 15 voltmon1"}]}')
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_section_name_with_whitespace_rejected(self, tmp_path):
+        """Parser must exit non-zero when a section name contains whitespace.
+        A space in a section name shifts bash read -r fields: section='my',
+        key='section', losing the real key and spec entirely."""
+        bad = tmp_path / "bad.json"
+        bad.write_text('{"my section": [{"key": "mp29816_0", "spec": "mp29816 0x61 15 voltmon1"}]}')
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+    def test_spec_with_embedded_newline_rejected(self, tmp_path):
+        """Parser must exit non-zero when spec contains an embedded newline.
+        A newline in spec causes print() to emit two physical lines; bash
+        read -r then misparses the second fragment as an independent entry,
+        e.g. section='0x61', key='15', spec='voltmon1', silently corrupting
+        the alternatives array.
+        json.dumps() is used to produce a valid JSON encoding of the newline
+        (\n escape) so that json.load() successfully decodes it and passes
+        the string with the embedded newline to validate_bom()."""
+        bad = tmp_path / "bad.json"
+        payload = json.dumps({"swb": [{"key": "mp29816_0", "spec": "mp29816\n0x61 15 voltmon1"}]})
+        bad.write_text(payload)
+        _, _, rc = run_parser(bad)
+        assert rc != 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/usr/usr/bin/hw-management-devtree-json-parser.py
+++ b/usr/usr/bin/hw-management-devtree-json-parser.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# hw-management devtree BOM JSON parser
+#
+# Reads and validates a devtree BOM JSON file, then prints every entry across
+# all sections as:
+#   <section> <key> <spec>
+# one per line, for consumption by hw-management-devtree.sh.
+#
+# Usage: hw-management-devtree-json-parser.py <json_file>
+#
+# The JSON file is expected to have the structure:
+#   {
+#       "<section>": [
+#           { "key": "<key>", "spec": "<spec>" },
+#           ...
+#       ],
+#       ...
+#   }
+#
+# All sections present in the JSON file are output; no predefined list is used.
+# Each section name must correspond to a declared <section>_alternatives
+# associative array in hw-management-devtree.sh, e.g.: swb, port, pwr, platform,
+# comex, fan, clk, dpu, etc.
+#
+# Any new section can be added to the JSON, provided a matching
+# <section>_alternatives array is declared in hw-management-devtree.sh.
+################################################################################
+
+import json
+import sys
+
+
+def validate_bom(data):
+    """
+    Validate the structure of the BOM JSON.
+    Raises ValueError with a descriptive message on any structural problem.
+    """
+    if not isinstance(data, dict):
+        raise ValueError("top-level value must be a JSON object")
+
+    for section, entries in data.items():
+        if any(c.isspace() for c in section):
+            raise ValueError(
+                f"section name '{section}' must not contain whitespace"
+            )
+        if not isinstance(entries, list):
+            raise ValueError(
+                f"section '{section}': expected an array, got {type(entries).__name__}"
+            )
+        for idx, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"section '{section}' entry {idx}: expected an object, "
+                    f"got {type(entry).__name__}"
+                )
+            for field in ("key", "spec"):
+                if field not in entry:
+                    raise ValueError(
+                        f"section '{section}' entry {idx}: missing required field '{field}'"
+                    )
+                if not isinstance(entry[field], str) or not entry[field].strip():
+                    raise ValueError(
+                        f"section '{section}' entry {idx}: "
+                        f"'{field}' must be a non-empty string"
+                    )
+            if any(c.isspace() for c in entry["key"]):
+                raise ValueError(
+                    f"section '{section}' entry {idx}: "
+                    f"'key' must not contain whitespace"
+                )
+            if any(c in "\n\r" for c in entry["spec"]):
+                raise ValueError(
+                    f"section '{section}' entry {idx}: "
+                    f"'spec' must not contain newlines"
+                )
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <json_file>", file=sys.stderr)
+        sys.exit(1)
+
+    json_file = sys.argv[1]
+
+    try:
+        with open(json_file) as f:
+            data = json.load(f)
+    except OSError as e:
+        print(f"Error: cannot read '{json_file}': {e}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"Error: JSON syntax error in '{json_file}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        validate_bom(data)
+    except ValueError as e:
+        print(f"Error: invalid BOM JSON '{json_file}': {e}", file=sys.stderr)
+        sys.exit(1)
+
+    for section, entries in data.items():
+        for entry in entries:
+            print(f"{section} {entry['key']} {entry['spec']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -34,6 +34,7 @@
 
 devtr_verb_display=0
 devtree_codes_file=
+devtree_json_parser=/usr/bin/hw-management-devtree-json-parser.py
 
 # Declare common associative arrays for SMBIOS System Version parsing.
 declare -A board_arr=( \
@@ -951,6 +952,32 @@ devtr_clean()
 	fi
 }
 
+# Load all sections from a SKU devtree BOM JSON file into the corresponding
+# *_alternatives associative arrays. Calls $devtree_json_parser.
+# Returns non-zero and logs an error on parse failure.
+# Usage: devtr_bom_load_from_json <json_file>
+devtr_bom_load_from_json()
+{
+	local json_file="$1"
+	local output rc section key spec
+
+	output=$($devtree_json_parser "$json_file")
+	rc=$?
+	if [ $rc -ne 0 ]; then
+		return $rc
+	fi
+
+	while read -r section key spec; do
+		if ! declare -p "${section}_alternatives" &>/dev/null; then
+			log_info "SMBIOS BOM info: no array for section '${section}', skipping"
+			continue
+		fi
+		local -n _arr="${section}_alternatives"
+		_arr["$key"]="$spec"
+		unset -n _arr
+	done <<< "$output"
+}
+
 # Check if system has SMBIOS BOM changes mechanism support.
 # If yes, init appropriate associative arrays.
 # Jaguar, Leopard, Gorilla are added just for debug.
@@ -1035,6 +1062,18 @@ devtr_check_supported_system_init_alternatives()
 			return 1
 			;;
 	esac
+
+	# For platforms with a per-SKU devtree JSON, load all board sections
+	# (swb, port, pwr, platform, etc.) and skip the hardcoded switch-case below.
+	local devtr_bom_json="/etc/hw-management-cfg/${sku}/devtree.json"
+	if [ -f "$devtr_bom_json" ] && [ -f "$devtree_json_parser" ]; then
+		if ! devtr_bom_load_from_json "$devtr_bom_json"; then
+			log_info "SMBIOS BOM info: invalid JSON for sku ${sku}: ${devtr_bom_json}"
+			return 1
+		fi
+		return 0
+	fi
+
 	case $board_type in
 #		VMOD0005)
 #			case $sku in


### PR DESCRIPTION
Adding a python script to parse per sku, devtree BOM JSON files. The path for the platform specific devtree json files should be etc/hw-management-cfg/<SKU> directory. The json file name should be devtree.json.
    
As an example, the devtree json file should be of the form
    
    {
        "swb": [
            {
                "key": "mp29816_0",
                "spec": "mp29816 0x61 15 voltmon1"
            }
            ...
         ]
         ...
    }
    
 There can be any section like "swb" such as platform, port, etc.
    
In the devtree parsing, the platform sku based json will be loaded and the xxx_alternatives arrays will be populated. While adding a new platform, it's just as simple as creating a config file etc/hw-management-cfg/<sku>/devtree.json with the required sections. No need to add any arrays or sku checks in the hw-management-devtree.sh
    
Signed-off-by: Ciju Rajan K <crajank@nvidia.com>