### PR TITLE
hw-mgmt: scripts: Fix SN5600/SN5400 PSU EEPROM size

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2168,6 +2168,9 @@ sn5x00_specific()
 	else
 		echo 4 > $config_path/cpld_num
 	fi
+	if [ "$sku" == "HI144" ] || [ "$sku" == "HI147" ] ; then
+		echo 24c02 > $config_path/psu_eeprom_type
+	fi
 	lm_sensors_config="$lm_sensors_configs_path/sn5600_sensors.conf"
 	named_busses+=(${sn5600_named_busses[@]})
 	add_come_named_busses $ng800_cpu_bus_offset


### PR DESCRIPTION
New models of SN5600/SN5400 PSU Delta PSUs have much smaller EEPROMs than the original ones (256 bytes vs 4096 bytes). As a result EEPROM driver fails to instantiate the EEPROM on new PSU models, producing the following errors:

[51276.012793] i2c i2c-4: Failed to register i2c client 24c32 at 0x51 (-16)
[51323.978315] i2c i2c-4: Failed to register i2c client 24c32 at 0x52 (-16)

To fix that, assume that all SN5600/SN5400 PSUs have small EEPROM, since smaller size works also for large EEPROMs and all relevant EEPROM data fits into the first 256 bytes

Bug: 5146441