### PR TITLE
hw-mgmt: thermal: Add module configuration for Tmax limitation

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn5600.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn5600.json
@@ -1,6 +1,6 @@
  {
 	"name": "msn5600",
-	"tc_version": "2.0",
+	"tc_version": "2.5",
 	"dmin" : {
 		"C2P": {
 			"fan_err": {
@@ -40,7 +40,9 @@
 	"dev_parameters" : {
 		"asic\\d*":           {"pwm_min": 30, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":100}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3, "sensor_read_error":100},
-		"module\\d+":     {"pwm_min": 30, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
+		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "val_max_clamp": 65000, "poll_time": 20,
+						   "reg_extra_param": {"increase_step" : 5, "decrease_step": 0.1, "Iterm_down_trh": -10,
+                                         	   "val_up_trh" : 1, "val_down_trh": 3, "range": 3}},
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 30, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 30, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60},

--- a/usr/etc/hw-management-thermal/tc_config_sn5610.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5610.json
@@ -37,7 +37,7 @@
 	"dev_parameters" : {
 		"asic\\d*":        {"pwm_min": 30, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":100}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3, "sensor_read_error":100},
-		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "poll_time": 20,
+		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "val_max_clamp": 65000, "poll_time": 20,
 						   "reg_extra_param": {"increase_step" : 5, "decrease_step": 0.1, "Iterm_down_trh": -10,
                                          	   "val_up_trh" : 1, "val_down_trh": 3, "range": 3}},
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},

--- a/usr/etc/hw-management-thermal/tc_config_sn5640.json
+++ b/usr/etc/hw-management-thermal/tc_config_sn5640.json
@@ -37,7 +37,7 @@
 	"dev_parameters" : {
 		"asic\\d*":        {"pwm_min": 30, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":100}, 
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 30, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!100000", "poll_time": 3, "sensor_read_error":100},
-		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "poll_time": 20,
+		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "val_max_clamp": 65000, "poll_time": 20,
 						   "reg_extra_param": {"increase_step" : 5, "decrease_step": 0.1, "Iterm_down_trh": -10,
                                          	   "val_up_trh" : 1, "val_down_trh": 3, "range": 3}},
 		"sensor_amb":     {"pwm_min": 30, "pwm_max" : 50, "val_min": 30000, "val_max": 55000, "poll_time": 30},

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -157,7 +157,7 @@ class CONST:
     SENSOR_POLL_TIME_DEF = 30
     TEMP_INIT_VAL_DEF = 25.0
     TEMP_SENSOR_SCALE = 1000.0
-    TEMP_MIN_MAX = {"val_min": 35000, "val_max": 70000, "val_crit": 80000, "val_lcrit": None, "val_hcrit": None}
+    TEMP_MIN_MAX = {"val_min": 35000, "val_max": 70000, "val_crit": 80000, "val_lcrit": None, "val_hcrit": None, "val_max_clamp": 1000000}
     RPM_MIN_MAX = {"val_min": 5000, "val_max": 30000}
     MODULE_MAX_COOLING_LVL = 960
     TEMP_NA_VAL = 255
@@ -1891,6 +1891,11 @@ class thermal_module_sensor(system_device):
         # taking default values for val_min_offset and val_max_offset
         self.val_min_offset = self.sensors_config.get("val_min_offset", 0)
         self.val_max_offset = self.sensors_config.get("val_max_offset", 0)
+
+        # Tmax_crit should be used if module reported Tmax > Tmax_crit
+        # So Tmax should be never bigger than Tmax_crit. (Optional parameter)
+        self.val_max_clamp = self.read_val_min_max(None, "val_max_clamp", self.scale)
+
         self._validate_config()
 
         self.eeprom_data_timestamp = None
@@ -2038,6 +2043,7 @@ class thermal_module_sensor(system_device):
         val_max = self.read_val_min_max("thermal/{}_temp_crit".format(self.base_file_name), "val_max", scale=self.scale)
         if val_max != 0 and self.scale != 0:
             self.val_max = val_max + self.val_max_offset / self.scale
+            self.val_max = min(self.val_max, self.val_max_clamp)
             self.val_min = self.val_max + self.val_min_offset / self.scale
         else:
             self.val_max = 0.0


### PR DESCRIPTION
Add platform configs to cap module-reported Tmax so fan
control does not follow critical thresholds above the board thermal
limit.

New config in tc_config.json:

"val_max_clamp": 65000

Tmax will never exceed this value, even if module reporting bigger value.

FR: 4964651

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
