### PR TITLE
hw-mgmt: patches: Fix Renesas RAA228942/943 isl68137 probe in 6.1 and…

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -14,14 +14,14 @@ dedicated OF match entries are needed.
 Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 ---
  Documentation/hwmon/isl68137.rst | 20 ++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   |  2 ++
- 2 files changed, 22 insertions(+)
+ drivers/hwmon/pmbus/isl68137.c   | 22 ++++++++++++++++++++++---
+ 2 files changed, 40 insertions(+), 2 deletions(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
 --- a/Documentation/hwmon/isl68137.rst
 +++ b/Documentation/hwmon/isl68137.rst
-@@ -374,6 +374,26 @@ Supported chips:
+@@ -374,6 +374,26 @@
  
        Publicly available (after August 2020 launch) at the Renesas website
  
@@ -49,10 +49,45 @@ index 0e71b22047f8..1a1424dd640f 100644
  
      Prefix: 'raa229001'
 diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
-index 1a8caff1ac5f..5f7438905aa4 100644
+index 1a8caff1ac5f..2e78d716de59 100644
 --- a/drivers/hwmon/pmbus/isl68137.c
 +++ b/drivers/hwmon/pmbus/isl68137.c
-@@ -311,6 +311,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
+@@ -178,6 +178,19 @@
+ 	return ret;
+ }
+ 
++static int raa_dmpvr2_nontc_read_word_data(struct i2c_client *client, int page,
++					   int phase, int reg)
++{
++	switch (reg) {
++	case PMBUS_UT_FAULT_LIMIT:
++	case PMBUS_UT_WARN_LIMIT:
++	case PMBUS_POUT_MAX:
++		return -EIO;
++	default:
++		return raa_dmpvr2_read_word_data(client, page, phase, reg);
++	}
++}
++
+ static struct pmbus_driver_info raa_dmpvr_info = {
+ 	.pages = 3,
+ 	.format[PSC_VOLTAGE_IN] = direct,
+@@ -244,9 +261,13 @@
+ 		info->read_word_data = raa_dmpvr2_read_word_data;
+ 		break;
+ 	case raa_dmpvr2_2rail_nontc:
++		info->func[0] &= ~PMBUS_HAVE_VMON;
++		info->func[0] &= ~PMBUS_HAVE_TEMP2;
+ 		info->func[0] &= ~PMBUS_HAVE_TEMP3;
+ 		info->func[1] &= ~PMBUS_HAVE_TEMP3;
+-		fallthrough;
++		info->pages = 2;
++		info->read_word_data = raa_dmpvr2_nontc_read_word_data;
++		break;
+ 	case raa_dmpvr2_2rail:
+ 		info->pages = 2;
+ 		info->read_word_data = raa_dmpvr2_read_word_data;
+@@ -311,6 +332,8 @@
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},
@@ -63,4 +98,3 @@ index 1a8caff1ac5f..5f7438905aa4 100644
  	{}
 -- 
 2.34.1
-

--- a/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -14,14 +14,14 @@ dedicated OF match entries are needed.
 Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 ---
  Documentation/hwmon/isl68137.rst | 20 ++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   |  2 ++
- 2 files changed, 22 insertions(+)
+ drivers/hwmon/pmbus/isl68137.c   | 22 ++++++++++++++++++++++---
+ 2 files changed, 40 insertions(+), 2 deletions(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
 --- a/Documentation/hwmon/isl68137.rst
 +++ b/Documentation/hwmon/isl68137.rst
-@@ -374,6 +374,26 @@ Supported chips:
+@@ -374,6 +374,26 @@
  
        Publicly available (after August 2020 launch) at the Renesas website
  
@@ -49,10 +49,45 @@ index 0e71b22047f8..1a1424dd640f 100644
  
      Prefix: 'raa229001'
 diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
-index 7e53fb1d5ea3..f3baaee6227a 100644
+index 2af921039309..39e38e01e630 100644
 --- a/drivers/hwmon/pmbus/isl68137.c
 +++ b/drivers/hwmon/pmbus/isl68137.c
-@@ -311,6 +311,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
+@@ -244,6 +244,19 @@
+ 	return ret;
+ }
+ 
++static int raa_dmpvr2_nontc_read_word_data(struct i2c_client *client, int page,
++					   int phase, int reg)
++{
++	switch (reg) {
++	case PMBUS_UT_FAULT_LIMIT:
++	case PMBUS_UT_WARN_LIMIT:
++	case PMBUS_POUT_MAX:
++		return -EIO;
++	default:
++		return raa_dmpvr2_read_word_data(client, page, phase, reg);
++	}
++}
++
+ static struct pmbus_driver_info raa_dmpvr_info = {
+ 	.pages = 3,
+ 	.format[PSC_VOLTAGE_IN] = direct,
+@@ -389,9 +406,13 @@
+ 		info->write_word_data = raa_dmpvr2_write_word_data;
+ 		break;
+ 	case raa_dmpvr2_2rail_nontc:
++		info->func[0] &= ~PMBUS_HAVE_VMON;
++		info->func[0] &= ~PMBUS_HAVE_TEMP2;
+ 		info->func[0] &= ~PMBUS_HAVE_TEMP3;
+ 		info->func[1] &= ~PMBUS_HAVE_TEMP3;
+-		fallthrough;
++		info->pages = 2;
++		info->read_word_data = raa_dmpvr2_nontc_read_word_data;
++		break;
+ 	case raa_dmpvr2_2rail:
+ 		info->pages = 2;
+ 		info->read_word_data = raa_dmpvr2_read_word_data;
+@@ -463,6 +484,8 @@
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},
@@ -63,4 +98,3 @@ index 7e53fb1d5ea3..f3baaee6227a 100644
  	{}
 -- 
 2.34.1
