### PR TITLE
hw-mgmt: bmc: sync ethaddr from BMC FRU fallback

### DIFF
--- a/bmc/DEVELOPER_GUIDE.md
+++ b/bmc/DEVELOPER_GUIDE.md
@@ -69,7 +69,7 @@ For **`HINNN`**, add parallel **`dh_installdirs`** and **`cp -a bmc/usr/etc/HINN
 - [ ] **`debian/rules`** installs **`/etc/HINNN/`** on the image.
 - [ ] Device-tree exposes **`nvsw*hidNNN*`** so plat-specific-preps resolves **`sku`**.
 - [ ] Kernel patches / DTS applied; **`mlxreg-io`** / **`mlxreg-hotplug`** nodes match rules and **`hw-management-bmc-gpio-pins.json`**.
-- [ ] Boot: **`journalctl -b -u hw-management-bmc-plat-specific-preps`**, **`-u hw-management-bmc-init`**, **`udevadm verify`** / rules under **`/lib/udev/rules.d/`**.
+- [ ] Boot: **`journalctl -b -u hw-management-bmc-plat-specific-preps`**, **`-u hw-management-bmc-sync-ethaddr`**, **`-u hw-management-bmc-init`**, **`udevadm verify`** / rules under **`/lib/udev/rules.d/`**.
 
 ## 5. Further reading
 

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -47,7 +47,7 @@ SONiC BMC first-boot installs **`hw-management-bmc`** from **`rc.local`** while 
 | Script | Role |
 |--------|------|
 | **`debian/hw-management-bmc.postinst`** | After **`#DEBHELPER#`**: **`systemctl daemon-reload`** on configure (fresh + upgrade); on **fresh install** only, **`systemctl start --no-block`** for **`boot-complete`**, **`health-monitor`**, **`i2c-slave-setup`**, **`recovery-handler`**, **`reset-cause-logger`**. **Upgrade** does not start/restart (operator **`systemctl restart hw-management-bmc-init.service`** or reboot). **`DPKG_ROOT`** guard skips systemd when configuring a staging rootfs. **`abort-*`** cases are explicit no-ops. |
-| **`debian/hw-management-bmc.prerm`** | On **`remove`**: one **`systemctl stop`** for all nine BMC units (parallel). On **upgrade** / **deconfigure** / **failed-upgrade**: no-op. Needed because **`--no-start --no-restart-after-upgrade`** suppresses debhelper’s **`prerm`** stop snippets. |
+| **`debian/hw-management-bmc.prerm`** | On **`remove`**: one **`systemctl stop`** for all BMC units (parallel). On **upgrade** / **deconfigure** / **failed-upgrade**: no-op. Needed because **`--no-start --no-restart-after-upgrade`** suppresses debhelper’s **`prerm`** stop snippets. |
 
 **Operator note:** **`apt install hw-management-bmc=NEW`** on a running BMC installs files and re-enables units but does **not** auto-restart the init chain.
 
@@ -161,7 +161,8 @@ bmc/
     │       ├── hw-management-bmc-i2c-slave-setup.service
     │       ├── hw-management-bmc-plat-specific-preps.service
     │       ├── hw-management-bmc-recovery-handler.service
-    │       └── hw-management-bmc-reset-cause-logger.service
+    │       ├── hw-management-bmc-reset-cause-logger.service
+    │       └── hw-management-bmc-sync-ethaddr.service
     └── usr/bin/
         ├── hw-management-bmc-a2d-leakage-config.sh
         ├── hw-management-bmc-a2d-leakage-read.sh
@@ -192,6 +193,7 @@ bmc/
         ├── hw-management-bmc-powerctrl.sh
         ├── hw-management-bmc-ready.sh
         ├── hw-management-bmc-ready-common.sh
+        ├── hw-management-bmc-sync-ethaddr.sh
         ├── hw-management-bmc-recovery-handler.sh
         ├── hw-management-bmc-get-reset-cause.sh
         ├── hw-management-bmc-show-reset-cause.sh
