### PR TITLE
hw-mgmt: patches: Fix SN6600_LD SODIMM temperature sensor driver

### DIFF
--- a/usr/etc/hw-management-sensors/sn66xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn66xxld_sensors.conf
@@ -455,10 +455,10 @@ chip "mp2975-i2c-*-6a"
     ignore curr6
 
 # Management board DDR temperature sensors
-chip "jc42-i2c-*-52"
+chip "spd5118-i2c-*-52"
     label temp1 "SODIMM1 Temp"
 
-chip "jc42-i2c-*-53"
+chip "spd5118-i2c-*-53"
     label temp1 "SODIMM2 Temp"
 
 # AMD CPU temperature sensor

--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -116,6 +116,9 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/virtual/thermal/thermal_zone*/hwmon*", AC
 SUBSYSTEM=="hwmon", DRIVERS=="jc42", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
 SUBSYSTEM=="hwmon", DRIVERS=="jc42", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sodimm_temp %p %k %S %n"
 
+SUBSYSTEM=="hwmon", DRIVERS=="spd5118", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
+SUBSYSTEM=="hwmon", DRIVERS=="spd5118", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sodimm_temp %p %k %S %n"
+
 # QEMU SODIMM temp
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add sodimm_temp %p %k %S %n"
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/mlxplat/i2c_mlxcpld*/i2c-*/*-001*/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm sodimm_temp %p %k %S %n"

--- a/usr/usr/bin/hw-management-devtree.sh
+++ b/usr/usr/bin/hw-management-devtree.sh
@@ -78,7 +78,7 @@ declare -A thermal_arr=( \
 	["i"]="tmp411" \
 	["j"]="tmp1075" \
 	["k"]="tmp451" \
-	["l"]="jc42" \
+	["l"]="spd5118" \
 )
 
 declare -A regulator_arr=( \
@@ -733,8 +733,8 @@ declare -A sn66xxld_pwr_alternatives=( \
 # Devices located on SN66XX_LD platform board
 declare -A sn66xxld_platform_alternatives=( \
 	["24c512_1"]="24c512 0x51 1 vpd_info" \
-	["jc42_0"]="jc42 0x52 10 somdimm_temp1" \
-	["jc42_1"]="jc42 0x53 10 somdimm_temp2" \
+	["spd5118_0"]="spd5118 0x52 10 somdimm_temp1" \
+	["spd5118_1"]="spd5118 0x53 10 somdimm_temp2" \
 	["mp2845_0"]="mp2845 0x69 5 comex_voltmon1" \
 	["mp2975_1"]="mp2975 0x6a 5 comex_voltmon2" \
 )

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -767,7 +767,7 @@ if [ "$1" == "add" ]; then
 	fi
 	if [ "$2" == "sodimm_temp" ]; then
 		name=$(< /sys/"$3"/name)
-		if [ "$name" != "jc42" ]; then
+		if [ "$name" != "jc42" ] && [ "$name" != "spd5118" ]; then
 			exit
 		fi
 		check_cpu_type
@@ -798,7 +798,6 @@ if [ "$1" == "add" ]; then
 			$AMD_V3000_CPU)
 				sodimm1_addr='0052'
 				sodimm2_addr='0053'
-				set_sodimm_temp_limits
 			;;
 			*)
 				exit 0
@@ -1379,7 +1378,7 @@ else
 	fi
 	if [ "$2" == "sodimm_temp" ]; then
 		name=$(< /sys/"$3"/name)
-		if [ "$name" != "jc42" ]; then
+		if [ "$name" != "jc42" ] && [ "$name" != "spd5118" ]; then
 			exit
 		fi
 		find "$thermal_path" -iname "sodimm*_temp*" -exec unlink {} \;


### PR DESCRIPTION
SN6600_LD was erroneusly using JC42 SODIMM temperature sensor driver, which is not suitable for DDR5 memories. This patch switches the platform to use SPD5118 driver instead.