### PR TITLE
hw-mgmt: thermal: Add dummy PSU support to TC

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2076,6 +2076,7 @@ class psu_fan_sensor(system_device):
         self.prsnt_err_pwm_min = self.get_file_val("config/pwm_min_psu_not_present")
         self.pwm_decode = sys_config.get(CONST.SYS_CONF_FAN_PWM, PSU_PWM_DECODE_DEF)
         self.fan_dir = CONST.C2P
+        self.psu_dummy = False
         self.pwm_last = CONST.PWM_MIN
         self.fault_list_old = []
 
@@ -2095,7 +2096,11 @@ class psu_fan_sensor(system_device):
         @summary: refresh sensor attributes.
         @return None
         """
-        self.fan_dir = self._read_dir()
+        self.psu_dummy = self._get_dummy()
+        if self.psu_dummy:
+            self.fan_dir = CONST.UNKNOWN
+        else:
+            self.fan_dir = self._read_dir()
 
     # ----------------------------------------------------------------------
     def _read_dir(self):
@@ -2139,6 +2144,16 @@ class psu_fan_sensor(system_device):
         return psu_status
 
     # ----------------------------------------------------------------------
+    def _get_dummy(self):
+        """
+        @summary: Check if PSU is dummy
+        @return: Return True if PSU is dummy, False otherwise
+        """
+        if self.check_file("config/{}_is_dummy".format(self.base_file_name)):
+            return True
+        return False
+
+    # ----------------------------------------------------------------------
     def set_pwm(self, pwm):
         """
         @summary: Set PWM level for PSU FAN
@@ -2146,7 +2161,7 @@ class psu_fan_sensor(system_device):
         """
         try:
             present = self.thermal_read_file_int("{0}_pwr_status".format(self.base_file_name))
-            if present == 1:
+            if present == 1 and not self.psu_dummy:
                 self.log.info("Write {} PWM {}".format(self.name, pwm))
                 psu_pwm, _, _ = g_get_range_val(self.pwm_decode, pwm)
                 if psu_pwm is None:
@@ -2200,14 +2215,16 @@ class psu_fan_sensor(system_device):
         # check if PSU present.
         # if PSU is plugged in then PSU fan missing is not an error
         psu_status = self._get_status()
-        val_read_file = "thermal/{}".format(self.file_input)
         if psu_status == 1:
             try:
+                val_read_file = "thermal/{}".format(self.file_input)
                 value = int(self.read_file(val_read_file))
                 self.update_value(value)
                 self.log.debug("{} value {}".format(self.name, self.value))
             except (ValueError, TypeError, OSError, IOError):
                 self.update_value(-1)
+        else:
+            self.update_value(-1)
         return
 
     # ----------------------------------------------------------------------
@@ -2215,7 +2232,7 @@ class psu_fan_sensor(system_device):
         self.clear_fault_list()
 
         psu_status = self._get_status()
-        if psu_status == 0:
+        if psu_status == 0 and not self.psu_dummy:
             self.append_fault(CONST.PRESENT)
 
         # truth table for fan direction
@@ -2229,8 +2246,9 @@ class psu_fan_sensor(system_device):
         #  UNKNOWN C2P        False
         #  UNKNOWN P2C        False
         #  UNKNOWN UNKNOWN    False
-        if (self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or \
-           (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
+        if not self.psu_dummy and \
+           ((self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or
+                (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P)):
             self.append_fault(CONST.DIRECTION)
 
         if self.fread_err.check_err():
@@ -2290,16 +2308,22 @@ class psu_fan_sensor(system_device):
         """
         @summary: returning info about device state.
         """
-        if self.value == -1:
-            value = "N/A"
-        else:
-            value = self.value
-        return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
-                                                                         value,
-                                                                         self.fan_dir,
+        if self.psu_dummy:
+            return "\"{}\" dummy psu, faults:[{}] tz_pwm: {}, {}".format(self.name,
                                                                          self.get_fault_list_str(),
                                                                          self.pwm,
                                                                          self.state)
+        else:
+            if self.value == -1:
+                value = "N/A"
+            else:
+                value = self.value
+            return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
+                                                                             value,
+                                                                             self.fan_dir,
+                                                                             self.get_fault_list_str(),
+                                                                             self.pwm,
+                                                                             self.state)
 
 
 class fan_sensor(system_device):

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2446,6 +2446,7 @@ class psu_fan_sensor(system_device):
         self.prsnt_err_pwm_min = self.get_file_val("config/pwm_min_psu_not_present")
         self.pwm_decode = sys_config.get(CONST.SYS_CONF_FAN_PWM, PSU_PWM_DECODE_DEF)
         self.fan_dir = CONST.C2P
+        self.psu_dummy = False
         self.pwm_last = CONST.PWM_MIN
         self.fault_list_old = []
 
@@ -2466,7 +2467,11 @@ class psu_fan_sensor(system_device):
         @summary: refresh sensor attributes.
         @return None
         """