@@ -326,6 +328,7 @@ SONiC BMC images often ship **BusyBox** (`/bin/sh` → **ash**) and may also inc
 | **`hw-management-bmc-early-config.sh`**, **`hw-management-bmc-plat-specific-preps.sh`**, **`hw-management-bmc-early-i2c-init.sh`**, **`hw-management-bmc-recovery-handler.sh`**, and most other **`usr/usr/bin/*.sh`** helpers | Parse OK under ash | Shebang may still say **`#!/bin/bash`**; runtime is fine on ash-heavy systems if invoked via **`sh`** or **`ash`**. |
 | **`hw-management-bmc-devtree.sh`**, **`hw-management-bmc-devtree-check.sh`**, **`hw-management-bmc.sh`** | **bash** | Associative arrays / bash-only syntax; require **`bash`**. |
 | **`hw-management-bmc-powerctrl.sh`** | **bash** | **`#!/bin/bash`**, **`set -euo pipefail`**, **`logger`** for journal messages; requires **`bash`**. |
+| **`hw-management-bmc-sync-ethaddr.sh`** | **bash** | **`#!/bin/bash`**: validates U-Boot **`ethaddr`**, uses a validated BMC FRU MAC as fallback, updates env with **`fw_setenv`**, applies the selected MAC to running **`eth0`**, and renews DHCP best-effort. Uses **`[[ ]]`** regex matching. |
 | **`hw-management-bmc-boot-complete.sh`** | Yes | **`#!/bin/sh`**: waits on **`/var/run/hw-management/`** entry counts vs **`/etc/hw-management-bmc-boot-complete.conf`**. |
 | **`hw-management-bmc-cpld-dump.sh`** | **bash** | **`#!/bin/bash`**: **`[[`**, **`BASH_SOURCE`**, **`take_cpld_dump_internal`** (256× **`r1`**, array + grid print), sourced **`return`** guard; **`take_cpld_dump`** uses **`timeout bash -c '. …; take_cpld_dump_internal'`**. |
 | **`hw-management-bmc-generate-dump.sh`** | **bash** | **`#!/bin/bash`**: parallel **`run_collect_bg`** collectors, **`MAX_PARALLEL`**, **`-v`** for **`systemd-analyze`**, **`source`** **`hw-management-bmc-cpld-dump.sh`**, single-pass **`find`** + stride workers for **`/var/run/hw-management`**. **`tar cf - \| gzip -9`**; BusyBox-friendly **`find`** / **`readlink_canonical`**. Needs **`gzip`**, **`bash`**. |
@@ -343,7 +346,7 @@ Units are installed to **`/lib/systemd/system/`**. Below: **`ExecStart`** / **`E
 
 1. **Before / at sysinit:** reset-cause logger runs very early (`Before=sysinit.target`).
 2. **Sysinit chain (`WantedBy=sysinit.target`):** plat-specific deploy → early-config → early I2C init (strict order via **`After=`** / **`Before=`**).
-3. **Multi-user:** BMC init (ready script) → boot-complete (ready-common + sysfs entry-count gate), plus health monitor; optional I2C recovery stack if **`/etc/hw-management-bmc-recovery.conf`** exists.
+3. **Multi-user:** validate U-Boot **`ethaddr`** and use BMC FRU fallback if needed → BMC init (ready script) → boot-complete (ready-common + sysfs entry-count gate), plus health monitor; optional I2C recovery stack if **`/etc/hw-management-bmc-recovery.conf`** exists.
 
 ```mermaid
 flowchart TB
@@ -354,10 +357,11 @@ flowchart TB
     PS --> EC --> EI
   end
   subgraph multi["multi-user.target"]
+    SE[sync-ethaddr]
     INIT[bmc-init]
     BC[boot-complete]
     HM[health-monitor]
-    EI --> INIT --> BC
+    EI --> SE --> INIT --> BC
   end
   subgraph recovery["optional: hw-management-bmc-recovery.conf"]
     SS[i2c-slave-setup]
