### PR TITLE
hw-mgmt: scripts: Fix warning in add_come_named_busses

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -1094,8 +1094,7 @@ add_come_named_busses()
 		come_named_busses+=( ${amd_snw_named_busses[@]} )
 		;;
 	*)
-		log_err "unsupported cpu_type '${cpu_type}' for add_come_named_busses"
-		return 1
+		return
 		;;
 	esac
 


### PR DESCRIPTION
The merge commit c424833f6 introduced a log_err()
for add_come_named_busses(). Earlier, this was a
silent return. Now there will be a message like
"unsupported cpu_type <cpu_id> for add_come_named_busses", for the cpu types which are not specifically handled. This commit is to restore the original behavior.

Bug #5170326