-        self.fan_dir = self._read_dir()
+        self.psu_dummy = self._get_dummy()
+        if self.psu_dummy:
+            self.fan_dir = CONST.UNKNOWN
+        else:
+            self.fan_dir = self._read_dir()
 
     # ----------------------------------------------------------------------
     def _read_dir(self):
@@ -2510,6 +2515,16 @@ class psu_fan_sensor(system_device):
         return psu_status
 
     # ----------------------------------------------------------------------
+    def _get_dummy(self):
+        """
+        @summary: Check if PSU is dummy
+        @return: Return True if PSU is dummy, False otherwise
+        """
+        if self.check_file("config/{}_is_dummy".format(self.base_file_name)):
+            return True
+        return False
+
+    # ----------------------------------------------------------------------
     def set_pwm(self, pwm):
         """
         @summary: Set PWM level for PSU FAN
@@ -2517,7 +2532,7 @@ class psu_fan_sensor(system_device):
         """
         try:
             present = self.thermal_read_file_int("{0}_pwr_status".format(self.base_file_name))
-            if present == 1:
+            if present == 1 and not self.psu_dummy:
                 self.log.info("Write {} PWM {}".format(self.name, pwm))
                 psu_pwm, _, _ = g_get_range_val(self.pwm_decode, round(pwm))
                 if psu_pwm is None:
@@ -2571,14 +2586,16 @@ class psu_fan_sensor(system_device):
         # check if PSU present.
         # if PSU is plugged in then PSU fan missing is not an error
         psu_status = self._get_status()
-        val_read_file = "thermal/{}".format(self.file_input)
         if psu_status == 1:
             try:
+                val_read_file = "thermal/{}".format(self.file_input)
                 value = int(self.read_file(val_read_file))
                 self.update_value(value)
                 self.log.debug("{} value {}".format(self.name, self.value))
             except (ValueError, TypeError, OSError, IOError):
                 self.update_value(-1)
+        else:
+            self.update_value(-1)
         return
 
     # ----------------------------------------------------------------------
@@ -2586,7 +2603,7 @@ class psu_fan_sensor(system_device):
         self.clear_fault_list()
 
         psu_status = self._get_status()
-        if psu_status == 0:
+        if psu_status == 0 and not self.psu_dummy:
             self.append_fault(CONST.PRESENT)
 
         # truth table for fan direction
@@ -2600,8 +2617,9 @@ class psu_fan_sensor(system_device):
         #  UNKNOWN C2P        False
         #  UNKNOWN P2C        False
         #  UNKNOWN UNKNOWN    False
-        if (self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or \
-           (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
+        if not self.psu_dummy and \
+           ((self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or
+                (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P)):
             self.append_fault(CONST.DIRECTION)
 
         if self.fread_err.check_err():
@@ -2661,16 +2679,22 @@ class psu_fan_sensor(system_device):
         """
         @summary: returning info about device state.
         """
-        if self.value == -1:
-            value = "N/A"
-        else:
-            value = int(self.value)
-        return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
-                                                                         value,
-                                                                         self.fan_dir,
+        if self.psu_dummy:
+            return "\"{}\" dummy psu, faults:[{}] tz_pwm: {}, {}".format(self.name,
                                                                          self.get_fault_list_str(),
                                                                          g_safe_round(self.pwm, 1),
                                                                          self.state)
+        else:
+            if self.value == -1:
+                value = "N/A"
+            else:
+                value = int(self.value)
+            return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
+                                                                             value,
+                                                                             self.fan_dir,
+                                                                             self.get_fault_list_str(),
+                                                                             g_safe_round(self.pwm, 1),
+                                                                             self.state)
 
 
 class fan_sensor(system_device):


### PR DESCRIPTION
iDummy PSU slots are present without a real I2C device
(config/psuN_is_dummy). Treat them as non-faulting in
thermal control: skip RPM reads, fan and PWM i2c writes,
suppress present faults, keep fan direction unknown, and
report them as dummy in TC status.

Bug: 4931230

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
