### PR TITLE
hw-mgmt: Fix chipup I2C trace collection on mlxsw_minimal failure

### DIFF
--- a/usr/etc/logrotate.d/hw-mgmt-trace
+++ b/usr/etc/logrotate.d/hw-mgmt-trace
@@ -22,3 +22,9 @@
     missingok
     notifempty
 }
+
+# NOTE: /var/log/chipup_i2c_trace_log is intentionally NOT rotated here. It is
+# rotated by the chipup handler in hw-management.sh (per-invocation, size-based,
+# with a bounded number of timestamped archives - see chipup_log_size and
+# chipup_log_archive_max). Using logrotate as well would risk copytruncate
+# splitting a capture mid chipup run.

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -1226,6 +1226,12 @@ set_sodimm_temp_limits()
 
 # Start i2c trace (ftrace i2c event class under tracefs).
 KERN_TRACE_FS="/sys/kernel/debug/tracing"
+I2C_TRACE_LOG="/var/log/hw-mgmt-i2c-trace.log"
+# Bound the per-CPU ftrace ring buffer so a stuck or looping bus cannot grow the
+# captured trace without limit. Applied to both the boot-wide tracer and the
+# chipup tracer. This is the primary size cap: it bounds every "cat trace" dump
+# regardless of how long the tracer runs.
+I2C_TRACE_BUF_SIZE_KB=1024
 start_i2c_trace() {
 	if [ ! -d "$KERN_TRACE_FS/events/i2c" ]; then
 		return
@@ -1237,8 +1243,8 @@ start_i2c_trace() {
 		return
 	fi
 
-	# configure i2c trace buffer size
-	# echo 1024 > "$KERN_TRACE_FS"/buffer_size_kb  # 1 MiB (per-buffer; see tracing doc)
+	# Bound the ring buffer size (per-CPU) so the capture cannot grow unbounded.
+	echo "$I2C_TRACE_BUF_SIZE_KB" > "$KERN_TRACE_FS"/buffer_size_kb 2>/dev/null || true
 	# reset i2c trace
 	echo 0 > "$KERN_TRACE_FS"/events/i2c/enable
 	# clear i2c trace buffer
@@ -1266,9 +1272,109 @@ stop_i2c_trace() {
 	# disable (stop) i2c trace
 	echo 0 > "$KERN_TRACE_FS"/events/i2c/enable
 	# save i2c trace to file
-	cat "$KERN_TRACE_FS"/trace >> /var/log/hw-mgmt-i2c-trace.log
+	cat "$KERN_TRACE_FS"/trace >> "$I2C_TRACE_LOG"
 	# clear i2c trace buffer
 	echo 0 > "$KERN_TRACE_FS"/trace
+}
+
+# Snapshot the boot-wide (top-level) I2C trace buffer into the trace log, tagged
+# with the supplied reason, then clear the buffer so the tracer keeps running
+# with a fresh window.
+#
+# Unlike stop_i2c_trace this does NOT disable the tracer: it is meant to be
+# called mid-boot to preserve evidence for a device other than the ASIC
+# (mlxsw_minimal), e.g. a device that fails to connect in connect_platform, so
+# the failure context is not lost when the (now bounded) ring buffer wraps or
+# when the final stop_i2c_trace dump happens much later. The chipup path has its
+# own dedicated tracer (start/save/stop_chipup_i2c_trace) and does not use this.
+# $1 - human-readable reason written as a delimiter before the trace data.
+save_i2c_trace_on_failure() {
+	local reason="${1:-unspecified failure}"
+
+	# Only act when the boot-wide tracer is available and actually running.
+	[ -f "$KERN_TRACE_FS"/events/i2c/enable ] || return
+	[ "$(cat "$KERN_TRACE_FS"/events/i2c/enable 2>/dev/null)" = "1" ] || return
+
+	echo "# --- i2c trace saved on: ${reason} ($(date '+%Y-%m-%d %H:%M:%S')) ---" >> "$I2C_TRACE_LOG"
+	cat "$KERN_TRACE_FS"/trace >> "$I2C_TRACE_LOG" 2>/dev/null
+	# Clear so the tracer continues with a fresh, bounded window (and the final
+	# stop_i2c_trace dump does not duplicate what we just saved).
+	echo 0 > "$KERN_TRACE_FS"/trace 2>/dev/null
+}
+
+# Chipup I2C tracer.
+#
+# The chipup tracer runs on its own ftrace instance so it never disturbs the
+# boot-wide tracer (start_i2c_trace/stop_i2c_trace), which uses the top-level
+# tracing instance. This matters because chipup is triggered asynchronously
+# (sx-core udev event) and may run while do_start's boot-wide tracer is active;
+# sharing the single top-level buffer/filter/enable would clobber it.
+#
+# start_chipup_i2c_trace stores the tracing directory in CHIPUP_TRACE_DIR
+# (empty when tracing could not be started). The ftrace instance name includes
+# the ASIC index so concurrent chipup on multi-ASIC platforms do not share one
+# buffer.
+# Default filter: capture all CPLD bridge child adapters (i2c-2 and up), not
+# just the ASIC bus, so bus-wide contention is visible. i2c-0 (CPU SMBus) and
+# i2c-1 (bridge parent) are excluded as noise.
+CHIPUP_I2C_TRACE_FILTER="adapter_nr>=2"
+CHIPUP_TRACE_DIR=""
+CHIPUP_I2C_TRACE_INSTANCE=""
+
+start_chipup_i2c_trace() {
+	local asic_index="${1:-0}"
+
+	CHIPUP_TRACE_DIR=""
+	CHIPUP_I2C_TRACE_INSTANCE="$KERN_TRACE_FS/instances/hwmgmt_chipup_${asic_index}"
+
+	if [ ! -d "$KERN_TRACE_FS/events/i2c" ]; then
+		return
+	fi
+
+	# Preferred: dedicated, isolated ftrace instance per ASIC.
+	if [ -d "$KERN_TRACE_FS/instances" ] &&
+	   mkdir -p "$CHIPUP_I2C_TRACE_INSTANCE" 2>/dev/null &&
+	   [ -d "$CHIPUP_I2C_TRACE_INSTANCE/events/i2c" ]; then
+		CHIPUP_TRACE_DIR="$CHIPUP_I2C_TRACE_INSTANCE"
+	# Fallback: top-level instance, but only when the boot-wide tracer is not
+	# already running, otherwise skip entirely to avoid clobbering it.
+	elif [ "$(cat "$KERN_TRACE_FS"/events/i2c/enable 2>/dev/null)" = "0" ]; then
+		CHIPUP_TRACE_DIR="$KERN_TRACE_FS"
+	else
+		return
+	fi
+
+	echo 0 > "$CHIPUP_TRACE_DIR"/events/i2c/enable 2>/dev/null
+	echo 0 > "$CHIPUP_TRACE_DIR"/trace 2>/dev/null
+	# Bound the ring buffer size (per-CPU) so a stuck bus during chipup retries
+	# cannot grow the capture without limit.
+	echo "$I2C_TRACE_BUF_SIZE_KB" > "$CHIPUP_TRACE_DIR"/buffer_size_kb 2>/dev/null || true
+	echo "$CHIPUP_I2C_TRACE_FILTER" > "$CHIPUP_TRACE_DIR"/events/i2c/filter 2>/dev/null || true
+	echo 1 > "$CHIPUP_TRACE_DIR"/events/i2c/enable 2>/dev/null
+}
+
+# Append the current chipup trace buffer to the log and clear it (called
+# between retries so each attempt is recorded separately).
+# $1 - attempt number (optional, written as a delimiter before the trace data).
+save_chipup_i2c_trace() {
+	local attempt="${1:-}"
+
+	[ -n "$CHIPUP_TRACE_DIR" ] || return
+	if [ -n "$attempt" ]; then
+		echo "# --- chipup attempt ${attempt} ---" >> /var/log/chipup_i2c_trace_log
+	fi
+	cat "$CHIPUP_TRACE_DIR"/trace >> /var/log/chipup_i2c_trace_log 2>/dev/null
+	echo 0 > "$CHIPUP_TRACE_DIR"/trace 2>/dev/null
+}
+
+# Stop the chipup tracer and release the dedicated instance (if one was used).
+stop_chipup_i2c_trace() {
+	[ -n "$CHIPUP_TRACE_DIR" ] || return
+	echo 0 > "$CHIPUP_TRACE_DIR"/events/i2c/enable 2>/dev/null
+	if [ "$CHIPUP_TRACE_DIR" = "$CHIPUP_I2C_TRACE_INSTANCE" ]; then
+		rmdir "$CHIPUP_I2C_TRACE_INSTANCE" 2>/dev/null || true
+	fi
+	CHIPUP_TRACE_DIR=""
 }
 
 # Print function trace to the log file(s)

--- a/usr/usr/bin/hw-management-platform-json.sh
+++ b/usr/usr/bin/hw-management-platform-json.sh
@@ -23,6 +23,7 @@ PLATFORM_JSON_NUMERIC_VARS=(
 	cartridge_count
 	chipup_delay_default
 	chipup_log_size
+	chipup_log_archive_max
 	chipup_retry_count
 	cpld_num
 	device_connect_retry

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -120,7 +120,8 @@ leakage_count=0
 leakage_rope_count=0
 asic_chipup_retry=2
 device_connect_retry=2
-chipup_log_size=4096
+chipup_log_size=65536
+chipup_log_archive_max=3
 reset_dflt_attr_num=18
 smart_switch_reset_attr_num=17
 n51xx_reset_attr_num=22
@@ -3265,14 +3266,24 @@ connect_platform()
 	fi
 
 	for ((i=0; i<${#connect_table[@]}; i+=$dev_step)); do
+		local dev_connected=0
 		for ((j=0; j<${device_connect_retry}; j++)); do
 			connect_device "${connect_table[i]}" "${connect_table[i+1]}" \
 					"${connect_table[i+2]}"
 			if [ $? -eq 0 ]; then
+				dev_connected=1
 				break;
 			fi
 			disconnect_device "${connect_table[i+1]}" "${connect_table[i+2]}"
 		done
+		# A device (other than the ASIC/mlxsw_minimal, which has its own chipup
+		# tracer) failed to bind after all retries. Preserve the current I2C
+		# trace so the bus activity leading to the failure is captured, not just
+		# ASIC chipup failures.
+		if [ "$dev_connected" -eq 0 ]; then
+			log_err "Failed to connect device ${connect_table[i]} ${connect_table[i+1]} on bus ${connect_table[i+2]} after ${device_connect_retry} attempts"
+			save_i2c_trace_on_failure "device connect failed: ${connect_table[i]} ${connect_table[i+1]} bus ${connect_table[i+2]}"
+		fi
 	done
 	if [ ! -z $mctp_addr ]; then
 		echo $mctp_addr > $config_path/mctp_addr
@@ -4256,40 +4267,53 @@ case $ACTION in
 		if [ -d /var/run/hw-management ]; then
 			asic_retry="$asic_chipup_retry"
 			asic_chipup_rc=1
+			asic_index="$2"
+			chipup_trace_attempt=1
+
+			# Rotate the trace log at invocation start so all retries within one
+			# chipup run stay in the same file (rotation at the end could split
+			# attempts across chipup_i2c_trace_log and chipup_i2c_trace_log.*).
+			if [ -f /var/log/chipup_i2c_trace_log ]; then
+				file_size=`du -b /var/log/chipup_i2c_trace_log | tr -s '\t' ' ' | cut -d' ' -f1`
+				if [ $file_size -gt $chipup_log_size ]; then
+					timestamp=`date +%s`
+					mv /var/log/chipup_i2c_trace_log /var/log/chipup_i2c_trace_log.$timestamp
+					touch /var/log/chipup_i2c_trace_log
+					# Cap the number of per-run archives so repeated chipup
+					# failures cannot fill the disk.
+					ls -1t /var/log/chipup_i2c_trace_log.* 2>/dev/null | \
+						tail -n +$((chipup_log_archive_max + 1)) | \
+						xargs -r rm -f
+				fi
+			fi
+
+			# Start the chipup I2C tracer on a dedicated ftrace instance
+			# (isolated from the boot-wide tracer). Enabled before the first
+			# attempt so every retry - including the first - is captured, and
+			# scoped to all CPLD bridge adapters so bus-wide contention is
+			# visible, not just the ASIC bus.
+			start_chipup_i2c_trace "$asic_index"
 
 			while [ "$asic_chipup_rc" -ne 0 ] && [ "$asic_retry" -gt 0 ]; do
 				do_chip_up_down 1 "$2" "$3"
 				asic_chipup_rc=$?
-				asic_index="$2"
-				if [ "$asic_chipup_rc" -ne 0 ];then
+				if [ "$asic_chipup_rc" -ne 0 ]; then
 					do_chip_up_down 0 "$2" "$3"
+					# Save this attempt's I2C trace and clear the buffer
+					# before the next retry.
+					save_chipup_i2c_trace "$chipup_trace_attempt"
+					chipup_trace_attempt=$((chipup_trace_attempt + 1))
 				else
 					echo "$asic_chipup_retry" > "$config_path"/asic_chipup_counter
+					stop_chipup_i2c_trace
 					exit 0
 				fi
 
 				asic_retry=$(< $config_path/asic_chipup_counter)
-				if [ "$asic_retry" -eq "$asic_chipup_retry" ]; then
-					# Start I2C tracer.
-					echo 1 >/sys/kernel/debug/tracing/events/i2c/enable
-					echo adapter_nr=="$2" >/sys/kernel/debug/tracing/events/i2c/filter
-				else
-					cat /sys/kernel/debug/tracing/trace >> /var/log/chipup_i2c_trace_log
-					echo 0>/sys/kernel/debug/tracing/trace
-				fi
-
 				change_file_counter $config_path/asic_chipup_counter -1
 			done
-			echo 0 >/sys/kernel/debug/tracing/events/i2c/enable
+			stop_chipup_i2c_trace
 			log_info "chipup failed for ASIC $asic_index"
-
-			# Check log size in (bytes) and rotate if necessary.
-			file_size=`du -b /var/log/chipup_i2c_trace_log | tr -s '\t' ' ' | cut -d' ' -f1`
-			if [ $file_size -gt $chipup_log_size ]; then
-				timestamp=`date +%s`
-				mv /var/log/chipup_i2c_trace_log /var/log/chipup_i2c_trace_log.$timestamp
-				touch /var/log/chipup_i2c_trace_log
-			fi
 		fi
 	;;
 	chipdown)


### PR DESCRIPTION
chipup_i2c_trace_log was empty on field failures because the chipup retry path recorded no usable ftrace data.

Fixes:
- Use a dedicated ftrace instance (instances/hwmgmt_chipup) so chipup tracing does not clobber the boot-wide hw-mgmt I2C tracer started in do_start().
- Start tracing before the first chipup attempt and save the buffer after each failed retry, so all attempts are captured.
- Filter on adapter_nr>=2 (all CPLD bridge child buses) instead of adapter_nr==$2, which is the ASIC index and not the I2C adapter number.
- Fix trace buffer clear (echo 0 > .../trace) and guard log rotation when chipup_i2c_trace_log does not exist.

Add start_chipup_i2c_trace(), save_chipup_i2c_trace(), and stop_chipup_i2c_trace() helpers in hw-management-helpers.sh.