### PR TITLE
hw-mgmt: bmc: leakage: Enable MAX1363 A2D readings on HI189

### DIFF
--- a/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
+++ b/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
@@ -14,24 +14,25 @@
                 "Probe": true,
                 "Scale": 0.0008,
                 "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max by hw-management-bmc-a2d-leakage-config.sh (leakage-handler in-band check: raw*Scale vs min/max). Scale 0.0008 V/LSB matches the HI189 platform Excel MAX1363 column (0.8 mV).",
+                "Severity_comment": "Severity bounds are contiguous (WarningMax=NormalMin, CriticalMax=WarningMin) so no reading falls between bands. The leakage handler (hw-management-bmc-leakage-handler.sh) triggers on the Normal band only (min/max = NormalMin/NormalMax); warn/crit/lwarn/lcrit are informational severity bounds.",
                 "Types": [
                     {
                         "Type": "flex",
-                        "NormalMin": 1.99,
-                        "NormalMax": 2.17,
-                        "WarningMin": 1.73,
-                        "CriticalMin": 0.13,
-                        "WarningMax": 1.99,
-                        "CriticalMax": 1.73
+                        "NormalMin": 1.9,
+                        "NormalMax": 3.0,
+                        "WarningMin": 1.3,
+                        "CriticalMin": 0.2,
+                        "WarningMax": 1.9,
+                        "CriticalMax": 1.3
                     },
                     {
                         "Type": "embedded",
-                        "NormalMin": 2.8,
-                        "NormalMax": 3.09,
-                        "WarningMin": 2.27,
-                        "CriticalMin": 0.13,
-                        "WarningMax": 2.8,
-                        "CriticalMax": 2.27
+                        "NormalMin": 2.7,
+                        "NormalMax": 3.3,
+                        "WarningMin": 1.1,
+                        "CriticalMin": 0.2,
+                        "WarningMax": 2.7,
+                        "CriticalMax": 1.1
                     }
                 ],
                 "Channels": [
@@ -39,7 +40,7 @@
                     { "Id": 2, "Type": "embedded" }
                 ],
                 "CfgReg": "0x00",
-                "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15",
+                "CfgRegVal": "0x01 0x00 0x11 0x1f 0x13 0x14 0x15",
                 "CfgRegVal_comment": "MAX1363 monitor burst (reg 0x00). Channels maps each logical channel to a hardware A2D input (AINx = Id-1) and to a Type whose thresholds are defined in Types. Script patches the scan/monitor bytes for the first mapped channel; author the burst to scan all mapped channels when monitoring more than one."
             },
             {
@@ -133,24 +134,25 @@
                 "Probe": true,
                 "Scale": 0.0008,
                 "NormalMinMax_comment": "Per-type NormalMin/NormalMax are written to runtime .../min and .../max by hw-management-bmc-a2d-leakage-config.sh (leakage-handler in-band check: raw*Scale vs min/max). Scale 0.0008 V/LSB matches the HI189 platform Excel MAX1363 column (0.8 mV).",
+                "Severity_comment": "Severity bounds are contiguous (WarningMax=NormalMin, CriticalMax=WarningMin) so no reading falls between bands. The leakage handler (hw-management-bmc-leakage-handler.sh) triggers on the Normal band only (min/max = NormalMin/NormalMax); warn/crit/lwarn/lcrit are informational severity bounds.",
                 "Types": [
                     {
                         "Type": "flex",
-                        "NormalMin": 1.99,
-                        "NormalMax": 2.17,
-                        "WarningMin": 1.73,
-                        "CriticalMin": 0.13,
-                        "WarningMax": 1.99,
-                        "CriticalMax": 1.73
+                        "NormalMin": 1.9,
+                        "NormalMax": 3.0,
+                        "WarningMin": 1.3,
+                        "CriticalMin": 0.2,
+                        "WarningMax": 1.9,
+                        "CriticalMax": 1.3
                     },
                     {
                         "Type": "embedded",
-                        "NormalMin": 2.8,
-                        "NormalMax": 3.09,
-                        "WarningMin": 2.27,
-                        "CriticalMin": 0.13,
-                        "WarningMax": 2.8,
-                        "CriticalMax": 2.27
+                        "NormalMin": 2.7,
+                        "NormalMax": 3.3,
+                        "WarningMin": 1.1,
+                        "CriticalMin": 0.2,
+                        "WarningMax": 2.7,
+                        "CriticalMax": 1.1
                     }
                 ],
                 "Channels": [
@@ -158,7 +160,7 @@
                     { "Id": 4, "Type": "embedded" }
                 ],
                 "CfgReg": "0x00",
-                "CfgRegVal": "0x07 0x00 0x1f 0x1f 0x13 0x14 0x15",
+                "CfgRegVal": "0x01 0x00 0x11 0x1f 0x13 0x14 0x15",
                 "CfgRegVal_comment": "MAX1363 monitor burst (reg 0x00). Channels maps each logical channel to a hardware A2D input (AINx = Id-1) and to a Type whose thresholds are defined in Types. Script patches the scan/monitor bytes for the first mapped channel; author the burst to scan all mapped channels when monitoring more than one."
             },
             {

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-config.sh
@@ -747,6 +747,48 @@ configure_max1363_raw_i2c()
 	return 1
 }
 
