### PR TITLE
hw-mgmt: patches: 6.1: Fix AMD I2C controller init after kexec

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -734,6 +734,7 @@ Kernel-6.1
 |0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch  |                    | Downstream accepted                      |            | mlxplat_post_init after last mux               |
 |0117-nvme-pci-try-flr-on-controller-disable-failure.patch        |                    | Downstream accepted                      |            | NVME SSD FLR additional flow                   |
 |0118-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch   |                    | Downstream accepted                      |            | Fix NULL deref in mux completion_notify        |
+|0119-i2c-designware-Fix-ACPI-power-on-of-AMD-I2C-after-ke.patch  |                    | Downstream accepted                      |            | Fix AMD V3000 I2C controller init after kexec  |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Rejected                                 |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |

--- a/recipes-kernel/linux/linux-6.1/0119-i2c-designware-Fix-ACPI-power-on-of-AMD-I2C-after-ke.patch
+++ b/recipes-kernel/linux/linux-6.1/0119-i2c-designware-Fix-ACPI-power-on-of-AMD-I2C-after-ke.patch
@@ -1,0 +1,39 @@
+From b67bc9a5f01fea21a3c2697b8fa62d843157062e Mon Sep 17 00:00:00 2001
+From: Felix Radensky <fradensky@nvidia.com>
+Date: Wed, 17 Jun 2026 19:57:44 +0300
+Subject: [PATCH] i2c: designware: Fix ACPI power-on of AMD I2C after kexec
+
+After kexec, AMD DesignWare I2C controllers (AMDI0010) may be left in a
+low-power state by the previous kernel while the ACPI core assumes D0
+because the DSDT provides _PS0/_PS3 without _PSC. acpi_device_set_power()
+then skips _PS0 evaluation and the driver reads 0xffffffff from
+DW_IC_COMP_TYPE.
+
+Call acpi_device_fix_up_power() before accessing the controller, matching
+the approach used by i2c-hid-acpi and ACPI LPSS enumeration.
+
+Signed-off-by: Felix Radensky <fradensky@nvidia.com>
+---
+ drivers/i2c/busses/i2c-designware-platdrv.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/i2c/busses/i2c-designware-platdrv.c b/drivers/i2c/busses/i2c-designware-platdrv.c
+index 7466d748b..ad5fcc7b5 100644
+--- a/drivers/i2c/busses/i2c-designware-platdrv.c
++++ b/drivers/i2c/busses/i2c-designware-platdrv.c
+@@ -285,6 +285,12 @@ static int dw_i2c_plat_probe(struct platform_device *pdev)
+ 	dev->irq = irq;
+ 	platform_set_drvdata(pdev, dev);
+ 
++	if (has_acpi_companion(&pdev->dev)) {
++		ret = acpi_device_fix_up_power(ACPI_COMPANION(&pdev->dev));
++		if (ret)
++			return ret;
++	}
++
+ 	ret = dw_i2c_plat_request_regs(dev);
+ 	if (ret)
+ 		return ret;
+-- 
+2.34.1
+


### PR DESCRIPTION
AMD I2C controllers on V3000 CPU are powered off after kexec boot. In kernel 6.1 the controllers's init fails with the following errors:

i2c_designware AMDI0010:00: Unknown Synopsys component type: 0xffffffff
i2c_designware AMDI0010:01: Unknown Synopsys component type: 0xffffffff
i2c_designware AMDI0010:02: Unknown Synopsys component type: 0xffffffff
i2c_designware AMDI0010:03: Unknown Synopsys component type: 0xffffffff

The patch adds powering up the controllers during the driver probe to avoid the failure.

Bug: 4889170