@@ -373,9 +377,10 @@ flowchart TB
 | **hw-management-bmc-reset-cause-logger** | oneshot | `/usr/bin/hw-management-bmc-reset-cause-logger.sh` | `WantedBy=sysinit.target` | **`After=local-fs.target`**, **`Before=sysinit.target`**. **`ConditionPathExists=`** the script. |
 | **hw-management-bmc-plat-specific-preps** | oneshot | `/usr/bin/hw-management-bmc-plat-specific-preps.sh` | `WantedBy=sysinit.target` | **`After=local-fs.target systemd-udevd.service`** (avoids sysinit ordering cycles with **`local-fs` / NVMe-FC helpers / udev**). **`Before=`** `hw-management-bmc-early-config`, **`systemd-networkd`**. Script runs **`udevadm control --reload-rules`** and targeted **`udevadm trigger`** after installing udev rules. Deploys **`/etc/<HID>/`** (fallback **`/usr/etc/<HID>/`** on older images): **symlinks** **`*.sh`** → **`/usr/bin/`**, **`*.rules`** → **`/lib/udev/rules.d/`**, **`hw-management-bmc.conf`** → **`/etc/modprobe.d/hw-management-bmc.conf`**; **copies** **`*.json`**, **`hw-management-bmc-platform.conf`**, eeprom/boot-complete conf into **`/etc/`** (see **Platform deploy**). Also copies or generates **`hw-management-bmc-network.conf`** / **`/etc/hw-management-bmc-usb0.conf`** and renders **`/etc/systemd/network/00-hw-management-bmc-usb0.network`** (see **USB0 / systemd-networkd** below). |
 | **hw-management-bmc-early-config** | oneshot | `/usr/bin/hw-management-bmc-early-config.sh` | `WantedBy=sysinit.target` | **`After=`** `local-fs` **and** `hw-management-bmc-plat-specific-preps`. **`Before=`** `systemd-modules-load`, **`hw-management-bmc-early-i2c-init`**. **Copies** A2D leakage JSON; optional files under **`/etc/hw-management-bmc/`**; early I2C JSON to **`/etc/`**; **symlinks** **`/etc/<HID>/*.sh`** → **`/usr/bin/`** (same targets as plat-specific-preps). Platform **`hw-management-bmc-platform.conf`** is deployed to **`/etc/`** by plat-specific-preps only. |
