### PR TITLE
feat(dts): spc6-bmc bump eMMC to HS200 8-bit/200MHz (OpenBMC)

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch
+++ b/recipes-kernel/linux/linux-6.12/0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch
@@ -69,8 +69,8 @@ kconfig changes live in their own layers and are out of scope.
 
 Signed-off-by: Dvir Zaguri <dzaguri@nvidia.com>
 ---
- .../boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts     | 69 +++++++++++++++++++---
- 1 file changed, 69 insertions(+), 2 deletions(-)
+ .../boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts     | 70 +++++++++++++++++++---
+ 1 file changed, 70 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
 --- a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
@@ -167,7 +167,7 @@ diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/
  	};
  };
  
-@@ -363,8 +427,10 @@
+@@ -363,8 +427,11 @@
  &emmc {
  	status = "okay";
  	non-removable;
@@ -175,6 +175,7 @@ diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/
 -	max-frequency = <52000000>;
 +	bus-width = <8>;
 +	max-frequency = <200000000>;
++	pinctrl-names = "default";
 +	pinctrl-0 = <&pinctrl_emmcg8_default>;
 +	mmc-pwrseq = <&mmc_pwrseq>;
  };

--- a/recipes-kernel/linux/linux-6.12/0009-arm64-dts-aspeed-split-SPC6-BMC-DTS-for-SONiC-and-Op.patch
+++ b/recipes-kernel/linux/linux-6.12/0009-arm64-dts-aspeed-split-SPC6-BMC-DTS-for-SONiC-and-Op.patch
@@ -26,11 +26,11 @@ with the existing ramrofs node and irot.dtsi.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- .../aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts | 527 ++++++++++++++++++
+ .../aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts | 536 ++++++++++++++++++
  .../dts/aspeed/aspeed-nvidia-spc6-bmc.dts     |   2 +-
  .../dts/aspeed/nvidia-ast27xx-irot-sonic.dtsi |  14 +
  .../aspeed/nvidia-ast27xx-sunda-sonic.dtsi    |   8 +
- 4 files changed, 549 insertions(+), 1 deletion(-)
+ 4 files changed, 558 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
  create mode 100644 arch/arm64/boot/dts/aspeed/nvidia-ast27xx-irot-sonic.dtsi
  create mode 100644 arch/arm64/boot/dts/aspeed/nvidia-ast27xx-sunda-sonic.dtsi
@@ -40,7 +40,7 @@ new file mode 100644
 index 000000000..e825c106d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
-@@ -0,0 +1,527 @@
+@@ -0,0 +1,536 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/dts-v1/;
 +
@@ -86,6 +86,12 @@ index 000000000..e825c106d
 +			reg = <0x00000004 0x237ff000 0x0 0x00001000>;
 +			no-map;
 +		};
++	};
++
++	/* eMMC hardware reset (RST_n) driven by EMMC_1V8_RST* on GPIOQ7 (ball N15). */
++	mmc_pwrseq: mmc-pwrseq {
++		compatible = "mmc-pwrseq-emmc";
++		reset-gpios = <&gpio1 ASPEED_GPIO(Q, 7) GPIO_ACTIVE_LOW>;
 +	};
 +};
 +
@@ -464,8 +470,11 @@ index 000000000..e825c106d
 +&emmc {
 +	status = "okay";
 +	non-removable;
-+	bus-width = <4>;
-+	max-frequency = <52000000>;
++	bus-width = <8>;
++	max-frequency = <200000000>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&pinctrl_emmcg8_default>;
++	mmc-pwrseq = <&mmc_pwrseq>;
 +};
 +
 +/* eSPI Controller - Communication with host CPU */


### PR DESCRIPTION
Port OpenBMC commit 4148acb3 ("L1 Switch: increase emmc frequency to 200Mhz") into the SPC6 AST2700 OpenBMC BMC DTS patch. Set &emmc bus-width=8, max-frequency=200000000, add pinctrl_emmcg8_default, and add an mmc-pwrseq-emmc node resetting the device via GPIOQ7.

Folded into patch 0009 (OpenBMC dts) since it already carries the other OpenBMC DTS commits for this file.