### PR TITLE
hw-mgmt: kernel 6.12 BMC: add ftgmac100 SGMII fixes (0010, 0011)

### DIFF
--- a/recipes-kernel/linux/Patch_BMC_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_BMC_Status_Table.txt
@@ -11,6 +11,8 @@ Kernel-6.12
 |0007-JTAG-Aspeed-Fix-kernel-configuration.patch                  |                    | Downstream;skip[ALL];take[sonic]         |            | BMC                                            |
 |0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch  |                    | Downstream;skip[ALL];take[sonic]         |            | BMC; SPC6 AST2700 A2 DTS                       |
 |0009-arm64-dts-aspeed-split-SPC6-BMC-DTS-for-SONiC-and-Op.patch  |                    | Downstream;skip[ALL];take[sonic]         |            | BMC; SPC6 SONiC/OpenBMC DTS split (ramrofs)   |
+|0010-net-ftgmac100-hard-reset-mac-for-sgmii.patch                |                    | Downstream;skip[ALL];take[sonic]         |            | BMC; AST2700 SGMII eth0 RX stall after down/up |
+|0011-arm64-dts-aspeed-spc6-bmc-fix-sgmii-phy-names.patch         |                    | Downstream;skip[ALL];take[sonic]         |            | BMC; mac2 phy-names match ftgmac100 "sgmii"    |
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Legend:

--- a/recipes-kernel/linux/linux-6.12/0010-net-ftgmac100-hard-reset-mac-for-sgmii.patch
+++ b/recipes-kernel/linux/linux-6.12/0010-net-ftgmac100-hard-reset-mac-for-sgmii.patch
@@ -1,0 +1,48 @@
+From: Sergejs Hatinecs <shatinecs@nvidia.com>
+Date: Thu, 12 Jun 2026 12:00:00 +0300
+Subject: [PATCH 6.12 1/1] net: ftgmac100: hard-reset MAC for SGMII to clear RX stall
+
+Upstream-Status: Pending
+
+On AST2700 + Marvell 88E151x over SGMII, an "ifconfig down/up" (or a
+partner-side link flap) intermittently leaves the MAC receive path wedged:
+the link comes back up and reports resolved, TX works, but RX stays frozen
+(no DHCP, no ping). The MDIO/serdes registers look identical to a healthy
+link in this state, so the wedge is below the register layer.
+
+The only reliable recovery is "modprobe -r ftgmac100 / modprobe ftgmac100",
+which re-runs probe and performs a full reset_control cycle of the MAC IP
+block. The ndo_open/ftgmac100_reset() path only issues the soft MACCR reset,
+which does not clear the wedged RX path.
+
+ftgmac100_reset_and_config_mac() already does the reset_control assert/
+deassert for RMII; extend it to SGMII so every MAC reset hard-resets the IP
+block and clears the RX path, matching the modprobe-reload behaviour. With
+this, repeated down/up cycles and partner link flaps recover reliably.
+
+Signed-off-by: Sergejs Hatinecs <shatinecs@nvidia.com>
+---
+ drivers/net/ethernet/faraday/ftgmac100.c | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/net/ethernet/faraday/ftgmac100.c b/drivers/net/ethernet/faraday/ftgmac100.c
+index 8ef2b736f23e..a3534b467aa6 100644
+--- a/drivers/net/ethernet/faraday/ftgmac100.c
++++ b/drivers/net/ethernet/faraday/ftgmac100.c
+@@ -157,8 +157,14 @@ static int ftgmac100_reset_and_config_mac(struct ftgmac100 *priv)
+ {
+ 	u32 maccr = 0;
+ 
+-	/* RMII needs SCU reset to clear status */
+-	if (priv->netdev->phydev->interface == PHY_INTERFACE_MODE_RMII) {
++	/* RMII needs SCU reset to clear status. SGMII (AST2700 + 88E151x) needs
++	 * it too: after ifconfig down/up the soft MACCR reset alone leaves the
++	 * MAC RX path wedged (link reads resolved but RX stays frozen). Only a
++	 * full reset_control cycle clears it - this is why "modprobe -r/modprobe"
++	 * (which hard-resets at probe) always recovers while down/up does not.
++	 */
++	if (priv->netdev->phydev->interface == PHY_INTERFACE_MODE_RMII ||
++	    priv->netdev->phydev->interface == PHY_INTERFACE_MODE_SGMII) {
+ 		int err;
+ 
+ 		err = reset_control_assert(priv->rst);

--- a/recipes-kernel/linux/linux-6.12/0011-arm64-dts-aspeed-spc6-bmc-fix-sgmii-phy-names.patch
+++ b/recipes-kernel/linux/linux-6.12/0011-arm64-dts-aspeed-spc6-bmc-fix-sgmii-phy-names.patch
@@ -1,0 +1,60 @@
+From: Sergejs Hatinecs <shatinecs@nvidia.com>
+Date: Thu, 12 Jun 2026 12:30:00 +0300
+Subject: [PATCH 6.12 1/1] arm64: dts: aspeed: spc6-bmc: fix mac2 SGMII phy-names
+
+Upstream-Status: Pending
+
+ftgmac100 probes the optional SGMII serdes PHY with devm_phy_optional_get()
+using the name "sgmii". mac2 in the SPC6 BMC device trees used
+phy-names = "sgmii-phy", so the serdes PHY was never bound and SGMII
+management traffic did not run through the expected path.
+
+Use phy-names = "sgmii" on mac2 in the A1, SONiC, and OpenBMC SPC6 BMC
+DTS variants so the name matches the driver.
+
+Signed-off-by: Sergejs Hatinecs <shatinecs@nvidia.com>
+---
+ arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-a1-bmc.dts      | 2 +-
+ arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts | 2 +-
+ arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts         | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-a1-bmc.dts b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-a1-bmc.dts
+index 810d50fe11ac..741bd588ec2a 100644
+--- a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-a1-bmc.dts
++++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-a1-bmc.dts
+@@ -170,7 +170,7 @@
+ 	phy-mode = "sgmii";
+ 	phy-handle = <&ethphy2>;
+ 	phys = <&sgmii>;
+-	phy-names = "sgmii-phy";
++	phy-names = "sgmii";
+ };
+ 
+ /*
+diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
+index 0817034b8658..e16559039ed5 100644
+--- a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
++++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
+@@ -207,7 +207,7 @@
+ 	phy-mode = "sgmii";
+ 	phy-handle = <&ethphy2>;
+ 	phys = <&sgmii>;
+-	phy-names = "sgmii-phy";
++	phy-names = "sgmii";
+ };
+ 
+ /*
+diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
+index cfe5743b90fe..bcdb5a463b42 100644
+--- a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
++++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
+@@ -215,7 +215,7 @@
+ 	phy-mode = "sgmii";
+ 	phy-handle = <&ethphy2>;
+ 	phys = <&sgmii>;
+-	phy-names = "sgmii-phy";
++	phy-names = "sgmii";
+ };
+ 
+ /*


### PR DESCRIPTION
Add SONiC BMC kernel patches for AST2700 SPC6 eth0 over SGMII (Marvell 88E151x), from validated sonic/src tree diff:

0010-net-ftgmac100-hard-reset-mac-for-sgmii.patch
  Extend reset_control assert/deassert to SGMII in
  ftgmac100_reset_and_config_mac(). After ifconfig down/up or partner link
  flap, soft MACCR reset alone can leave RX wedged while link reads up;
  hard reset matches modprobe-reload recovery.

0011-arm64-dts-aspeed-spc6-bmc-fix-sgmii-phy-names.patch
  Set mac2 phy-names to "sgmii" (was "sgmii-phy") in spc6-a1-bmc,
  spc6-bmc, and spc6-bmc-openbmc DTS so devm_phy_optional_get() in
  ftgmac100 binds the serdes PHY.

Update Patch_BMC_Status_Table.txt for both patches (Downstream;skip[ALL];take[sonic]).

Co-developed-by: Sergejs Hatinecs <shatinecs@nvidia.com>