### PR TITLE
hw-mgmt: bmc: Add boot journal to debug dump

### DIFF
--- a/bmc/README.md
+++ b/bmc/README.md
@@ -234,7 +234,7 @@ Documentation and sample data only. Nothing here is required at runtime unless y
 |--------|------|
 | **`hw-management-bmc-helpers-common.sh`** | From OpenBMC **`hw-management-helpers-common.sh`**: shared routines (**`log_event`**, **`log_cpld_dump`** — compact CPLD read for events), PHY **`mdio`** helpers, **`bmc_init_eth`**, **`get_mgmt_board_revision`**, etc.). **`hw-management-bmc-ready.sh`** sources it before **`hw-management-bmc-helpers.sh`**. Requires **bash** (uses **`[[ ]]`, `(( ))`, …). |
 | **`hw-management-bmc-cpld-dump.sh`** | **Merged** from OpenBMC **`recipes-phosphor/dump/files/cpld_dump.sh`** and **`dump_utils.sh`** (**`take_cpld_dump_internal`**, **`take_cpld_dump`** only). Full **16×16** CPLD grid via **256× `i2ctransfer … r1`** (one byte per offset), then prints the grid; optional **`.tar.xz`** CLI (**`-p`**, **`-i`**). Uses **`log_message`** and **`${HW_MANAGEMENT_BMC_PLATFORM_CONF:-/etc/hw-management-bmc-platform.conf}`** (via **`hw-management-bmc-helpers-common.sh`**); no Phosphor **`add_copy_file`**. Requires **bash**. |
-| **`hw-management-bmc-generate-dump.sh`** | SONiC BMC debug bundle (host analog **`hw-management-generate-dump.sh`**). **Parallel** collectors; default **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. **`-v` / `--verbose`** adds **`systemd-analyze/`** (~1 min). Without **`-v`**, writes **`systemd-analyze/skipped.txt`**. See **BMC debug bundle** below. Requires **bash**. |
+| **`hw-management-bmc-generate-dump.sh`** | SONiC BMC debug bundle (host analog **`hw-management-generate-dump.sh`**). **Parallel** collectors include the current boot journal under **`journal/`**; default **`/tmp/hw-mgmt-bmc-dump.tar.gz`**. **`-v` / `--verbose`** adds **`systemd-analyze/`** (~1 min). Without **`-v`**, writes **`systemd-analyze/skipped.txt`**. See **BMC debug bundle** below. Requires **bash**. |
 | **`hw-management-bmc-json-parser.sh`** | From OpenBMC **`switch_json_parser.sh`**: **`json_validate`**, **`json_get_nested_array_element`**, etc. (awk/BusyBox). Sourced by **`hw-management-bmc-a2d-leakage-config.sh`**, **`hw-management-bmc-early-i2c-init.sh`**, **`hw-management-bmc-gpio-set.sh`** (**`bmc_init_sysfs_gpio`**). |
 | **`hw-management-bmc-copy-cartridge-data.sh`** | **Cartridge SKUs:** sources **`/usr/bin/switch_json_parser.sh`** when **`/etc/hw-mgmt-bmc-copy-cartridge-data.json`** exists; reads cartridge FRU over I2C and programs SWB CPLD registers. See **`README-hw-management-bmc-copy-cartridge-data.md`**. |
 | **`hw-management-bmc-helpers.sh`** | Platform / ASIC helpers; sources **`hw-management-bmc-helpers-common.sh`** by absolute path. |
