### PR TITLE
hw-mgmt: patches: Expand commit descriptions for SONiC integration

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0001-mctp-driver-net-Extend-MCTP-support.patch
+++ b/recipes-kernel/linux/linux-6.12/0001-mctp-driver-net-Extend-MCTP-support.patch
@@ -3,7 +3,15 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 18:26:40 +0300
 Subject: [PATCH 6.12 1/5] mctp: driver: net: Extend MCTP support.
 
-Add support for MCTP over SPI, VRoT.
+Extend the in-kernel MCTP stack with additional transports and the
+supporting infrastructure used by NVIDIA BMC platforms.
+
+This adds new MCTP transport backends, including MCTP over SPI and the
+NVIDIA OP-TEE VRoT transport, together with their headers and the
+associated Kconfig and Makefile entries. It also adds infrastructure
+shared by the transports: MCTP tracepoints, transport statistics, and
+error-injection helpers (I2C/SPI/USB/socket) used for testing, and
+extends the core MCTP routing, device and socket code accordingly.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0002-mctp-aspeed-IRoT-Add-initial-support.patch
+++ b/recipes-kernel/linux/linux-6.12/0002-mctp-aspeed-IRoT-Add-initial-support.patch
@@ -3,7 +3,14 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 11:31:35 +0300
 Subject: [PATCH 6.12 2/5] mctp: aspeed: IRoT: Add initial support
 
-Add support for MCTP over IRoT.
+Add initial support for NVIDIA's Internal Root of Trust (IRoT) on the
+Aspeed AST27xx BMC, exposed as an MCTP transport over the hardware
+mailbox.
+
+A new CONFIG_NVIDIA_AST27XX_IROT option (depends on ARCH_ASPEED) builds
+the nvidia-ast27xx-irot driver, which creates an MCTP network device for
+a BMC device-tree node compatible with "nvidia,ast27xx,irot" (for
+example mctpirot0).
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0003-mctp-driver-net-Add-global-APIs-for-MCTP.patch
+++ b/recipes-kernel/linux/linux-6.12/0003-mctp-driver-net-Add-global-APIs-for-MCTP.patch
@@ -3,6 +3,12 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 18:29:00 +0300
 Subject: [PATCH 6.12 3/5] mctp: driver: net: Add global APIs for MCTP
 
+Export the MCTP transport tracepoints (mctp_transport_tx,
+mctp_transport_rx and mctp_transport_error) via
+EXPORT_TRACEPOINT_SYMBOL_GPL() so that MCTP transport drivers built as
+loadable modules can emit them, and add the missing
+MODULE_LICENSE("GPL") to the MCTP I2C error-injection module.
+
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
  drivers/net/mctp/mctp-i2c-error-inject.c | 2 ++

--- a/recipes-kernel/linux/linux-6.12/0004-mctp-driver-net-Fix-MCTP-over-VDM-PCIe.patch
+++ b/recipes-kernel/linux/linux-6.12/0004-mctp-driver-net-Fix-MCTP-over-VDM-PCIe.patch
@@ -3,7 +3,17 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 14:37:56 +0300
 Subject: [PATCH 6.12 4/5] mctp: driver: net: Fix MCTP over VDM/PCIe
 
-Add fixes for MCTP over VDM/PCIe (option MCTP_TRANSPORT_PCIE_VDM).
+Fix two issues in the MCTP over VDM/PCIe transport
+(CONFIG_MCTP_TRANSPORT_PCIE_VDM):
+
+- mctp-pcie-vdm.c was missing MODULE_LICENSE() and MODULE_DESCRIPTION(),
+  which causes a module taint/warning when the transport is built and
+  loaded as a module. Add both.
+- The header guarded its declarations with
+  "#ifdef CONFIG_MCTP_TRANSPORT_PCIE_VDM", which does not handle the
+  option being built as a module (=m). Include <linux/kconfig.h> and use
+  IS_ENABLED() so the declarations are visible in both built-in and
+  module configurations.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0005-mctp-driver-net-Fix-MCTP-over-USB.patch
+++ b/recipes-kernel/linux/linux-6.12/0005-mctp-driver-net-Fix-MCTP-over-USB.patch
@@ -3,7 +3,14 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 18:58:36 +0300
 Subject: [PATCH 6.12 5/5] mctp: driver: net: Fix MCTP over USB
 
