### PR TITLE
Docs remove system aliases v.7.0070.1000 br

### DIFF
--- a/Documentation/CHANGELOG_User_Manual.md
+++ b/Documentation/CHANGELOG_User_Manual.md
@@ -119,19 +119,19 @@ SN6600 BMC ambient sensor on I2C `4-0048`, `lm75` driver).
 
 ### Rev. 3.2.1 - May 31, 2026
 
-#### Fixed: Juliet (N51XX_LD) reset-cause documentation (#5014001)
+#### Fixed: N51XX_LD reset-cause documentation (#5014001)
 
-**Affected platforms:** Juliet platform family (N51XX_LD), including GB200 systems such as N5110_LD and N5500_LD.
+**Affected platforms:** N51XX_LD platform family, including GB200 systems such as N5110_LD and N5500_LD.
 
 **Overview:**  
-Aligned the user manual with Juliet CPLD-supported reset causes. The following are not supported by the Juliet CPLD and must not be documented as available sysfs attributes: `reset_ac_pwr_fail`, `reset_aux_pwr_or_ref`, `reset_from_asic`, `reset_reload_bios`.
+Aligned the user manual with N51XX_LD CPLD-supported reset causes. The following are not supported by the N51XX_LD CPLD and must not be documented as available sysfs attributes: `reset_ac_pwr_fail`, `reset_aux_pwr_or_ref`, `reset_from_asic`, `reset_reload_bios`.
 
 **User manual updates:**
 
 | Area | Change |
 |------|--------|
-| Get Reset Cause (3.18.39) | Added Juliet platform family table with 22 supported reset causes |
-| Get Reset Cause (3.18.39) | Documented unsupported legacy causes for Juliet |
+| Get Reset Cause (3.18.39) | Added N51XX_LD platform family table with 22 supported reset causes |
+| Get Reset Cause (3.18.39) | Documented unsupported legacy causes for N51XX_LD |
 | Config | Referenced `reset_attr_num` = 22 for N51XX_LD |
 
 **Validation source:**

--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -412,7 +412,7 @@ Rev. 3.2.6
 | 3.2.4 | June 2026 | Added §2.2 **Host and BMC software stacks**: separate repo paths (`usr/` vs `bmc/usr/`), packages, handlers, and examples; stack notes in §3 intro and §3.20 Thermal |
 | 3.2.3 | June 2026 | §3.20 thermal: filled missing section bodies; TOC aligned; per-HID BMC examples under `bmc/examples/<HID>/examples/` |
 | 3.2.2 | June 2026 | BMC thermal sysfs (HI189 / `lm75`): documented `bmc_temp_input` and `bmc_temp`; removed obsolete TOC entries for `bmc_crit` / `bmc_min` (not created on BMC stack) |
