### PR TITLE
hw-mgmt: scripts: Fix log file names in generate dump tool

### DIFF
--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -93,8 +93,8 @@ fi
 [ -f /var/log/udev_events.log ] && cp -a /var/log/udev* "$DUMP_FOLDER/" 2>/dev/null || true
 [ -f /var/log/hw-mgmt.trace.log ] && cp -a /var/log/hw-mgmt.trace* "$DUMP_FOLDER/" 2>/dev/null || true
 [ -f /var/log/hw_mgmt_cpldreg.log ] && cp /var/log/hw_mgmt_cpldreg.log "$DUMP_FOLDER/" 2>/dev/null || true
-[ -f /var/log/hw_management_thermal_updater_log ] && cp /var/log/hw_management_thermal_updater_log* "$DUMP_FOLDER/" 2>/dev/null || true
-[ -f /var/log/hw_management_peripheral_updater_log ] && cp /var/log/hw_management_peripheral_updater_log* "$DUMP_FOLDER/" 2>/dev/null || true
+[ -f /var/log/hw-management-thermal-updater.log ] && cp /var/log/hw-management-thermal-updater.log* "$DUMP_FOLDER/" 2>/dev/null || true
+[ -f /var/log/hw-management-peripheral-updater.log ] && cp /var/log/hw-management-peripheral-updater.log* "$DUMP_FOLDER/" 2>/dev/null || true
 [ -f /var/log/hw-mgmt-i2c-trace.log ] && cp /var/log/hw-mgmt-i2c-trace.log* "$DUMP_FOLDER/" 2>/dev/null || true
 uname -a > "$DUMP_FOLDER/sys_version"
 mkdir "$DUMP_FOLDER/bin/"


### PR DESCRIPTION
Fix log file names in generate dump tool
hw_management_thermal_updater_log -> hw-management-thermal-updater.log
hw_management_peripheral_updater_log -> hw-management-peripheral-updater.log

Bug: 5114977

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
