### PR TITLE
hw-mgmt: scripts: Fix hw-management stop timeout handling

### DIFF
--- a/debian/hw-management.hw-management-peripheral-updater.service
+++ b/debian/hw-management.hw-management-peripheral-updater.service
@@ -10,7 +10,7 @@ StartLimitBurst=5
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw_management_peripheral_updater.py"
 ExecStop=/bin/kill $MAINPID
-TimeoutStopSec=1
+TimeoutStopSec=5
 
 Restart=on-failure
 RestartSec=10s

--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -11,7 +11,7 @@ StartLimitBurst=15
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_control.py"
 ExecStop=/bin/kill $MAINPID
-TimeoutStopSec=5
+TimeoutStopSec=10
 
 Restart=on-failure
 RestartSec=60s

--- a/debian/hw-management.hw-management-thermal-updater.service
+++ b/debian/hw-management.hw-management-thermal-updater.service
@@ -10,7 +10,7 @@ StartLimitBurst=5
 [Service]
 ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_updater.py"
 ExecStop=/bin/kill $MAINPID
-TimeoutStopSec=1
+TimeoutStopSec=5
 
 Restart=on-failure
 RestartSec=10s

--- a/usr/usr/bin/hw_management_lib.py
+++ b/usr/usr/bin/hw_management_lib.py
@@ -99,7 +99,7 @@ def atomic_file_write(file_name, value):
 # ----------------------------------------------------------------------
 
 
-def exit_wait(exit_event, timeout, chunk_sec=1.0):
+def exit_wait(exit_event, timeout, chunk_sec=0.2):
     """
     @summary:
         Wait up to timeout seconds in short chunks for graceful shutdown visibility.

--- a/usr/usr/bin/hw_management_peripheral_updater.py
+++ b/usr/usr/bin/hw_management_peripheral_updater.py
@@ -706,7 +706,7 @@ def main():
             LOGGER.notice(traceback.format_exc())
             # Continue running despite error
 
-        exit_wait(EXIT, 1, chunk_sec=0.2)
+        exit_wait(EXIT, 1)
 
     LOGGER.notice("hw-management-peripheral-updater: stopped main loop ({})".format(_sig_condition_name))
     return

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -4258,6 +4258,8 @@ class ThermalManagement(hw_management_file_op):
             curr_timestamp = current_milli_time()
 
             for dev_obj in self.dev_obj_list:
+                if self.exit.is_set():
+                    return
                 if dev_obj.enable:
                     if curr_timestamp >= dev_obj.get_timestamp():
                         # process sensors
@@ -4271,6 +4273,8 @@ class ThermalManagement(hw_management_file_op):
                 conf["skip_err"] = False
 
             for dev_obj in self.dev_obj_list:
+                if self.exit.is_set():
+                    return
                 if dev_obj.enable:
                     if dev_obj.state != CONST.RUNNING:
                         continue
@@ -4310,6 +4314,8 @@ class ThermalManagement(hw_management_file_op):
                 continue
 
             for dev_obj in self.dev_obj_list:
+                if self.exit.is_set():
+                    return
                 if dev_obj.enable:
                     if curr_timestamp >= dev_obj.get_timestamp():
                         if dev_obj.state == CONST.RUNNING:

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -4718,6 +4718,8 @@ class ThermalManagement(hw_management_file_op):
             curr_timestamp = current_milli_time()
 
             for dev_obj in self.dev_obj_list:
+                if self.exit.is_set():
+                    return
                 if dev_obj.enable:
                     if curr_timestamp >= dev_obj.get_timestamp():
                         # process sensors
@@ -4731,6 +4733,8 @@ class ThermalManagement(hw_management_file_op):
                 conf["skip_err"] = False
 
             for dev_obj in self.dev_obj_list:
+                if self.exit.is_set():
+                    return
                 if dev_obj.enable:
                     if dev_obj.state != CONST.RUNNING:
                         continue
@@ -4770,6 +4774,8 @@ class ThermalManagement(hw_management_file_op):
                 continue
 
             for dev_obj in self.dev_obj_list:
+                if self.exit.is_set():
+                    return
                 if dev_obj.enable:
                     if curr_timestamp >= dev_obj.get_timestamp():
                         if dev_obj.state == CONST.RUNNING:

--- a/usr/usr/bin/hw_management_thermal_updater.py
+++ b/usr/usr/bin/hw_management_thermal_updater.py
@@ -267,6 +267,8 @@ def asic_temp_populate(arg_list, arg):
     @param arg: Unused parameter (for interface compatibility)
     """
     for asic_name, asic_attr in arg_list.items():
+        if EXIT.is_set():
+            break
         cntrs_obj = asic_attr.get("counters")
         if not cntrs_obj:
             cntrs_obj = Counter()
@@ -360,6 +362,8 @@ def module_temp_populate(arg_list, _dummy):
     offset = arg_list["fout_idx_offset"]
     LOGGER.debug("module_temp_populate")
     for idx in range(module_count):
+        if EXIT.is_set():
+            break
         module_name = "module{}".format(idx + offset)
         f_dst_name = "/var/run/hw-management/thermal/{}_temp_input".format(module_name)
         if os.path.islink(f_dst_name):
@@ -588,6 +592,8 @@ def main():
     while not EXIT.is_set():
         try:
             for attr in thermal_attr:
+                if EXIT.is_set():
+                    break
                 update_thermal_attr(attr)
             try:
                 log_level_filename = os.path.join(CONST.HW_MGMT_FOLDER_DEF, CONST.LOG_LEVEL_FILENAME)
@@ -606,7 +612,7 @@ def main():
             LOGGER.notice(traceback.format_exc())
             # Continue running despite error
 
-        exit_wait(EXIT, 1, chunk_sec=0.2)
+        exit_wait(EXIT, 1)
 
     LOGGER.notice("hw-management-thermal-updater: stopped main loop ({})".format(_sig_condition_name))
 


### PR DESCRIPTION
Description: hw-management services could exceed systemd stop timeout
because SIGTERM handling was delayed by long waits and thermal update loops.
Reduce the shared wait chunk, exit thermal loops as soon as the stop
event is set, and extend the TC service stop timeout to allow
graceful cleanup.

Bug 5107746, 5103562

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
