### PR TITLE
hw-mgmt: patches: Update platform driver for N6XXX_LD platforms

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0106-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
+++ b/recipes-kernel/linux/linux-6.1/0106-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
@@ -1,4 +1,4 @@
-From be10bc8ec297096ff4919ad91eef8ca17ff0461c Mon Sep 17 00:00:00 2001
+From 31fee0781e6497a0d15fb628282ecf2369ae4f20 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 15 Jun 2025 13:13:26 +0300
 Subject: [PATCH] platform/mellanox: nvsw-bmc: Add system control and
@@ -120,7 +120,7 @@ index 2b774cdf4..100ed1676 100644
  obj-$(CONFIG_MLXREG_DPU)	+= mlxreg-dpu.o
 diff --git a/drivers/platform/mellanox/nvsw-bmc-hid162.c b/drivers/platform/mellanox/nvsw-bmc-hid162.c
 new file mode 100644
-index 000000000..96908494c
+index 000000000..eb1216684
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-bmc-hid162.c
 @@ -0,0 +1,2832 @@
@@ -3657,15 +3657,15 @@ index 000000000..0dae7e076
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/platform/mellanox/nvsw-host-l1.c b/drivers/platform/mellanox/nvsw-host-l1.c
 new file mode 100644
-index 000000000..6b9837e1c
+index 000000000..3706787b5
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-host-l1.c
 @@ -0,0 +1,736 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
-+ * Nvidia BMC platform driver
++ * Nvidia L1 host platform driver
 + *
-+ * Copyright (C) 2025 Nvidia Technologies Ltd.
++ * Copyright (C) 2025-2026 Nvidia Technologies Ltd.
 + */
 +
 +#include <linux/device.h>

--- a/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
+++ b/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
@@ -1,8 +1,8 @@
-From ac19027ee711c9ab109c8cacde22af73483179db Mon Sep 17 00:00:00 2001
+From 79d11ae9b4611ac726289d9a27f4ac065c6a0efc Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 4 Jul 2024 23:50:27 +0300
-Subject: [PATCH BMC platform-next 1/4] platform/mellanox: nvsw-bmc: Add system
- control and monitoring driver for Nvidia BMC
+Subject: [PATCH] platform/mellanox: nvsw-bmc: Add system control and
+ monitoring driver for Nvidia BMC
 
 The driver allows system control and monitoring of Nvidia switches
 through CPLD/FPGA devices from Based Management Controller SoC.
@@ -23,13 +23,13 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  .../devicetree/bindings/trivial-devices.yaml  |    5 +
  drivers/platform/mellanox/Kconfig             |   38 +
  drivers/platform/mellanox/Makefile            |    4 +
- drivers/platform/mellanox/nvsw-bmc-hid162.c   | 7289 +++++++++++++++++
+ drivers/platform/mellanox/nvsw-bmc-hid162.c   | 7304 +++++++++++++++++
  drivers/platform/mellanox/nvsw-core.c         |  717 ++
- drivers/platform/mellanox/nvsw-host-l1.c      |  770 ++
+ drivers/platform/mellanox/nvsw-host-l1.c      |  735 ++
  drivers/platform/mellanox/nvsw-host-spc5.c    |  943 +++
  drivers/platform/mellanox/nvsw-host-spc6.c    |  852 ++
  drivers/platform/mellanox/nvsw.h              |  318 +
- 9 files changed, 10936 insertions(+)
+ 9 files changed, 10916 insertions(+)
  create mode 100644 drivers/platform/mellanox/nvsw-bmc-hid162.c
  create mode 100644 drivers/platform/mellanox/nvsw-core.c
  create mode 100644 drivers/platform/mellanox/nvsw-host-l1.c
@@ -38,7 +38,7 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
  create mode 100644 drivers/platform/mellanox/nvsw.h
 
 diff --git a/Documentation/devicetree/bindings/trivial-devices.yaml b/Documentation/devicetree/bindings/trivial-devices.yaml
