### PR TITLE
hw-mgmt: bmc: Add support for BMC watchdog service

### DIFF
--- a/bmc/FILE_MAPPING.md
+++ b/bmc/FILE_MAPPING.md
@@ -15,8 +15,8 @@ Use this as a checklist when copying or updating files from the OpenBMC meta-nvi
 | File | Role |
 |------|------|
 | **`debian/hw-management-bmc.postinst`** | Custom **`configure`**: **`daemon-reload`**; fresh-install **`systemctl start --no-block`** (non-blocking first-boot under **`rc.local`**). See **`bmc/README.md`** § *Debian maintainer scripts*. Issue **#4992267**. |
-| **`debian/hw-management-bmc.prerm`** | Custom **`remove`**: parallel **`systemctl stop`** for nine BMC units. Upgrade path no-op. |
-| **`debian/rules`** (BMC **`override_dh_systemd_*`**) | Single positional **`dh_systemd_enable`** / **`dh_systemd_start --no-start --no-restart-after-upgrade`** allow-list (nine services). |
+| **`debian/hw-management-bmc.prerm`** | Custom **`remove`**: parallel **`systemctl stop`** for the BMC units. Upgrade path no-op. |
+| **`debian/rules`** (BMC **`override_dh_systemd_*`**) | Single positional **`dh_systemd_enable`** / **`dh_systemd_start --no-start --no-restart-after-upgrade`** allow-list. |
 
 ---
 
@@ -32,6 +32,7 @@ Use this as a checklist when copying or updating files from the OpenBMC meta-nvi
 | meta-nvidia/meta-switch/recipes-nvidia/**bmc-post-boot-cfg**/files/bmc-plat-specific-preps.service | **hw-management-bmc-plat-specific-preps.service** |
 | meta-nvidia/meta-switch/recipes-nvidia/**bmc-post-boot-cfg**/files/bmc-recovery-handler.service | **hw-management-bmc-recovery-handler.service** |
 | *(SONiC BMC only; not copied from OpenBMC by default)* | **hw-management-bmc-early-config.service** |
