### PR TITLE
hw-mgmt: bmc: Extend support for ADS7924 device configuration

### DIFF
--- a/bmc/examples/hw-management-bmc-a2d-leakage-config-example.json
+++ b/bmc/examples/hw-management-bmc-a2d-leakage-config-example.json
@@ -34,12 +34,12 @@
       "Ads7924SlpConfig": "string, optional. Hex byte SLPCONFIG (0x13), default 0x00.",
       "Ads7924AcqConfig": "string, optional. Hex byte ACQCONFIG (0x14), default 0x00.",
       "Ads7924PwrConfig": "string, optional. Hex byte PWRCONFIG (0x15), default 0x00.",
-      "Ads7924Mode": "string, optional. MODECNTRL final mode byte (reg 0x00), default 0x33 (auto-scan).",
-      "Ads7924AwakeMode": "string, optional. MODECNTRL awake step before Ads7924Mode, default 0x20.",
+      "Ads7924Mode": "string, optional. MODECNTRL final mode byte (reg 0x00), default 0xcc (auto-scan). MODE[5:0] occupies bits[7:2], SEL[1:0] bits[1:0]: 0xcc=auto-scan ch0, 0xec=auto-scan with sleep.",
+      "Ads7924AwakeMode": "string, optional. MODECNTRL awake step before Ads7924Mode, default 0x80 (awake).",
       "Ads7924AlarmEnable": "string, optional. INTCNTRL AEN[3:0] (reg 0x01), default 0x0f.",
       "Ads7924UlChN": "string, optional. Per-channel ULR override, N=1..4, hex byte.",
       "Ads7924LlChN": "string, optional. Per-channel LLR override, N=1..4, hex byte.",