-index 9bf0fb17a05e..b6c6576f7702 100644
+index 9bf0fb17a..b6c6576f7 100644
 --- a/Documentation/devicetree/bindings/trivial-devices.yaml
 +++ b/Documentation/devicetree/bindings/trivial-devices.yaml
 @@ -305,6 +305,11 @@ properties:
@@ -54,10 +54,10 @@ index 9bf0fb17a05e..b6c6576f7702 100644
            - nuvoton,w83773g
              # OKI ML86V7667 video decoder
 diff --git a/drivers/platform/mellanox/Kconfig b/drivers/platform/mellanox/Kconfig
-index 7204b10388ca..a8e4619f56d2 100644
+index f7dfa0e78..53e5a04aa 100644
 --- a/drivers/platform/mellanox/Kconfig
 +++ b/drivers/platform/mellanox/Kconfig
-@@ -104,6 +104,44 @@ config MLXBF_PMC
+@@ -79,6 +79,44 @@ config MLXBF_PMC
  	  to performance monitoring counters within various blocks in the
  	  Mellanox BlueField SoC via a sysfs interface.
  
@@ -103,10 +103,10 @@ index 7204b10388ca..a8e4619f56d2 100644
  	tristate "Nvidia SN2201 platform driver support"
  	depends on HWMON && I2C
 diff --git a/drivers/platform/mellanox/Makefile b/drivers/platform/mellanox/Makefile
-index e86723b44c2e..123edaa99d77 100644
+index 04703c041..5ad42435e 100644
 --- a/drivers/platform/mellanox/Makefile
 +++ b/drivers/platform/mellanox/Makefile
-@@ -11,4 +11,8 @@ obj-$(CONFIG_MLXREG_DPU)	+= mlxreg-dpu.o
+@@ -9,4 +9,8 @@ obj-$(CONFIG_MLXBF_TMFIFO)	+= mlxbf-tmfifo.o
  obj-$(CONFIG_MLXREG_HOTPLUG)	+= mlxreg-hotplug.o
  obj-$(CONFIG_MLXREG_IO) += mlxreg-io.o
  obj-$(CONFIG_MLXREG_LC) += mlxreg-lc.o
@@ -117,7 +117,7 @@ index e86723b44c2e..123edaa99d77 100644
  obj-$(CONFIG_NVSW_SN2201) += nvsw-sn2201.o
 diff --git a/drivers/platform/mellanox/nvsw-bmc-hid162.c b/drivers/platform/mellanox/nvsw-bmc-hid162.c
 new file mode 100644
-index 000000000000..89343d7660a4
+index 000000000..9f4c94f5d
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-bmc-hid162.c
 @@ -0,0 +1,7304 @@
@@ -7427,7 +7427,7 @@ index 000000000000..89343d7660a4
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/platform/mellanox/nvsw-core.c b/drivers/platform/mellanox/nvsw-core.c
 new file mode 100644
-index 000000000000..1bd2dfc622ce
+index 000000000..1bd2dfc62
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-core.c
 @@ -0,0 +1,717 @@
@@ -8150,15 +8150,15 @@ index 000000000000..1bd2dfc622ce
 +MODULE_LICENSE("Dual BSD/GPL");
 diff --git a/drivers/platform/mellanox/nvsw-host-l1.c b/drivers/platform/mellanox/nvsw-host-l1.c
 new file mode 100644
-index 000000000000..83d305080150
+index 000000000..6fb8cf07a
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-host-l1.c
-@@ -0,0 +1,770 @@
+@@ -0,0 +1,735 @@
 +// SPDX-License-Identifier: GPL-2.0+
 +/*
-+ * Nvidia BMC platform driver
++ * Nvidia L1 host platform driver
 + *
-+ * Copyright (C) 2025 Nvidia Technologies Ltd.
++ * Copyright (C) 2025-2026 Nvidia Technologies Ltd.
 + */
 +
 +#include <linux/device.h>
