### PR TITLE
hw-mgmt: bmc: reset cuase: Add fixup logic for uncontrolled power cycle

### DIFF
--- a/bmc/usr/usr/bin/hw-management-bmc-boot-complete.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-boot-complete.sh
@@ -27,6 +27,71 @@ count_entries() {
 	ls -A "$_d" 2>/dev/null | wc -l
 }
 
+# When CPLD reports auxiliary-power or firmware-update reset, prefer power_on over
+# ambiguous SCU-derived watchdog/software flags (see hw-management-bmc-get-reset-cause.sh).
+# Runs only after system sysfs is populated (boot-complete gate). HI189 uses
+# reset_aux_pwr_or_fu; other platforms may expose reset_aux_pwr_or_ref.
+bmc_reset_cause_apply_aux_pwr_correction() {
+	aux_attr=""
+	aux_val=""
+
+	for attr in reset_aux_pwr_or_ref reset_aux_pwr_or_fu; do
+		_f="${SYS_DIR}/${attr}"
+		if [ ! -r "${_f}" ]; then
+			continue
+		fi
+		if ! read -r aux_val _ <"${_f}" 2>/dev/null; then
+			continue
+		fi
+		case "${aux_val}" in
+		1)
+			aux_attr="${attr}"
+			break
+			;;
+		esac
+	done
+
+	[ -n "${aux_attr}" ] || return 0
+
+	BMC_DIR=/var/run/hw-management/bmc
+	if [ ! -d "${BMC_DIR}" ]; then
+		return 0
+	fi
+
+	for _f in "${BMC_DIR}"/*; do
+		[ -f "${_f}" ] || continue
+		_base=$(basename "${_f}")
+		case "${_base}" in
+		reset_power_on)
+			_v=""
+			if read -r _v _ <"${_f}" 2>/dev/null && [ "${_v}" = "1" ]; then
+				:
+			elif echo 1 >"${_f}" 2>/dev/null; then
+				if [ -n "${_v}" ]; then
+					echo "hw-management-bmc-boot-complete: ${aux_attr}=1, set reset_power_on=1 (was ${_v})" >&2
+				else
+					echo "hw-management-bmc-boot-complete: ${aux_attr}=1, set reset_power_on=1 (previous value unreadable)" >&2
+				fi
+			fi
+			;;
+		reset_*)
+			if ! read -r _v _ <"${_f}" 2>/dev/null; then
+				continue
+			fi
+			case "${_v}" in
+			1)
+				if echo 0 >"${_f}" 2>/dev/null; then
+					echo "hw-management-bmc-boot-complete: ${aux_attr}=1, cleared ${_base}" >&2
+				fi
+				;;
+			esac
+			;;
+		esac
+	done
+
+	return 0
+}
+
 if [ ! -f "$CONF" ]; then
 	echo "hw-management-bmc-boot-complete: missing $CONF" >&2
 	exit 1
@@ -52,6 +117,7 @@ while :; do
 
 	if [ "$c_sys" -ge "$need_sys" ] && [ "$c_thr" -ge "$need_thr" ] && [ "$c_eep" -ge "$need_eep" ]; then
 		echo "hw-management-bmc-boot-complete: thresholds met (system=$c_sys>=$need_sys thermal=$c_thr>=$need_thr eeprom=$c_eep>=$need_eep)" >&2
+		bmc_reset_cause_apply_aux_pwr_correction || true
 		exit 0
 	fi
 


### PR DESCRIPTION
Problem:
BMC reset cause from SCU registers (hw-management-bmc-get-reset-cause.sh) is inconsistent after remote reboot: reset_power_on and reset_watchdog are reported interchangeably.
After aux_pwr_cycle followed by remote reboot, the CPLD reset cause (reset_aux_pwr_or_ref / reset_aux_pwr_or_fu under
/var/run/hw-management/system/) reliably indicates auxiliary power cycle, which should map to reset_power_on.
That CPLD attribute is available only after udev has populated system sysfs, which completes at the end of hw-management-bmc-boot-complete.sh - after the early get-reset-cause run in hw-management-bmc-init.

Solution:
At the end of hw-management-bmc-boot-complete.sh, when system sysfs thresholds are met, check reset_aux_pwr_or_ref or reset_aux_pwr_or_fu. If set to 1, set reset_power_on to 1 and clear all other top-level reset_* files under /var/run/hw-management/bmc/ (regular files only; domains/ subdirectory is skipped).

Corner cases:
- Plain remote reboot without aux_pwr_cycle: CPLD flag stays 0; no fixup. SCU ambiguity for that path is unchanged.
- BMC watchdog before boot-complete: fixup does not run; reset cause may still reflect watchdog.
- Boot-complete timeout: fixup does not run.
- get-reset-cause failure during init: fixup only updates existing files.