### PR TITLE
hw-mgmt: sensors: Add scaling factor for SN6600_LD power and current

### DIFF
--- a/usr/etc/hw-management-sensors/sn66xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn66xxld_sensors.conf
@@ -337,7 +337,9 @@ chip "lm5066i-i2c-6-12"
     label in3       "PDB-1 HSC Vout Volt (out)"
     ignore in2
     label power1    "PDB-1 HSC VinDC Pwr (in)"
+    compute power1  (5.333)*@, @/(5.333)
     label curr1     "PDB-1 HSC VinDC Curr (in)"
+    compute curr1   (5.333)*@, @/(5.333)
     label temp1     "PDB-1 HSC Temp"
 chip "mp5926-i2c-6-12"
     label in1       "PDB-1 HSC VinDC Volt (in)"
@@ -352,7 +354,9 @@ chip "lm5066i-i2c-7-12"
     label in3       "PDB-2 HSC Vout Volt (out)"
     ignore in2
     label power1    "PDB-2 HSC VinDC Pwr (in)"
+    compute power1  (5.333)*@, @/(5.333)
     label curr1     "PDB-2 HSC VinDC Curr (in)"
+    compute curr1   (5.333)*@, @/(5.333)
     label temp1     "PDB-2 HSC Temp"
 chip "mp5926-i2c-7-12"
     label in1       "PDB-2 HSC VinDC Volt (in)"

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1110,6 +1110,9 @@ if [ "$1" == "add" ]; then
 					echo 0 > $environment_path/"$prefix"_in2_min
 				fi
 			fi
+			# Add power and current scaling factor links
+			check_n_link $config_path/pdb_hotswap_scale $environment_path/"$prefix"_power1_scale
+			check_n_link $config_path/pdb_hotswap_scale $environment_path/"$prefix"_curr1_scale
 		fi
 	fi
 	if [ "$2" == "led" ]; then
@@ -1548,6 +1551,12 @@ else
 			fi
 			if [ -L $environment_path/"$prefix"_power"$i"_input ]; then
 				unlink $environment_path/"$prefix"_power"$i"_input
+			fi
+			if [ -L  $environment_path/"$prefix"_curr"$i"_scale ]; then
+				unlink $environment_path/"$prefix"_curr"$i"_scale
+			fi
+			if [ -L  $environment_path/"$prefix"_power"$i"_scale ]; then
+				unlink $environment_path/"$prefix"_power"$i"_scale
 			fi
 			if [ -L $thermal_path/"$prefix"_temp"$i"_input ]; then
 				unlink $thermal_path/"$prefix"_temp"$i"_input

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2830,6 +2830,7 @@ sn66xxld_specific()
 		leakage_count=2
 		i2c_asic_bus_default=5
 		hotplug_pdbs=2
+		echo 5.333 > $config_path/pdb_hotswap_scale
 		;;
 	esac
 


### PR DESCRIPTION
Add scaling factor for SN6600_LD power and current definitions of LM5066I hot-swap controller.

This patch updates sensors.conf and creates new attibute /var/run/hw-management/config/pdb_hotswap_scale that provides the scaling factor value.

Bug: 5046588