@@ -8201,9 +8201,9 @@ index 000000000000..83d305080150
 +static const int nvsw_host_l1_mgmt_channels[] = {
 +	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
 +	18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
-+	33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 48, 49,
-+	50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
-+	65, 66, 67, 68, 69, 70, 71,
++	33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
++	48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
++	63, 64, 65, 66, 67,
 +};
 +
 +/* Platform L1 scale out mux data */
@@ -8411,12 +8411,6 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "cartridge_status_clear",
-+		.reg = NVSW_REG_FRU1_EVENT_OFFSET,
-+		.bit = GENMASK(3, 0),
-+		.mode = 0644,
-+	},
-+	{
 +		.label = "leakage1",
 +		.reg = NVSW_REG_LEAK_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(0),
@@ -8429,12 +8423,6 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "leakage_status_clear",
-+		.reg = NVSW_REG_LEAK_EVENT_OFFSET,
-+		.bit = GENMASK(1, 0),
-+		.mode = 0644,
-+	},
-+	{
 +		.label = "asic_reset",
 +		.reg = NVSW_REG_RESET_GP2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
@@ -8444,6 +8432,24 @@ index 000000000000..83d305080150
 +		.label = "sgmii_phy_reset",
 +		.reg = NVSW_REG_RESET_GP2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "cpu_erot_reset",
++		.reg = NVSW_REG_RESET_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0644,
++	},
++	{
++		.label = "mcu1_reset",
++		.reg = NVSW_REG_RESET_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0644,
++	},
++	{
++		.label = "mcu2_reset",
++		.reg = NVSW_REG_RESET_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0644,
 +	},
 +	{
@@ -8459,7 +8465,7 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_aux_pwr_or_fu",
++		.label = "reset_aux_pwr_or_reload",
 +		.reg = NVSW_REG_RESET_CAUSE_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(2),
 +		.mode = 0444,
@@ -8471,7 +8477,13 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_pwr_button_or_leak_con",
++		.label = "reset_platform",
++		.reg = NVSW_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_pwr_button",
 +		.reg = NVSW_REG_RESET_CAUSE_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
 +		.mode = 0444,
@@ -8489,21 +8501,21 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_comex_pwr_fail",
-+		.reg = NVSW_REG_RESET_CAUSE1_OFFSET,
-+		.mask = GENMASK(7, 0) & ~BIT(3),
-+		.mode = 0444,
-+	},
-+	{
-+		.label = "reset_platform",
-+		.reg = NVSW_REG_RESET_CAUSE1_OFFSET,
-+		.mask = GENMASK(7, 0) & ~BIT(4),
-+		.mode = 0444,
-+	},
-+	{
 +		.label = "reset_soc",
 +		.reg = NVSW_REG_RESET_CAUSE1_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(5),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_cpu_erot",
++		.reg = NVSW_REG_RESET_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(6),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_leak_con",
++		.reg = NVSW_REG_RESET_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0444,
 +	},
 +	{
@@ -8519,15 +8531,9 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_comex_thermal",
++		.label = "reset_cpu_thermal",
 +		.reg = NVSW_REG_RESET_CAUSE2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
-+		.mode = 0444,
-+	},
-+	{
-+		.label = "reset_comex_power",
-+		.reg = NVSW_REG_RESET_CAUSE2_OFFSET,
-+		.mask = GENMASK(7, 0) & ~BIT(4),
 +		.mode = 0444,
 +	},
 +	{
@@ -8543,7 +8549,7 @@ index 000000000000..83d305080150
 +		.mode = 0444,
 +	},
 +	{
-+		.label = "reset_mgmt_pwr",
++		.label = "reset_mgmt_pwr_fail",
 +		.reg = NVSW_REG_RESET_CAUSE2_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(7),
 +		.mode = 0444,
@@ -8610,52 +8616,10 @@ index 000000000000..83d305080150
 +		.mode = 0644,
 +	},
 +	{
-+		.label = "config1",
-+		.reg = NVSW_REG_CONFIG1_OFFSET,
-+		.bit = GENMASK(7, 0),
-+		.mode = 0444,
-+	},
-+	{
-+		.label = "config2",
-+		.reg = NVSW_REG_CONFIG2_OFFSET,
-+		.bit = GENMASK(7, 0),
-+		.mode = 0444,
-+	},
-+	{
-+		.label = "config3",
-+		.reg = NVSW_REG_CONFIG3_OFFSET,
-+		.bit = GENMASK(7, 0),
-+		.mode = 0444,
-+	},
-+	{
-+		.label = "sgmii_phy",
-+		.reg = NVSW_REG_BRD1_OFFSET,
-+		.mask = GENMASK(7, 0) & ~BIT(5),
-+		.mode = 0444,
-+	},
-+	{
-+		.label = "graseful_pwr_off",
++		.label = "graceful_pwr_off",
 +		.reg = NVSW_REG_GP7_OFFSET,
 +		.mask = GENMASK(7, 0) & ~BIT(3),
 +		.mode = 0644,
-+	},
-+	{
-+		.label = "power_button_evt",
-+		.reg = NVSW_REG_PWRB_EVENT_OFFSET,
-+		.mask = GENMASK(7, 0) & ~NVSW_PWR_BUTTON_MASK,
-+		.mode = 0644,
-+	},
-+	{
-+		.label = "power_button_mask",
-+		.reg = NVSW_REG_PWRB_MASK_OFFSET,
-+		.mask = GENMASK(7, 0) & ~NVSW_PWR_BUTTON_MASK,
-+		.mode = 0644,
-+	},
-+	{
-+		.label = "amb_sens",
-+		.reg = NVSW_REG_PWRB_OFFSET,
-+		.mask = GENMASK(7, 0) & ~BIT(1),
-+		.mode = 0444,
 +	},
 +};
 +
