### PR TITLE
hw-mgmt: scripts: Improve robustness for fanX_dir init

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -69,7 +69,6 @@ linecard_folders=("alarm" "config" "eeprom" "environment" "led" "system" "therma
 mlxreg_lc_addr=32
 lc_max_num=8
 dpu_folders=("alarm" "config" "environment" "events" "system" "thermal")
-fan_debounce_timeout_ms=2000
 cfl_comex_vcore_out_idx=2
 
 case "$dmi_board_name" in
@@ -454,102 +453,6 @@ function asic_cpld_add_handler()
 			ln -sf "${ASIC_I2C_PATH}"/cpld3_version $system_path/cpld3_version
 		fi
 	fi
-}
-
-# Set fan direction for a single fan
-#
-# Input parameters:
-# 1 - "$attribute" (fan1, fan2, fan3, fan4)
-# 2 - "$event" (1 - Present, 0 - Removed)
-# Return: None
-#
-# Example:
-# set_fan_direction "fan1" 1 # Set fan1 direction
-# set_fan_direction "fan1" 0 # Remove fan1 direction
-function set_fan_direction()
-{
-	print_function_call "$0" "${FUNCNAME[0]}" "attr:$1 evt:$2 entering..."
-	attribute=$1
-	event=$2
-	case $attribute in
-	
-	fan*)
-		if [ "$event" -eq 0 ]; then
-			echo 2 > "$thermal_path/${attribute}_dir"
-			return
-		fi
-		if [ -f "$config_path/fan_dir_eeprom" ]; then
-			return
-		fi
-		# Check if CPLD fan direction exists
-		if [ ! -f "$system_path/fan_dir" ]; then
-			print_function_call "$0" "${FUNCNAME[0]}" "./system/fan_dir not found"
-			return
-		fi
-		if [[ "$dmi_sku" == "HI117" ]]; then
-			return
-		fi
-		local fan_debounce_timer
-		local fan_debounce_counter
-		local fan_dir
-		local fan_dir_old
-		# if $thermal_path / fanN_dir attribute missing - run debounce logic.
-		fan_dir=$(< "$system_path/fan_dir")
-		fan_debounce_counter=0
-		fan_dir_old=-1
-		fan_debounce_timer=$fan_debounce_timeout_ms
-		while (("$fan_debounce_timer" > 0)) && (("$fan_debounce_counter" < 2))
-		do
-			if [ "${fan_dir}_" == "${fan_dir_old}_" ];
-			then
-				fan_debounce_counter=$((fan_debounce_counter + 1))
-			else
-				fan_dir_old=$fan_dir
-				fan_debounce_counter=0
-			fi
-			fan_debounce_timer=$((fan_debounce_timer - 200))
-			sleep 0.2
-			fan_dir=$(< "$system_path/fan_dir")
-		done
-
-		# fanN: N must be a positive integer (1-based); becomes bit (N-1) in fan_dir.
-		fan_index=${attribute#fan}
-		if [ -z "$fan_index" ] || [[ ! "$fan_index" =~ ^[0-9]+$ ]] || [ "$fan_index" -le 0 ]; then
-			return
-		fi
-		fan_index=$((fan_index - 1))
-
-		#  Debounce is not success. Set fan dir as not recognized value "2".
-		if [ ! -z "$fan_debounce_timer" ] && [ "$fan_debounce_timer" -le 0 ]; then
-			fan_direction=2
-		else
-			# fan_dir is an integer bitfield; one bit per fan direction.
-			fan_direction=$(( (fan_dir >> fan_index) & 1 ))
-		fi
-		print_function_call "$0" "${FUNCNAME[0]}" "$1 $2 $3. Debounce timer left: $fan_debounce_timer ms, fan_dir: $fan_dir, fan_index: $fan_index, fan_direction: $fan_direction"
-		echo "$fan_direction" > "$thermal_path/${attribute}_dir"
-		print_function_call "$0" "${FUNCNAME[0]}" "attr:$1 evt:$2 exiting..."
-	;;
-	*)
-		;;
-	esac
-}
-
-# Set fan direction for all fans
-function set_fan_direction_for_all_fans()
-{
-	print_function_call "$0" "${FUNCNAME[0]}" "Starting..."
-	local -r max_tachos=$(<"$config_path"/max_tachos)
-	for ((i=1; i<="$max_tachos"; i+=1)); do
-		if [ -L "${thermal_path}"/fan"${i}"_status ]; then
-			# check if fan status is set
-			status=$(< "${thermal_path}"/fan"${i}"_status)
-			if [ "$status" -eq 1 ]; then
-				set_fan_direction "fan${i}" "$status"
-			fi
-		fi
-	done
-	print_function_call "$0" "${FUNCNAME[0]}" "Finished"
 }
 
 # Get FAN direction based on VPD PN field

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -119,6 +119,7 @@ declare -A sys_fandir_vs_pn=(["00MP584"]=F ["00MP594"]=R ["00MP593"]=R \
 
 base_cpu_bus_offset=10
 max_tachos=20
+fan_debounce_timeout_ms=2000
 i2c_asic_bus_default=2
 i2c_asic2_bus_default=3
 i2c_bus_min=1
@@ -1298,4 +1299,117 @@ print_function_call() {
 		"$TS" \
 		"$function_name" \
 		"$argument" >> "$LOG_FILE"
+}
+
+# Set fan direction for a single fan
+#
+# Input parameters:
+# 1 - "$attribute" (fan1, fan2, fan3, fan4)
+# 2 - "$event" (1 - Present, 0 - Removed)
+# Return: None
+#
+# Example:
+# set_fan_direction "fan1" 1 # Set fan1 direction
+# set_fan_direction "fan1" 0 # Remove fan1 direction
+function set_fan_direction()
+{
+	local attribute="$1"
+	local event="$2"
+	local fan_debounce_timer
+	local fan_debounce_counter
+	local fan_dir
+	local fan_dir_old
+	local fan_index
+	local fan_direction
+
+	print_function_call "$0" "${FUNCNAME[0]}" "attr:$attribute evt:$event entering..."
+	case $attribute in
+	fan*)
+		if [ "$event" -eq 0 ]; then
+			echo 2 > "$thermal_path/${attribute}_dir"
+			return
+		fi
+		if [ -f "$config_path/fan_dir_eeprom" ]; then
+			return
+		fi
+		# Check if CPLD fan direction exists
+		if [ ! -f "$system_path/fan_dir" ]; then
+			print_function_call "$0" "${FUNCNAME[0]}" "./system/fan_dir not found"
+			return
+		fi
+		if [[ "$ui_tree_sku" == "HI117" ]]; then
+			return
+		fi
+		fan_dir=$(< "$system_path/fan_dir")
+		fan_debounce_counter=0
+		fan_dir_old=-1
+		fan_debounce_timer=$fan_debounce_timeout_ms
+		while (("$fan_debounce_timer" > 0)) && (("$fan_debounce_counter" < 2))
+		do
+			if [ "${fan_dir}_" == "${fan_dir_old}_" ];
+			then
+				fan_debounce_counter=$((fan_debounce_counter + 1))
+			else
+				fan_dir_old=$fan_dir
+				fan_debounce_counter=0
+			fi
+			fan_debounce_timer=$((fan_debounce_timer - 200))
+			sleep 0.2
+			fan_dir=$(< "$system_path/fan_dir")
+		done
+
+		# fanN: N must be a positive integer (1-based); becomes bit (N-1) in fan_dir.
+		fan_index=${attribute#fan}
+		if [ -z "$fan_index" ] || [[ ! "$fan_index" =~ ^[0-9]+$ ]] || [ "$fan_index" -le 0 ]; then
+			return
+		fi
+		fan_index=$((fan_index - 1))
+
+		#  Debounce is not success. Set fan dir as not recognized value "2".
+		if [ ! -z "$fan_debounce_timer" ] && [ "$fan_debounce_timer" -le 0 ]; then
+			fan_direction=2
+		else
+			# fan_dir is an integer bitfield; one bit per fan direction.
+			fan_direction=$(( (fan_dir >> fan_index) & 1 ))
+		fi
+		print_function_call "$0" "${FUNCNAME[0]}" "$attribute $event. Debounce timer left: $fan_debounce_timer ms, fan_dir: $fan_dir, fan_index: $fan_index, fan_direction: $fan_direction"
+		echo "$fan_direction" > "$thermal_path/${attribute}_dir"
+		print_function_call "$0" "${FUNCNAME[0]}" "attr:$attribute evt:$event exiting..."
+	;;
+	*)
+		;;
+	esac
+}
+
+# Set fan direction for all fans
+# $1 - "force" to pass fan_dir re-init even if it already exists.
+#       if not set - threat it as True
+function set_fan_direction_for_all_fans()
+{
+	local -r max_tachos=$(<"$config_path"/max_tachos)
+	local i
+	local status
+
+	print_function_call "$0" "${FUNCNAME[0]}" "Starting..."
+	print_function_call "$0" "${FUNCNAME[0]}" "max_tachos: $max_tachos"
+	local force="$1"
+	if [ -z "$force" ]; then
+		force=1
+	fi
+	for ((i=1; i<="$max_tachos"; i+=1)); do
+		if [ -L "${thermal_path}"/fan"${i}"_status ]; then
+			# check if forse is not set and fan_dir present - skip
+			if [ "$force" -ne 1 ] && [ -f "$thermal_path/fan${i}_dir" ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" "fan${i}_dir present and force is not set - skipping"
+				continue
+			fi
+			# check if fan status is set
+			status=$(< "${thermal_path}"/fan"${i}"_status)
+			print_function_call "$0" "${FUNCNAME[0]}" "fan${i}_status: $status"
+			if [ "$status" -eq 1 ]; then
+				set_fan_direction "fan${i}" "$status"
+			fi
+		fi
+	done
+	print_function_call "$0" "${FUNCNAME[0]}" "Finished"
 }

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -255,3 +255,7 @@ if [ $tc_should_reload -eq 1 ] ||
 	# to run it in the background to avoid blocking the startup process.
 	nohup bash -c "$cmd_line echo thermal control service configured" &>/dev/null &
 fi
+
+
+# double check fan_dir present and initialize it
+set_fan_direction_for_all_fans 0


### PR DESCRIPTION
fan_dir and fan status are initialized from different asynchronous udev
events, so set_fan_direction() for a fan can run before its status is
ready and leave fanX_dir uninitialized.

Move set_fan_direction() and set_fan_direction_for_all_fans() into the
shared hw-management-helpers.sh library and run an additional
set_fan_direction_for_all_fans() pass at the end of
hw-management-start-post.sh, after udev has settled, to initialize any
fanX_dir that was missed. Debounce is only applied for fans whose
fanX_dir attribute is not present yet.

Bug: 5151050

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
