### PR TITLE
hw-mgmt: pathes: [6.1, 6.12]: Fix module loading/booting timing issue

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch
+++ b/recipes-kernel/linux/linux-6.1/0116-platform-mellanox-Downstream-Defer-post-init-until-I.patch
@@ -9,20 +9,27 @@ callbacks complete, with spinlock, completion, 120s timeout, NULL-adapter path,
 mux teardown vs late-notifier coordination, and unconditional mux completion_notify
 on i2c-mux-reg.
 
+Pin the mux platform driver module with try_module_get() while registering mux
+platform devices so the driver cannot unload before probe completes. Return
+-EPROBE_DEFER when the driver is not registered yet (e.g. CONFIG_I2C_MUX_REG=m
+and modules-load runs after mlx-platform probe).
+
+Signal mux_platdevs_done before clearing mux_post_init_claimed, and re-check
+completion_done() after wait_for_completion_timeout() expires, so a successful
+post_init that finishes at the deadline is not misread as -ETIMEDOUT.
+
 Honor mux_platdevs_err after timeout when post_init is already running; skip
 !adapters handling when mux_abandon is set. Document why probe blocks up to 120s
 on mux_platdevs_done; log timeout only when muxes fail to complete, not when
 post_init exceeds the bound but later succeeds.
 
-Generated against linux-6.1.150 mlx-platform.c (parent of this patch in series).
+Generated against linux-6.1.123 mlx-platform.c (parent of this patch in series).
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 142 ++++++++++++++++++++++++++++---
- 1 file changed, 130 insertions(+), 12 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 201 +++++++++++++++++++++---
+ 1 file changed, 188 insertions(+), 13 deletions(-)
 
-diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index d5efcbb7..a23cfb5c 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -19,6 +19,9 @@
@@ -42,7 +49,7 @@ index d5efcbb7..a23cfb5c 100644
 - * @hi2c_main_init_status: init status of I2C main bus
 - * @mux_added: number of added mux segments
 + * @i2c_main_init_status: init status of I2C main bus
-+ * @mux_added: mux segments that have completed i2c-mux-reg/regmap probe (completion_notify)
++ * @mux_added: number of mux segments that finished probe (completion_notify)
 + * @mux_notify_lock: serializes mux_added and hotplug bus-nr fixup
 + * @mux_platdevs_done: signaled when deferred mlxplat_post_init() has finished
 + * @mux_platdevs_err: result of mlxplat_post_init() from completion_notify; updated with
@@ -52,7 +59,7 @@ index d5efcbb7..a23cfb5c 100644
   * @irq_fpga: FPGA IRQ number
   */
  struct mlxplat_priv {
-@@ -441,6 +450,11 @@ struct mlxplat_priv {
+@@ -441,6 +450,11 @@
  	unsigned int hotplug_resources_size;
  	u8 i2c_main_init_status;
  	int mux_added;
@@ -64,20 +71,27 @@ index d5efcbb7..a23cfb5c 100644
  	int irq_fpga;
  };
  
-@@ -9068,14 +9082,47 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+@@ -9063,19 +9077,52 @@
+ }
+ 
+ static int
+-mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
++mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent __maybe_unused,
+ 				  struct i2c_adapter *adapters[])
  {
- 	struct mlxplat_priv *priv = handle;
+-	struct mlxplat_priv *priv = handle;
  	struct mlxreg_core_item *item;
++	struct mlxplat_priv *priv = handle;
++	unsigned long flags;
 +	bool run_post_init = false;
 +	bool need_complete = false;
-+	unsigned long flags;
 +	int ret = 0;
  	int i, j;
  
-+	/*
+ 	/*
 +	 * i2c-mux-reg / i2c-mux-regmap may call this with @adapters NULL when this
-+	 * mux probe failed after mlx-platform began waiting (so mux_added still
-+	 * reaches mlxplat_mux_num).
++	 * mux probe failed after mlx-platform began waiting, so mux_added still
++	 * reaches mlxplat_mux_num.
 +	 */
 +	if (!adapters) {
 +		bool last;
@@ -96,8 +110,7 @@ index d5efcbb7..a23cfb5c 100644
 +		return -EIO;
 +	}
 +
-+	spin_lock_irqsave(&priv->mux_notify_lock, flags);
- 	/*
++	/*
  	 * Hotplug platform driver data structure contains static mux channels for I2C hotplug
  	 * devices. These channels numbers can be updated dynamically and returned by mux callback
  	 * through the adapters array. Update mux channels according to the dynamic adapters data.
@@ -109,11 +122,12 @@ index d5efcbb7..a23cfb5c 100644
 +	 * probes have completed.
  	 */
 -	if (priv->mux_added == mlxplat_mux_hotplug_num) {
++	spin_lock_irqsave(&priv->mux_notify_lock, flags);
 +	if (priv->mux_added == mlxplat_mux_hotplug_num && mlxplat_hotplug) {
  		item = mlxplat_hotplug->items;
  		for (i = 0; i < mlxplat_hotplug->counter; i++, item++) {
  			struct mlxreg_core_data *data = item->data;
-@@ -9087,15 +9134,34 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+@@ -9087,15 +9134,51 @@
  		}
  	}
  
@@ -130,29 +144,45 @@ index d5efcbb7..a23cfb5c 100644
 +		}
 +	}
 +	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+