-

--- a/usr/etc/hw-management-sensors/n61xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n61xxld_sensors.conf
@@ -142,9 +142,8 @@ chip "xdpe1a2g7-i2c-*-6e"
 
 chip "raa228943-i2c-*-66"
 	label in1      "PMIC-1 PVIN1_VDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-1 ASIC_VDD Volt (out1)"
-	ignore in4
+	label in2      "PMIC-1 ASIC_VDD Volt (out1)"
+	ignore in3
 	label temp1    "PMIC-1 Temp 1"
 	ignore temp2
 	ignore temp3
@@ -159,9 +158,8 @@ chip "raa228943-i2c-*-66"
 
 chip "raa228943-i2c-*-68"
 	label in1      "PMIC-2 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
-	label in4      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
+	label in2      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
+	label in3      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
 	label temp1    "PMIC-2 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-2 Temp 2"
@@ -176,9 +174,8 @@ chip "raa228943-i2c-*-68"
 
 chip "raa228943-i2c-*-6c"
 	label in1      "PMIC-3 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
-	label in4      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
+	label in2      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
+	label in3      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
 	label temp1    "PMIC-3 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-3 Temp 2"
@@ -193,9 +190,8 @@ chip "raa228943-i2c-*-6c"
 
 chip "raa228943-i2c-*-6e"
 	label in1      "PMIC-4 PVIN1_AVCC_HVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
-	label in4      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
+	label in2      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
+	label in3      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
 	label temp1    "PMIC-4 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-4 Temp 2"

--- a/usr/etc/hw-management-sensors/n63xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n63xxld_sensors.conf
@@ -127,9 +127,8 @@ chip "xdpe1a2g7-i2c-*-6e"
 
 chip "raa228943-i2c-24-66"
 	label in1      "PMIC-1 PVIN1_VDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-1 ASIC_VDD Volt (out1)"
-	ignore in4
+	label in2      "PMIC-1 ASIC_VDD Volt (out1)"
+	ignore in3
 	label temp1    "PMIC-1 Temp 1"
 	ignore temp2
 	ignore temp3
@@ -144,9 +143,8 @@ chip "raa228943-i2c-24-66"
 
 chip "raa228943-i2c-24-68"
 	label in1      "PMIC-2 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
-	label in4      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
+	label in2      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
+	label in3      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
 	label temp1    "PMIC-2 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-2 Temp 2"
@@ -161,9 +159,8 @@ chip "raa228943-i2c-24-68"
 
 chip "raa228943-i2c-24-6c"
 	label in1      "PMIC-3 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
-	label in4      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
+	label in2      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
+	label in3      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
 	label temp1    "PMIC-3 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-3 Temp 2"
@@ -178,9 +175,8 @@ chip "raa228943-i2c-24-6c"
 
 chip "raa228943-i2c-24-6e"
 	label in1      "PMIC-4 PVIN1_AVCC_HVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
-	label in4      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
+	label in2      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
+	label in3      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
 	label temp1    "PMIC-4 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-4 Temp 2"


### PR DESCRIPTION
… 6.12

Add missing raa_dmpvr2_2rail_nontc probe hunks to 0112 and 0064 Renesas patches: clear PMBUS_HAVE_VMON and PMBUS_HAVE_TEMP2 on page 0 (alongside existing TEMP3 clear) for vendor sysfs compatibility.