### PR TITLE
hw-mgmt: udev rules: set TPM power state to always-on in the sysfs ph…

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -768,3 +768,4 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/i2c-*
 
 # TPM - disable TPM runtime power management
 SUBSYSTEM=="tpm", KERNEL=="tpm0", ATTR{power/control}="on"
+SUBSYSTEM=="tpm", KERNEL=="tpm0", ACTION=="add", RUN+="/bin/sh -c 'echo on > /sys%p/device/power/control'"


### PR DESCRIPTION
…ysical device.

Set TPM power state to always-on in the sysfs physical device, in addition to the already updated power state of the tpm0 class device.

Addition to commit f7c685cd2b83.

Bug #4542714