-      "Ads7924_configuration_note": "All Ads7924* keys are optional. When omitted, hw-management-bmc-a2d-leakage-config.sh uses defaults: soft reset on (0xaa @ RESET), INT/SLP/ACQ/PWR = 0xe0 0x00 0x00 0x00, INTCNTRL AEN = 0x0f, AWAKE 0x20 then MODE 0x33 (auto-scan). For ULR/LLR and comparator-driven INT you need Scale plus NormalMin/NormalMax (or if those are absent, WarningMin/WarningMax) on raw I2C (Probe false). Per-channel ULR/LLR overrides use Ads7924UlCh1..4 / Ads7924LlCh1..4 only when you need registers to differ from that voltage-derived window."
+      "Ads7924_configuration_note": "All Ads7924* keys are optional. When omitted, hw-management-bmc-a2d-leakage-config.sh uses defaults: soft reset on (0xaa @ RESET), INT/SLP/ACQ/PWR = 0xe0 0x00 0x00 0x00, INTCNTRL AEN = 0x0f, AWAKE 0x80 then MODE 0xcc (auto-scan). For ULR/LLR and comparator-driven INT you need Scale plus NormalMin/NormalMax (or if those are absent, WarningMin/WarningMax) on raw I2C (Probe false). Per-channel ULR/LLR overrides use Ads7924UlCh1..4 / Ads7924LlCh1..4 only when you need registers to differ from that voltage-derived window."
     },
     "runtime_paths": {
       "leakage_i_j": "/var/run/hw-management/leakage/<i>/<j>/ where i = detector index, j = channel number = the mapped hardware input from Channels[].Id (non-contiguous, e.g. 1 and 4). Legacy: 1..NumChnl for a scalar/absent ChannelId, or the 1-based Device[] position in per-channel device-map mode.",

--- a/bmc/examples/hw-management-bmc-a2d-leakage-config-hi188-eample.json
+++ b/bmc/examples/hw-management-bmc-a2d-leakage-config-hi188-eample.json
@@ -1,0 +1,581 @@
+[
+  {
+    "Name": "Mngm_ADC0",
+    "_draft_note": "DRAFT from 'Leak Detection Application Notes.docx'. Fill real BMC I2C bus and ADS7924 address before deployment. Management ADC has one active sensor; channels 2-4 are marked unused with a full-scale window to suppress floating-input alarms.",
+    "NumChnl": 4,
+    "ChnlNames": [
+      "Mngm_ADC0_Ch0_Embedded_0",
+      "Mngm_ADC0_Ch1_Unused",
+      "Mngm_ADC0_Ch2_Unused",
+      "Mngm_ADC0_Ch3_Unused"
+    ],
+    "Device": [
+      {
+        "DeviceType": "MAX1363",
+        "Bus": 27,
+        "Bus_comment": "HI188 management BMC I2C bus (i2c-27).",
+        "Address": "0x36",
+        "Probe": true,
+        "Scale": 0.0005,
+        "Max1363_comment": "TODO: CfgRegVal is a generic hw-mgmt MAX1363 monitor burst placeholder. Verify the exact HI188 monitor/threshold sequence before enabling MAX1363 as a hardware-alarm source.",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          },
+          {
+            "Type": "unused",
+            "NormalMin": 0.0,
+            "NormalMax": 2.048,
+            "WarningMin": 0.0,
+            "CriticalMin": 0.0,
+            "WarningMax": 2.048,
+            "CriticalMax": 2.048
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "unused"
+          },
+          {
+            "Id": 3,
+            "Type": "unused"
+          },
+          {
+            "Id": 4,
+            "Type": "unused"
+          }
+        ],
+        "CfgReg": "0x00",
+        "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15"
+      },
+      {
+        "DeviceType": "ADS7924",
+        "Bus": 27,
+        "Bus_comment": "HI188 management BMC I2C bus (i2c-27).",
+        "Address": "0x49",
+        "Address_comment": "HI188 ADS7924 address on management bus (A0/A1-selected).",
+        "Probe": true,
+        "Scale": 0.0006103515625,
+        "Ads7924_comment": "Vref=2.5V. Normal window is 0.8-0.9*Vref => LLR=0xcc, ULR=0xe6. Mode 0xcc = auto-scan (MODE[5:0] in bits[7:2]); use 0xec for auto-scan with sleep.",
+        "Ads7924IntConfig": "0xe0",
+        "Ads7924AlarmEnable": "0x0f",
+        "Ads7924Mode": "0xcc",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          },
+          {
+            "Type": "unused",
+            "NormalMin": 0.0,
+            "NormalMax": 2.5,
+            "WarningMin": 0.0,
+            "CriticalMin": 0.0,
+            "WarningMax": 2.5,
+            "CriticalMax": 2.5
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "unused"
+          },
+          {
+            "Id": 3,
+            "Type": "unused"
+          },
+          {
+            "Id": 4,
+            "Type": "unused"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "CSM0_ADC0",
+    "_draft_note": "DRAFT from application note. Fill real BMC I2C bus and ADS7924 address before deployment.",
+    "NumChnl": 4,
+    "ChnlNames": [
+      "CSM0_ADC0_Ch0_Embedded_0",
+      "CSM0_ADC0_Ch1_Embedded_1",
+      "CSM0_ADC0_Ch2_Flex_0",
+      "CSM0_ADC0_Ch3_Flex_1"
+    ],
+    "Device": [
+      {
+        "DeviceType": "MAX1363",
+        "Bus": 28,
+        "Bus_comment": "HI188 CSM0_ADC0 BMC I2C bus (i2c-28). Pending re-check.",
+        "Address": "0x36",
+        "Probe": true,
+        "Scale": 0.0005,
+        "Max1363_comment": "TODO: CfgRegVal is a generic hw-mgmt MAX1363 monitor burst placeholder. Verify exact HI188 MAX1363 threshold programming before deployment.",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ],
+        "CfgReg": "0x00",
+        "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15"
+      },
+      {
+        "DeviceType": "ADS7924",
+        "Bus": 28,
+        "Bus_comment": "HI188 CSM0_ADC0 BMC I2C bus (i2c-28). Pending re-check.",
+        "Address": "0x48",
+        "Address_comment": "HI188 ADS7924 address on CSM bus (A0/A1-selected).",
+        "Probe": true,
+        "Scale": 0.0006103515625,
+        "Ads7924IntConfig": "0xe0",
+        "Ads7924AlarmEnable": "0x0f",
+        "Ads7924Mode": "0xcc",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "CSM1_ADC0",
+    "_draft_note": "DRAFT from application note. Fill real BMC I2C bus and ADS7924 address before deployment.",
+    "NumChnl": 4,
+    "ChnlNames": [
+      "CSM1_ADC0_Ch0_Embedded_0",
+      "CSM1_ADC0_Ch1_Embedded_1",
+      "CSM1_ADC0_Ch2_Flex_0",
+      "CSM1_ADC0_Ch3_Flex_1"
+    ],
+    "Device": [
+      {
+        "DeviceType": "MAX1363",
+        "Bus": 29,
+        "Bus_comment": "HI188 CSM1_ADC0 BMC I2C bus (i2c-29). Pending re-check.",
+        "Address": "0x36",
+        "Probe": true,
+        "Scale": 0.0005,
+        "Max1363_comment": "TODO: CfgRegVal is a generic hw-mgmt MAX1363 monitor burst placeholder. Verify exact HI188 MAX1363 threshold programming before deployment.",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ],
+        "CfgReg": "0x00",
+        "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15"
+      },
+      {
+        "DeviceType": "ADS7924",
+        "Bus": 29,
+        "Bus_comment": "HI188 CSM1_ADC0 BMC I2C bus (i2c-29). Pending re-check.",
+        "Address": "0x48",
+        "Address_comment": "HI188 ADS7924 address on CSM bus (A0/A1-selected).",
+        "Probe": true,
+        "Scale": 0.0006103515625,
+        "Ads7924IntConfig": "0xe0",
+        "Ads7924AlarmEnable": "0x0f",
+        "Ads7924Mode": "0xcc",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "CSM2_ADC0",
+    "_draft_note": "DRAFT from application note. Fill real BMC I2C bus and ADS7924 address before deployment.",
+    "NumChnl": 4,
+    "ChnlNames": [
+      "CSM2_ADC0_Ch0_Embedded_0",
+      "CSM2_ADC0_Ch1_Embedded_1",
+      "CSM2_ADC0_Ch2_Flex_0",
+      "CSM2_ADC0_Ch3_Flex_1"
+    ],
+    "Device": [
+      {
+        "DeviceType": "MAX1363",
+        "Bus": 30,
+        "Bus_comment": "HI188 CSM2_ADC0 BMC I2C bus (i2c-30). Pending re-check.",
+        "Address": "0x36",
+        "Probe": true,
+        "Scale": 0.0005,
+        "Max1363_comment": "TODO: CfgRegVal is a generic hw-mgmt MAX1363 monitor burst placeholder. Verify exact HI188 MAX1363 threshold programming before deployment.",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ],
+        "CfgReg": "0x00",
+        "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15"
+      },
+      {
+        "DeviceType": "ADS7924",
+        "Bus": 30,
+        "Bus_comment": "HI188 CSM2_ADC0 BMC I2C bus (i2c-30). Pending re-check.",
+        "Address": "0x48",
+        "Address_comment": "HI188 ADS7924 address on CSM bus (A0/A1-selected).",
+        "Probe": true,
+        "Scale": 0.0006103515625,
+        "Ads7924IntConfig": "0xe0",
+        "Ads7924AlarmEnable": "0x0f",
+        "Ads7924Mode": "0xcc",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "CSM3_ADC0",
+    "_draft_note": "DRAFT from application note. Fill real BMC I2C bus and ADS7924 address before deployment.",
+    "NumChnl": 4,
+    "ChnlNames": [
+      "CSM3_ADC0_Ch0_Embedded_0",
+      "CSM3_ADC0_Ch1_Embedded_1",
+      "CSM3_ADC0_Ch2_Flex_0",
+      "CSM3_ADC0_Ch3_Flex_1"
+    ],
+    "Device": [
+      {
+        "DeviceType": "MAX1363",
+        "Bus": 31,
+        "Bus_comment": "HI188 CSM3_ADC0 BMC I2C bus (i2c-31). Pending re-check.",
+        "Address": "0x36",
+        "Probe": true,
+        "Scale": 0.0005,
+        "Max1363_comment": "TODO: CfgRegVal is a generic hw-mgmt MAX1363 monitor burst placeholder. Verify exact HI188 MAX1363 threshold programming before deployment.",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 1.6384,
+            "NormalMax": 1.8432,
+            "WarningMin": 1.4336,
+            "CriticalMin": 0.2048,
+            "WarningMax": 1.8432,
+            "CriticalMax": 2.048
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ],
+        "CfgReg": "0x00",
+        "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15"
+      },
+      {
+        "DeviceType": "ADS7924",
+        "Bus": 31,
+        "Bus_comment": "HI188 CSM3_ADC0 BMC I2C bus (i2c-31). Pending re-check.",
+        "Address": "0x48",
+        "Address_comment": "HI188 ADS7924 address on CSM bus (A0/A1-selected).",
+        "Probe": true,
+        "Scale": 0.0006103515625,
+        "Ads7924IntConfig": "0xe0",
+        "Ads7924AlarmEnable": "0x0f",
+        "Ads7924Mode": "0xcc",
+        "Types": [
+          {
+            "Type": "embedded",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          },
+          {
+            "Type": "flex",
+            "NormalMin": 2.0,
+            "NormalMax": 2.25,
+            "WarningMin": 1.75,
+            "CriticalMin": 0.25,
+            "WarningMax": 2.25,
+            "CriticalMax": 2.5
+          }
+        ],
+        "Channels": [
+          {
+            "Id": 1,
+            "Type": "embedded"
+          },
+          {
+            "Id": 2,
+            "Type": "embedded"
+          },
+          {
+            "Id": 3,
+            "Type": "flex"
+          },
+          {
+            "Id": 4,
+            "Type": "flex"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
@@ -103,9 +103,9 @@ check_config_file()
 	return 0
 }
 
-# Optional JSON field "Probe": true — bind kernel driver (new_device) before register programming,
-# briefly unbind for raw i2ctransfer, then rebind for IIO sysfs so driver probe does not run after
-# our final register values are written.
+# Optional JSON field "Probe": true — bind kernel driver (new_device) for IIO sysfs links.
+# MAX1363/ADS1015/ADS7924: bind driver (probe runs), then program registers via i2ctransfer -f
+# while the driver stays bound so our values are the last writer after probe.
 # JSON booleans are unquoted (true/false); json_get_string only sees quoted values — use json_get_bool.
 json_probe_true()
 {
@@ -168,7 +168,7 @@ bind_kernel_driver()
 		log_message "warning" "Bind $driver to $dev_id failed (client present, driver not attached)"
 		return 1
 	fi
-	log_message "info" "Binding $driver at $address on bus $bus (new_device before register config, then unbind/program/rebind)"
+	log_message "info" "Binding $driver at $address on bus $bus (new_device)"
 	if ! echo "$driver $address" > "${adapter}/new_device" 2>/dev/null; then
 		log_message "warning" "new_device failed for $driver $address on i2c-$bus (driver missing or device conflict) — continuing with raw I2C config"
 		return 1
@@ -692,6 +692,7 @@ max1363_cfg_reg_val_for_channel()
 }
 
 # Program MAX1363 register burst from JSON CfgReg/CfgRegVal (channel-aware when ChannelId set).
+# Optional 6th arg post_driver=post_driver: driver may stay bound (i2ctransfer -f).
 configure_max1363_raw_i2c()
 {
 	local device_json="$1"
@@ -699,8 +700,13 @@ configure_max1363_raw_i2c()
 	local bus="$3"
 	local address="$4"
 	local hw_channel_id="${5:-0}"
+	local post_driver="${6:-}"
 
 	local cfg_reg cfg_reg_val patched hw_ch scan_ch k cid
+
+	if [ "$post_driver" = "post_driver" ]; then
+		log_message "info" "MAX1363 $device_name: post-driver I2C programming"
+	fi
 
 	cfg_reg=$(echo "$device_json" | json_get_string "CfgReg")
 	cfg_reg_val=$(echo "$device_json" | json_get_string "CfgRegVal")
@@ -809,6 +815,7 @@ ads1015_set_iio_scale_for_raw()
 }
 
 # Program ADS1015 config (and optional window comparator Lo/Hi) per MUX channel (TI SBAS173).
+# Optional 7th arg post_driver=post_driver: driver may stay bound (i2ctransfer -f).
 configure_ads1015_raw_i2c()
 {
 	local device_json="$1"
@@ -817,9 +824,14 @@ configure_ads1015_raw_i2c()
 	local address="$4"
 	local num_channels="$5"
 	local hw_channel_id="${6:-0}"
+	local post_driver="${7:-}"
 
 	local cfg_lo lo_val hi_val lo_reg hi_reg mux mux_handoff ch nch ch_end ch_step failed skip_thresh mode_msg
 	local t ch_label ch_list k cid
+
+	if [ "$post_driver" = "post_driver" ]; then
+		log_message "info" "ADS1015 $device_name: post-driver I2C programming"
+	fi
 
 	cfg_lo="0x94"
 	t=$(echo "$device_json" | json_get_string "CfgRegVal" 2>/dev/null) || true
@@ -945,7 +957,9 @@ configure_ads1015_raw_i2c()
 	return 0
 }
 
-# Program ADS7924 when no kernel driver is bound (TI SBAS482 register map).
+# Program ADS7924 over raw I2C (TI SBAS482 register map).
+# Optional 6th arg post_driver=post_driver: driver may stay bound (i2ctransfer -f); soft reset
+# is skipped so we do not undo kernel probe state.
 configure_ads7924_raw_i2c()
 {
 	local device_json="$1"
@@ -953,6 +967,7 @@ configure_ads7924_raw_i2c()
 	local bus="$3"
 	local address="$4"
 	local num_channels="$5"
+	local post_driver="${6:-}"
 
 	local scale_s v_min v_max ll ul i b c t gtype
 	local int_b slp_b acq_b pwr_b mode_b awake_b aen_b
@@ -1083,8 +1098,8 @@ configure_ads7924_raw_i2c()
 	slp_b="0x00"
 	acq_b="0x00"
 	pwr_b="0x00"
-	mode_b="0x33"
-	awake_b="0x20"
+	mode_b="0xcc"
+	awake_b="0x80"
 	aen_b="0x0f"
 	t=$(json_hex_byte_or_empty "$device_json" "Ads7924IntConfig") && int_b="$t"
 	t=$(json_hex_byte_or_empty "$device_json" "Ads7924SlpConfig") && slp_b="$t"
@@ -1094,13 +1109,15 @@ configure_ads7924_raw_i2c()
 	t=$(json_hex_byte_or_empty "$device_json" "Ads7924AwakeMode") && awake_b="$t"
 	t=$(json_hex_byte_or_empty "$device_json" "Ads7924AlarmEnable") && aen_b="$t"
 
-	if json_ads7924_soft_reset_default_true "$device_json"; then
+	if [ "$post_driver" != "post_driver" ] && json_ads7924_soft_reset_default_true "$device_json"; then
 		log_message "info" "ADS7924 $device_name: software reset (write 0xaa to RESET)"
 		if ! i2c_write_ads7924_burst "$bus" "$address" 0x16 0xaa; then
 			log_message "warning" "ADS7924 $device_name: soft reset write failed"
 			return 1
 		fi
 		sleep 0.05
+	elif [ "$post_driver" = "post_driver" ]; then
+		log_message "info" "ADS7924 $device_name: post-driver programming (soft reset skipped)"
 	fi
 
 	if ! i2c_write_ads7924_burst "$bus" "$address" 0x00 0x00; then
@@ -1131,6 +1148,12 @@ configure_ads7924_raw_i2c()
 	fi
 	sleep 0.02
 
+	# Clear any stale alarm interrupt before starting the scan. TI SBAS482: reading
+	# INTCONFIG (0x12) clears a latched alarm-condition interrupt.
+	log_message "info" "ADS7924 $device_name: clearing stale alarm (read INTCONFIG 0x12)"
+	i2ctransfer -f -y "$bus" w1@"$address" 0x12 r1 >/dev/null 2>&1 || true
+	sleep 0.002
+
 	log_message "info" "ADS7924 $device_name: AWAKE then MODE ($awake_b then $mode_b)"
 	if ! i2c_write_ads7924_burst "$bus" "$address" 0x00 $awake_b; then
 		log_message "warning" "ADS7924 $device_name: AWAKE write failed"
@@ -1142,7 +1165,11 @@ configure_ads7924_raw_i2c()
 		return 1
 	fi
 
-	log_message "info" "ADS7924 $device_name: raw I2C configuration complete"
+	if [ "$post_driver" = "post_driver" ]; then
+		log_message "info" "ADS7924 $device_name: post-driver I2C configuration complete"
+	else
+		log_message "info" "ADS7924 $device_name: raw I2C configuration complete"
+	fi
 	return 0
 }
 
@@ -1710,7 +1737,8 @@ populate_single_leakage_channel()
 	return 0
 }
 
-# Program device registers over raw I2C (caller must have unbound any kernel driver).
+# Program device registers over raw I2C (i2ctransfer -f). When post_driver is set, the
+# kernel driver may remain bound after probe.
 configure_a2d_registers_raw()
 {
 	local device_json="$1"
@@ -1720,6 +1748,7 @@ configure_a2d_registers_raw()
 	local device_type="$5"
 	local num_channels="$6"
 	local hw_channel_id="${7:-0}"
+	local post_driver="${8:-}"
 
 	local cfg_reg cfg_reg_val lo_thresh_reg lo_thresh_val hi_thresh_reg hi_thresh_val
 	local success failed
@@ -1732,15 +1761,15 @@ configure_a2d_registers_raw()
 	hi_thresh_val=$(echo "$device_json" | json_get_string "HiThreshRegVal")
 
 	if [ "$device_type" = "ADS7924" ]; then
-		configure_ads7924_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels"
+		configure_ads7924_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels" "$post_driver"
 		return $?
 	fi
 	if [ "$device_type" = "ADS1015" ]; then
-		configure_ads1015_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels" "$hw_channel_id"
+		configure_ads1015_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$num_channels" "$hw_channel_id" "$post_driver"
 		return $?
 	fi
 	if [ "$device_type" = "MAX1363" ]; then
-		configure_max1363_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$hw_channel_id"
+		configure_max1363_raw_i2c "$device_json" "$device_name" "$bus" "$address" "$hw_channel_id" "$post_driver"
 		return $?
 	fi
 
@@ -1803,6 +1832,25 @@ configure_device()
 
 	log_message "info" "Configuring $device_type for $device_name..."
 
+	# Probe: bind driver (probe runs), then program registers as the last writer.
+	if json_probe_true "$device_json"; then
+		case "$device_type" in
+		ADS7924|MAX1363|ADS1015)
+			if ! bind_kernel_driver "$bus" "$address" "$device_type"; then
+				log_message "info" "$device_type $device_name: driver bind failed — try next Device alternative"
+				return 1
+			fi
+			if ! configure_a2d_registers_raw "$device_json" "$device_name" "$bus" "$address" \
+				"$device_type" "$num_channels" "$hw_channel_id" post_driver; then
+				log_message "info" "$device_type $device_name: post-probe register programming failed — try next Device alternative"
+				return 1
+			fi
+			log_message "info" "Device configuration complete for $device_name"
+			return 0
+			;;
+		esac
+	fi
+
 	# 2) Bind kernel driver first when Probe is true (instantiates client; driver probe may run once).
 	if json_probe_true "$device_json"; then
 		if ! bind_kernel_driver "$bus" "$address" "$device_type"; then
@@ -1810,7 +1858,7 @@ configure_device()
 		fi
 	fi
 
-	# 3) Unbind so i2ctransfer can program registers (MAX1363 / ADS1015 / ADS7924).
+	# 3) Unbind so i2ctransfer can program registers (MAX1363 / ADS1015).
 	if i2c_client_has_bound_driver "$bus" "$address"; then
 		if ! unbind_kernel_driver "$bus" "$address"; then
 			log_message "info" "Leak detector $device_name: driver unbind failed — try next Device alternative"

--- a/bmc/usr/usr/bin/hw-management-bmc-ads7924-force-alarm.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ads7924-force-alarm.sh
@@ -59,8 +59,8 @@ INT_B=0xe0
 SLP_B=0x00
 ACQ_B=0x00
 PWR_B=0x00
-AWAKE_B=0x20
-MODE_B=0x33
+AWAKE_B=0x80
+MODE_B=0xcc
 
 usage() {
     echo "Usage: $0 <bus> <i2c_addr> <channels>"
@@ -153,6 +153,9 @@ if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x01 "$aen" >/dev/null 2>&1; then
     echo "ADS7924 INTCNTRL (alarm enable) write failed"
     exit 1
 fi
+
+# Clear any stale alarm interrupt before starting the scan (read INTCONFIG 0x12).
+i2ctransfer -f -y "$BUS" w1@"$ADDR" 0x12 r1 >/dev/null 2>&1 || true
 
 if ! i2ctransfer -f -y "$BUS" w2@"$ADDR" 0x00 "$AWAKE_B" >/dev/null 2>&1; then
     echo "ADS7924 AWAKE mode write failed"


### PR DESCRIPTION
ADS7924 support:
- Program ULR/LLR window comparator from per-channel voltage thresholds (Scale + Normal/Warning min/max), 8-bit codes.
- Add optional Ads7924* register overrides (INTCONFIG, SLP/ACQ/ PWR, INTCNTRL alarm enable, AWAKE and final MODE bytes).
- Clear a stale alarm before scanning by reading INTCONFIG (0x12), per TI SBAS482.
- Default final MODE byte set to 0x80 per HW request (auto-scan with sleep + INT), still overridable via Ads7924Mode.
- Mirror the stale-alarm clear and MODE default in the ads7924-force-alarm debug tool.
- Add HI188 leakage config example (Mngm + CSM0..3, MAX1363 and ADS7924 alternatives).

Probing order:
- For Probe:true devices, bind the kernel driver first so the driver probe runs, then program registers via i2ctransfer with the driver left bound. This makes our configuration the last writer and keeps the IIO voltage sysfs links.
- Applies to ADS7924, MAX1363 and ADS1015; drops the previous unbind/program/rebind cycle that let the driver re-probe (and potentially overwrite our values) after configuration.