### PR TITLE
hw-mgmt: scripts: Fix loading of JC42 DRAM temperature sensor driver

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -1189,8 +1189,9 @@ set_sodimm_temp_limits()
 	# Broadwell-DE Comex can be installed interchangeably with new
 	# Coffee Lake Comex on part of systems e.g. on SN3700.
 	# Thus check by CPU type and not by system type.
+	# JC42 driver is not relevant on systems with DDR5 DRAM
 	case $cpu_type in
-		$BDW_CPU|$BF3_CPU)
+		$BDW_CPU|$BF3_CPU|$AMD_V3000_CPU|$AMD_FRNG_CPU)
 			return 0
 			;;
 		*)


### PR DESCRIPTION
JC42 DRAM temperature sensor driver should not be loaded on systems with DDR5 DRAM, which use SPD5118 driver to read DRAM temperature.