-| 3.2.1 | May 2026 | Corrected Juliet platform family (N51XX_LD) reset-cause list in **Get Reset Cause** (#5014001)<br>• Documented 22 CPLD-supported reset causes for Juliet/GB200 systems<br>• Removed unsupported causes: `reset_ac_pwr_fail`, `reset_aux_pwr_or_ref`, `reset_from_asic`, `reset_reload_bios` |
+| 3.2.1 | May 2026 | Corrected N51XX_LD platform family reset-cause list in **Get Reset Cause** (#5014001)<br>• Documented 22 CPLD-supported reset causes for N51XX_LD/GB200 systems<br>• Removed unsupported causes: `reset_ac_pwr_fail`, `reset_aux_pwr_or_ref`, `reset_from_asic`, `reset_reload_bios` |
 | 3.2 | March 2026 | Added SN6600_LD (SN66XX_LD family, SKU HI193) liquid-cooled platform support<br>• Validation: `usr/etc/hw-management-sensors/sn66xxld_sensors.conf`, `hw-management.sh` / event scripts<br>**Platform notes:**<br>• Single ASIC (`asic_num`=1), 4 CPLDs, `hotplug_pdbs`=2, `pdb_hotswap1/2` and `pdb_pwr_conv1/2`<br>• ASIC voltmons: 19 sysfs indexes (`voltmon1`-`14`, `voltmon16`-`20` on captured tree)<br>• SODIMM temp: JC42 at 0x52/0x53 on I2C bus 10<br>• Watchdog: `watchdog/main/` and `watchdog/aux/` hierarchy<br>• PDB hot-plug events: `events/pdb1`, `events/pdb2`<br>**Updated Sections:**<br>• Liquid-cooled applicability notes extended to SN66XX_LD across environment, alarms, thermal, and leakage-related text<br>• Config: documented optional `psu<X>_i2c_bus` (hw-management internal; OS must not require it) |
 | 3.1 | January 2026 | Added N6100_LD (N61XX_LD family) liquid-cooled multi-ASIC platform support<br>**New Sections for N6100_LD:**<br>• Multi-ASIC Health (asic_health, asic2_health, asic3_health, asic4_health)<br>• MCU Reset Control (mcu1_reset, mcu2_reset)<br>• Cable Cartridge EEPROM (cable_cartridge1-4_eeprom)<br>• Cartridge Counter (config/cartridge_counter)<br>• Cartridge Status (cartridge1-4)<br>• eRoT Events (erot1_ap, erot1_error)<br>• Config: asic_num=4, erot_count=1<br>**Updated Sections:**<br>• Power Converters: Added pwr_conv naming (vs pdb_pwr_conv for SN58XX_LD)<br>• Updated all liquid-cooled references to include N61XX_LD family<br>• Extended voltmon support for 16 PMICs (voltmon1-16)<br>• SODIMM Temperature Sensors: Updated to include both SN58XX_LD and N61XX_LD |
 | 3.0 | September 2025 | Complete document alignment with Word document source<br>• Updated title and branding to NVIDIA<br>• Complete sysfs hierarchy coverage with 300+ attributes<br>• Professional markdown formatting throughout<br>• Added comprehensive examples for all attributes<br>• Updated all 22 major sections (3.1-3.22)<br>• Added Watchdog, JTAG, and BMC sections<br>• Complete thermal monitoring documentation<br>• Enterprise-grade documentation ready for production |
@@ -5518,9 +5518,9 @@ cat $bsp_path/system/reset_long_pb
 cat $bsp_path/system/reset_cause
 ```
 
-#### Juliet platform family (N51XX_LD)
+#### N51XX_LD platform family
 
-Per CPLD design, Juliet platforms do **not** support `reset_ac_pwr_fail`, `reset_aux_pwr_or_ref`, `reset_from_asic`, or `reset_reload_bios`. Those attributes must not be documented or tested as available on Juliet systems.
+Per CPLD design, N51XX_LD platforms do **not** support `reset_ac_pwr_fail`, `reset_aux_pwr_or_ref`, `reset_from_asic`, or `reset_reload_bios`. Those attributes must not be documented or tested as available on N51XX_LD systems.
 
 Applies to N5110_LD, N5112_LD, N5100_LD, N5101_LD, N5200_LD, N5201_LD, N5300_LD, N5400_LD, N5120_LD, N5121_LD, N5320_LD, N5500_LD (GB200/GB300), and N5240_LD (Kyber). `config/reset_attr_num` = 22.
 

--- a/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
+++ b/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
@@ -13,7 +13,7 @@
                 "Address": "0x34",
                 "Probe": true,
                 "Scale": 0.0008,
-                "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max by hw-management-bmc-a2d-leakage-config.sh (leakage-handler in-band check: raw*Scale vs min/max). Scale 0.0008 V/LSB matches the Salamandra Excel MAX1363 column (0.8 mV).",
+                "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max by hw-management-bmc-a2d-leakage-config.sh (leakage-handler in-band check: raw*Scale vs min/max). Scale 0.0008 V/LSB matches the HI189 platform Excel MAX1363 column (0.8 mV).",
                 "Types": [
                     {
                         "Type": "flex",
@@ -85,11 +85,11 @@
                 "DeviceType": "ADS7924",
                 "Bus": 27,
                 "Address": "0x49",
-                "Address_comment": "PLACEHOLDER: ADS7924 BOM alternative listed at the same socket/address as the ADS1015. Confirm the populated ADS7924 I2C address for Salamandra.",
+                "Address_comment": "PLACEHOLDER: ADS7924 BOM alternative listed at the same socket/address as the ADS1015. Confirm the populated ADS7924 I2C address for HI189 platform.",
                 "Probe": true,
                 "Scale": 0.002,
                 "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max and used to derive the ADS7924 window comparator ULR/LLR codes (volts/Scale, 12-bit, >>4 to 8-bit).",
-                "Types_comment": "PLACEHOLDER thresholds copied from the Salamandra ADS1015 (same 2 mV scale). The Excel has no ADS7924 column yet — replace with characterized ADS7924 values when available.",
+                "Types_comment": "PLACEHOLDER thresholds copied from the HI189 platform ADS1015 (same 2 mV scale). The Excel has no ADS7924 column yet — replace with characterized ADS7924 values when available.",
                 "Types": [
                     {
                         "Type": "flex",
@@ -132,7 +132,7 @@
                 "Address": "0x35",
                 "Probe": true,
                 "Scale": 0.0008,
-                "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max by hw-management-bmc-a2d-leakage-config.sh (leakage-handler in-band check: raw*Scale vs min/max). Scale 0.0008 V/LSB matches the Salamandra Excel MAX1363 column (0.8 mV).",
+                "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max by hw-management-bmc-a2d-leakage-config.sh (leakage-handler in-band check: raw*Scale vs min/max). Scale 0.0008 V/LSB matches the HI189 platform Excel MAX1363 column (0.8 mV).",
                 "Types": [
                     {
                         "Type": "flex",
@@ -204,11 +204,11 @@
                 "DeviceType": "ADS7924",
                 "Bus": 28,
                 "Address": "0x48",
-                "Address_comment": "PLACEHOLDER: ADS7924 BOM alternative listed at the same socket/address as the ADS1015. Confirm the populated ADS7924 I2C address for Salamandra.",
+                "Address_comment": "PLACEHOLDER: ADS7924 BOM alternative listed at the same socket/address as the ADS1015. Confirm the populated ADS7924 I2C address for HI189 platform.",
                 "Probe": true,
                 "Scale": 0.002,
                 "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max and used to derive the ADS7924 window comparator ULR/LLR codes (volts/Scale, 12-bit, >>4 to 8-bit).",
-                "Types_comment": "PLACEHOLDER thresholds copied from the Salamandra ADS1015 (same 2 mV scale). The Excel has no ADS7924 column yet — replace with characterized ADS7924 values when available.",
+                "Types_comment": "PLACEHOLDER thresholds copied from the HI189 platform ADS1015 (same 2 mV scale). The Excel has no ADS7924 column yet — replace with characterized ADS7924 values when available.",
                 "Types": [
                     {
                         "Type": "flex",

--- a/debian/Release.txt
+++ b/debian/Release.txt
@@ -288,7 +288,7 @@
     o #5040812, hw-mgmt: scripts: Restrict udev event log size (#2588), c49905d
     o #5027944, hw-mgmt: service: Improve hw-mgmt trace log rotation, 3fd3993
     o #N/A, hw-mgmt: bmc: read AST2700 reset-cause SCU words from /proc/cmdline, a9f7033
-    o #5014001, docs: Fix Juliet N51XX_LD reset-cause list in user manual (#5014001), 30282bc
+    o #5014001, docs: Fix N51XX_LD reset-cause list in user manual (#5014001), 30282bc
     o #N/A, hw-mgmt: ci: Remove obsolete ONL 4.9/4.19 CI kernel patches, cbf7f60
     o #N/A, hw-mgmt: debian: Update package maintainer to NVIDIA Switch BSP, 1671dd4
     o #N/A, hw-mgmt: bmc: leakage: Update json config file for system HI189, 3dcf115
@@ -328,7 +328,7 @@
     o #5040812, hw-mgmt: scripts: Restrict udev event log size (#2588), c49905d
     o #5027944, hw-mgmt: service: Improve hw-mgmt trace log rotation, 3fd3993
     o #N/A, hw-mgmt: bmc: read AST2700 reset-cause SCU words from /proc/cmdline, a9f7033
-    o #5014001, docs: Fix Juliet N51XX_LD reset-cause list in user manual (#5014001), 30282bc
+    o #5014001, docs: Fix N51XX_LD reset-cause list in user manual (#5014001), 30282bc
     o #N/A, hw-mgmt: ci: Remove obsolete ONL 4.9/4.19 CI kernel patches, cbf7f60
     o #N/A, hw-mgmt: debian: Update package maintainer to NVIDIA Switch BSP, 1671dd4
     o #N/A, hw-mgmt: bmc: leakage: Update json config file for system HI189, 3dcf115
@@ -364,7 +364,7 @@
     o #5040812, hw-mgmt: scripts: Restrict udev event log size (#2588), c49905d
     o #5027944, hw-mgmt: service: Improve hw-mgmt trace log rotation, 3fd3993
     o #N/A, hw-mgmt: bmc: read AST2700 reset-cause SCU words from /proc/cmdline, a9f7033
-    o #5014001, docs: Fix Juliet N51XX_LD reset-cause list in user manual (#5014001), 30282bc
+    o #5014001, docs: Fix N51XX_LD reset-cause list in user manual (#5014001), 30282bc
     o #N/A, hw-mgmt: ci: Remove obsolete ONL 4.9/4.19 CI kernel patches, cbf7f60
     o #N/A, hw-mgmt: debian: Update package maintainer to NVIDIA Switch BSP, 1671dd4
     o #N/A, hw-mgmt: bmc: leakage: Update json config file for system HI189, 3dcf115
@@ -420,7 +420,7 @@
     o #5020389, hw-mgmt: scripts: Update usb0 hotplug handling, f818eae
     o #N/A, hw-mgmt: thermal: drive TC version from tc_config.json, f3cbea5
     o #N/A, hw-mgmt: kernel: bmc: patches: Update patches, 39d5905
-    o #N/A, hw-mgmt: Use 0x2E for MP29502 Power Controller in Juliet system, 03df97c
+    o #N/A, hw-mgmt: Use 0x2E for MP29502 Power Controller in N51XX_LD system, 03df97c
     o #4944920, hw-mgmt: kernel 6.1: Upgrade patches to support version up to 6.1.169, 98e58bf
     o #N/A, hw-mgmt: bmc: Add script for setting cartridge info, f3bf462
     o #N/A, hw-mgmt: bmc: Extend leakage support with ADS7924 follow up, 376dc16
@@ -460,7 +460,7 @@
     o #5020389, hw-mgmt: scripts: Update usb0 hotplug handling, f818eae
     o #N/A, hw-mgmt: thermal: drive TC version from tc_config.json, f3cbea5
     o #N/A, hw-mgmt: kernel: bmc: patches: Update patches, 39d5905
-    o #N/A, hw-mgmt: Use 0x2E for MP29502 Power Controller in Juliet system, 03df97c
+    o #N/A, hw-mgmt: Use 0x2E for MP29502 Power Controller in N51XX_LD system, 03df97c
     o #4944920, hw-mgmt: kernel 6.1: Upgrade patches to support version up to 6.1.169, 98e58bf
     o #N/A, hw-mgmt: bmc: Add script for setting cartridge info, f3bf462
     o #N/A, hw-mgmt: bmc: Extend leakage support with ADS7924 follow up, 376dc16
@@ -717,7 +717,7 @@
     o Add support for SN2201_M – ES level quality
     o Add support for Q3400 – GA level quality
     o Add support for SN4280 – GA level quality
-    o Add support for N5110_LD - GA level Quality + TTM/ NSO/ Ariel-JSO - ES level quality
+    o Add support for N5110_LD - GA level Quality + TTM/ NSO/ N5112_LD - ES level quality
     o Add support for fan_speed_tolerance sysfs attribute (in addition to mix/max)
     o Add support for SPC-4 SN5400 P2C Forward airflow
     o Add support for hw-mgmt package version to debug dump
@@ -747,13 +747,13 @@
 --------------------------------------------------------------------------------
 
 - New features 
-    o  Add support for QM3400 Blackmamba - ES level quality
-    o  Add support for SN4280 SmartSwitch Bobcat - ES level quality
-    o  Add support for N5110_LD Juliet Scaleout PO + TTM - ES level quality
+    o  Add support for Q3400-RA - ES level quality
+    o  Add support for SN4280 SmartSwitch - ES level quality
+    o  Add support for N5110_LD Scaleout PO + TTM - ES level quality
     o  Add support in VPD parser for System VPD vendor specific SSD SED PSID block
 
 - Bug fixes
-	#3649551	SN4700 : [Independent Module] | on r-leopard-41 with IM enabled, there was a thermal overload. 
+	#3649551	SN4700 : [Independent Module] | on r-msn4700-41 with IM enabled, there was a thermal overload. 
 	#3878328	SN4700 : Switch rebooted with "Thermal Overload" because ASIC thermal is not available 
 	#3885405	TC: [Thermal Algorithm] | Blacklist is malfunctions
 	#3883147	TC: [Thermal Algorithm] | Counts errors even it was paused by black list
@@ -790,8 +790,8 @@
 --------------------------------------------------------------------------------
 
 - New features 
-    o  Add support for QM3400 Crocodile - ES level quality
-    o  Add support for SN5400 Hippo - ES level quality
+    o  Add support for Q3200-RA - ES level quality
+    o  Add support for SN5400 - ES level quality
     o  Add support thermal algorithm configurable minimum N PSUs and M Fans for error reporting
     o  Add support different power supply redundency policies
     o  Update HW-MGMT package installation dependency list
@@ -850,7 +850,7 @@
 
 - Bug fixes
 	Issue		Title	
-	#3613781	BF3 - Leopard BF3 missing voltmon sensor links 
+	#3613781	BF3 - SN4700 BF3 missing voltmon sensor links 
 	#3560591	[SN2010/SN2100/SN2410/SN2700/SN2740] (SPC1 -MSN2410} "sensors" - the FAN numbers not align in the right order and in accordance with "nv show platform environment fan
 	#3630148	TC - 7.0030.2000: Logging Error in TC Log writing dmesg: RuntimeError: reentrant call inside
 	#3634579	There are missing sysfs nodes in hw-management 7.0030.2000
@@ -860,7 +860,7 @@
 	#3706219	use tc_config copy instead of soft link to /etc (pmon cannot access /etc)
 	#3450086	[CL-support] "tar: ./hw-management_val: file changed as we read it" error/warning during cl-support generation. 
 	#3696439	TC: Should dynamically start/enable or stop/disable + Support more SKUs for SimX
-	#3660884	[MSN2700-A1]: Panther Respin | FANs] | SONIC reports invalid FANs airflow direction
+	#3660884	[MSN2700-A1]: MSN2700-A1 respin | FANs] | SONIC reports invalid FANs airflow direction
 	#3650418	[SN2201]: upload process get "nvsw-sn2201 NVSN2201:00: Failed to get adapter for bus 10 /11 /12/ 13" & switch reboot all time
 	#3632299	BF3 - 'r-hw-bf3-10' : some kernel loadable modules for X86 platforms are not available on ARM platforms (created separate kernel module list for ARM)
 	#3632297	BF3 - 'r-hw-bf3-10' kern :err : [Fri Oct 13 17:34:27 2023] mlxbf3_gpio MLNXBF33:01: IRQ index 0 not found 
@@ -919,21 +919,21 @@
 	#3534779	TC: "hw-management-tc failed to start after cold reboot and no automatic restart
 	#3517930	TC: [nv-xh3000hse] fanless system fails hw-management-tc.service at boot up and also fails to restart after boot up
 	#3541643	[SN3700/SN3700] Missing support for old MSN3700 systems in which SMBIOS SKU field is programmed as "MSN3700", instead of the new format HIXXX
-	#3559366	TC: Moose switch comes with default tc_config.json file instead of special one for MSN5600
+	#3559366	TC: SN5600 switch comes with default tc_config.json file instead of special one for MSN5600
 	#3565326	TC: Thermal Algorithm unexpected jumping to 100%
 	#3567299	TC: Thermal Algorithm doesn’t decrease under 60% fan PWM
 	#3567934	TC: json file comes with sensor_amb min value is 60 but it should be 30
-	#3505271	[SN4600]Sensors not as expected on tigon setup
+	#3505271	[SN4600]Sensors not as expected on MSN4600C setup
 	#3569409	TC: Thermal Control missing support for predefined sensors
 	#3544619	platform_tests/test_reboot.py::test_watchdog_reboot Failed, reboot cause showing unknown
 	#3586921	[SPC1] TC: ERR hw-management-tc: ERROR - Read PWM error. Possible hw-management is not running
 	#3584693	There are issues in hw-mgmt sensor conf
 	#3575228	[SN3750] TC: tc_config.json file have only single value 100 and not graded as define by spec.
-	#3556737	[Sensor|simx emulation|leopard] | some sensor alarm on psu-1 and psu-2
+	#3556737	[Sensor|simx emulation|SN4700] | some sensor alarm on psu-1 and psu-2
 	#3537920	[SN2201] Missing thermal sysfs for fans on 2201 platform 
 	#3546759	[SIMX]: unable to parse psu modle serial and hardware rev number
 	#3594368	pmon#syseepromd: Can not read File /var/run/hw-management/config/labels_ready: [Errno 2] No such file or directory: '/var/run/hw-	management/config/labels_ready'
-	#3608425	[SN2201] chipup error on alligator
+	#3608425	[SN2201] chipup error on SN2201 setup
 	NA	[SN2201] TC: missing PWM initialization causing it to be zero until TC started  
 	NA	[SN2201] hw-mgmt: scripts: supress Unsupported CPU message for Denverton CPU on
 	NA	 Missing attribute index, redundant attributes, incorrect the path for psu temperature
@@ -1027,7 +1027,7 @@
     o  add support for SN5600 ASIC enabled - GA level.
     o  add support for SN5600/MQM9700 MFT’s quicker CPLD update flow
     o  add support for MQM9700 show voltage CLI labels
-    o  add support for MSN27002 Panther-Comex respin
+    o  add support for MSN27002 MSN2700-A1 respin
 
 - Bug fixes
 	Issue		Title	
@@ -1038,18 +1038,18 @@
 	#3445789        TC: hw_management_thermal_control.py[11773]: error: [Errno 101] Network is unreachable']	
 	#3479181	TC: [PWM in Thermal Algorithm] | pwm doesn't increase to max value after reboot on SPC1	
 	#3482761	TC: [PWM in Thermal Algorithm | Unexpected pwm1 value 100 after clean install of OS	
-	#3491842        r-leopard-29 sh[8563]: --- Logging error -	
+	#3491842        r-msn4700-29 sh[8563]: --- Logging error -	
 	#3469070        TC:  blacklist doesn't work as expected , bad sensor after inserting to blacklist still recognizes as bad sensor by hw-management	
 	#3452101        TC: Syslog is flooded with error/warning messages (error every 6 seconds) for platforms with one PSU connected to power | Every 1h new log file is created (Degradation from previous RC)	
 	#3393287	I2C bus is stuck - Unable to probe I2C bus 2-0048, which causes /var/run/hw-management/config/sfp_counter, module_counter to be zero and pmon docker unable to start	
 	#3465854        TC:  sometimes hw-management-tc exited with Error "Missing max tachos config" on SPC1	
-	#3493132	Komodo 3750 200G post Respin - The fans are continuously running at their maximum speed	
+	#3493132	MSN3750SX 200G post Respin - The fans are continuously running at their maximum speed	
 			Relevant 5.10 patches:
 			0283-mlxsw-core_hwmon-Align-modules-label-name-assignment.patch
 	#3509363	HW-MGMT service failed to start.	
 	#3481808	TC: hw-management-tc.service service failed to start after warmboot enabled on nv-xh3000hse-02 (atos) platform	
 	#3519355	TC: sensor_read_error for cpu_pack doesn't work	
-	#3516804	Moose| The CPLD4 version is not as expected after upgrade to newer version	
+	#3516804	SN5600| The CPLD4 version is not as expected after upgrade to newer version	
 			Relevant 5.10 patches:
 			0284-platform-mellanox-mlx-platform-fix-CPLD4-PN-report.patch
 	#3412851	[NVUE] Traceback in NVUE log after CL installation. /usr/cumulus/bin/decode-syseeprom : ERROR : [Errno 13] Permission denied: '/run/hw-management/eeprom/vpd_info'	
@@ -1057,14 +1057,14 @@
 	#3507860	[201911] hw-management failed to initialize due to "mlxsw_minimal 2-0048: Fail to register core bus		
 	#3516754	systemd[1]: systemd-modules-load.service: Failed with result 'exit-code'		
 	#3529307	hw-mgmt documentation: System returns "amber" color when FAN/PSU has some issue , but in user manual "amber" not exists		
-	#3485095	r-tigris-18(MSN3800) during running test: test_mgmt_reset Check reset causes failed  - unnecessary 180 sec delay in case mlxplt path is not ready quick enough		
+	#3485095	r-msn3800-18 (MSN3800) during running test: test_mgmt_reset Check reset causes failed  - unnecessary 180 sec delay in case mlxplt path is not ready quick enough		
 	#3447830	I2C bus is getting stuck, recovered only by a power cycle		
 	N/A		TC: Fix TC start on SPC1 systems : On SPC1 systems FAN tacho and PWM is controlled by ASIC FW. If ASIC is not initialized we will not have pwm and fan_tacho links in hw-management folder. 
 			It can cause errors and stop TC. This fix adds a wait loop till ASIC FW will be initialized		
 	N/A		sn2100, sn2010: Thermal: Fan dir is not readable in these systems and requires 1 set of dmin values for both P2C/C2P dir.		
 	N/A		TC: Remove suspend/resume on asic down/up which is not needed for new TC		
 	N/A		TC: Fix unneeded tc suspend due PSU being pulled out scenario		
-	N/A		Fix missing fan attributes on Panther-Comex system		
+	N/A		Fix missing fan attributes on MSN2700-A1 system		
 	N/A		TC: Fix coverItly scan findings in TC python script - Fix thermal log ASCI count info message		
 	N/A		TC: Fix rare error message which can happens on TC stop		
 	N/A		TC: Add dynamic sfp module add/remove		
@@ -2249,7 +2249,7 @@
     o	Add hw-mgmt: events: Add udev rules for SODIMM temperature sensor
     o	Add hw-mgmt: system: add coffeelake cpu
     o	Add hw-mgmt: events: Add support for SDK OFFLINE event for handling flow with in service firmware upgrade (ISSU) 
-    o	For MQM9700 (Gorilla) 
+    o	For MQM9700 
         add lm-sensors config for MQM9700 system
        
 - Bug fixes
@@ -2308,8 +2308,8 @@
 - Sun, 10 Jan 2021
 --------------------------------------------------------------------------------
 - New Feature
-    o	For MSN4700 A1 (Leopard re-spin): add support 5 mp2975 instead of 7 xdpe12284 
-    o	For MQM9700 (Gorilla) 
+    o	For MSN4700 A1 (re-spin): add support 5 mp2975 instead of 7 xdpe12284 
+    o	For MQM9700 
         add support for mp2975 and mp2888, (Align driver mp2975 with upstream)
         *Kernel 4.19 - 0032-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2975-c.patch
         *Kernel 4.19 - 0037-hwmon-pmbus-Add-support-for-MPS-Multi-phase-mp2888-c.patch
@@ -2323,7 +2323,7 @@
     o	For any non-Broadwell CPU: Initialize temperature limits critical, max, min and hysteresis of all discovered SODIMMs with temp sensor.
     o	Export appropriate GPIO pins (through sysfs) that are used for JTAG bit-bang CPLD burning. For platforms that support JTAG-GPIO FU. (Broadwell & Coffeelake)
     o	Add common fan direction attribute for SPC1/2/3 using sysfs, and replace existing thermal algorithm temperature difference mechanism for detecting fan direction with   	new fan_dir attribute 
-    o	For MSN4600 A1 (Liger re-spin like existing Leopard re-spin) add support 5 mp2975 instead of 7 xdpe12284.
+    o	For MSN4600 A1 (re-spin like existing MSN4700 re-spin) add support 5 mp2975 instead of 7 xdpe12284.
 
 - Bug fixes
     o	Fix dmesg dump
@@ -2841,7 +2841,7 @@
 - Bug fixes
     HW Mgmt core:
     o   Fix - Prevent start action for hw-mangment service while already runs.
-    o   Fix - Anaconda, Tigris reset cause for power cycle.
+    o   Fix - SN3700, MSN3800 reset cause for power cycle.
         - see backport patch kernel 4.9  #40
         - see backport patch kernel 4.19 #10
 

--- a/tests/offline/test_hw_management_redfish_client.py
+++ b/tests/offline/test_hw_management_redfish_client.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 ########################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Comprehensive Test Suite for hw_management_redfish_client.py
 # Tests RedfishClient and BMCAccessor classes with simple, medium, and complex scenarios
@@ -472,7 +472,7 @@ class TestBMCAccessorPasswordGeneration:
             base64.b64decode(password)
 
     def test_complex_legacy_platform_password(self, mock_subprocess, temp_dir):
-        """Complex: Generate password for legacy platform (Juliet)"""
+        """Complex: Generate password for legacy platform (N51XX_LD)"""
         # Mock platform name (legacy pattern)
         mock_file_data = 'N5100_LD'
 

--- a/usr/etc/hw-management-sensors/n51xxld_sensors_labels.json
+++ b/usr/etc/hw-management-sensors/n51xxld_sensors_labels.json
@@ -1,5 +1,5 @@
 {
-	"name": "Juliet",
+	"name": "n51xxld",
 	"labels_HI162_rev1_array" : {
 		"swb_asic1" : "SWB+ASIC1+PCB+Temp",
 		"swb_asic2" : "SWB+ASIC2+PCB+Temp",

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -980,8 +980,8 @@ devtr_bom_load_from_json()
 
 # Check if system has SMBIOS BOM changes mechanism support.
 # If yes, init appropriate associative arrays.
-# Jaguar, Leopard, Gorilla are added just for debug.
-# This mechanism is enabled on new systems starting from Moose.
+# MQM8700, SN4700, MQM9700 are added just for debug.
+# This mechanism is enabled on new systems starting from SN5600.
 devtr_check_supported_system_init_alternatives()
 {
 	case $cpu_type in
@@ -1093,7 +1093,7 @@ devtr_check_supported_system_init_alternatives()
 #			;;
 #		VMOD0010)
 #			case $sku in
-#				HI122|HI123|HI124|HI125)	# Leopard, Liger, Tigon, Leo
+#				HI122|HI123|HI124|HI125)	# SN4700, MSN4600, MSN4600C
 #					for key in "${!msn4700_msn4600_alternatives[@]}"; do
 #						swb_alternatives["$key"]="${msn4700_msn4600_alternatives["$key"]}"
 #					done

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -1176,7 +1176,7 @@ set_sodimm_temp_limits()
 	# SODIMM temp reading is not supported on Broadwell-DE Comex
 	# and on BF# Comex.
 	# Broadwell-DE Comex can be installed interchangeably with new
-	# Coffee Lake Comex on part of systems e.g. on Anaconda.
+	# Coffee Lake Comex on part of systems e.g. on SN3700.
 	# Thus check by CPU type and not by system type.
 	case $cpu_type in
 		$BDW_CPU|$BF3_CPU)

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -988,7 +988,7 @@ add_cpu_board_to_connection_table()
 			board=$(< /sys/devices/virtual/dmi/id/product_name)
 			case $board in
 				MSN241*|MSN27*)
-					# Spider Panther removed A2D from SFF
+					# SN2410/SN2700 removed A2D from SFF
 					cpu_connection_table=( ${cpu_type0_connection_table[@]} )
 					;;
 				*)
@@ -1231,7 +1231,7 @@ msn27xx_msb_msx_specific()
 	product=$(< /sys/devices/virtual/dmi/id/product_name)
 	case $product in
 		MSN27*|MSN241*)
-			# Panther Spider
+			# SN2700/SN2410
 			connect_table+=(${msn2700_base_connect_table[@]})
 			;;
 		*)
@@ -1241,11 +1241,11 @@ msn27xx_msb_msx_specific()
 	# Connect TC data table 
 	case $product in
 		MSN27*)
-			# Panther
+			# SN2700
 			thermal_control_config="$thermal_control_configs_path/tc_config_msn2700.json"
 			;;
 		MSN241*)
-			# Spider
+			# SN2410
 			thermal_control_config="$thermal_control_configs_path/tc_config_msn2410.json"
 			;;
 		MSB78*|MSB77*)
@@ -1383,7 +1383,7 @@ mqmxxx_msn37x_msn34x_specific()
 			thermal_control_config="$thermal_control_configs_path/tc_config_msn3700C.json"
 		;;
 		HI110)
-			# Jaguar
+			# MQM8700 (HI110)
 			connect_table+=(${mqm8700_connect_table[@]})
 			voltmon_connection_table=(${mqm8700_voltmon_connect_table[@]})
 			thermal_control_config="$thermal_control_configs_path/tc_config_mqm8700.json"
@@ -2545,17 +2545,17 @@ n51xxld_specific()
 	else
 		# Adding Cable Cartridge support which is not included to BOM string.
 		case $sku in
-		HI166)	# Juliet SO.
+		HI166)	# N5110_LD (HI166).
 			add_i2c_dynamic_bus_dev_connection_table "${so_cartridge_eeprom_connect_table[@]}"
 			echo -n "${so_cartridge_eeprom_connect_table[@]}" >> "$devtree_file"
 			echo 4 > $config_path/cartridge_counter
 			;;
-		HI169)	# Juliet Ariel.
+		HI169)	# N5112_LD (HI169).
 			add_i2c_dynamic_bus_dev_connection_table "${ariel_cartridge_eeprom_connect_table[@]}"
 			echo -n "${ariel_cartridge_eeprom_connect_table[@]}" >> "$devtree_file"
 			echo 2 > $config_path/cartridge_counter
 			;;
-		HI167|HI170)	# Juliet NSO
+		HI167|HI170)	# N5100_LD (HI167/HI170)
 			add_i2c_dynamic_bus_dev_connection_table "${nso_cartridge_eeprom_connect_table[@]}"
 			echo -n "${nso_cartridge_eeprom_connect_table[@]}" >> "$devtree_file"
 			echo 4 > $config_path/cartridge_counter
@@ -2569,7 +2569,7 @@ n51xxld_specific()
 		HI177)	# Kyber
 			echo 0 > $config_path/cartridge_counter
 			;;
-		*)	# According Juliet SO.
+		*)	# Default N5110_LD cartridge layout.
 			add_i2c_dynamic_bus_dev_connection_table "${so_cartridge_eeprom_connect_table[@]}"
 			echo -n "${so_cartridge_eeprom_connect_table[@]}" >> "$devtree_file"
 			echo 4 > $config_path/cartridge_counter
@@ -2598,7 +2598,7 @@ n51xxld_specific()
 			echo 6 > $config_path/fan_drwr_num
 			thermal_control_config="$thermal_control_configs_path/tc_config_n5110ld.json"
 		;;
-		HI166|HI169)	# TTM, ARIEL
+		HI166|HI169)	# N5110_LD TTM (HI166), N5112_LD (HI169)
 			echo 4 > $config_path/fan_drwr_num
 			thermal_control_config="$thermal_control_configs_path/tc_config_n5110ld_ttm.json"
 		;;
@@ -2765,10 +2765,10 @@ sn5640_specific()
 	lm_sensors_config="$lm_sensors_configs_path/sn5640_sensors.conf"
 
 	case $sku in
-		HI172)	# Gaur
+		HI172)	# SN5610 (HI172)
 			thermal_control_config="$thermal_control_configs_path/tc_config_sn5610.json"
 		;;
-		HI171)	# Bison
+		HI171)	# SN5640 (HI171)
 			thermal_control_config="$thermal_control_configs_path/tc_config_sn5640.json"
 		;;
 		*)
@@ -3193,7 +3193,7 @@ load_modules()
 	esac
 
 	case $sku in
-		HI162|HI166|HI167|HI169|HI170|HI176|HI177)	# Juliet
+		HI162|HI166|HI167|HI169|HI170|HI176|HI177)	# N51XX_LD
 			modprobe i2c_asf
 			modprobe i2c_designware_platform
 		;;

--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -493,7 +493,7 @@ class BMCAccessor(object):
             pass
 
     def _handle_legacy_password(self):
-        """Handle legacy password generation for juliet platforms (e.g. N5500_LD)"""
+        """Handle legacy password generation for N51XX_LD platforms (e.g. N5500_LD)"""
         pass_len = 13
         attempt = 1
         max_attempts = 100


### PR DESCRIPTION
Replace system aliases with model numbers / platform IDs in documentation, release notes, labels, and comments.
Changes are limited to text/comments and the approved UI label name update.