+| *(SONiC BMC only; stop-gap ABR-watchdog heartbeat to Bali/Caliptra over MCTP)* | **hw-management-bmc-wd-heartbeat.service** |
 | ~~bmc-svn-update.service~~ | removed (Microsoft doesn't need) |
 
 ---
@@ -66,6 +67,7 @@ On the target system the **hw-management-bmc** Debian package installs this tree
 | .../spc6-ast2700-a1/.../spc6-bmc.conf | usr/etc/HI189/**hw-management-bmc.conf** (→ **`/etc/modprobe.d/hw-management-bmc.conf`** at boot) |
 | *(maintain in repo per platform)* | usr/etc/HI189/**hw-management-bmc-network.conf** (→ **`/etc/hw-management-bmc-usb0.conf`**, drives **`usb0`** **`Address=`** in generated **`.network`**) |
 | *(SONiC BMC; not from OpenBMC)* | usr/etc/HI189/**hw-management-bmc-boot-complete.conf** (→ **`/etc/hw-management-bmc-boot-complete.conf`** at boot; thresholds for **`hw-management-bmc-boot-complete.sh`**) |
+| *(SONiC BMC; not from OpenBMC)* | usr/etc/HI189/**hw-management-bmc-wd-heartbeat.conf** (→ **`/etc/hw-management-bmc-wd-heartbeat.conf`** at boot; EID / interval / payload for **`hw-management-bmc-wd-heartbeat.sh`**) |
 | .../spc6-ast2700-a1/.../spc6-ast2700-a1-bmc/ (directory) | usr/etc/HI189/ |
 
 ---
@@ -94,6 +96,7 @@ On the target system the **hw-management-bmc** Debian package installs this tree
 | ~~ast2700-a1-spc6-switch-erots-info.sh~~ | removed (Microsoft doesn't need) |
 | .../spc6-ast2700-a1/.../bmc-plat-specific-preps.sh | usr/usr/bin/**hw-management-bmc-plat-specific-preps.sh** |
 | *(SONiC BMC; replaces OpenBMC i2c-boot-progress.sh)* | usr/usr/bin/**hw-management-bmc-boot-complete.sh** |
+| *(SONiC BMC; stop-gap ABR-watchdog heartbeat)* | usr/usr/bin/**hw-management-bmc-wd-heartbeat.sh** — starts **`mctpd`**, brings up **`mctpirot0`**, discovers the Bali (Caliptra) EID via **`busctl … SetupEndpoint`** (fallback EID 8), then loops **`mctp-client eid <EID> type control data 80 03`**; no-ops when disabled in conf or **`mctp-client`** absent |
 | .../spc6-ast2700-a1/.../i2c-slave-config.sh | usr/usr/bin/**hw-management-bmc-i2c-slave-config.sh** |
 | ~~spc6-svn-check.sh~~ | removed (Microsoft doesn't need) |
 | meta-nvidia/meta-switch/recipes-phosphor/**dump**/files/**cpld_dump.sh** + **dump_utils.sh** ( **`take_cpld_dump_internal`**, **`take_cpld_dump`** only) | usr/usr/bin/**hw-management-bmc-cpld-dump.sh** (merged SONiC script; no **`switch-erots-info`** / Phosphor **`add_copy_file`**; **`log_message`** + **`hw-management-bmc-platform.conf`** via **`helpers-common`**) |

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -145,6 +145,7 @@ bmc/
     │       ├── hw-management-bmc-a2d-leakage-config.json
     │       ├── hw-management-bmc-bom.json   # SMBIOS BOM alternates → /etc/hw-management-bmc-bom.json (hw-management-bmc-devtree.sh)
     │       ├── hw-management-bmc-boot-complete.conf   # → /etc/hw-management-bmc-boot-complete.conf (boot gate)
+    │       ├── hw-management-bmc-wd-heartbeat.conf   # → /etc/hw-management-bmc-wd-heartbeat.conf (ABR watchdog heartbeat: EID/interval/payload)
     │       ├── hw-management-bmc-gpio-pins.json   # GPIO sysfs init → /etc/hw-management-bmc-gpio-pins.json
     │       ├── hw-management-bmc.conf
     │       ├── hw-management-bmc-early-i2c-devices.json
@@ -162,7 +163,8 @@ bmc/
     │       ├── hw-management-bmc-plat-specific-preps.service
     │       ├── hw-management-bmc-recovery-handler.service
     │       ├── hw-management-bmc-reset-cause-logger.service
-    │       └── hw-management-bmc-sync-ethaddr.service
+    │       ├── hw-management-bmc-sync-ethaddr.service
+    │       └── hw-management-bmc-wd-heartbeat.service   # ABR watchdog heartbeat to Bali/Caliptra over MCTP (starts after boot-complete)
     └── usr/bin/
         ├── hw-management-bmc-a2d-leakage-config.sh
         ├── hw-management-bmc-a2d-leakage-read.sh
@@ -199,6 +201,7 @@ bmc/
         ├── hw-management-bmc-show-reset-cause.sh
         ├── hw-management-bmc-reset-cause-logger.sh
         ├── hw-management-bmc-set-extra-params.sh
+        ├── hw-management-bmc-wd-heartbeat.sh   # Periodic ABR watchdog heartbeat to Bali/Caliptra via mctp-client
         └── hw-management-bmc.sh
 ```
 
@@ -384,6 +387,7 @@ flowchart TB
 | **hw-management-bmc-health-monitor** | simple | `/usr/bin/hw-management-bmc-health-monitor.sh` | `WantedBy=multi-user.target` | **`After=multi-user.target`**, **`Wants=syslog.target`**. **`Restart=always`**. |
 | **hw-management-bmc-i2c-slave-setup** | oneshot | `/usr/bin/hw-management-bmc-i2c-slave-setup.sh` | `WantedBy=multi-user.target` | **`After=multi-user.target`**. **`Before=`** `hw-management-bmc-recovery-handler`. **`ConditionPathExists=/etc/hw-management-bmc-recovery.conf`**. |
 | **hw-management-bmc-recovery-handler** | simple | `/usr/bin/hw-management-bmc-recovery-handler.sh` | `WantedBy=multi-user.target` | **`After=`** `multi-user.target`, **`hw-management-bmc-i2c-slave-setup`**. **`Requires=`** i2c-slave-setup. **`EnvironmentFile=/etc/hw-management-bmc-recovery.conf`**. **`ConditionPathExists=/etc/hw-management-bmc-recovery.conf`**. **`Restart=always`**. |
+| **hw-management-bmc-wd-heartbeat** | simple | `/usr/bin/hw-management-bmc-wd-heartbeat.sh` | `WantedBy=multi-user.target` | **`After=multi-user.target`**, **`hw-management-bmc-boot-complete.service`** and **`Wants=`** it (heartbeat only after the BMC has booted). **`EnvironmentFile=-/etc/hw-management-bmc-wd-heartbeat.conf`**. **`Restart=on-failure`**. Stop-gap ABR watchdog servicing — see **ABR watchdog heartbeat** below. |
 
 Scripts **`hw-management-bmc-powerctrl.sh`**, **`hw-management-bmc-devtree.sh`**, **`hw-management-bmc-gpio-set.sh`**, **`hw-management-bmc-leakage-handler.sh`**, **`hw-management-bmc-get-reset-cause.sh`**, **`hw-management-bmc-show-reset-cause.sh`**, etc., are invoked by other scripts, **udev**, or operators; they are not tied 1:1 to a dedicated systemd unit in this package. The logger unit uses **`hw-management-bmc-reset-cause-logger.sh`** for boot diagnostics, while **`hw-management-bmc-get-reset-cause.sh`** exports reset-cause sysfs-style files: primary **`reset_pwr_cycle`** / **`reset_soft_reboot`** / **`reset_unknown`** at **`/var/run/hw-management/bmc/`** (exactly one **1**), hardware **`reset_*`** under **`/var/run/hw-management/bmc/domains/`** (see reset-cause policy table), raw SCU words at the bmc runtime root.
 
@@ -530,6 +534,39 @@ Installed to **`/usr/bin/hw-management-bmc-leakage-handler.sh`**. HID-agnostic: 
 **Behavior:** For each numeric channel subdirectory **`j`** under **`leakage/n/`**, read **`input`**, **`min`**, and **`max`**. If the raw sample is below **`min`** or above **`max`**, write **`last_sample`** (12-bit aligned code from **`input`**) and **`last_event`** (the passed-in timestamp) into that channel directory. Channels without **`input`** / thresholds are skipped.
 
 Platform differences are limited to which **`LEAKAGE<n>`** lines appear in **`5-hw-management-bmc-events.rules`** (or equivalent) and how many detectors/channels the JSON configures; keep the generic **`LEAKAGE<n>`** branch in each HID’s **`hw-management-bmc-events.sh`** in sync when adding platforms.
+
+### ABR watchdog heartbeat (`hw-management-bmc-wd-heartbeat.sh`)
+
+Stop-gap for the **AST2700 ABR (Alternate Boot Recovery) watchdog** on the SONiC BMC. The ABR watchdog is intended for systems that boot from **redundant SPI flashes**: on expiry the **BootMCU** performs Alternate Boot Recovery and switches the boot source to the backup SPI image. On the SONiC BMC the BMC boots from **eMMC** while the SPI flash holds the **OpenBMC** image, so an ABR expiry would switch to the undesired OpenBMC image. The ABR watchdog is armed **only once the OTP fuse is programmed** — not an issue during development, but relevant on production (fused) systems.
+
+Until SONiC selects a final approach (disable in U-Boot, disable from Linux by writing the WDTA control register, or handle it in Bali/Caliptra firmware), this service **services the ABR watchdog over MCTP** so it never expires. On start it: (1) starts the MCTP daemon (**`systemctl start mctpd`**), (2) brings the IRoT link up (**`mctp link set mctpirot0 up`**), (3) discovers the Bali (Caliptra) endpoint EID from the MCTP **bus owner** (**`busctl … SetupEndpoint ay 0`**, EID taken from the reply; falls back to a configured EID, default **8**), then (4) loops sending the service-watchdog request to that EID via **`mctp-client`**.
+
+**Unit:** **`hw-management-bmc-wd-heartbeat.service`** (`Type=simple`, `Restart=on-failure`). It is ordered **`After=hw-management-bmc-boot-complete.service`** (and **`Wants=`** it), so the heartbeat starts only once the BMC has successfully booted.
+
+**Config:** **`/etc/hw-management-bmc-wd-heartbeat.conf`** (deployed from **`/etc/<HID>/hw-management-bmc-wd-heartbeat.conf`** by plat-specific-preps; override the path with **`HW_MANAGEMENT_BMC_WD_HEARTBEAT_CONF`**):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| **`WD_HEARTBEAT_ENABLE`** | **`1`** | Master enable. **`0`** = script exits cleanly (no heartbeat, no restart). |
+| **`WD_HEARTBEAT_INTERFACE`** | **`mctpirot0`** | MCTP-over-IRoT link brought up and used for **`SetupEndpoint`**. |
+| **`WD_HEARTBEAT_MCTPD_SERVICE`** | **`mctpd`** | systemd service started (best-effort) before the link is brought up. Empty = skip. |
+| **`WD_HEARTBEAT_SETUP_ENDPOINT`** | **`1`** | **`1`** = discover the EID via the MCTP bus owner **`SetupEndpoint`**; **`0`** = skip and use **`WD_HEARTBEAT_EID`**. |
+| **`WD_HEARTBEAT_EID`** | **`8`** | Fallback EID of the Bali (Caliptra) target, used when discovery is disabled or returns no usable EID. |
+| **`WD_HEARTBEAT_MSG_TYPE`** | **`control`** | MCTP message type keyword passed to **`mctp-client`**. |
+| **`WD_HEARTBEAT_DATA`** | **`80 03`** | Request payload bytes (hex, space separated). |
+| **`WD_HEARTBEAT_INTERVAL`** | **`30`** | Seconds to sleep after each heartbeat attempt. Not the full period alone — see timing bound below. |
+| **`WD_HEARTBEAT_CMD_TIMEOUT`** | **`10`** | Per-call **`timeout(1)`** bound (s) for each **`mctp-client`** / **`busctl`** call; auto-clamped below **`WD_HEARTBEAT_INTERVAL`**. Counts toward the worst-case heartbeat period together with **`WD_HEARTBEAT_INTERVAL`**. Ignored if **`timeout(1)`** is absent (warned). |
+| **`WD_HEARTBEAT_MCTP_CLIENT`** | *(PATH lookup)* | Optional explicit path to the **`mctp-client`** binary. |
+
+**Endpoint discovery:** **`busctl call au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1/interfaces/<IFACE> au.com.codeconstruct.MCTP.BusOwner1 SetupEndpoint ay 0`**; the EID is the second field of the reply (e.g. reply `yisb 8 …` → EID `8`). If **`busctl`** is unavailable, discovery fails, or the parsed EID is non-numeric, the service falls back to **`WD_HEARTBEAT_EID`**.
+
+**Effective command each interval:** **`mctp-client eid <EID> type <WD_HEARTBEAT_MSG_TYPE> data <WD_HEARTBEAT_DATA>`** (e.g. `mctp-client eid 8 type control data 80 03`).
+
+**Timing bound:** each loop iteration runs one bounded **`mctp-client`** call (up to **`WD_HEARTBEAT_CMD_TIMEOUT`** seconds) then sleeps **`WD_HEARTBEAT_INTERVAL`** seconds. The worst-case gap between consecutive heartbeats is **`WD_HEARTBEAT_CMD_TIMEOUT + WD_HEARTBEAT_INTERVAL`** (with defaults **40 s**; after clamping, at most **`2 × WD_HEARTBEAT_INTERVAL − 1`**). That sum must be **shorter than the ABR watchdog timeout** on fused production systems — configuring **`WD_HEARTBEAT_INTERVAL`** alone against the watchdog period is not sufficient.
+
+**No-op / safety behavior:** the script **exits 0** (so systemd does not restart-loop) when disabled via config or when **`mctp-client`** is not present on the image — safe to list in the package on images without MCTP tooling. The **`mctpd`** start and **`mctp link set … up`** steps are best-effort (logged, non-fatal, since they may already be done). It **exits non-zero** only when the resolved EID is invalid. Success/failure of the request is logged only on state change to avoid flooding the journal every interval. Requires **bash**, **`mctp-client`**, and (for discovery) **`busctl`** / **`mctp`**.
+
+**Timeout guard:** every external call (heartbeat **`mctp-client`** and discovery **`busctl`**) is wrapped in **`timeout WD_HEARTBEAT_CMD_TIMEOUT`** so a hung or unresponsive MCTP transport cannot block the loop indefinitely — an unbounded stall would stop heartbeats, let the ABR watchdog expire, and switch the boot source to OpenBMC (the exact failure this service prevents). A timed-out call is treated as a normal failure: the loop logs it and retries on the next interval. If **`timeout(1)`** is not on the image the script logs a warning and runs the calls unguarded.
 
 ### Power control (`hw-management-bmc-powerctrl.sh`)
 

--- a/bmc/usr/etc/HI189/hw-management-bmc-wd-heartbeat.conf
+++ b/bmc/usr/etc/HI189/hw-management-bmc-wd-heartbeat.conf
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+#
+# Configuration for hw-management-bmc-wd-heartbeat.service.
+# Installed to /etc/hw-management-bmc-wd-heartbeat.conf by
+# hw-management-bmc-plat-specific-preps.
+#
+# Stop-gap for the AST2700 ABR (Alternate Boot Recovery) watchdog on the SONiC
+# BMC: the BMC boots from eMMC while the SPI flash holds the OpenBMC image, so
+# an ABR watchdog expiry would switch the boot source to the (undesired)
+# OpenBMC image. Until SONiC decides on a final solution, this service brings
+# up the MCTP stack, discovers the Bali (Caliptra) endpoint, and keeps sending
+# the "service watchdog" request so the ABR watchdog never expires.
+
+# Master enable. 1 = run the heartbeat, 0 = do nothing and exit cleanly.
+WD_HEARTBEAT_ENABLE=1
+
+# MCTP over IRoT interface used to reach Bali (Caliptra). The service sets this
+# link up and (when WD_HEARTBEAT_SETUP_ENDPOINT=1) runs SetupEndpoint on it.
+WD_HEARTBEAT_INTERFACE=mctpirot0
+
+# systemd service that owns the MCTP daemon; started (best-effort) before the
+# link is brought up. Leave empty to skip starting it.
+WD_HEARTBEAT_MCTPD_SERVICE=mctpd
+
+# 1 = discover the Bali (Caliptra) EID via the MCTP bus owner SetupEndpoint
+# call on WD_HEARTBEAT_INTERFACE; 0 = skip discovery and use WD_HEARTBEAT_EID.
+WD_HEARTBEAT_SETUP_ENDPOINT=1
+
+# EID of the Bali (Caliptra) firmware target. Used as the fallback when
+# endpoint discovery is disabled or returns no usable EID. Default 8.
+WD_HEARTBEAT_EID=8
+
+# MCTP message type keyword passed to mctp-client (e.g. control).
+WD_HEARTBEAT_MSG_TYPE=control
+
+# MCTP request payload bytes (hex, space separated) that ask Bali to
+# disable/service the ABR watchdog.
+WD_HEARTBEAT_DATA="80 03"
+
+# Seconds to sleep after each heartbeat attempt (not the full period by itself).
+# Worst-case gap between consecutive heartbeats is WD_HEARTBEAT_INTERVAL plus
+# WD_HEARTBEAT_CMD_TIMEOUT (each loop: up to CMD_TIMEOUT for the call, then
+# INTERVAL sleep). That sum must be shorter than the ABR watchdog timeout.
+WD_HEARTBEAT_INTERVAL=30
+
+# Per-call timeout (seconds) for each mctp-client / busctl invocation. Bounds a
+# hung MCTP transport so it cannot stall the loop (a stall would let the ABR
+# watchdog expire). Counts toward the worst-case heartbeat period together with
+# WD_HEARTBEAT_INTERVAL (see above). Automatically clamped below
+# WD_HEARTBEAT_INTERVAL. Requires timeout(1) (coreutils or busybox) on the image;
+# ignored if it is absent.
+WD_HEARTBEAT_CMD_TIMEOUT=10
+
+# Optional override of the mctp-client binary (default: search in PATH).
+# WD_HEARTBEAT_MCTP_CLIENT=/usr/bin/mctp-client

--- a/bmc/usr/lib/systemd/system/hw-management-bmc-wd-heartbeat.service
+++ b/bmc/usr/lib/systemd/system/hw-management-bmc-wd-heartbeat.service
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+[Unit]
+Description=BMC ABR Watchdog Heartbeat (MCTP to Bali/Caliptra)
+# Start only after the BMC has successfully booted, per the SONiC requirement
+# to disable/service the ABR watchdog once boot is complete.
+After=multi-user.target hw-management-bmc-boot-complete.service
+Wants=hw-management-bmc-boot-complete.service
+
+[Service]
+Type=simple
+# No EnvironmentFile: hw-management-bmc-wd-heartbeat.sh sources
+# /etc/hw-management-bmc-wd-heartbeat.conf itself (after applying its built-in
+# defaults), so injecting the same file into the environment here would be
+# shadowed by those defaults and never take effect. The script honors
+# HW_MANAGEMENT_BMC_WD_HEARTBEAT_CONF to relocate the config if needed.
+ExecStart=/usr/bin/hw-management-bmc-wd-heartbeat.sh
+# on-failure (not always): the script exits 0 when disabled or when mctp-client
+# is absent, and we do not want to restart-loop in those cases. A crash or the
+# invalid-EID exit(1) is retried after RestartSec.
+Restart=on-failure
+RestartSec=30
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hw-management-bmc-wd-heartbeat
+
+# Resource limits: this is a tiny periodic requester.
+MemoryMax=50M
+CPUQuota=10%
+
+[Install]
+WantedBy=multi-user.target

--- a/bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-plat-specific-preps.sh
@@ -156,6 +156,11 @@ deploy_hw_management_bmc_platform_files()
 		chmod 0644 /etc/hw-management-bmc-boot-complete.conf
 		echo "plat-specific: installed /etc/hw-management-bmc-boot-complete.conf from $HID_SRC"
 	fi
+	if [ -f "$HID_SRC/hw-management-bmc-wd-heartbeat.conf" ]; then
+		cp -f "$HID_SRC/hw-management-bmc-wd-heartbeat.conf" /etc/hw-management-bmc-wd-heartbeat.conf
+		chmod 0644 /etc/hw-management-bmc-wd-heartbeat.conf
+		echo "plat-specific: installed /etc/hw-management-bmc-wd-heartbeat.conf from $HID_SRC"
+	fi
 	if [ -f "$HID_SRC/hw-management-bmc.conf" ]; then
 		mkdir -p /etc/modprobe.d
 		ln -sfn "$HID_SRC/hw-management-bmc.conf" /etc/modprobe.d/hw-management-bmc.conf

--- a/bmc/usr/usr/bin/hw-management-bmc-wd-heartbeat.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-wd-heartbeat.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+################################################################################
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+################################################################################
+# BMC ABR watchdog heartbeat.
+#
+# AST2700 ABR (Alternate Boot Recovery) watchdog is intended for systems that
+# boot from redundant SPI flashes: on expiry the BootMCU switches the boot
+# source to the backup SPI image. On the SONiC BMC the BMC boots from eMMC
+# while the SPI flash holds the OpenBMC image, so an ABR expiry would switch to
+# the undesired OpenBMC image. The ABR watchdog is only armed once the OTP fuse
+# is programmed (production systems).
+#
+# Until SONiC settles on a final solution, this service brings up the MCTP
+# stack (mctpd + the mctpirot link), discovers the Bali (Caliptra) endpoint EID
+# via the MCTP bus owner (falling back to a configured EID), and periodically
+# sends the "service watchdog" request to it over MCTP (mctp-client), so the
+# ABR watchdog is serviced before it can expire.
+
+LOG_TAG="hw-management-bmc-wd-heartbeat"
+
+# shellcheck source=/dev/null
+source /usr/bin/hw-management-bmc-helpers-common.sh
+
+CONFIG_FILE="${HW_MANAGEMENT_BMC_WD_HEARTBEAT_CONF:-/etc/hw-management-bmc-wd-heartbeat.conf}"
+
+# Defaults (overridden by CONFIG_FILE if present).
+WD_HEARTBEAT_ENABLE=1
+WD_HEARTBEAT_INTERFACE="mctpirot0"
+WD_HEARTBEAT_EID=8
+WD_HEARTBEAT_MSG_TYPE="control"
+WD_HEARTBEAT_DATA="80 03"
+WD_HEARTBEAT_INTERVAL=30
+WD_HEARTBEAT_CMD_TIMEOUT=10
+WD_HEARTBEAT_MCTP_CLIENT=""
+WD_HEARTBEAT_MCTPD_SERVICE="mctpd"
+WD_HEARTBEAT_SETUP_ENDPOINT=1
+
+if [ -f "$CONFIG_FILE" ]; then
+	# shellcheck source=/dev/null
+	source "$CONFIG_FILE"
+else
+	log_message "warning" "Config $CONFIG_FILE not found; using built-in defaults"
+fi
+
+# Disabled by configuration: exit cleanly so systemd does not treat it as a
+# failure and does not restart us.
+if [ "${WD_HEARTBEAT_ENABLE}" != "1" ]; then
+	log_message "notice" "ABR watchdog heartbeat disabled (WD_HEARTBEAT_ENABLE=${WD_HEARTBEAT_ENABLE}); exiting"
+	exit 0
+fi
+
+# Resolve the mctp-client binary. Without it there is nothing to do (e.g. an
+# image that does not ship the MCTP tooling): exit 0 so we do not restart-loop.
+MCTP_CLIENT="${WD_HEARTBEAT_MCTP_CLIENT:-}"
+if [ -z "$MCTP_CLIENT" ]; then
+	MCTP_CLIENT="$(command -v mctp-client 2>/dev/null)"
+fi
+if [ -z "$MCTP_CLIENT" ] || [ ! -x "$MCTP_CLIENT" ]; then
+	log_message "warning" "mctp-client not found; ABR watchdog heartbeat cannot run; exiting"
+	exit 0
+fi
+
+# Validate the send period and the per-call timeout, and keep the timeout below
+# the period. Worst-case gap between consecutive heartbeats is
+# WD_HEARTBEAT_CMD_TIMEOUT + WD_HEARTBEAT_INTERVAL (each loop: up to CMD_TIMEOUT
+# for the call, then INTERVAL sleep); that sum must be shorter than the ABR
+# watchdog timeout. A hung mctp-client / busctl call must NOT stall the loop:
+# if the transport is unhealthy an unbounded call would block forever, no
+# further heartbeats would be sent, the ABR watchdog would expire, and the
+# BootMCU would switch to the OpenBMC image - the exact failure this service
+# prevents.
+case "$WD_HEARTBEAT_INTERVAL" in
+	''|*[!0-9]*) WD_HEARTBEAT_INTERVAL=30 ;;
+esac
+[ "$WD_HEARTBEAT_INTERVAL" -lt 1 ] 2>/dev/null && WD_HEARTBEAT_INTERVAL=30
+
+case "$WD_HEARTBEAT_CMD_TIMEOUT" in
+	''|*[!0-9]*) WD_HEARTBEAT_CMD_TIMEOUT=10 ;;
+esac
+[ "$WD_HEARTBEAT_CMD_TIMEOUT" -lt 1 ] 2>/dev/null && WD_HEARTBEAT_CMD_TIMEOUT=10
+if [ "$WD_HEARTBEAT_CMD_TIMEOUT" -ge "$WD_HEARTBEAT_INTERVAL" ] 2>/dev/null; then
+	if [ "$WD_HEARTBEAT_INTERVAL" -gt 1 ]; then
+		WD_HEARTBEAT_CMD_TIMEOUT=$((WD_HEARTBEAT_INTERVAL - 1))
+	else
+		WD_HEARTBEAT_CMD_TIMEOUT=1
+	fi
+fi
+
+# timeout(1) (coreutils or busybox) bounds each external call. If it is missing
+# we run unguarded and warn, since the time bound cannot be enforced.
+TIMEOUT_BIN="$(command -v timeout 2>/dev/null)"
+if [ -z "$TIMEOUT_BIN" ]; then
+	log_message "warning" "timeout(1) not found; mctp-client/busctl calls will run without a time bound"
+fi
+
+# Run "$@" bounded by WD_HEARTBEAT_CMD_TIMEOUT seconds when timeout(1) exists,
+# otherwise run it directly. timeout exits 124 on expiry, which the callers
+# treat as a normal failure (retry / fall back).
+run_bounded() {
+	if [ -n "$TIMEOUT_BIN" ]; then
+		"$TIMEOUT_BIN" "$WD_HEARTBEAT_CMD_TIMEOUT" "$@"
+	else
+		"$@"
+	fi
+}
+
+# Bring up the MCTP stack: start mctpd and set the IRoT link up. Best-effort -
+# mctpd may already be running and the link already up; failures here are
+# logged but do not abort (the heartbeat loop below still retries).
+if [ -n "$WD_HEARTBEAT_MCTPD_SERVICE" ] && command -v systemctl >/dev/null 2>&1; then
+	if systemctl start "$WD_HEARTBEAT_MCTPD_SERVICE" >/dev/null 2>&1; then
+		log_message "info" "Started ${WD_HEARTBEAT_MCTPD_SERVICE}"
+	else
+		log_message "warning" "Failed to start ${WD_HEARTBEAT_MCTPD_SERVICE} (may already be running)"
+	fi
+fi
+
+if [ -n "$WD_HEARTBEAT_INTERFACE" ] && command -v mctp >/dev/null 2>&1; then
+	if mctp link set "$WD_HEARTBEAT_INTERFACE" up >/dev/null 2>&1; then
+		log_message "info" "Set MCTP link ${WD_HEARTBEAT_INTERFACE} up"
+	else
+		log_message "warning" "Failed to set MCTP link ${WD_HEARTBEAT_INTERFACE} up (may already be up)"
+	fi
+fi
+
+# Discover the Bali (Caliptra) endpoint EID from the MCTP bus owner.
+# busctl SetupEndpoint returns a reply whose second field is the assigned EID
+# (e.g. "yisb 8 1 "/.../endpoints/8" true"). If discovery fails or yields no
+# usable EID, fall back to the configured WD_HEARTBEAT_EID (default 8).
+discover_eid() {
+	local iface="$1"
+	local out eid
+	command -v busctl >/dev/null 2>&1 || return 1
+	out=$(run_bounded busctl call au.com.codeconstruct.MCTP1 \
+		"/au/com/codeconstruct/mctp1/interfaces/${iface}" \
+		au.com.codeconstruct.MCTP.BusOwner1 SetupEndpoint ay 0 2>/dev/null) || return 1
+	# log_message echoes to stdout; this function's stdout IS the EID (captured
+	# via command substitution), so send the log to stderr to avoid polluting it.
+	log_message "info" "SetupEndpoint(${iface}) -> ${out}" >&2
+	eid=$(echo "$out" | awk '{print $2}')
+	case "$eid" in
+		''|*[!0-9]*) return 1 ;;
+	esac
+	echo "$eid"
+}
+
+EID=""
+if [ "${WD_HEARTBEAT_SETUP_ENDPOINT}" = "1" ] && [ -n "$WD_HEARTBEAT_INTERFACE" ]; then
+	EID=$(discover_eid "$WD_HEARTBEAT_INTERFACE") || EID=""
+fi
+if [ -z "$EID" ]; then
+	EID="$WD_HEARTBEAT_EID"
+	log_message "notice" "Using fallback EID=${EID} (endpoint discovery unavailable or skipped)"
+fi
+
+# EID must be numeric; without it there is nothing to address.
+case "$EID" in
+	''|*[!0-9]*)
+		log_message "err" "No valid MCTP EID (got '${EID}'); cannot address Bali (Caliptra); refusing to start"
+		exit 1
+		;;
+esac
+
+log_message "info" "Starting ABR watchdog heartbeat: eid=${EID} type=${WD_HEARTBEAT_MSG_TYPE} data=[${WD_HEARTBEAT_DATA}] interval=${WD_HEARTBEAT_INTERVAL}s timeout=${WD_HEARTBEAT_CMD_TIMEOUT}s worst_case=$((WD_HEARTBEAT_CMD_TIMEOUT + WD_HEARTBEAT_INTERVAL))s via ${MCTP_CLIENT}"
+
+# Log only on state change (ok<->fail) to avoid flooding the journal every
+# interval while the link is healthy.
+_prev_ok=-1
+
+while true; do
+	# shellcheck disable=SC2086
+	# WD_HEARTBEAT_DATA is intentionally unquoted so each hex byte becomes a
+	# separate mctp-client argument (matches "data 80 03"). run_bounded caps the
+	# call at WD_HEARTBEAT_CMD_TIMEOUT so a hung transport cannot stall the loop.
+	if run_bounded "$MCTP_CLIENT" eid "$EID" type "$WD_HEARTBEAT_MSG_TYPE" data $WD_HEARTBEAT_DATA >/dev/null 2>&1; then
+		if [ "$_prev_ok" != "1" ]; then
+			log_message "info" "ABR watchdog heartbeat OK (eid=${EID})"
+			_prev_ok=1
+		fi
+	else
+		if [ "$_prev_ok" != "0" ]; then
+			log_message "warning" "ABR watchdog heartbeat request failed or timed out (eid=${EID}); will keep retrying"
+			_prev_ok=0
+		fi
+	fi
+	sleep "$WD_HEARTBEAT_INTERVAL"
+done

--- a/debian/hw-management-bmc.postinst
+++ b/debian/hw-management-bmc.postinst
@@ -90,12 +90,23 @@ case "$1" in
                 # producing a successful-looking package configure that
                 # leaves HW-MGMT unstarted.  Suppress systemctl chatter on
                 # success (>/dev/null 2>&1); real failures hit the WARNING below.
+                #
+                #   wd-heartbeat        stop-gap ABR-watchdog heartbeat to Bali
+                #                       (Caliptra) over MCTP.  Independent of the
+                #                       init chain; ordered After=boot-complete so
+                #                       it only heartbeats once the BMC has booted.
+                #                       No-ops (exit 0) when disabled in
+                #                       /etc/hw-management-bmc-wd-heartbeat.conf or
+                #                       when mctp-client is absent, so listing it
+                #                       here is safe on images without MCTP tooling.
+                #
                 if ! systemctl start --no-block \
                         hw-management-bmc-boot-complete.service \
                         hw-management-bmc-health-monitor.service \
                         hw-management-bmc-i2c-slave-setup.service \
                         hw-management-bmc-recovery-handler.service \
                         hw-management-bmc-reset-cause-logger.service \
+                        hw-management-bmc-wd-heartbeat.service \
                         >/dev/null 2>&1; then
                     echo "WARNING: hw-management-bmc.postinst: failed to queue HW-MGMT BMC startup; package configure will continue, but HW-MGMT will only come up on the next reboot" >&2
                 fi

--- a/debian/hw-management-bmc.prerm
+++ b/debian/hw-management-bmc.prerm
@@ -41,6 +41,7 @@ case "$1" in
                     hw-management-bmc-i2c-slave-setup.service \
                     hw-management-bmc-recovery-handler.service \
                     hw-management-bmc-reset-cause-logger.service \
+                    hw-management-bmc-wd-heartbeat.service \
                     >/dev/null 2>&1; then
                 echo "WARNING: hw-management-bmc.prerm: failed to stop some BMC services; check systemctl status before removing package files" >&2
             fi

--- a/debian/rules
+++ b/debian/rules
@@ -168,7 +168,8 @@ ifeq ($(with_bmc),1)
 		hw-management-bmc-health-monitor.service \
 		hw-management-bmc-reset-cause-logger.service \
 		hw-management-bmc-i2c-slave-setup.service \
-		hw-management-bmc-recovery-handler.service
+		hw-management-bmc-recovery-handler.service \
+		hw-management-bmc-wd-heartbeat.service
 endif
 
 override_dh_systemd_start:
@@ -219,7 +220,8 @@ ifeq ($(with_bmc),1)
 		hw-management-bmc-health-monitor.service \
 		hw-management-bmc-reset-cause-logger.service \
 		hw-management-bmc-i2c-slave-setup.service \
-		hw-management-bmc-recovery-handler.service
+		hw-management-bmc-recovery-handler.service \
+		hw-management-bmc-wd-heartbeat.service
 endif
 
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
Motivation
On AST2700 SONiC BMC, the ABR watchdog is intended for redundant SPI boot. The BMC boots from eMMC while SPI holds the OpenBMC image. If the ABR watchdog expires, BootMCU may switch to the OpenBMC image. This is not desired on SONiC. The watchdog is armed only when the OTP fuse is programmed, so it matters on production systems.

Considered approaches
1. Disable the watchdog in U-Boot before handing off to Linux.
2. Disable the watchdog from Linux by writing the WDTA register.
3. Service the watchdog over MCTP to Bali (Caliptra) firmware.
4. Change Bali firmware to disable the watchdog instead of servicing it (avoided to limit Sonic-specific firmware divergence).

Solution
Add hw-management-bmc-wd-heartbeat as a stop-gap until SONiC picks a final approach. A systemd service starts after boot-complete and runs hw-management-bmc-wd-heartbeat.sh, which periodically sends mctp-client eid <EID> type control data 80 03 to Bali. Platform settings live in /etc/hw-management-bmc-wd-heartbeat.conf (deployed from HI189). The service no-ops when disabled or when mctp-client is missing. WD_HEARTBEAT_EID must be set after verification on target.