### PR TITLE
hw-mgmt: script: Fix cpu_type init order on hw-mgmt start

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -218,6 +218,7 @@ show_hw_info()
 check_cpu_type()
 {
 	if [ ! -f $config_path/cpu_type ]; then
+		mkdir -p $config_path
 		# ARM CPU provide "CPU part" field, x86 does not. Check for ARM first.
 		cpu_pn=$(grep -m1 "CPU part" /proc/cpuinfo | awk '{print $4}')
 		cpu_pn=`echo $cpu_pn | cut -c 3- | tr a-z A-Z`


### PR DESCRIPTION
On early call cpu_type reading (before hw-mgmt tree init) it
can cause log error:

/usr/bin/hw-management-helpers.sh: line 234:
/var/run/hw-management/config/cpu_type: No such file or directory

For example run iorw before hw-mgmt start

Fix: add explicit folder create on cpu_type call.

Bug: 5100761

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
