### PR TITLE
hw-mgmt: kernel 6.12 BMC: revert spc6-bmc eMMC HS200 changes (#2673)

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch
+++ b/recipes-kernel/linux/linux-6.12/0008-arm64-dts-aspeed-spc6-bmc-ext-phram-env-tpm-i3c-pull.patch
@@ -2,10 +2,10 @@ From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Dvir Zaguri <dzaguri@nvidia.com>
 Date: Sun, 31 May 2026 10:15:00 +0300
 Subject: [PATCH 6.12 1/1] arm64: dts: aspeed: spc6-bmc: phram-env, TPM init,
- GPIO expander reset, I3C pull-ups, eMMC HS200
+ GPIO expander reset, I3C pull-ups
 
 Extend arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
-(AST2700-A2 SPC6 CPU BMC) with five downstream fixes taken from
+(AST2700-A2 SPC6 CPU BMC) with four downstream fixes taken from
 the OpenBMC Switch-26.05-1_br branch. Only the kernel DTS hunks
 from each commit are taken; the matching userspace / U-Boot /
 kconfig changes live in their own layers and are out of scope.
@@ -55,28 +55,15 @@ kconfig changes live in their own layers and are out of scope.
       bus pull-ups and the controller comes up at boot without the
       previous late user-space bind workaround.
 
-  4148acb3e1d418f46069af41d3da3e5fd76b206e
-  "L1 Switch: increase emmc frequency to 200Mhz"
-  Sergejs Hatinecs <shatinecs@nvidia.com>, Jul 2 2026
-
-    * Bump the eMMC to HS200 8-bit / 200 MHz: set &emmc bus-width = <8>
-      and max-frequency = <200000000>, and add
-      pinctrl-0 = <&pinctrl_emmcg8_default> for the 8-bit data lines.
-    * Add an mmc-pwrseq-emmc node (mmc_pwrseq) that hardware-resets the
-      device via EMMC_1V8_RST* on gpio1 ASPEED_GPIO(Q, 7) (active-low)
-      and reference it from &emmc through mmc-pwrseq, so the card is
-      reset to a known state before the faster mode is negotiated.
-
 Signed-off-by: Dvir Zaguri <dzaguri@nvidia.com>
 ---
- .../boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts     | 70 +++++++++++++++++++---
- 1 file changed, 70 insertions(+), 2 deletions(-)
+ .../boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts     | 59 ++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
 
 diff --git a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
-index 81f4bee..1dd843e 100644
 --- a/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
 +++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc.dts
-@@ -29,6 +29,21 @@
+@@ -29,6 +29,15 @@
  		ranges;
  
  		#include "ast2700-reserved-mem.dtsi"
@@ -89,16 +76,10 @@ index 81f4bee..1dd843e 100644
 +			reg = <0x00000004 0x237ff000 0x0 0x00001000>;
 +			no-map;
 +		};
-+	};
-+
-+	/* eMMC hardware reset (RST_n) driven by EMMC_1V8_RST* on GPIOQ7 (ball N15). */
-+	mmc_pwrseq: mmc-pwrseq {
-+		compatible = "mmc-pwrseq-emmc";
-+		reset-gpios = <&gpio1 ASPEED_GPIO(Q, 7) GPIO_ACTIVE_LOW>;
  	};
  };
  
-@@ -55,6 +70,30 @@
+@@ -55,6 +64,30 @@
  		compatible = "st,st33htpm-spi", "infineon,slb9670", "tcg,tpm_tis-spi";
  		reg = <1>;
  		spi-max-frequency = <10000000>;
@@ -129,7 +110,7 @@ index 81f4bee..1dd843e 100644
  	};
  };
  
-@@ -243,6 +282,7 @@
+@@ -243,6 +276,7 @@
  		#gpio-cells = <2>;
  		#address-cells = <1>;
  		#size-cells = <0>;
@@ -137,7 +118,7 @@ index 81f4bee..1dd843e 100644
  
  		gpio-line-names =
  			"RSRVD_0", "GP_EROT_RST_IN_L",