-| **hw-management-bmc-early-i2c-init** | oneshot | `/usr/bin/hw-management-bmc-early-i2c-init.sh` | `WantedBy=sysinit.target` | **`After=`** `hw-management-bmc-early-config`. **`Before=`** `nvidia_update_mac.service`. Creates early I2C devices from **`/etc/hw-management-bmc-early-i2c-devices.json`**. |
-| **hw-management-bmc-init** | oneshot | `/bin/bash /usr/bin/hw-management-bmc-ready.sh` | `WantedBy=multi-user.target` | **`After=`** `local-fs`, **`hw-management-bmc-early-i2c-init`**. **`Requires=`** early-i2c-init. **`Before=`** `hw-management-bmc-boot-complete`. **`ConditionPathExists=`** `/usr/bin/hw-management-bmc-ready.sh`. |
-| **hw-management-bmc-boot-complete** | simple | **`ExecStartPre=`** `/usr/bin/env hw-management-bmc-ready-common.sh`; **`ExecStart=`** `/usr/bin/env hw-management-bmc-boot-complete.sh` | `WantedBy=multi-user.target` | **`After=`** `hw-management-bmc-early-i2c-init`, **`hw-management-bmc-init`**. **`Requires=`** early-i2c-init. **`Wants=`** bmc-init (ordering without hard-failing if init is disabled). When **`hw-management-bmc-boot-complete.service`** exits successfully, SONiC BMC may treat hw-management runtime as ready for dependent services. |
+| **hw-management-bmc-early-i2c-init** | oneshot | `/usr/bin/hw-management-bmc-early-i2c-init.sh` | `WantedBy=sysinit.target` | **`After=`** `hw-management-bmc-early-config`. **`Before=`** `hw-management-bmc-sync-ethaddr`. Creates early I2C devices from **`/etc/hw-management-bmc-early-i2c-devices.json`**. |
+| **hw-management-bmc-sync-ethaddr** | oneshot | `/bin/bash /usr/bin/hw-management-bmc-sync-ethaddr.sh` | `WantedBy=multi-user.target` | **`After=`** and **`Requires=`** `hw-management-bmc-early-i2c-init`. **`Before=`** `hw-management-bmc-init`, **`hw-management-bmc-boot-complete`**. Validates U-Boot **`ethaddr`** as the primary BMC MAC; if empty/invalid/random-like, reads and validates BMC FRU MAC from **`eeprom_bmc`** (fallback **`4-0050/eeprom`**) and writes **`ethaddr`** with **`fw_setenv`**. Best-effort short wait/warning if valid **`ethaddr`** differs from FRU. Applies the selected MAC to running **`eth0`** and renews DHCP best-effort, so current boot is corrected without reboot. If **`fw_printenv`** or **`fw_setenv`** is missing, logs a warning and exits successfully. |
+| **hw-management-bmc-init** | oneshot | `/bin/bash /usr/bin/hw-management-bmc-ready.sh` | `WantedBy=multi-user.target` | **`After=`** `local-fs`, **`hw-management-bmc-early-i2c-init`**, **`hw-management-bmc-sync-ethaddr`**. **`Requires=`** early-i2c-init and sync-ethaddr. **`Before=`** `hw-management-bmc-boot-complete`. **`ConditionPathExists=`** `/usr/bin/hw-management-bmc-ready.sh`. |
+| **hw-management-bmc-boot-complete** | simple | **`ExecStartPre=`** `/usr/bin/env hw-management-bmc-ready-common.sh`; **`ExecStart=`** `/usr/bin/env hw-management-bmc-boot-complete.sh` | `WantedBy=multi-user.target` | **`After=`** `hw-management-bmc-early-i2c-init`, **`hw-management-bmc-init`**. **`Requires=`** early-i2c-init and bmc-init. When **`hw-management-bmc-boot-complete.service`** exits successfully, SONiC BMC may treat hw-management runtime as ready for dependent services. |
 | **hw-management-bmc-health-monitor** | simple | `/usr/bin/hw-management-bmc-health-monitor.sh` | `WantedBy=multi-user.target` | **`After=multi-user.target`**, **`Wants=syslog.target`**. **`Restart=always`**. |
 | **hw-management-bmc-i2c-slave-setup** | oneshot | `/usr/bin/hw-management-bmc-i2c-slave-setup.sh` | `WantedBy=multi-user.target` | **`After=multi-user.target`**. **`Before=`** `hw-management-bmc-recovery-handler`. **`ConditionPathExists=/etc/hw-management-bmc-recovery.conf`**. |
 | **hw-management-bmc-recovery-handler** | simple | `/usr/bin/hw-management-bmc-recovery-handler.sh` | `WantedBy=multi-user.target` | **`After=`** `multi-user.target`, **`hw-management-bmc-i2c-slave-setup`**. **`Requires=`** i2c-slave-setup. **`EnvironmentFile=/etc/hw-management-bmc-recovery.conf`**. **`ConditionPathExists=/etc/hw-management-bmc-recovery.conf`**. **`Restart=always`**. |

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-early-i2c-init.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-early-i2c-init.service
@@ -7,7 +7,7 @@ DefaultDependencies=no
 # before this unit reads it.  See issue #4992267.
 Requires=hw-management-bmc-early-config.service
 After=hw-management-bmc-early-config.service
-Before=nvidia_update_mac.service
+Before=hw-management-bmc-sync-ethaddr.service
 
 [Service]
 Type=oneshot

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-init.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-init.service
@@ -3,8 +3,8 @@
 Description=BMC hardware management init (hw-management-bmc-ready)
 Documentation=file:///usr/share/doc/hw-management-bmc/README.md
 DefaultDependencies=no
