### PR TITLE
hw-mgmt: scripts: Fix polling for graceful power off request on HI162

### DIFF
--- a/usr/usr/bin/hw_management_platform_config.py
+++ b/usr/usr/bin/hw_management_platform_config.py
@@ -123,7 +123,7 @@ PLATFORM_CONFIG = {
         {'fin': '/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage2', 'fn': 'run_cmd', 'arg': ['/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE2 {arg1}'], 'poll': 2, 'ts': 0},
         {'fin': '/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage3', 'fn': 'run_cmd', 'arg': ['/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE3 {arg1}'], 'poll': 2, 'ts': 0},
         {'fin': '/sys/devices/platform/mlxplat/mlxreg-io/hwmon/{hwmon}/leakage4', 'fn': 'run_cmd', 'arg': ['/usr/bin/hw-management-chassis-events.sh hotplug-event LEAKAGE4 {arg1}'], 'poll': 2, 'ts': 0},
-        {'fin': '/var/run/hw-management/system/power_button_evt', 'fn': 'run_power_button_event', 'arg': [], 'poll': 1, 'ts': 0},
+        {'fin': '/var/run/hw-management/system/cpu_shutdown_req', 'fn': 'run_power_button_event', 'arg': [], 'poll': 1, 'ts': 0},
         {'fin': None, 'fn': 'asic_temp_populate', 'poll': 3, 'ts': 0, 'arg': {'asic': {'fin': '/sys/module/sx_core/asic0/'}, 'asic1': {'fin': '/sys/module/sx_core/asic0/'}, 'asic2': {'fin': '/sys/module/sx_core/asic1/'}}},
         {'fin': None, 'fn': 'monitor_asic_chipup_status', 'poll': 5, 'ts': 0, 'arg': {'asic1': {'fin': '/sys/module/sx_core/asic0/'}, 'asic2': {'fin': '/sys/module/sx_core/asic1/'}}},
         {'fin': None, 'fn': 'module_temp_populate', 'poll': 20, 'ts': 0, 'arg': {'fin': '/sys/module/sx_core/asic0/module{}/', 'fout_idx_offset': 1, 'module_count': 36}},


### PR DESCRIPTION
HW-MGMT is polling a wrong attribute to detect graceful power off request from the BMC. Instead of monitoring cpu_shutdown_req attribute, we are monitoring power_button_evt.

Bug: 4984971