@@ -8924,9 +8888,10 @@ index 000000000000..83d305080150
 +MODULE_AUTHOR("Vadim Pasternak <vadimp@mellanox.com>");
 +MODULE_DESCRIPTION("Nvidia platform driver");
 +MODULE_LICENSE("Dual BSD/GPL");
++
 diff --git a/drivers/platform/mellanox/nvsw-host-spc5.c b/drivers/platform/mellanox/nvsw-host-spc5.c
 new file mode 100644
-index 000000000000..e54bd4109b79
+index 000000000..e54bd4109
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-host-spc5.c
 @@ -0,0 +1,943 @@
@@ -9875,7 +9840,7 @@ index 000000000000..e54bd4109b79
 +
 diff --git a/drivers/platform/mellanox/nvsw-host-spc6.c b/drivers/platform/mellanox/nvsw-host-spc6.c
 new file mode 100644
-index 000000000000..449ba5ffd589
+index 000000000..449ba5ffd
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw-host-spc6.c
 @@ -0,0 +1,852 @@
@@ -10733,7 +10698,7 @@ index 000000000000..449ba5ffd589
 +
 diff --git a/drivers/platform/mellanox/nvsw.h b/drivers/platform/mellanox/nvsw.h
 new file mode 100644
-index 000000000000..4fa0d9d31bdd
+index 000000000..4fa0d9d31
 --- /dev/null
 +++ b/drivers/platform/mellanox/nvsw.h
 @@ -0,0 +1,318 @@


### PR DESCRIPTION
 1. Fix mux channel table in kernel 6.12 driver
 2. Sync 6.12 driver regio table with 6.1 driver
 2. Update description and copyright in both 6.1 and 6.12 drivers

The mux channel table update fixes the problem of i2c device enumeration on N6100_LD system under kernel 6.12

Bug: 5156400