### PR TITLE
hw-management: sn6600 (HI186): use normal init in SimX, drop mock tgz

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -4291,8 +4291,8 @@ case $ACTION in
 			log_err "hw-management is already started"
 			exit 1
 		fi
-		# TEMPORARY hw-management mockup values for HI180/HI181/HI185/HI186/HI193/HI194 in simx
-		if check_simx && [ "$sku" == "HI180" -o "$sku" == "HI181" -o "$sku" == "HI185" -o "$sku" == "HI186" -o "$sku" == "HI193" -o "$sku" == "HI194" ]; then
+		# TEMPORARY hw-management mockup values for HI180/HI181/HI185/HI193/HI194 in simx
+		if check_simx && [ "$sku" == "HI180" -o "$sku" == "HI181" -o "$sku" == "HI185" -o "$sku" == "HI193" -o "$sku" == "HI194" ]; then
 			tar -xzf /etc/hw-management-virtual/hwmgmt_$sku.tgz -C /var/run/
 			process_simx_links
 			log_info "Created mock hw management tree, exiting."
@@ -4392,7 +4392,7 @@ case $ACTION in
 		do_stop
 		sleep 3
 		# TEMPORARY hw-management mockup values for SIMX
-		if check_simx && [ "$sku" == "HI180" -o "$sku" == "HI181" -o "$sku" == "HI185" -o "$sku" == "HI186" -o "$sku" == "HI193" ]; then
+		if check_simx && [ "$sku" == "HI180" -o "$sku" == "HI181" -o "$sku" == "HI185" -o "$sku" == "HI193" ]; then
 			tar -xzf /etc/hw-management-virtual/hwmgmt_$sku.tgz -C /var/run/
 			log_info "Created mock hw management tree, exiting."
 			exit 0


### PR DESCRIPTION
## What
On SimX, HI186 took the TEMPORARY mock-tgz shortcut in the `start` and `restart` actions, which extracts `/etc/hw-management-virtual/hwmgmt_HI186.tgz`. That tarball does not exist, so hw-management exited (`exit 0`) without building `/var/run/hw-management` — leaving no sensors / fan / PSU data on the emulated platform.

## Change
Removed `HI186` from the two mock conditions only (hw-management.sh line 4202 in `start`, line 4302 in `restart`) so it falls through to the normal `do_start` -> `sn66xx_specific` path.

## Why it is safe
- HI186 stays listed in `check_if_simx_supported_platform` (hw-management-helpers.sh) and in the `sn66xx_specific` / asic-pci config — unchanged.
- The mock block is gated by `check_simx`, so this has **no effect on real hardware**.
- Validated on sn6600_v3000 SimX: all 4 dps460 PSUs bound with real telemetry, 10 fan tachos reporting, thermal control daemon running.