-Add fixes for MCTP over USB (option MCTP_TRANSPORT_USB).
+Fix and extend the MCTP over USB transport (CONFIG_MCTP_TRANSPORT_USB).
+
+This reworks the USB TX error statistics so that errors which cannot be
+attributed to a single destination EID (for example batched transfers)
+are accounted under a dedicated unknown-EID bucket rather than a
+specific EID, removes a stale Makefile reference to a USB
+error-injection object, and adds a USB gadget function (f_mctp) so the
+device side can expose an MCTP-over-USB interface.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0007-JTAG-Aspeed-Fix-kernel-configuration.patch
+++ b/recipes-kernel/linux/linux-6.12/0007-JTAG-Aspeed-Fix-kernel-configuration.patch
@@ -3,7 +3,16 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 23 Apr 2026 21:40:40 +0300
 Subject: [PATCH 6.12 1/1] JTAG: Aspeed: Fix kernel configuration
 
-Change Kconfig and Makefile.
+The JTAG subsystem was not properly wired into the kernel build:
+drivers/jtag/Kconfig was not sourced from the top-level drivers/Kconfig,
+so its configuration options were not exposed in menuconfig, and
+drivers/Makefile descended into drivers/jtag/ only when
+CONFIG_JTAG_ASPEED was set instead of for the generic CONFIG_JTAG
+option.
+
+Source drivers/jtag/Kconfig from drivers/Kconfig so the JTAG options
+become selectable, and build drivers/jtag/ based on CONFIG_JTAG so the
+subsystem is compiled whenever JTAG support is enabled.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0061-platform-mellanox-mlxreg-io-Increase-max-supported-a.patch
+++ b/recipes-kernel/linux/linux-6.12/0061-platform-mellanox-mlxreg-io-Increase-max-supported-a.patch
@@ -6,7 +6,11 @@ Date: Thu, 28 Aug 2025 20:57:42 +0300
 Subject: [PATCH] platform/mellanox: mlxreg-io: Increase max supported
  attributes
 
-Increase the number of supported mlxreg-io attributes.
+Newer NVIDIA/Mellanox platforms expose more mlxreg-io register
+attributes than the current limit of 128 allows, so attributes beyond
+that count cannot be registered on those platforms.
+
+Raise MLXREG_IO_ATT_NUM from 128 to 250 to accommodate them.
 
 Signed-off-by: Aaron Komisar <akomisar@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0062-Add-support-for-NXP-s-PCF85053A-RTC-chip.patch
+++ b/recipes-kernel/linux/linux-6.12/0062-Add-support-for-NXP-s-PCF85053A-RTC-chip.patch
@@ -3,6 +3,12 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Mon, 26 Jan 2026 11:28:09 +0200
 Subject: [PATCH RTC 1/1] Add support for NXP's PCF85053A RTC chip.
 
+Add a driver for NXP's PCF85053A I2C real-time clock (RTC).
+
+Introduce the rtc-pcf85053a driver together with its
+CONFIG_RTC_DRV_PCF85053A Kconfig and Makefile entries, so the chip can
+be used as a standard Linux RTC device on platforms that include it.
+
 Upstream-Status: Pending
 
 Signed-off-by: Carlos Menin <menin@carlosaurelio.net>

--- a/recipes-kernel/linux/linux-6.12/0063-reset-phy-using-polling-function-not-register-write.patch
+++ b/recipes-kernel/linux/linux-6.12/0063-reset-phy-using-polling-function-not-register-write.patch
@@ -1,14 +1,19 @@
 From d380e09439f8576e4a89dd1f5c32850ce1c14d62 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 2 Apr 2026 12:24:00 +0300
-Subject: [PATCH BMC Realtek PHY 1/1] From
- d2e5ed78b4233e73d5b392cb0ca7b61d4409e8de Mon Sep 17 00:00:00 2001 Subject:
- [PATCH BMC Realtek PHY 1/1] reset phy using polling function not  register
- write
+Subject: [PATCH BMC Realtek PHY 1/1] net: phy: realtek: reset PHY using polling function instead of register write
 
-replace the code to reset the phy with a call to a
-function that resets the phy and waits for the reset to be done,
-preventing race conditions.
+When resetting the Realtek PHY, the driver previously triggered the
+reset by writing the reset bit directly to a PHY register and continued
+without confirming that the reset had actually completed. Because the
+reset takes a finite, non-zero time, configuration accesses that ran
+immediately afterwards could observe the PHY in an intermediate state,
+leading to intermittent, hard-to-reproduce link/initialization failures.
+
+Replace the bare register write with a polling-based reset that triggers
+the reset and then waits until the PHY reports that the reset has
+completed before returning. This closes the timing window between the
+reset request and the subsequent PHY access.
 
 Signed-off-by: Mohammad Abu Gazala <mabugazala@nvidia.com>
 ---


### PR DESCRIPTION
Extend the commit-message bodies of the kernel patches integrated into sonic-linux-kernel (PR #584, HW-MGMT 7.0060.1047) so they describe the motivation and changes, as requested by upstream reviewers. Also fix the malformed Subject line of the Realtek PHY reset patch.

Only commit-message text is changed; no diff/code lines are modified.