-After=local-fs.target hw-management-bmc-early-i2c-init.service
-Requires=hw-management-bmc-early-i2c-init.service
+After=local-fs.target hw-management-bmc-early-i2c-init.service hw-management-bmc-sync-ethaddr.service
+Requires=hw-management-bmc-early-i2c-init.service hw-management-bmc-sync-ethaddr.service
 Before=hw-management-bmc-boot-complete.service
 ConditionPathExists=/usr/bin/hw-management-bmc-ready.sh
 

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-sync-ethaddr.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-sync-ethaddr.service
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+[Unit]
+Description=Sync BMC FRU MAC to U-Boot ethaddr
+DefaultDependencies=no
+Requires=hw-management-bmc-early-i2c-init.service
+After=hw-management-bmc-early-i2c-init.service
+Before=hw-management-bmc-init.service hw-management-bmc-boot-complete.service
+ConditionPathExists=/usr/bin/hw-management-bmc-sync-ethaddr.sh
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/bash /usr/bin/hw-management-bmc-sync-ethaddr.sh
+SyslogIdentifier=hw-management-bmc-sync-ethaddr
+
+[Install]
+WantedBy=multi-user.target

--- a/bmc/usr/usr/bin/hw-management-bmc-sync-ethaddr.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-sync-ethaddr.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Ensure U-Boot ethaddr has a valid BMC MAC.
+#
+# A valid ethaddr is authoritative. The BMC FRU MAC is only a fallback when
+# ethaddr is empty or invalid. After selecting the MAC, apply it to the running
+# eth0 interface too so the current boot is fixed without waiting for a reboot.
+################################################################################
+
+EEPROM_BMC="/var/run/hw-management/eeprom/eeprom_bmc"
+EEPROM_BMC_FALLBACK="/sys/bus/i2c/devices/4-0050/eeprom"
+
+log()
+{
+	echo "sync-ethaddr: $*"
+}
+
+log_crit()
+{
+	log "CRITICAL: $*"
+	if command -v logger >/dev/null 2>&1; then
+		logger -p user.crit -t hw-management-bmc-sync-ethaddr "$*"
+	fi
+}
+
+bring_eth0_up()
+{
+	local reason="$1"
+	local i
+
+	for i in 1 2 3; do
+		if ip link set eth0 up 2>/dev/null; then
+			if [ "$i" -gt 1 ]; then
+				log "brought eth0 up on attempt ${i} (${reason})"
+			fi
+			return 0
+		fi
+		sleep 0.5
+	done
+
+	log_crit "failed to bring eth0 up after MAC change (${reason})"
+	return 1
+}
+
+normalize_mac()
+{
+	local mac="$1"
+
+	mac="${mac//-/:}"
+	mac="$(echo "$mac" | tr '[:upper:]' '[:lower:]')"
+	if [[ "$mac" =~ ^([0-9a-f]{2}:){5}[0-9a-f]{2}$ ]]; then
+		echo "$mac"
+	fi
+}
+
+mac_first_octet()
+{
+	local mac="$1"
+	local first="${mac%%:*}"
+
+	printf "%d" "0x${first}"
+}
+
+is_valid_unicast_mac()
+{
+	local mac
+	mac="$(normalize_mac "$1")"
+	[ -n "$mac" ] || return 1
+
+	case "$mac" in
+	00:00:00:00:00:00|ff:ff:ff:ff:ff:ff)
+		return 1
+		;;
+	esac
+
+	local first
+	first="$(mac_first_octet "$mac")"
+	# Multicast bit set means the address is not a valid interface MAC.
+	[ $((first & 1)) -eq 0 ]
+}
+
+is_local_admin_mac()
+{
+	local mac
+	mac="$(normalize_mac "$1")"
+	[ -n "$mac" ] || return 1
+
+	local first
+	first="$(mac_first_octet "$mac")"
+	[ $((first & 2)) -ne 0 ]
+}
+
+extract_fru_mac_field()
+{
+	# Avoid awk {N} interval quantifiers; BusyBox awk may not support them.
+	awk '
+		match($0, /MAC:[[:space:]]*[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]:[0-9A-Fa-f][0-9A-Fa-f]/) {
+			mac = substr($0, RSTART, RLENGTH)
+			sub(/^MAC:[[:space:]]*/, "", mac)
+			print mac
+			exit
+		}
+	'
+}
+
+wait_for_bmc_eeprom()
+{
+	local i
+
+	for i in 1 2 3 4 5; do
+		if find_bmc_eeprom; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	return 1
+}
+
+wait_for_bmc_eeprom_short()
+{
+	local i
+
+	for i in 1 2 3 4 5; do
+		if find_bmc_eeprom; then
+			return 0
+		fi
+		sleep 0.2
+	done
+
+	return 1
+}
+
+find_bmc_eeprom()
+{
+	if [ -r "$EEPROM_BMC" ]; then
+		echo "$EEPROM_BMC"
+		return 0
+	fi
+	if [ -r "$EEPROM_BMC_FALLBACK" ]; then
+		echo "$EEPROM_BMC_FALLBACK"
+		return 0
+	fi
+
+	return 1
+}
+
+read_fru_mac()
+{
+	local eeprom="$1"
+	local mac=""
+
+	if command -v ipmi-fru >/dev/null 2>&1; then
+		mac="$(ipmi-fru --fru-file="$eeprom" 2>/dev/null | extract_fru_mac_field)"
+		if [ -n "$mac" ]; then
+			echo "sync-ethaddr: FRU MAC read using ipmi-fru" >&2
+		fi
+	fi
+
+	if [ -z "$mac" ] && command -v strings >/dev/null 2>&1; then
+		mac="$(strings "$eeprom" 2>/dev/null | extract_fru_mac_field)"
+		if [ -n "$mac" ]; then
+			echo "sync-ethaddr: WARNING: FRU MAC read using strings fallback" >&2
+		fi
+	fi
+
+	normalize_mac "$mac"
+}
+
+read_ethaddr_raw()
+{
+	local value=""
+
+	if ! command -v fw_printenv >/dev/null 2>&1; then
+		return 0
+	fi
+
+	value="$(fw_printenv -n ethaddr 2>/dev/null || true)"
+	if [ -z "$value" ]; then
+		value="$(fw_printenv ethaddr 2>/dev/null | sed -n 's/^ethaddr=//p')"
+	fi
+
+	echo "$value"
+}
+
+set_ethaddr()
+{
+	local mac="$1"
+
+	if ! command -v fw_setenv >/dev/null 2>&1; then
+		log "ERROR: fw_setenv is not available"
+		return 1
+	fi
+
+	fw_setenv ethaddr "$mac"
+}
+
+clear_ethaddr()
+{
+	if ! command -v fw_setenv >/dev/null 2>&1; then
+		log "WARNING: fw_setenv is not available; cannot clear invalid ethaddr"
+		return 0
+	fi
+
+	fw_setenv ethaddr
+}
+
+uboot_env_tools_available()
+{
+	local missing=0
+
+	if ! command -v fw_printenv >/dev/null 2>&1; then
+		log "WARNING: fw_printenv is not available"
+		missing=1
+	fi
+
+	if ! command -v fw_setenv >/dev/null 2>&1; then
+		log "WARNING: fw_setenv is not available"
+		missing=1
+	fi
+
+	return "$missing"
+}
+
+renew_eth0_dhcp()
+{
+	if command -v systemctl >/dev/null 2>&1; then
+		systemctl start systemd-networkd 2>/dev/null || true
+	fi
+
+	if command -v networkctl >/dev/null 2>&1; then
+		networkctl reload 2>/dev/null || true
+		if networkctl renew eth0 2>/dev/null; then
+			log "renewed eth0 DHCP using networkctl"
+			return 0
+		fi
+	fi
+
+	if command -v dhclient >/dev/null 2>&1; then
+		dhclient -r eth0 2>/dev/null || true
+		if dhclient eth0 2>/dev/null; then
+			log "renewed eth0 DHCP using dhclient"
+			return 0
+		fi
+	fi
+
+	if command -v udhcpc >/dev/null 2>&1; then
+		if udhcpc -q -n -i eth0 2>/dev/null; then
+			log "renewed eth0 DHCP using udhcpc"
+			return 0
+		fi
+	fi
+
+	log "WARNING: could not renew eth0 DHCP automatically"
+	return 0
+}
+
+apply_runtime_mac()
+{
+	local expected_mac="$1"
+	local source="$2"
+	local eth0_mac=""
+
+	[ -r /sys/class/net/eth0/address ] || return 0
+	eth0_mac="$(normalize_mac "$(cat /sys/class/net/eth0/address 2>/dev/null)")"
+	[ -n "$eth0_mac" ] || return 0
+
+	if [ "$eth0_mac" != "$expected_mac" ]; then
+		log "WARNING: current eth0 MAC is ${eth0_mac}, ${source} MAC is ${expected_mac}"
+		log "applying ${source} MAC to running eth0"
+		if ! command -v ip >/dev/null 2>&1; then
+			log "WARNING: ip command is not available; cannot update running eth0"
+			return 0
+		fi
+		if ! ip link set eth0 down; then
+			log "WARNING: failed to set eth0 down"
+			return 0
+		fi
+		if ! ip link set eth0 address "$expected_mac"; then
+			log "WARNING: failed to set eth0 MAC to ${expected_mac}"
+			bring_eth0_up "MAC set failed; restoring link" || true
+			return 0
+		fi
+		if ! bring_eth0_up "MAC updated"; then
+			return 0
+		fi
+		renew_eth0_dhcp
+	fi
+}
+
+handle_missing_fru()
+{
+	local env_raw="$1"
+	local env_mac="$2"
+
+	log "WARNING: BMC FRU MAC is missing or invalid"
+
+	if [ -z "$env_raw" ]; then
+		log "ethaddr is empty; leaving it empty so U-Boot can choose fallback"
+		return 0
+	fi
+
+	if [ -z "$env_mac" ] || ! is_valid_unicast_mac "$env_mac"; then
+		log "WARNING: clearing invalid ethaddr ${env_raw}"
+		clear_ethaddr
+		return 0
+	fi
+
+	if is_local_admin_mac "$env_mac"; then
+		log "WARNING: clearing locally-administered ethaddr ${env_mac}"
+		clear_ethaddr
+		return 0
+	fi
+}
+
+main()
+{
+	local eeprom=""
+	local fru_mac=""
+	local env_raw=""
+	local env_mac=""
+
+	log "starting"
+
+	if ! uboot_env_tools_available; then
+		log "WARNING: skipping ethaddr sync because U-Boot env tools are missing"
+		log "complete"
+		return 0
+	fi
+
+	env_raw="$(read_ethaddr_raw)"
+	env_mac="$(normalize_mac "$env_raw")"
+
+	if [ -n "$env_mac" ] && is_valid_unicast_mac "$env_mac" &&
+	   ! is_local_admin_mac "$env_mac"; then
+		log "preserving valid ethaddr ${env_mac}"
+		if eeprom="$(wait_for_bmc_eeprom_short)"; then
+			fru_mac="$(read_fru_mac "$eeprom")"
+			if is_valid_unicast_mac "$fru_mac" && ! is_local_admin_mac "$fru_mac"; then
+				if [ "$env_mac" != "$fru_mac" ]; then
+					log "WARNING: ethaddr ${env_mac} differs from FRU MAC ${fru_mac}"
+					log "WARNING: preserving ethaddr because it has priority"
+				fi
+			else
+				log "WARNING: cannot compare ethaddr with missing, invalid, or LAA FRU MAC"
+			fi
+		else
+			log "FRU EEPROM is not available after short wait; skip ethaddr/FRU comparison"
+		fi
+		apply_runtime_mac "$env_mac" "ethaddr"
+		log "complete"
+		return 0
+	fi
+
+	if [ -n "$env_raw" ]; then
+		log "WARNING: ethaddr ${env_raw} is invalid or locally-administered"
+	fi
+
+	if ! eeprom="$(wait_for_bmc_eeprom)"; then
+		log "WARNING: BMC FRU EEPROM is not available"
+		handle_missing_fru "$env_raw" "$env_mac"
+		return 0
+	fi
+
+	fru_mac="$(read_fru_mac "$eeprom")"
+	if ! is_valid_unicast_mac "$fru_mac" || is_local_admin_mac "$fru_mac"; then
+		if [ -n "$fru_mac" ]; then
+			log "WARNING: BMC FRU MAC ${fru_mac} is invalid or locally-administered"
+		fi
+		handle_missing_fru "$env_raw" "$env_mac"
+		return 0
+	fi
+
+	log "setting ethaddr to FRU fallback MAC ${fru_mac}"
+	if ! set_ethaddr "$fru_mac"; then
+		log_crit "failed to persist ethaddr ${fru_mac}; continuing best-effort"
+	fi
+
+	apply_runtime_mac "$fru_mac" "FRU fallback"
+	log "complete"
+	return 0
+}
+
+main "$@"

