### PR TITLE
hw-mgmt: sensors: Fix RAA228943 labels on N61XX_LD and N63XX_LD

### DIFF
--- a/usr/etc/hw-management-sensors/n61xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n61xxld_sensors.conf
@@ -142,9 +142,8 @@ chip "xdpe1a2g7-i2c-*-6e"
 
 chip "raa228943-i2c-*-66"
 	label in1      "PMIC-1 PVIN1_VDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-1 ASIC_VDD Volt (out1)"
-	ignore in4
+	label in2      "PMIC-1 ASIC_VDD Volt (out1)"
+	ignore in3
 	label temp1    "PMIC-1 Temp 1"
 	ignore temp2
 	ignore temp3
@@ -159,9 +158,8 @@ chip "raa228943-i2c-*-66"
 
 chip "raa228943-i2c-*-68"
 	label in1      "PMIC-2 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
-	label in4      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
+	label in2      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
+	label in3      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
 	label temp1    "PMIC-2 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-2 Temp 2"
@@ -176,9 +174,8 @@ chip "raa228943-i2c-*-68"
 
 chip "raa228943-i2c-*-6c"
 	label in1      "PMIC-3 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
-	label in4      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
+	label in2      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
+	label in3      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
 	label temp1    "PMIC-3 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-3 Temp 2"
@@ -193,9 +190,8 @@ chip "raa228943-i2c-*-6c"
 
 chip "raa228943-i2c-*-6e"
 	label in1      "PMIC-4 PVIN1_AVCC_HVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
-	label in4      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
+	label in2      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
+	label in3      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
 	label temp1    "PMIC-4 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-4 Temp 2"

--- a/usr/etc/hw-management-sensors/n63xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/n63xxld_sensors.conf
@@ -128,9 +128,8 @@ chip "xdpe1a2g7-i2c-24-6e"
 
 chip "raa228943-i2c-24-66"
 	label in1      "PMIC-1 PVIN1_VDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-1 ASIC_VDD Volt (out1)"
-	ignore in4
+	label in2      "PMIC-1 ASIC_VDD Volt (out1)"
+	ignore in3
 	label temp1    "PMIC-1 Temp 1"
 	ignore temp2
 	ignore temp3
@@ -145,9 +144,8 @@ chip "raa228943-i2c-24-66"
 
 chip "raa228943-i2c-24-68"
 	label in1      "PMIC-2 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
-	label in4      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
+	label in2      "PMIC-2 ASIC_AVDD_PL0 Volt (out1)"
+	label in3      "PMIC-2 ASIC_DVDD_PL0 Volt (out2)"
 	label temp1    "PMIC-2 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-2 Temp 2"
@@ -162,9 +160,8 @@ chip "raa228943-i2c-24-68"
 
 chip "raa228943-i2c-24-6c"
 	label in1      "PMIC-3 PVIN1_AVDD_DVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
-	label in4      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
+	label in2      "PMIC-3 ASIC_AVDD_PL1 Volt (out1)"
+	label in3      "PMIC-3 ASIC_DVDD_PL1 Volt (out2)"
 	label temp1    "PMIC-3 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-3 Temp 2"
@@ -179,9 +176,8 @@ chip "raa228943-i2c-24-6c"
 
 chip "raa228943-i2c-24-6e"
 	label in1      "PMIC-4 PVIN1_AVCC_HVDD_ASIC Volt (in)"
-	ignore in2
-	label in3      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
-	label in4      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
+	label in2      "PMIC-4 ASIC_AVCC_PL0_PL1 Volt (out1)"
+	label in3      "PMIC-4 ASIC_HVDD_PL0_PL1 Volt (out2)"
 	label temp1    "PMIC-4 Temp 1"
 	ignore temp2
 	label temp3    "PMIC-4 Temp 2"


### PR DESCRIPTION
Remap raa228943 lm-sensors channels after VMON is stripped from the driver: label in2/in3 as out1/out2 instead of in3/in4. PMIC-1 @ 0x66 ignores idle in3 (single-rail). Applies to all four Renesas PMICs (0x66, 0x68, 0x6c, 0x6e) in n61xxld_sensors.conf and n63xxld_sensors.conf.

(cherry picked from commit 478115915df543388b3f0e3d5c2c566f8c16d131)
(cherry picked from commit 5d295cf2f1b2c204128523078168d80f06da1c97)