@@ -298,7 +298,20 @@ Collectors run **in parallel** (disjoint subdirs under **`/tmp/hw-mgmt-bmc-dump/
 | **`HW_MGMT_CAPTURE_PARALLEL_MAX`** | fallback for **`HW_MGMT_BMC_DUMP_WORKERS`** | same |
 | **`SYSTEMD_ANALYZE_PARALLEL_MAX`** | **`$MAX_PARALLEL`** | Per-unit **`systemd-analyze critical-chain`** pool (verbose only) |
 
-Archive top-level: **`dmesg.txt`**, **`uname.txt`**, **`proc/`**, **`network/`**, **`i2c/`**, **`systemctl/`**, **`cpld/`** (**`cpld_dump.log`** via **`take_cpld_dump`**), **`var_run_hw-management/`** (**`tree/`**, **`values/`**).
+Archive top-level: **`dmesg.txt`**, **`uname.txt`**, **`journal/`**, **`proc/`**,
+**`network/`**, **`i2c/`**, **`systemctl/`**, **`cpld/`** (**`cpld_dump.log`** via
+**`take_cpld_dump`**), and **`var_run_hw-management/`** (**`tree/`**, **`values/`**).
+
+**`journal/`** — **`journalctl-b0.txt.gz`** is `journalctl -b0 --no-pager`
+streamed through **`gzip -5`** (full current boot, no line cap). Mid-level
+compression keeps **`/tmp`** usage low on small tmpfs BMCs without the CPU
+cost of **`-9`** on plain text; nested **`.gz`** inside the outer **`.tar.gz`**
+is expected. Collection has a 60-second timeout. If **`journalctl`** or
+**`gzip`** is unavailable, **`skipped.txt`** records that the section was
+skipped. On non-zero **`PIPESTATUS`** from the **`journalctl | gzip`** pipe
+(timeout, kill, or other failure), **`failed.txt`** is written (**.gz** may
+still exist but be truncated). Exit codes come from bash **`PIPESTATUS`**, so a
+truncated capture is not silent even without **`pipefail`**.
 
 **`var_run_hw-management/`** — single **`find`** over **`/var/run/hw-management`**, then parallel capture of file/symlink values (EEPROM: **`hexdump -C`**). **`hw-management-bmc-show-reset-cause.sh`** runs first into live **`bmc/show-reset-cause`** (archive **`values/bmc_show-reset-cause.txt`**). For **mlxreg-io** sysfs nodes that are **write-only** (**`--w-------`**), **`[ -r file ]`** may still succeed as root; the dump runs **`cat`** and records **`cat`** errors plus **`(cat returned non-zero; likely write-only or EIO)`** when read fails.
 

--- a/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
@@ -33,10 +33,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ################################################################################
-# BMC debug bundle (SONiC BMC): dmesg, /proc/interrupts, ifconfig (or ip),
-# i2cdetect per non-mux bus, CPLD grid dump, systemctl for hw-management-bmc
-# units, systemd-analyze (time, blame, critical-chain), and /var/run/hw-management
-# tree + file contents (EEPROM via hexdump -C).
+# BMC debug bundle (SONiC BMC): dmesg, journalctl -b0, /proc/interrupts,
+# ifconfig (or ip), i2cdetect per non-mux bus, CPLD grid dump, systemctl for
+# hw-management-bmc units, systemd-analyze (time, blame, critical-chain), and
+# /var/run/hw-management tree + file contents (EEPROM via hexdump -C).
 # Output: gzip-compressed tar (default /tmp/hw-mgmt-bmc-dump.tar.gz). Pattern
 # aligned with usr/usr/bin/hw-management-generate-dump.sh (CPU).
 #
@@ -83,14 +83,17 @@ help()
 	cat <<EOF
 Usage: hw-management-bmc-generate-dump.sh [-v|--verbose] [output_tarball]
 
-  Collects dmesg, /proc/interrupts, ifconfig (fallback: ip addr), i2cdetect -y
-  for each bus from "i2cdetect -l | grep -v mux", CPLD dump (hw-management-bmc-cpld-dump),
-  systemctl status/show for all hw-management-bmc* units, and /var/run/hw-management tree
-  + values (EEPROM paths: hexdump -C).
+  Collects dmesg, journalctl -b0 (gzip'd on the fly), /proc/interrupts,
+  ifconfig (fallback: ip addr), i2cdetect -y for each bus from
+  "i2cdetect -l | grep -v mux", CPLD dump (hw-management-bmc-cpld-dump),
+  systemctl status/show for all hw-management-bmc* units, and
+  /var/run/hw-management tree + values (EEPROM paths: hexdump -C).
   Before archiving, hw-management-bmc-show-reset-cause.sh output is written to
-  /var/run/hw-management/bmc/show-reset-cause so it is included with the runtime snapshot.
+  /var/run/hw-management/bmc/show-reset-cause so it is included with the
+  runtime snapshot.
 
-  -v, --verbose   Also collect systemd-analyze (time, blame, critical-chain); slow (~1 min).
+  -v, --verbose   Also collect systemd-analyze (time, blame, critical-chain);
+                  slow (~1 min).
 
   Default output: /tmp/hw-mgmt-bmc-dump.tar.gz
 EOF
@@ -403,6 +406,38 @@ collect_proc_interrupts()
 	fi
 }
 
+collect_journalctl_boot()
+{
+	local d=$1
+	local rc_j rc_g
+	mkdir -p "$d"
+	if ! command -v journalctl >/dev/null 2>&1; then
+		log_message warning "journalctl not found — skipping boot journal"
+		echo "journalctl not found" >"${d}/skipped.txt"
+		return 0
+	fi
+	if ! command -v gzip >/dev/null 2>&1; then
+		log_message warning "gzip not found — skipping boot journal"
+		echo "gzip not found" >"${d}/skipped.txt"
+		return 0
+	fi
+	# Stream through gzip so a long-lived / verbose boot cannot exhaust /tmp
+	# (often a small tmpfs) while still keeping the full current-boot journal.
+	# stderr is merged into the stream so failures land in the .gz too.
+	# Use bash PIPESTATUS (not pipefail alone): without pipefail, gzip's 0
+	# exit would hide a timeout that kills journalctl and leave a truncated
+	# .gz with no warning.
+	timeout 60 journalctl -b0 --no-pager 2>&1 | gzip -5 >"${d}/journalctl-b0.txt.gz"
+	rc_j=${PIPESTATUS[0]}
+	rc_g=${PIPESTATUS[1]}
+	if [ "$rc_j" -eq 0 ] && [ "$rc_g" -eq 0 ]; then
+		return 0
+	fi
+	log_message warning "journalctl -b0 | gzip failed or timed out (journalctl=${rc_j} gzip=${rc_g})"
+	printf 'journalctl -b0 | gzip failed or timed out (journalctl=%s gzip=%s); output may be truncated\n' \
+		"$rc_j" "$rc_g" >"${d}/failed.txt"
+}
+
 collect_network_ifconfig()
 {
 	local d=$1
@@ -475,6 +510,7 @@ uname -a >"${DUMP_FOLDER}/uname.txt" 2>&1
 
 timeout 20 dmesg >"${DUMP_FOLDER}/dmesg.txt" 2>&1 || log_message warning "dmesg failed or timed out"
 
+run_collect_bg journalctl_boot collect_journalctl_boot "${DUMP_FOLDER}/journal"
 run_collect_bg proc_interrupts collect_proc_interrupts "${DUMP_FOLDER}/proc"
 run_collect_bg network_ifconfig collect_network_ifconfig "${DUMP_FOLDER}/network"
 run_collect_bg i2c_non_mux collect_i2c_non_mux "${DUMP_FOLDER}/i2c"


### PR DESCRIPTION
Collect the current boot journal in the SONiC BMC debug bundle to improve post-failure diagnostics. Run `journalctl -b0 --no-pager` with a bounded timeout and document the archive path and fallback behavior.