+# All MAX1363 leak sensors on this platform are wired with Vdd as the ADC reference
+# (full-scale = Vdd ~3.28 V, i.e. Scale 0.0008 V/LSB). With no "vref" regulator in the
+# devicetree the ti-max1363 driver defaults to its internal 2.048 V reference and rails
+# inputs above it to raw 4095; forcing Vdd via sysfs restores correct conversions. Call
+# after the kernel driver is (re)bound so the IIO voltage_reference node exists.
+MAX1363_IIO_REFERENCE="Vdd"
+
+max1363_set_iio_reference()
+{
+	local bus="$1"
+	local address="$2"
+	local a dev_id iio_dir vr d dirs
+
+	a="${address#0x}"
+	a="${a#0X}"
+	dev_id=$(printf '%d-%04x' "$bus" $((16#$a)))
+
+	# IIO device dirs, same discovery order as find_iio_channel_raw: under the I2C
+	# client, then /sys/bus/iio/devices entries whose device link is this client.
+	dirs=""
+	for d in /sys/bus/i2c/devices/"$dev_id"/iio:device*; do
+		[ -e "$d" ] && dirs="$dirs $d"
+	done
+	for d in /sys/bus/iio/devices/iio:device*; do
+		[ -e "$d" ] || continue
+		[ "$(basename "$(readlink -f "$d/device" 2>/dev/null)" 2>/dev/null)" = "$dev_id" ] && dirs="$dirs $d"
+	done
+
+	for iio_dir in $dirs; do
+		vr="$iio_dir/voltage_reference"
+		[ -w "$vr" ] || continue
+		if echo "$MAX1363_IIO_REFERENCE" >"$vr" 2>/dev/null; then
+			log_message "info" "MAX1363 $dev_id: voltage_reference=$MAX1363_IIO_REFERENCE (now: $(cat "$vr" 2>/dev/null))"
+			return 0
+		fi
+		log_message "err" "MAX1363 $dev_id: failed to set voltage_reference=$MAX1363_IIO_REFERENCE (available: $(cat "${vr}_available" 2>/dev/null)) - readings may rail to full scale (driver internal 2.048 V reference)"
+		return 1
+	done
+	log_message "err" "MAX1363 $dev_id: no voltage_reference sysfs node — cannot set $MAX1363_IIO_REFERENCE reference; readings may rail to full scale (driver internal 2.048 V reference)"
+	return 1
+}
+
 # True when ADS1015 config low byte has COMP_QUE=11 (comparator disabled, TI SBAS173).
 ads1015_cfg_comp_disabled()
 {
@@ -1662,6 +1704,7 @@ create_channel_infrastructure()
 		echo "$detector_name" >"$leakage_base/device_name"
 	fi
 	log_message "info" "Leakage runtime: $leakage_base (device_type=$device_type)"
+	write_reference_status_marker "$leakage_base" "$device_type"
 
 	if json_probe_true "$device_json"; then
 		sleep 0.5
@@ -1691,6 +1734,19 @@ create_channel_infrastructure()
 	return 0
 }
 
+# Record/clear a runtime marker when the MAX1363 Vdd reference could not be set, so a
+# railed configuration is observable in the leakage tree (not only the system log).
+write_reference_status_marker()
+{
+	local leakage_base="$1"
+	local device_type="$2"
+	if [ "$device_type" = "MAX1363" ] && [ "${MAX1363_REF_FAILED:-0}" = "1" ]; then
+		echo "voltage_reference not set to ${MAX1363_IIO_REFERENCE}; readings may rail to full scale (driver internal 2.048 V reference)" >"$leakage_base/reference_error"
+	else
+		rm -f "$leakage_base/reference_error"
+	fi
+}
+
 # One logical channel under leakage/<i>/<logical_ch>/ (per-channel Device[] map).
 populate_single_leakage_channel()
 {
@@ -1717,6 +1773,7 @@ populate_single_leakage_channel()
 	if [ ! -f "$leakage_base/device_type" ]; then
 		echo "$device_type" >"$leakage_base/device_type"
 	fi
+	write_reference_status_marker "$leakage_base" "$device_type"
 
 	if json_probe_true "$device_json"; then
 		sleep 0.5
@@ -1820,6 +1877,7 @@ configure_device()
 	bus=$(echo "$device_json" | json_get_number "Bus")
 	address=$(echo "$device_json" | json_get_string "Address")
 	need_rebind=0
+	MAX1363_REF_FAILED=0
 
 	log_message "info" "Checking $device_type device at Bus $bus, Address $address for $device_name"
 
@@ -1844,6 +1902,13 @@ configure_device()
 				"$device_type" "$num_channels" "$hw_channel_id" post_driver; then
 				log_message "info" "$device_type $device_name: post-probe register programming failed — try next Device alternative"
 				return 1
+			fi
+			# MAX1363: force the Vdd ADC reference while the driver is bound and the IIO
+			# sysfs is up, else the ti-max1363 default 2.048 V internal reference rails
+			# inputs above it to raw 4095. Record the outcome so a railed reference is
+			# observable in the leakage tree.
+			if [ "$device_type" = "MAX1363" ] && ! max1363_set_iio_reference "$bus" "$address"; then
+				MAX1363_REF_FAILED=1
 			fi
 			log_message "info" "Device configuration complete for $device_name"
 			return 0

--- a/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-read.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-a2d-leakage-read.sh
@@ -33,7 +33,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ################################################################################
-# A2D leakage channel reader: reads ADS1015, ADS7924 (IIO or raw I2C), and placeholder MAX1363
+# A2D leakage channel reader: reads ADS1015, ADS7924 (IIO or raw I2C), and MAX1363 (IIO)
 # and writes per-channel voltage files under /var/run/hw-management/leakage/,
 # alongside the tree created by hw-management-bmc-a2d-leakage-config.sh.
 # Origin: OpenBMC meta-nvidia bmc-post-boot-cfg a2d_leakage_read.sh
@@ -188,7 +188,9 @@ ads7924_parse_be16()
 # True if string is a signed decimal integer (POSIX / BusyBox friendly).
 ads7924_is_decimal_int()
 {
-    awk -v s="$1" 'BEGIN { if (s ~ /^-?[0-9]+$/) exit 0; exit 1 }'
+    # Delegates to the shared is_decimal_int (hw-management-bmc-helpers-common.sh);
+    # kept as a thin alias so existing ADS7924 call sites stay unchanged.
+    is_decimal_int "$1"
 }
 
 # Read ADS7924 channel (1..4): 12-bit code from DATAx_U/L via pointer INC, then volts = raw12 * scale.
@@ -299,19 +301,93 @@ ads7924_read_channels()
     return 0
 }
 
-# Function to read MAX1363 channels (placeholder - not implemented yet)
+# Function to read all MAX1363 channels for a device.
+# MAX1363 is read live through the kernel IIO driver: hw-management-bmc-a2d-leakage-config.sh
+# links <ch>/input to in_voltage<Id-1>_raw (JSON Probe: true), so each read triggers a fresh
+# conversion. Publish value = raw * scale, the same uniform value interface as the ADS1015/ADS7924
+# readers. Origin: OpenBMC meta-nvidia bmc-post-boot-cfg a2d_leakage_read.sh.
 # Usage: max1363_read_channels <bus> <address> <device_dir>
 max1363_read_channels()
 {
     local bus="$1"
     local addr="$2"
     local device_dir="$3"
+    local channels_read=0
+    local channels_skipped=0
+    local ch_dir ch_num scale_f raw_input result skip_channel link link_name
 
-    log_message "info" "MAX1363 reading not implemented yet (bus $bus addr $addr)"
+    log_message "info" "Reading MAX1363 channels on bus $bus addr $addr"
 
-    # TODO: Implement MAX1363 channel reading
-    # For now, just skip
+    # Device-level scale fallback (volts per LSB); a per-channel scale file overrides it below.
+    local dev_scale=""
+    [ -f "$device_dir/scale" ] && dev_scale=$(tr -d ' \t\r\n' <"$device_dir/scale")
 
+    for ch_dir in "$device_dir"/[0-9]*; do
+        if [ ! -d "$ch_dir" ]; then
+            continue
+        fi
+
+        ch_num=$(basename "$ch_dir")
+
+        # Skip Not_Connected channels (same convention as the ADS1015/ADS7924 readers).
+        skip_channel=0
+        for link in "$device_dir"/*; do
+            if [ -L "$link" ] && [ "$(readlink "$link")" = "$ch_num" ]; then
+                link_name=$(basename "$link")
+                case "$link_name" in
+                Not_Connected*)
+                    log_message "debug" "Skipping channel $ch_num ($link_name)"
+                    skip_channel=1
+                    channels_skipped=$((channels_skipped + 1))
+                    break
+                    ;;
+                esac
+            fi
+        done
+        if [ "$skip_channel" -eq 1 ]; then
+            continue
+        fi
+
+        # Per-channel scale (hw-management keeps scale beside each channel's input), else device scale.
+        scale_f="$dev_scale"
+        if [ -f "$ch_dir/scale" ]; then
+            scale_f=$(tr -d ' \t\r\n' <"$ch_dir/scale")
+        fi
+        if [ -z "$scale_f" ]; then
+            log_message "warning" "MAX1363 channel $ch_num: no scale available; skipping"
+            channels_skipped=$((channels_skipped + 1))
+            continue
+        fi
+
+        result=""
+        if [ -r "$ch_dir/input" ]; then
+            IFS= read -r raw_input <"$ch_dir/input" 2>/dev/null || raw_input=""
+            raw_input="${raw_input//$'\r'/}"
+            raw_input="${raw_input// /}"
+            if [ -n "$raw_input" ] && is_decimal_int "$raw_input"; then
+                result=$(echo "scale=10; ($raw_input * $scale_f) / 1" | hw_mgmt_bc)
+            fi
+        fi
+
+        if [ -n "$result" ]; then
+            case "$result" in
+            .*) result="0$result" ;;
+            esac
+            echo "$result" >"$ch_dir/value"
+            log_message "info" "Channel $ch_num: $result V"
+            channels_read=$((channels_read + 1))
+        else
+            # input is a symlink only when config bound the kernel IIO driver (JSON Probe: true);
+            # without a readable raw code there is no live conversion to publish.
+            if [ -L "$ch_dir/input" ]; then
+                log_message "warning" "MAX1363 channel $ch_num: IIO sysfs read failed (input symlink: $(readlink "$ch_dir/input" 2>/dev/null || echo '?'))"
+            else
+                log_message "warning" "MAX1363 channel $ch_num: no IIO input symlink; kernel driver required for live reads"
+            fi
+        fi
+    done
+
+    log_message "info" "MAX1363 read complete: $channels_read read, $channels_skipped skipped"
     return 0
 }
 

--- a/bmc/usr/usr/bin/hw-management-bmc-helpers-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-helpers-common.sh
@@ -397,6 +397,11 @@ _hw_mgmt_bc_resolve() {
 	return 1
 }
 
+# True (0) when the argument is a signed decimal integer (POSIX / BusyBox friendly).
+is_decimal_int() {
+	awk -v s="$1" 'BEGIN { if (s ~ /^-?[0-9]+$/) exit 0; exit 1 }'
+}
+
 # Pipe calculator expressions on stdin; prefer bc(1), else busybox bc on BMC images.
 hw_mgmt_bc() {
 	_hw_mgmt_bc_resolve || return 127


### PR DESCRIPTION
The MAX1363 leakage reader was a placeholder, so a board populated with a MAX1363 A2D built the runtime tree but never published any channel value.

- Implement max1363_read_channels(): read each channel's IIO input node and publish value = raw * scale, matching the other A2D readers.
- Force the MAX1363 Vdd IIO voltage_reference after the driver is rebound; otherwise the driver defaults to its internal 2.048 V reference and rails inputs above it to raw 4095, contradicting the 0.0008 V/LSB scale.
- Set the HI189 MAX1363 thresholds and monitor-burst config to the characterized platform values.