-@@ -257,6 +297,30 @@
+@@ -257,6 +291,30 @@
  			"RSRVD_7", "GP_PROD_CS_FLASH0_EN",
  			"RSRVD_8", "GP_PROD_CS_FLASH1_EN",
  			"RSRVD_9", "RSRVD_10";
@@ -168,21 +149,7 @@ index 81f4bee..1dd843e 100644
  	};
  };
  
-@@ -357,8 +421,11 @@
- &emmc {
- 	status = "okay";
- 	non-removable;
--	bus-width = <4>;
--	max-frequency = <52000000>;
-+	bus-width = <8>;
-+	max-frequency = <200000000>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pinctrl_emmcg8_default>;
-+	mmc-pwrseq = <&mmc_pwrseq>;
- };
- 
- /* eSPI Controller - Communication with host CPU */
-@@ -463,5 +530,6 @@
+@@ -463,5 +521,6 @@
  	status = "okay";
  	pinctrl-names = "default";
  	i3c-scl-hz = <12500000>;

--- a/recipes-kernel/linux/linux-6.12/0009-arm64-dts-aspeed-split-SPC6-BMC-DTS-for-SONiC-and-Op.patch
+++ b/recipes-kernel/linux/linux-6.12/0009-arm64-dts-aspeed-split-SPC6-BMC-DTS-for-SONiC-and-Op.patch
@@ -26,11 +26,11 @@ with the existing ramrofs node and irot.dtsi.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- .../aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts | 536 ++++++++++++++++++
+ .../aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts | 527 ++++++++++++++++++
  .../dts/aspeed/aspeed-nvidia-spc6-bmc.dts     |   2 +-
  .../dts/aspeed/nvidia-ast27xx-irot-sonic.dtsi |  14 +
  .../aspeed/nvidia-ast27xx-sunda-sonic.dtsi    |   8 +
- 4 files changed, 558 insertions(+), 1 deletion(-)
+ 4 files changed, 549 insertions(+), 1 deletion(-)
  create mode 100644 arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
  create mode 100644 arch/arm64/boot/dts/aspeed/nvidia-ast27xx-irot-sonic.dtsi
  create mode 100644 arch/arm64/boot/dts/aspeed/nvidia-ast27xx-sunda-sonic.dtsi
@@ -40,7 +40,7 @@ new file mode 100644
 index 000000000..e825c106d
 --- /dev/null
 +++ b/arch/arm64/boot/dts/aspeed/aspeed-nvidia-spc6-bmc-openbmc.dts
-@@ -0,0 +1,536 @@
+@@ -0,0 +1,527 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/dts-v1/;
 +
@@ -86,12 +86,6 @@ index 000000000..e825c106d
 +			reg = <0x00000004 0x237ff000 0x0 0x00001000>;
 +			no-map;
 +		};
-+	};
-+
-+	/* eMMC hardware reset (RST_n) driven by EMMC_1V8_RST* on GPIOQ7 (ball N15). */
-+	mmc_pwrseq: mmc-pwrseq {
-+		compatible = "mmc-pwrseq-emmc";
-+		reset-gpios = <&gpio1 ASPEED_GPIO(Q, 7) GPIO_ACTIVE_LOW>;
 +	};
 +};
 +
@@ -470,11 +464,8 @@ index 000000000..e825c106d
 +&emmc {
 +	status = "okay";
 +	non-removable;
-+	bus-width = <8>;
-+	max-frequency = <200000000>;
-+	pinctrl-names = "default";
-+	pinctrl-0 = <&pinctrl_emmcg8_default>;
-+	mmc-pwrseq = <&mmc_pwrseq>;
++	bus-width = <4>;
++	max-frequency = <52000000>;
 +};
 +
 +/* eSPI Controller - Communication with host CPU */


### PR DESCRIPTION
Revert eMMC HS200 8-bit/200 MHz and mmc-pwrseq from SPC6 BMC kernel patches 0008 (SONiC DTS) and 0009 (OpenBMC DTS split), matching V.7.0070.1000_BR commit b9e64ca6. Cherry-pick failed because master carries ee20a6ee hunk context on 0008; content was taken from the release branch instead.

This reverts the HS200 port from #2666 and #2667 (folded into master via #2665), restoring &emmc to 4-bit / 52 MHz.