### PR TITLE
hw-mgmt: scripts: Update list of modules to load

### DIFF
--- a/usr/etc/modules-load.d/05-hw-management-modules.conf
+++ b/usr/etc/modules-load.d/05-hw-management-modules.conf
@@ -4,7 +4,6 @@
 i2c-i801
 i2c-mux-mlxcpld
 i2c-mux-reg
-i2c-mux-regmap
 i2c-dev
 pmbus
 tps53679


### PR DESCRIPTION
This patch removes the module i2c-mux-regmap from
the list of modules to be loaded at the hw-mgmt
startup. This is not a required module.

Bug #5085644