--- a/debian/hw-management-bmc.postinst
+++ b/debian/hw-management-bmc.postinst
@@ -24,7 +24,8 @@
 # hw-management-bmc-boot-complete.service with `systemctl start --no-block`
 # so dpkg returns immediately; the Requires= chain in the .service files
 # pulls plat-specific-preps -> early-config -> early-i2c-init -> init ->
-# boot-complete into one transaction in declared After= order.
+# sync-ethaddr -> init -> boot-complete into one transaction in declared
+# After= order.
 
 set -e
 

--- a/debian/hw-management-bmc.prerm
+++ b/debian/hw-management-bmc.prerm
@@ -33,6 +33,7 @@ case "$1" in
             if ! systemctl stop \
                     hw-management-bmc-boot-complete.service \
                     hw-management-bmc-init.service \
+                    hw-management-bmc-sync-ethaddr.service \
                     hw-management-bmc-early-i2c-init.service \
                     hw-management-bmc-early-config.service \
                     hw-management-bmc-plat-specific-preps.service \

--- a/debian/rules
+++ b/debian/rules
@@ -153,7 +153,7 @@ ifeq ($(with_bmc),1)
 	# `dh_systemd_enable -phw-management-bmc <files>` invocation.  With
 	# positional arguments dh_systemd_enable processes ONLY those units
 	# (line 211: `@args = @ARGV > 0 ? @ARGV : @installed_units`).  This:
-	#   - emits exactly 9 enable snippets (one per service), ~7 s of
+	#   - emits exactly one enable snippet per service, ~7 s of
 	#     postinst work instead of ~65 s,
 	#   - keeps the allow-list explicit, so a future BMC service file
 	#     added under bmc/usr/lib/systemd/system/ is NOT silently auto-
@@ -162,6 +162,7 @@ ifeq ($(with_bmc),1)
 		hw-management-bmc-plat-specific-preps.service \
 		hw-management-bmc-early-config.service \
 		hw-management-bmc-early-i2c-init.service \
+		hw-management-bmc-sync-ethaddr.service \
 		hw-management-bmc-init.service \
 		hw-management-bmc-boot-complete.service \
 		hw-management-bmc-health-monitor.service \
@@ -212,6 +213,7 @@ ifeq ($(with_bmc),1)
 		hw-management-bmc-plat-specific-preps.service \
 		hw-management-bmc-early-config.service \
 		hw-management-bmc-early-i2c-init.service \
+		hw-management-bmc-sync-ethaddr.service \
 		hw-management-bmc-init.service \
 		hw-management-bmc-boot-complete.service \
 		hw-management-bmc-health-monitor.service \


### PR DESCRIPTION
Add a SONiC BMC boot service that validates the U-Boot ethaddr value on every boot and preserves it when it is valid. If ethaddr is empty, invalid, multicast, all-zero/all-ff, or locally-administered, use the BMC FRU MAC as the fallback and persist it with fw_setenv.

After selecting the MAC, apply it to the running eth0 interface when it differs and renew DHCP best-effort. This matches the OpenBMC behavior of updating both persistent U-Boot env and the live management interface, while using SONiC/Linux networking tools instead of phosphor-networkd D-Bus.

Wire the service after early I2C init and before BMC readiness so the FRU EEPROM is available before the sync runs. Update Debian service allow-lists, maintainer-script ordering, and BMC documentation for the new unit.

Bug: 5128938


(cherry picked from commit 613b700d98752227db61347127a8d40b2b7527d3)