### PR TITLE
hw-mgmt: patches: Fix kenel 6.1 patch status table

### DIFF
--- a/recipes-kernel/linux/Patch_Status_Table.txt
+++ b/recipes-kernel/linux/Patch_Status_Table.txt
@@ -730,6 +730,7 @@ Kernel-6.1
 |0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch  |                    | Downstream accepted                      |            | raa228942 raa228943                            |
 |0113-net-usb-usbnet-restore-usb-d-name-exception-for-loca.patch  | 07f8bdce68b9       | Bugfix accepted;skip[nvos]               | v6.1.133   | Required for kernels 6.1.115-6.1.132           |
 |0117-nvme-pci-try-flr-on-controller-disable-failure.patch        |                    | Downstream accepted                      |            | NVME SSD FLR additional flow                   |
+|0119-i2c-designware-Fix-ACPI-power-on-of-AMD-I2C-after-ke.patch  |                    | Downstream accepted                      |            | Fix AMD V3000 I2C controller init after kexec  |
 |8000-mlxsw-Use-weak-reverse-dependencies-for-firmware-fla.patch  |                    | Downstream accepted                      |            | Disable FW update                              |
 |8002-platform-mlx-platform-Downstream-Add-SPI-path-for-ra.patch  |                    | Rejected                                 |            | Add SPI                                        |
 |8003-mlxsw-i2c-SONIC-ISSU-Prevent-transaction-execution-f.patch  |                    | Downstream accepted                      |            | Sonic/ISSU                                     |


### PR DESCRIPTION
Commit ce1b2894 accidentally removed a patch from patch table. This commit adds it back.