### PR TITLE
Rebase two 6.12 patches onto 6.12.41 to unbreak SONiC kernel build

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch
+++ b/recipes-kernel/linux/linux-6.12/0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch
@@ -73,6 +73,7 @@ Signed-off-by: Dvir Zaguri <dzaguri@nvidia.com>
  1 file changed, 70 insertions(+), 2 deletions(-)
 
 diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
+index 81f4bee..1dd843e 100644
 --- a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
 +++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
 @@ -29,6 +29,21 @@
@@ -88,13 +89,13 @@ diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/
 +			reg = <0x00000004 0x237ff000 0x0 0x00001000>;
 +			no-map;
 +		};
- 	};
++	};
 +
 +	/* eMMC hardware reset (RST_n) driven by EMMC_1V8_RST* on GPIOQ7 (ball N15). */
 +	mmc_pwrseq: mmc-pwrseq {
 +		compatible = "mmc-pwrseq-emmc";
 +		reset-gpios = <&gpio1 ASPEED_GPIO(Q, 7) GPIO_ACTIVE_LOW>;
-+	};
+ 	};
  };
  
 @@ -55,6 +70,30 @@
@@ -167,7 +168,7 @@ diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/
  	};
  };
  
-@@ -363,8 +427,11 @@
+@@ -357,8 +421,11 @@
  &emmc {
  	status = "okay";
  	non-removable;
@@ -181,7 +182,7 @@ diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/
  };
  
  /* eSPI Controller - Communication with host CPU */
-@@ -463,5 +529,6 @@
+@@ -463,5 +530,6 @@
  	status = "okay";
  	pinctrl-names = "default";
  	i3c-scl-hz = <12500000>;

--- a/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -14,8 +14,8 @@ dedicated OF match entries are needed.
 Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 ---
  Documentation/hwmon/isl68137.rst | 20 ++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 21 +++++++++++++++++++++---
- 2 files changed, 39 insertions(+), 2 deletions(-)
+ drivers/hwmon/pmbus/isl68137.c   | 20 +++++++++++++++++++-
+ 2 files changed, 39 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
@@ -49,10 +49,10 @@ index 0e71b22047f8..1a1424dd640f 100644
  
      Prefix: 'raa229001'
 diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
-index 2af921039309..39e38e01e630 100644
+index 7e53fb1..5e22c38 100644
 --- a/drivers/hwmon/pmbus/isl68137.c
 +++ b/drivers/hwmon/pmbus/isl68137.c
-@@ -244,6 +244,19 @@
+@@ -178,6 +178,19 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
  	return ret;
  }
  
@@ -72,8 +72,8 @@ index 2af921039309..39e38e01e630 100644
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -389,9 +406,12 @@
- 		info->write_word_data = raa_dmpvr2_write_word_data;
+@@ -244,9 +257,12 @@ static int isl68137_probe(struct i2c_client *client)
+ 		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
 +		info->func[0] &= ~PMBUS_HAVE_VMON;
@@ -86,7 +86,7 @@ index 2af921039309..39e38e01e630 100644
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -463,6 +484,8 @@
+@@ -311,6 +327,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},


### PR DESCRIPTION
The SONiC Debian kernel build applies the patch series with fuzz 0. Two linux-6.12 patches failed to apply against kernel 6.12.41, breaking the sonic_bmc_main build (linux-headers source_sonic stage):

- 0064-hwmon-pmbus-isl68137: hunk 2 context was generated against a newer kernel where isl68137_probe() contains 'info->write_word_data = raa_dmpvr2_write_word_data;' before the raa_dmpvr2_2rail_nontc case. That line does not exist in 6.12.41, so the hunk only applied with fuzz 1 and the build rejected it. Regenerate the drivers/hwmon/pmbus/isl68137.c diff against 6.12.41.

- 0008-arm64-dts-aspeed-spc6-bmc: the hand-folded eMMC HS200 hunk (mmc_pwrseq node) produced an interleaved-context hunk shape that GNU patch 2.7.6 only accepts with fuzz 1 even though the context matches byte-for-byte. Regenerate the DTS diff canonically with git.

Verified: full SONiC 6.12 series (215 patches, common + aspeed/BMC tables) applies cleanly at fuzz 0 on vanilla v6.12.41, and the patched aspeed-nvidia-spc6-bmc.dts compiles to a DTB.