### PR TITLE
hw-mgmt: scripts: Use shared helper for kernel module checks

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -569,6 +569,16 @@ unlock_service_state_change_update_and_match()
 	/usr/bin/flock -u ${LOCKFD}
 }
 
+# Check if module is loaded
+# $1 - module name
+# return 0 if module is loaded, 1 otherwise
+is_module()
+{
+	/sbin/lsmod 2>/dev/null | grep -w "$1" > /dev/null
+	RC=$?
+	return $RC
+}
+
 # Connect device driver helper function. Returns 0 if device driver is connected, 1 otherwise.
 # Poll every 100 ms for device driver connection.
 # Input: 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -676,13 +676,6 @@ if [ "$board_type" == "VMOD0014" ]; then
 	psu2_i2c_addr=0x58
 fi
 
-is_module()
-{
-    /sbin/lsmod | grep -w "$1" > /dev/null
-    RC=$?
-    return $RC
-}
-
 function get_i2c_bus_frequency_default()
 {
 	# Get I2C base frequency default value.
@@ -3176,7 +3169,7 @@ load_modules()
 	# Some modules are not present in all the kernel
 	# versions. Use this function to load those modules
 	# which need to be loaded based on their availability
-	if ! lsmod | grep -q "drivetemp"; then
+	if ! is_module "drivetemp"; then
 		if [ -f /lib/modules/`uname -r`/kernel/drivers/hwmon/drivetemp.ko ]; then
 			modprobe drivetemp
 		fi
@@ -3673,7 +3666,7 @@ set_sodimms()
 		return 0
 	fi
 
-	if ! lsmod | grep -q i2c_designware_platform; then
+	if ! is_module "i2c_designware_platform"; then
 		modprobe i2c_designware_platform
 		sleep 0.5
 	fi


### PR DESCRIPTION
hw-management.sh had a local is_module() implementation and
still used ad-hoc lsmod/grep checks in some paths. This duplicated
module
detection logic and could produce inconsistent matching or noisy lsmod
output.
1. Move is_module() to hw-management-helpers.sh
2. Use it for drivetemp and i2c_designware_platform checks.
3. Suppress harmless log noise like
   lsmod: ERROR: could not open '/sys/module/sunrpc/holders': No such
file or directory

Issue: 5112578

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
