### PR TITLE
hw-mgmt: pathes: [6.1, 6.12]: Fix hotplug bus-nr fixup on multi-segme…

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -730,9 +730,10 @@ Kernel-6.1
 |0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch  |                    | Downstream accepted                      |            | raa228942 raa228943                            |
 |0113-net-usb-usbnet-restore-usb-d-name-exception-for-loca.patch  | 07f8bdce68b9       | Bugfix accepted;skip[nvos]               | v6.1.133   | Required for kernels 6.1.115-6.1.132           |
 |0114-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch  |                    | Downstream accepted                      |            | i2c-mux-reg completion_notify after adapters   |
-|0115-i2c-mux-regmap-Amend-completion-notify-flow.patch      |                    | Downstream accepted                      |            |                                                |
-|0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_post_init after last mux (4151613)     |
+|0115-i2c-mux-regmap-Amend-completion-notify-flow.patch           |                    | Downstream accepted                      |            |                                                |
+|0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_post_init after last mux               |
 |0117-nvme-pci-try-flr-on-controller-disable-failure.patch        |                    | Downstream accepted                      |            | NVME SSD FLR additional flow                   |
+|0118-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch   |                    | Downstream accepted                      |            | Fix NULL deref in mux completion_notify        |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Rejected                                 |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |
@@ -831,8 +832,9 @@ Kernel-6.12
 |0063-reset-phy-using-polling-function-not-register-write.patch   |                    | Downstream accepted                      |            |                                                |
 |0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch  |                    | Downstream accepted                      |            | raa228942 raa228943                            |
 |0065-i2c-mux-reg-Downstream-Completion-notify-after-mux-a.patch  |                    | Downstream accepted                      |            | i2c-mux-reg completion_notify after adapters   |
-|0066-i2c-mux-regmap-Amend-completion-notify-flow.patch      |                    | Downstream accepted                      |            |                                                |
-|0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_platdevs_init after last mux (4151613) |
+|0066-i2c-mux-regmap-Amend-completion-notify-flow.patch           |                    | Downstream accepted                      |            |                                                |
+|0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_platdevs_init after last mux           |
+|0068-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch   |                    | Downstream accepted                      |            | Fix NULL deref in mux completion_notify        |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8001-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Rejected                                 |            | Add SPI                                        |
 |8002-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |

--- a/recipes-kernel/linux/linux-6.1/0118-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
+++ b/recipes-kernel/linux/linux-6.1/0118-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 11 Jun 2026 12:00:00 +0300
+Subject: [PATCH] platform: mellanox: Fix hotplug bus-nr fixup on multi-segment mux
+
+mlxplat_i2c_mux_complition_notify() indexed adapters[data->hpdev.nr - 2],
+which assumes hotplug devices live on the first mux segment starting at
+MLXPLAT_CPLD_CH1. On multi-segment platforms this can dereference a NULL
+adapter during i2c-mux-reg probe: VMOD0009/COMEX (MSN2700) with PSU/FAN
+hotplug buses on segment 1 (bus nrs 10..14), and MSN4700 (VMOD0010) where
+the fault prevents mux completion (120s timeout, no I2C mux infra/VPD).
+
+Map hpdev.nr relative to the hotplug segment's base_nr with bounds checks.
+Keep the fixup on the mux_hotplug_num-th segment only so resolved bus
+numbers are not re-matched on a later segment. Set mux_hotplug_num to
+segment 1 for legacy MSN2700 and COMEX platforms.
+
+Bug: #4151613
+Bug: #5079211
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 56 +++++++++++++++++++++++---
+ 1 file changed, 50 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 0c3bb01a..b2c3d4e5 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -332,6 +332,7 @@
+ #define MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM	16
+ #define MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM	24
+ #define MLXPLAT_CPLD_DEFAULT_MUX_HOTPLUG_VECTOR	0
++#define MLXPLAT_CPLD_MUX_HOTPLUG_SEGMENT1	1
+ 
+ /* Number of channels in group */
+ #define MLXPLAT_CPLD_GRP_CHNL_NUM		8
+@@ -8032,6 +8033,7 @@
+ 	int i;
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_hotplug_num = MLXPLAT_CPLD_MUX_HOTPLUG_SEGMENT1;
+ 	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
+ 	mlxplat_mux_data = mlxplat_default_mux_data;
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+@@ -8198,6 +8200,7 @@
+ 	int i;
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM;
++	mlxplat_mux_hotplug_num = MLXPLAT_CPLD_MUX_HOTPLUG_SEGMENT1;
+ 	mlxplat_mux_num = ARRAY_SIZE(mlxplat_extended_mux_data);
+ 	mlxplat_mux_data = mlxplat_extended_mux_data;
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+@@ -9120,16 +9123,42 @@
+ 	 * while the post-init gate uses mux_added only after incrementing for this callback.
+ 	 * That asymmetry is intentional: fixup must observe the adapter map from the probe that
+ 	 * completes the hotplug_num-th mux segment, and post-init must run only after mux_num
+-	 * probes have completed.
++	 * probes have completed. Map hpdev.nr relative to that segment's base_nr, not a hardcoded
++	 * offset (PSU/FAN placeholders on segment 1 use bus nrs 10..14 on COMEX/MSN2700).
+ 	 */
+ 	if (priv->mux_added == mlxplat_mux_hotplug_num && mlxplat_hotplug) {
+-		item = mlxplat_hotplug->items;
+-		for (i = 0; i < mlxplat_hotplug->counter; i++, item++) {
+-			struct mlxreg_core_data *data = item->data;
+-
+-			for (j = 0; j < item->count; j++, data++) {
+-				if (data->hpdev.nr != MLXPLAT_CPLD_NR_NONE)
+-					data->hpdev.nr = adapters[data->hpdev.nr - 2]->nr;
++		int seg = priv->mux_added;
++		int base_nr, adap_count;
++
++		if (seg >= 0 && seg < mlxplat_mux_num) {
++			if (mlxplat_mux_data) {
++				base_nr = mlxplat_mux_data[seg].base_nr;
++				adap_count = mlxplat_mux_data[seg].n_values;
++			} else if (mlxplat_mux_regmap_data) {
++				adap_count =
++					mlxplat_mux_regmap_data[seg].num_adaps;
++				base_nr = adapters[0] ? adapters[0]->nr : 0;
++			} else {
++				adap_count = 0;
++				base_nr = 0;
++			}
++
++			item = mlxplat_hotplug->items;
++			for (i = 0; i < mlxplat_hotplug->counter; i++, item++) {
++				struct mlxreg_core_data *data = item->data;
++				int idx;
++
++				for (j = 0; j < item->count; j++, data++) {
++					if (data->hpdev.nr == MLXPLAT_CPLD_NR_NONE)
++						continue;
++					idx = data->hpdev.nr - base_nr;
++					if (idx < 0 || idx >= adap_count ||
++					    !adapters[idx])
++						continue;
++					if (data->hpdev.nr == adapters[idx]->nr)
++						continue;
++					data->hpdev.nr = adapters[idx]->nr;
++				}
+ 			}
+ 		}
+ 	}

--- a/recipes-kernel/linux/linux-6.12/0068-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
+++ b/recipes-kernel/linux/linux-6.12/0068-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@nvidia.com>
+Date: Wed, 11 Jun 2026 12:00:00 +0300
+Subject: [PATCH] platform: mellanox: Fix hotplug bus-nr fixup on multi-segment mux
+
+mlxplat_i2c_mux_complition_notify() indexed adapters[data->hpdev.nr - 2],
+which assumes hotplug devices live on the first mux segment starting at
+MLXPLAT_CPLD_CH1. On multi-segment platforms this can dereference a NULL
+adapter during i2c-mux-reg probe: VMOD0009/COMEX (MSN2700) with PSU/FAN
+hotplug buses on segment 1 (bus nrs 10..14), and MSN4700 (VMOD0010) where
+the fault prevents mux completion (120s timeout, no I2C mux infra/VPD).
+
+Map hpdev.nr relative to the hotplug segment's base_nr with bounds checks.
+Keep the fixup on the mux_hotplug_num-th segment only so resolved bus
+numbers are not re-matched on a later segment. Set mux_hotplug_num to
+segment 1 for legacy MSN2700 and COMEX platforms.
+
+Bug: #4151613
+Bug: #5079211
+
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
+---
+ drivers/platform/mellanox/mlx-platform.c | 56 +++++++++++++++++++++++---
+ 1 file changed, 50 insertions(+), 6 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
+index 0c3bb01a..b2c3d4e5 100644
+--- a/drivers/platform/mellanox/mlx-platform.c
++++ b/drivers/platform/mellanox/mlx-platform.c
+@@ -335,6 +335,7 @@
+ #define MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM	16
+ #define MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM	24
+ #define MLXPLAT_CPLD_DEFAULT_MUX_HOTPLUG_VECTOR	0
++#define MLXPLAT_CPLD_MUX_HOTPLUG_SEGMENT1	1
+ 
+ /* Number of channels in group */
+ #define MLXPLAT_CPLD_GRP_CHNL_NUM		8
+@@ -8010,6 +8011,7 @@ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
+ 	int i;
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
++	mlxplat_mux_hotplug_num = MLXPLAT_CPLD_MUX_HOTPLUG_SEGMENT1;
+ 	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
+ 	mlxplat_mux_data = mlxplat_default_mux_data;
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+@@ -8176,6 +8178,7 @@ static int __init mlxplat_dmi_comex_matched(const struct dmi_system_id *dmi)
+ 	int i;
+ 
+ 	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM;
++	mlxplat_mux_hotplug_num = MLXPLAT_CPLD_MUX_HOTPLUG_SEGMENT1;
+ 	mlxplat_mux_num = ARRAY_SIZE(mlxplat_extended_mux_data);
+ 	mlxplat_mux_data = mlxplat_extended_mux_data;
+ 	for (i = 0; i < mlxplat_mux_num; i++) {
+@@ -9104,16 +9107,42 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+ 	 * while the platdevs-init gate uses mux_added only after incrementing for this callback.
+ 	 * That asymmetry is intentional: fixup must observe the adapter map from the probe that
+ 	 * completes the hotplug_num-th mux segment, and platdevs init must run only after mux_num
+-	 * probes have completed.
++	 * probes have completed. Map hpdev.nr relative to that segment's base_nr, not a hardcoded
++	 * offset (PSU/FAN placeholders on segment 1 use bus nrs 10..14 on COMEX/MSN2700).
+ 	 */
+ 	if (priv->mux_added == mlxplat_mux_hotplug_num && mlxplat_hotplug) {
+-		item = mlxplat_hotplug->items;
+-		for (i = 0; i < mlxplat_hotplug->count; i++, item++) {
+-			struct mlxreg_core_data *data = item->data;
+-
+-			for (j = 0; j < item->count; j++, data++) {
+-				if (data->hpdev.nr != MLXPLAT_CPLD_NR_NONE)
+-					data->hpdev.nr = adapters[data->hpdev.nr - 2]->nr;
++		int seg = priv->mux_added;
++		int base_nr, adap_count;
++
++		if (seg >= 0 && seg < mlxplat_mux_num) {
++			if (mlxplat_mux_data) {
++				base_nr = mlxplat_mux_data[seg].base_nr;
++				adap_count = mlxplat_mux_data[seg].n_values;
++			} else if (mlxplat_mux_regmap_data) {
++				adap_count =
++					mlxplat_mux_regmap_data[seg].num_adaps;
++				base_nr = adapters[0] ? adapters[0]->nr : 0;
++			} else {
++				adap_count = 0;
++				base_nr = 0;
++			}
++
++			item = mlxplat_hotplug->items;
++			for (i = 0; i < mlxplat_hotplug->count; i++, item++) {
++				struct mlxreg_core_data *data = item->data;
++				int idx;
++
++				for (j = 0; j < item->count; j++, data++) {
++					if (data->hpdev.nr == MLXPLAT_CPLD_NR_NONE)
++						continue;
++					idx = data->hpdev.nr - base_nr;
++					if (idx < 0 || idx >= adap_count ||
++					    !adapters[idx])
++						continue;
++					if (data->hpdev.nr == adapters[idx]->nr)
++						continue;
++					data->hpdev.nr = adapters[idx]->nr;
++				}
+ 			}
+ 		}
+ 	}


### PR DESCRIPTION
…nt mux

mlxplat_i2c_mux_complition_notify() indexed adapters[data->hpdev.nr - 2], which assumes hotplug devices live on the first mux segment starting at MLXPLAT_CPLD_CH1. On VMOD0009/COMEX (MSN2700) PSU/FAN hotplug buses are on the second segment (10..14), so the callback could dereference a NULL adapter and crash during i2c-mux-reg probe.

Run the fixup on every mux completion, map hpdev.nr relative to the current segment base_nr (or the first adapter's nr for regmap mux), and bounds-check the adapter index before use.

Bug: #4151613