+ 
 +	if (run_post_init) {
 +		ret = mlxplat_post_init(priv);
 +		WRITE_ONCE(priv->mux_platdevs_err, ret);
++		complete(&priv->mux_platdevs_done);
 +		spin_lock_irqsave(&priv->mux_notify_lock, flags);
 +		priv->mux_post_init_claimed = false;
 +		spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+		complete(&priv->mux_platdevs_done);
 +	} else if (need_complete) {
 +		complete(&priv->mux_platdevs_done);
 +	}
- 
--	return 0;
++
 +	return ret;
++}
++
++static int mlxplat_mux_driver_pin(const char *drv_name, struct module **owner)
++{
++	struct device_driver *drv;
++
++	drv = driver_find(drv_name, &platform_bus_type);
++	if (!drv)
++		return -EPROBE_DEFER;
++	if (!try_module_get(drv->owner))
++		return -EPROBE_DEFER;
++
++	*owner = drv->owner;
+ 	return 0;
  }
  
  static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
  {
 +	unsigned long flags;
++	bool mux_regmap_no_notify = false;
++	unsigned int j;
++	struct module *mux_owner = NULL;
  	int i, err;
  
  	if (!priv->pdev_i2c) {
-@@ -9104,8 +9170,27 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+@@ -9104,8 +9187,51 @@
  	}
  
  	priv->i2c_main_init_status = MLXPLAT_I2C_MAIN_BUS_HANDLE_CREATED;
@@ -166,8 +196,33 @@ index d5efcbb7..a23cfb5c 100644
 +	priv->mux_abandon = false;
 +	priv->mux_post_init_claimed = false;
 +	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++
++	/*
++	 * Legacy synchronous post-init only when every regmap pdata slot leaves
++	 * completion_notify unset (do not infer from element 0 alone).
++	 */
++	if (!mlxplat_mux_data && mlxplat_mux_regmap_data) {
++		mux_regmap_no_notify = true;
++		for (j = 0; j < mlxplat_mux_num; j++) {
++			if (mlxplat_mux_regmap_data[j].completion_notify) {
++				mux_regmap_no_notify = false;
++				break;
++			}
++		}
++	}
++
 +	if (!mlxplat_mux_num)
 +		return mlxplat_post_init(priv);
++
++	if (mlxplat_mux_data) {
++		err = mlxplat_mux_driver_pin("i2c-mux-reg", &mux_owner);
++		if (err)
++			return err;
++	} else {
++		err = mlxplat_mux_driver_pin("i2c-mux-regmap", &mux_owner);
++		if (err)
++			return err;
++	}
 +
 +	reinit_completion(&priv->mux_platdevs_done);
 +	WRITE_ONCE(priv->mux_platdevs_err, 0);
@@ -175,27 +230,35 @@ index d5efcbb7..a23cfb5c 100644
  	for (i = 0; i < mlxplat_mux_num; i++) {
  		if (mlxplat_mux_data) {
 +			mlxplat_mux_data[i].handle = priv;
-+			mlxplat_mux_data[i].completion_notify =
-+				mlxplat_i2c_mux_complition_notify;
++			mlxplat_mux_data[i].completion_notify = mlxplat_i2c_mux_complition_notify;
  			priv->pdev_mux[i] =
  				platform_device_register_resndata(&priv->pdev_i2c->dev,
  								  "i2c-mux-reg", i, NULL, 0,
-@@ -9115,7 +9200,7 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+@@ -9114,8 +9240,9 @@
+ 		} else {
  			mlxplat_mux_regmap_data[i].handle = priv;
  			mlxplat_mux_regmap_data[i].regmap = priv->regmap;
- 			mlxplat_mux_regmap_data[i].completion_notify =
+-			mlxplat_mux_regmap_data[i].completion_notify =
 -								mlxplat_i2c_mux_complition_notify;
++			if (!mux_regmap_no_notify)
++				mlxplat_mux_regmap_data[i].completion_notify =
 +					mlxplat_i2c_mux_complition_notify;
  			priv->pdev_mux[i] =
  			platform_device_register_resndata(&priv->pdev_i2c->dev,
  							  "i2c-mux-regmap", i, NULL, 0,
-@@ -9128,14 +9213,45 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+@@ -9128,17 +9255,63 @@
  		}
  	}
  
 -	if (mlxplat_mux_regmap_data && mlxplat_mux_regmap_data->completion_notify)
 -		return 0;
--
++	if (mux_regmap_no_notify) {
++		err = mlxplat_post_init(priv);
++		if (mux_owner)
++			module_put(mux_owner);
++		return err;
++	}
+ 
 -	return mlxplat_post_init(priv);
 +	/*
 +	 * Block until every mux completion_notify has run, including
@@ -205,29 +268,35 @@ index d5efcbb7..a23cfb5c 100644
 +	 */
 +	if (!wait_for_completion_timeout(&priv->mux_platdevs_done,
 +					 msecs_to_jiffies(120000))) {
-+		spin_lock_irqsave(&priv->mux_notify_lock, flags);
-+		if (priv->mux_post_init_claimed) {
-+			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+			wait_for_completion(&priv->mux_platdevs_done);
-+			err = READ_ONCE(priv->mux_platdevs_err);
-+			if (err)
++		if (!completion_done(&priv->mux_platdevs_done)) {
++			spin_lock_irqsave(&priv->mux_notify_lock, flags);
++			if (priv->mux_post_init_claimed) {
++				spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++				wait_for_completion(&priv->mux_platdevs_done);
++				err = READ_ONCE(priv->mux_platdevs_err);
++				if (err)
++					goto fail_platform_mux_register;
++			} else {
++				if (!READ_ONCE(priv->mux_platdevs_err))
++					WRITE_ONCE(priv->mux_platdevs_err, -ETIMEDOUT);
++				spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++				dev_err(&priv->pdev_i2c->dev,
++					"timeout waiting for I2C mux probe\n");
++				err = -ETIMEDOUT;
 +				goto fail_platform_mux_register;
-+		} else {
-+			if (!READ_ONCE(priv->mux_platdevs_err))
-+				WRITE_ONCE(priv->mux_platdevs_err, -ETIMEDOUT);
-+			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+			dev_err(&priv->pdev_i2c->dev,
-+				"timeout waiting for I2C mux probe\n");
-+			err = -ETIMEDOUT;
-+			goto fail_platform_mux_register;
++			}
 +		}
 +	}
 +	err = READ_ONCE(priv->mux_platdevs_err);
 +	if (err)
 +		goto fail_platform_mux_register;
++	if (mux_owner)
++		module_put(mux_owner);
 +	return 0;
  
  fail_platform_mux_register:
++	if (mux_owner)
++		module_put(mux_owner);
 +	spin_lock_irqsave(&priv->mux_notify_lock, flags);
 +	priv->mux_abandon = true;
 +	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
@@ -239,7 +308,12 @@ index d5efcbb7..a23cfb5c 100644
  	return err;
  }
  
-@@ -9234,6 +9350,8 @@ static int mlxplat_probe(struct platform_device *pdev)
++
++
+ static void mlxplat_i2c_mux_topology_exit(struct mlxplat_priv *priv)
+ {
+ 	int i;
+@@ -9234,6 +9407,8 @@
  	priv->hotplug_resources = hotplug_resources;
  	priv->hotplug_resources_size = hotplug_resources_size;
  	priv->irq_fpga = irq_fpga;

--- a/recipes-kernel/linux/linux-6.1/0118-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
+++ b/recipes-kernel/linux/linux-6.1/0118-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
@@ -15,16 +15,18 @@ Keep the fixup on the mux_hotplug_num-th segment only so resolved bus
 numbers are not re-matched on a later segment. Set mux_hotplug_num to
 segment 1 for legacy MSN2700 and COMEX platforms.
 
+Generated against linux-6.1.123 mlx-platform.c after 0116 in series.
+
 Bug: #4151613
 Bug: #5079211
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 56 +++++++++++++++++++++++---
- 1 file changed, 50 insertions(+), 6 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 45 +++++++++++++++++++++---
+ 1 file changed, 37 insertions(+), 8 deletions(-)
 
 diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 0c3bb01a..b2c3d4e5 100644
+index 00000000..00000000 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -332,6 +332,7 @@
@@ -51,7 +53,7 @@ index 0c3bb01a..b2c3d4e5 100644
  	mlxplat_mux_num = ARRAY_SIZE(mlxplat_extended_mux_data);
  	mlxplat_mux_data = mlxplat_extended_mux_data;
  	for (i = 0; i < mlxplat_mux_num; i++) {
-@@ -9120,16 +9123,42 @@
+@@ -9119,17 +9122,43 @@
  	 * while the post-init gate uses mux_added only after incrementing for this callback.
  	 * That asymmetry is intentional: fixup must observe the adapter map from the probe that
  	 * completes the hotplug_num-th mux segment, and post-init must run only after mux_num
@@ -59,6 +61,7 @@ index 0c3bb01a..b2c3d4e5 100644
 +	 * probes have completed. Map hpdev.nr relative to that segment's base_nr, not a hardcoded
 +	 * offset (PSU/FAN placeholders on segment 1 use bus nrs 10..14 on COMEX/MSN2700).
  	 */
+ 	spin_lock_irqsave(&priv->mux_notify_lock, flags);
  	if (priv->mux_added == mlxplat_mux_hotplug_num && mlxplat_hotplug) {
 -		item = mlxplat_hotplug->items;
 -		for (i = 0; i < mlxplat_hotplug->counter; i++, item++) {
@@ -102,3 +105,6 @@ index 0c3bb01a..b2c3d4e5 100644
  			}
  		}
  	}
+
+-- 
+2.34.1

--- a/recipes-kernel/linux/linux-6.12/0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch
+++ b/recipes-kernel/linux/linux-6.12/0067-platform-mellanox-Downstream-Defer-post-init-until-I.patch
@@ -8,6 +8,15 @@ Defer mlxplat_platdevs_init() until i2c-mux-reg / i2c-mux-regmap completion_noti
 callbacks complete, with spinlock, completion, 120s timeout, NULL-adapter path,
 mux teardown vs late-notifier coordination, and unconditional regmap notify hooks.
 
+Pin the mux platform driver module with try_module_get() while registering mux
+platform devices so the driver cannot unload before probe completes. Return
+-EPROBE_DEFER when the driver is not registered yet (e.g. CONFIG_I2C_MUX_REG=m
+and modules-load runs after mlx-platform probe).
+
+Signal mux_platdevs_done before clearing mux_post_init_claimed, and re-check
+completion_done() after wait_for_completion_timeout() expires, so a successful
+platdevs_init that finishes at the deadline is not misread as -ETIMEDOUT.
+
 Honor mux_platdevs_err after timeout when platdevs_init is already running; skip
 !adapters handling when mux_abandon is set. Document why probe blocks up to 120s
 on mux_platdevs_done; log timeout only when muxes fail to complete, not when
@@ -17,11 +26,9 @@ Generated against linux-6.12.65 mlx-platform.c (parent of this patch in series).
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 142 ++++++++++++++++++++++++++++---
- 1 file changed, 130 insertions(+), 12 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 171 +++++++++++++++++++++++++---
+ 1 file changed, 160 insertions(+), 11 deletions(-)
 
-diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 5542ef9a..0c3bb01a 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
 @@ -19,6 +19,9 @@
@@ -34,7 +41,7 @@ index 5542ef9a..0c3bb01a 100644
  
  #define MLX_PLAT_DEVICE_NAME		"mlxplat"
  
-@@ -426,8 +429,14 @@
+@@ -449,8 +452,14 @@
   * @regmap: device register map
   * @hotplug_resources: system hotplug resources
   * @hotplug_resources_size: size of system hotplug resources
@@ -51,7 +58,7 @@ index 5542ef9a..0c3bb01a 100644
   * @irq_fpga: FPGA IRQ number
   */
  struct mlxplat_priv {
-@@ -444,6 +453,11 @@ struct mlxplat_priv {
+@@ -467,6 +476,11 @@
  	unsigned int hotplug_resources_size;
  	u8 i2c_main_init_status;
  	int mux_added;
@@ -63,7 +70,7 @@ index 5542ef9a..0c3bb01a 100644
  	int irq_fpga;
  };
  
-@@ -9052,14 +9066,47 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+@@ -10489,14 +10503,47 @@
  {
  	struct mlxplat_priv *priv = handle;
  	struct mlxreg_core_item *item;
@@ -73,7 +80,7 @@ index 5542ef9a..0c3bb01a 100644
 +	int ret = 0;
  	int i, j;
  
-+	/*
+ 	/*
 +	 * i2c-mux-reg / i2c-mux-regmap may call this with @adapters NULL when this
 +	 * mux probe failed after mlx-platform began waiting (so mux_added still
 +	 * reaches mlxplat_mux_num).
@@ -96,7 +103,7 @@ index 5542ef9a..0c3bb01a 100644
 +	}
 +
 +	spin_lock_irqsave(&priv->mux_notify_lock, flags);
- 	/*
++	/*
  	 * Hotplug platform driver data structure contains static mux channels for I2C hotplug
  	 * devices. These channels numbers can be updated dynamically and returned by mux callback
  	 * through the adapters array. Update mux channels according to the dynamic adapters data.
@@ -112,7 +119,7 @@ index 5542ef9a..0c3bb01a 100644
  		item = mlxplat_hotplug->items;
  		for (i = 0; i < mlxplat_hotplug->count; i++, item++) {
  			struct mlxreg_core_data *data = item->data;
-@@ -9072,15 +9119,34 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+@@ -10509,15 +10556,49 @@
  	}
  
  
@@ -129,29 +136,43 @@ index 5542ef9a..0c3bb01a 100644
 +		}
 +	}
 +	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+
+ 
 +	if (run_platdevs_init) {
 +		ret = mlxplat_platdevs_init(priv);
 +		WRITE_ONCE(priv->mux_platdevs_err, ret);
++		complete(&priv->mux_platdevs_done);
 +		spin_lock_irqsave(&priv->mux_notify_lock, flags);
 +		priv->mux_post_init_claimed = false;
 +		spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+		complete(&priv->mux_platdevs_done);
 +	} else if (need_complete) {
 +		complete(&priv->mux_platdevs_done);
 +	}
- 
--	return 0;
++
 +	return ret;
++}
++
++static int mlxplat_mux_driver_pin(const char *drv_name, struct module **owner)
++{
++	struct device_driver *drv;
++
++	drv = driver_find(drv_name, &platform_bus_type);
++	if (!drv)
++		return -EPROBE_DEFER;
++	if (!try_module_get(drv->owner))
++		return -EPROBE_DEFER;
++
++	*owner = drv->owner;
+ 	return 0;
  }
  
  static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
  {
 +	unsigned long flags;
++	struct module *mux_owner = NULL;
  	int i, err;
  
  	if (!priv->pdev_i2c) {
-@@ -9089,8 +9155,27 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+@@ -10526,8 +10607,37 @@
  	}
  
  	priv->i2c_main_init_status = MLXPLAT_I2C_MAIN_BUS_HANDLE_CREATED;
@@ -168,6 +189,16 @@ index 5542ef9a..0c3bb01a 100644
 +	if (!mlxplat_mux_num)
 +		return mlxplat_platdevs_init(priv);
 +
++	if (mlxplat_mux_data) {
++		err = mlxplat_mux_driver_pin("i2c-mux-reg", &mux_owner);
++		if (err)
++			return err;
++	} else {
++		err = mlxplat_mux_driver_pin("i2c-mux-regmap", &mux_owner);
++		if (err)
++			return err;
++	}
++
 +	reinit_completion(&priv->mux_platdevs_done);
 +	WRITE_ONCE(priv->mux_platdevs_err, 0);
 +
@@ -179,7 +210,7 @@ index 5542ef9a..0c3bb01a 100644
  			priv->pdev_mux[i] =
  				platform_device_register_resndata(&priv->pdev_i2c->dev,
  								  "i2c-mux-reg", i, NULL, 0,
-@@ -9100,7 +9185,7 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+@@ -10537,7 +10647,7 @@
  			mlxplat_mux_regmap_data[i].handle = priv;
  			mlxplat_mux_regmap_data[i].regmap = priv->regmap;
  			mlxplat_mux_regmap_data[i].completion_notify =
@@ -188,7 +219,7 @@ index 5542ef9a..0c3bb01a 100644
  			priv->pdev_mux[i] =
  			platform_device_register_resndata(&priv->pdev_i2c->dev,
  							  "i2c-mux-regmap", i, NULL, 0,
-@@ -9113,14 +9198,45 @@ static int mlxplat_i2c_mux_topology_init(struct mlxplat_priv *priv)
+@@ -10550,14 +10660,51 @@
  		}
  	}
  
@@ -204,29 +235,35 @@ index 5542ef9a..0c3bb01a 100644
 +	 */
 +	if (!wait_for_completion_timeout(&priv->mux_platdevs_done,
 +					 msecs_to_jiffies(120000))) {
-+		spin_lock_irqsave(&priv->mux_notify_lock, flags);
-+		if (priv->mux_post_init_claimed) {
-+			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+			wait_for_completion(&priv->mux_platdevs_done);
-+			err = READ_ONCE(priv->mux_platdevs_err);
-+			if (err)
++		if (!completion_done(&priv->mux_platdevs_done)) {
++			spin_lock_irqsave(&priv->mux_notify_lock, flags);
++			if (priv->mux_post_init_claimed) {
++				spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++				wait_for_completion(&priv->mux_platdevs_done);
++				err = READ_ONCE(priv->mux_platdevs_err);
++				if (err)
++					goto fail_platform_mux_register;
++			} else {
++				if (!READ_ONCE(priv->mux_platdevs_err))
++					WRITE_ONCE(priv->mux_platdevs_err, -ETIMEDOUT);
++				spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
++				dev_err(&priv->pdev_i2c->dev,
++					"timeout waiting for I2C mux probe\n");
++				err = -ETIMEDOUT;
 +				goto fail_platform_mux_register;
-+		} else {
-+			if (!READ_ONCE(priv->mux_platdevs_err))
-+				WRITE_ONCE(priv->mux_platdevs_err, -ETIMEDOUT);
-+			spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
-+			dev_err(&priv->pdev_i2c->dev,
-+				"timeout waiting for I2C mux probe\n");
-+			err = -ETIMEDOUT;
-+			goto fail_platform_mux_register;
++			}
 +		}
 +	}
 +	err = READ_ONCE(priv->mux_platdevs_err);
 +	if (err)
 +		goto fail_platform_mux_register;
++	if (mux_owner)
++		module_put(mux_owner);
 +	return 0;
  
  fail_platform_mux_register:
++	if (mux_owner)
++		module_put(mux_owner);
 +	spin_lock_irqsave(&priv->mux_notify_lock, flags);
 +	priv->mux_abandon = true;
 +	spin_unlock_irqrestore(&priv->mux_notify_lock, flags);
@@ -238,7 +275,7 @@ index 5542ef9a..0c3bb01a 100644
  	return err;
  }
  
-@@ -9221,6 +9337,8 @@ static int mlxplat_probe(struct platform_device *pdev)
+@@ -10658,6 +10805,8 @@
  	priv->hotplug_resources = hotplug_resources;
  	priv->hotplug_resources_size = hotplug_resources_size;
  	priv->irq_fpga = irq_fpga;

--- a/recipes-kernel/linux/linux-6.12/0068-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
+++ b/recipes-kernel/linux/linux-6.12/0068-platform-mellanox-Fix-hotplug-bus-nr-fixup-on-multi.patch
@@ -15,19 +15,19 @@ Keep the fixup on the mux_hotplug_num-th segment only so resolved bus
 numbers are not re-matched on a later segment. Set mux_hotplug_num to
 segment 1 for legacy MSN2700 and COMEX platforms.
 
+Generated against linux-6.12.65 mlx-platform.c after 0067 in series.
+
 Bug: #4151613
 Bug: #5079211
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/platform/mellanox/mlx-platform.c | 56 +++++++++++++++++++++++---
- 1 file changed, 50 insertions(+), 6 deletions(-)
+ drivers/platform/mellanox/mlx-platform.c | 45 +++++++++++++++++++++---
+ 1 file changed, 37 insertions(+), 8 deletions(-)
 
-diff --git a/drivers/platform/mellanox/mlx-platform.c b/drivers/platform/mellanox/mlx-platform.c
-index 0c3bb01a..b2c3d4e5 100644
 --- a/drivers/platform/mellanox/mlx-platform.c
 +++ b/drivers/platform/mellanox/mlx-platform.c
-@@ -335,6 +335,7 @@
+@@ -352,6 +352,7 @@
  #define MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM	16
  #define MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM	24
  #define MLXPLAT_CPLD_DEFAULT_MUX_HOTPLUG_VECTOR	0
@@ -35,7 +35,7 @@ index 0c3bb01a..b2c3d4e5 100644
  
  /* Number of channels in group */
  #define MLXPLAT_CPLD_GRP_CHNL_NUM		8
-@@ -8010,6 +8011,7 @@ static int __init mlxplat_dmi_default_matched(const struct dmi_system_id *dmi)
+@@ -9322,6 +9323,7 @@
  	int i;
  
  	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_ADAPTER_NUM;
@@ -43,7 +43,7 @@ index 0c3bb01a..b2c3d4e5 100644
  	mlxplat_mux_num = ARRAY_SIZE(mlxplat_default_mux_data);
  	mlxplat_mux_data = mlxplat_default_mux_data;
  	for (i = 0; i < mlxplat_mux_num; i++) {
-@@ -8176,6 +8178,7 @@ static int __init mlxplat_dmi_comex_matched(const struct dmi_system_id *dmi)
+@@ -9488,6 +9490,7 @@
  	int i;
  
  	mlxplat_max_adap_num = MLXPLAT_CPLD_MAX_PHYS_EXT_ADAPTER_NUM;
@@ -51,7 +51,7 @@ index 0c3bb01a..b2c3d4e5 100644
  	mlxplat_mux_num = ARRAY_SIZE(mlxplat_extended_mux_data);
  	mlxplat_mux_data = mlxplat_extended_mux_data;
  	for (i = 0; i < mlxplat_mux_num; i++) {
-@@ -9104,16 +9107,42 @@ mlxplat_i2c_mux_complition_notify(void *handle, struct i2c_adapter *parent,
+@@ -10541,16 +10544,42 @@
  	 * while the platdevs-init gate uses mux_added only after incrementing for this callback.
  	 * That asymmetry is intentional: fixup must observe the adapter map from the probe that
  	 * completes the hotplug_num-th mux segment, and platdevs init must run only after mux_num
@@ -102,3 +102,6 @@ index 0c3bb01a..b2c3d4e5 100644
  			}
  		}
  	}
+
+-- 
+2.34.1


### PR DESCRIPTION
Problem description:
Mux probing is failed on wait_for_completion_timeout() with kernel config: CONFIG_I2C_MUX_REG=m:
mlx-platform runs early. mlxplat_i2c_mux_topology_init() registers i2c-mux-reg platform devices.
Then it is blocked until every mux completion_notify has run (including mlxplat_post_init()).
i2c-mux-reg is not loaded yet -> no driver -> mux pdevs never probe -> mux_added never reaches mlxplat_mux_num -> timeout.

With CONFIG_I2C_MUX_REG=y, the driver is already registered when pdevs are created, probes run immediately, completion fires in seconds, so no issue in this case.

So, this is a module load order / boot timing problem,

Solution:
Return -EPROBE_DEFER when mux platform data is configured but the matching i2c-mux-reg or i2c-mux-regmap platform driver is not registered yet (e.g. CONFIG_I2C_MUX_REG=m and modules-load runs after mlx-platform probe).