### PR TITLE
hw-mgmt: patches: Read RAA228943 OV/UV limits relative to VID

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -6,22 +6,27 @@ Subject: [PATCH] hwmon: pmbus/isl68137: Add support for Renesas RAA228942 and
 
 Add I2C device IDs for Renesas RAA228942 and RAA228943.
 
-At the Linux PMBus hwmon interface level currently supported by this
-driver, these devices are compatible with the existing 2-rail non-TC
-controllers, so devicetree will use fallback compatibles and no
-dedicated OF match entries are needed.
+Both devices use the existing 2-rail non-TC behavior. RAA228943 also
+stores its VOUT OV/UV fault tolerances in vendor DMA registers instead
+of the standard PMBus limit registers. Add a dedicated variant that
+reads the per-page DMA tolerance and returns the absolute fault limit
+as VOUT_COMMAND (VID) plus or minus that tolerance.
+
+The dedicated variant keeps the DMA behavior isolated to RAA228943.
+RAA228942 and all existing devices retain their current behavior.
 
 Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
+Signed-off-by: Vasily Vityukov <vvityukov@nvidia.com>
 ---
- Documentation/hwmon/isl68137.rst | 20 ++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 49 ++++++++++++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 68 insertions(+), 1 deletion(-)
+ Documentation/hwmon/isl68137.rst | 23 +++++++++++++++++++++++
+ drivers/hwmon/pmbus/isl68137.c   | 113 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 135 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
 --- a/Documentation/hwmon/isl68137.rst
 +++ b/Documentation/hwmon/isl68137.rst
-@@ -374,6 +374,26 @@
+@@ -374,6 +374,29 @@
  
        Publicly available (after August 2020 launch) at the Renesas website
  
@@ -45,49 +50,41 @@ index 0e71b22047f8..1a1424dd640f 100644
 +
 +      Provided by Renesas upon request and NDA
 +
++    VOUT over/under-voltage fault limits are derived from the configured VID
++    and per-page tolerances read through the vendor DMA interface.
++
    * Renesas RAA229001
  
      Prefix: 'raa229001'
 diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
-index 1a8caff1ac5f..2e78d716de59 100644
+index 1a8caff1ac5f..fb794c42b3f2 100644
 --- a/drivers/hwmon/pmbus/isl68137.c
 +++ b/drivers/hwmon/pmbus/isl68137.c
-@@ -178,6 +178,48 @@
+@@ -21,6 +21,9 @@
+ #define ISL68137_VOUT_AVS	0x30
+ #define RAA_DMPVR2_READ_VMON	0xc8
+ 
++#define RAA228943_DMA_ADDR_REG  0xc7
++#define RAA228943_DMA_DATA_REG  0xc5
++
+ enum chips {
+ 	isl68137,
+ 	isl68220,
+@@ -68,6 +71,7 @@ enum variants {
+ 	raa_dmpvr2_1rail,
+ 	raa_dmpvr2_2rail,
+ 	raa_dmpvr2_2rail_nontc,
++	raa_dmpvr2_2rail_nontc_vidrel,
+ 	raa_dmpvr2_3rail,
+ 	raa_dmpvr2_hv,
+ };
+@@ -178,6 +182,101 @@
  	return ret;
  }
  
 +static int raa_dmpvr2_nontc_read_word_data(struct i2c_client *client, int page,
 +					   int phase, int reg)
 +{
-+	const struct i2c_device_id *data = i2c_match_id(raa_dmpvr_id, client);
-+	bool ov = (reg == PMBUS_VOUT_OV_FAULT_LIMIT);
-+
-+	if ((data != NULL) &&
-+	    (!strcmp(data->name, "raa228943")) &&
-+	    ((reg == PMBUS_VOUT_UV_FAULT_LIMIT) || ov)) {
-+		switch (client->addr) {
-+		case 0x66: /* VDD, page 0 */
-+			if (page != 0)
-+				return -EIO;
-+			return ov ? 796 : 590;
-+		case 0x68: /* AVDD PL0, page 0; DVDD PL0, page 1 */
-+		case 0x6c: /* AVDD PL1, page 0; DVDD PL1, page 1 */
-+			if (page == 0)
-+				return ov ? 1170 : 840;
-+			if (page == 1)
-+				return ov ? 770 : 550;
-+			return -EIO;
-+		case 0x6e: /* AVCC, page 0; HVDD, page 1 */
-+			if (page == 0)
-+				return ov ? 1910 : 1692;
-+			if (page == 1)
-+				return ov ? 1270 : 1120;
-+			return -EIO;
-+		default:
-+			return -EIO;
-+		}
-+	}
-+
 +	switch (reg) {
 +	case PMBUS_UT_FAULT_LIMIT:
 +	case PMBUS_UT_WARN_LIMIT:
@@ -98,29 +95,118 @@ index 1a8caff1ac5f..2e78d716de59 100644
 +	}
 +}
 +
++/*
++ * Read a 32-bit vendor-specific DMA register on RAA228943 (Renesas
++ * Gen3.5 indirect access path): write the 16-bit internal address to
++ * RAA228943_DMA_ADDR_REG (LSB first), then read 4 bytes back from
++ * RAA228943_DMA_DATA_REG. Returns the raw 32-bit value (host order,
++ * device returns LSB-first) or a negative errno on failure.
++ */
++static int read_dma_word(struct i2c_client *client, u16 addr)
++{
++	u8 addr_buf[2] = { addr & 0xff, (addr >> 8) & 0xff };
++	u8 data_buf[4];
++	int ret;
++
++	ret = i2c_smbus_write_i2c_block_data(client, RAA228943_DMA_ADDR_REG,
++					     sizeof(addr_buf), addr_buf);
++	if (ret < 0)
++		return ret;
++
++	ret = i2c_smbus_read_i2c_block_data(client, RAA228943_DMA_DATA_REG,
++					    sizeof(data_buf), data_buf);
++	if (ret < 0)
++		return ret;
++	if (ret != sizeof(data_buf))
++		return -EIO;
++
++	return data_buf[0] | (data_buf[1] << 8) |
++		(data_buf[2] << 16) | (data_buf[3] << 24);
++}
++
++/*
++ * RAA228943 only: compute VOUT_OV_FAULT_LIMIT / VOUT_UV_FAULT_LIMIT as
++ * VID +/- tolerance, where VID is PMBUS_VOUT_COMMAND and tolerance is
++ * the 12-bit unsigned value at dma_addr. Both are already expressed in
++ * the same integer 'direct format' units used by this chip for VOUT
++ * (m=1, b=0, R=3, i.e. raw millivolts), so plain integer add/sub gives
++ * a result directly usable as the PMBus word for the caller's reg.
++ */
++static int raa228943_ov_uv_fault_limit(struct i2c_client *client, int page,
++				       u16 dma_addr, bool is_ov_limit)
++{
++	int tol_raw, vid_raw;
++
++	tol_raw = read_dma_word(client, dma_addr);
++	if (tol_raw < 0)
++		return tol_raw;
++	tol_raw &= 0xfff;
++
++	vid_raw = pmbus_read_word_data(client, page, 0xff,
++				       PMBUS_VOUT_COMMAND);
++	if (vid_raw < 0)
++		return vid_raw;
++
++	return is_ov_limit ? (vid_raw + tol_raw) : (vid_raw - tol_raw);
++}
++
++static int raa228943_read_word_data(struct i2c_client *client, int page,
++				    int phase, int reg)
++{
++	u16 addr;
++
++	switch (reg) {
++	case PMBUS_VOUT_OV_FAULT_LIMIT:
++		if (page == 0)
++			addr = 0xea3e;
++		else if (page == 1)
++			addr = 0xeabe;
++		else
++			return -ENODATA;
++		return raa228943_ov_uv_fault_limit(client, page, addr, true);
++	case PMBUS_VOUT_UV_FAULT_LIMIT:
++		if (page == 0)
++			addr = 0xea3d;
++		else if (page == 1)
++			addr = 0xeabd;
++		else
++			return -ENODATA;
++		return raa228943_ov_uv_fault_limit(client, page, addr, false);
++	default:
++		return raa_dmpvr2_nontc_read_word_data(client, page, phase, reg);
++	}
++}
++
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -244,9 +286,12 @@
+@@ -244,9 +343,19 @@
  		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
++		info->func[0] &= ~PMBUS_HAVE_VMON;
++		info->func[0] &= ~PMBUS_HAVE_TEMP3;
++		info->func[1] &= ~PMBUS_HAVE_TEMP3;
++		info->pages = 2;
++		info->read_word_data = raa_dmpvr2_nontc_read_word_data;
++		break;
++	case raa_dmpvr2_2rail_nontc_vidrel:
 +		info->func[0] &= ~PMBUS_HAVE_VMON;
  		info->func[0] &= ~PMBUS_HAVE_TEMP3;
  		info->func[1] &= ~PMBUS_HAVE_TEMP3;
 -		fallthrough;
 +		info->pages = 2;
-+		info->read_word_data = raa_dmpvr2_nontc_read_word_data;
++		info->read_word_data = raa228943_read_word_data;
 +		break;
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -311,6 +356,8 @@
+@@ -311,6 +420,8 @@
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},
 +	{"raa228942", raa_dmpvr2_2rail_nontc},
-+	{"raa228943", raa_dmpvr2_2rail_nontc},
++	{"raa228943", raa_dmpvr2_2rail_nontc_vidrel},
  	{"raa229001", raa_dmpvr2_2rail},
  	{"raa229004", raa_dmpvr2_2rail},
  	{}

--- a/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -19,8 +19,8 @@ Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 Signed-off-by: Vasily Vityukov <vvityukov@nvidia.com>
 ---
  Documentation/hwmon/isl68137.rst | 23 +++++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 113 +++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 135 insertions(+), 1 deletion(-)
+ drivers/hwmon/pmbus/isl68137.c   | 116 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 138 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
@@ -78,7 +78,7 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
  	raa_dmpvr2_3rail,
  	raa_dmpvr2_hv,
  };
-@@ -178,6 +182,101 @@
+@@ -178,6 +182,104 @@
  	return ret;
  }
  
@@ -99,10 +99,11 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
 + * Read a 32-bit vendor-specific DMA register on RAA228943 (Renesas
 + * Gen3.5 indirect access path): write the 16-bit internal address to
 + * RAA228943_DMA_ADDR_REG (LSB first), then read 4 bytes back from
-+ * RAA228943_DMA_DATA_REG. Returns the raw 32-bit value (host order,
-+ * device returns LSB-first) or a negative errno on failure.
++ * RAA228943_DMA_DATA_REG. Stores the raw 32-bit value (host order,
++ * device returns LSB-first) in *val. Returns 0 on success or a
++ * negative errno on failure.
 + */
-+static int read_dma_word(struct i2c_client *client, u16 addr)
++static int read_dma_word(struct i2c_client *client, u16 addr, u32 *val)
 +{
 +	u8 addr_buf[2] = { addr & 0xff, (addr >> 8) & 0xff };
 +	u8 data_buf[4];
@@ -120,8 +121,9 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
 +	if (ret != sizeof(data_buf))
 +		return -EIO;
 +
-+	return data_buf[0] | (data_buf[1] << 8) |
-+		(data_buf[2] << 16) | (data_buf[3] << 24);
++	*val = data_buf[0] | ((u32)data_buf[1] << 8) |
++	       ((u32)data_buf[2] << 16) | ((u32)data_buf[3] << 24);
++	return 0;
 +}
 +
 +/*
@@ -135,12 +137,13 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
 +static int raa228943_ov_uv_fault_limit(struct i2c_client *client, int page,
 +				       u16 dma_addr, bool is_ov_limit)
 +{
-+	int tol_raw, vid_raw;
++	u32 dma_val;
++	int ret, tol_raw, vid_raw;
 +
-+	tol_raw = read_dma_word(client, dma_addr);
-+	if (tol_raw < 0)
-+		return tol_raw;
-+	tol_raw &= 0xfff;
++	ret = read_dma_word(client, dma_addr, &dma_val);
++	if (ret < 0)
++		return ret;
++	tol_raw = dma_val & 0xfff;
 +
 +	vid_raw = pmbus_read_word_data(client, page, 0xff,
 +				       PMBUS_VOUT_COMMAND);
@@ -180,7 +183,7 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -244,9 +343,19 @@
+@@ -244,9 +346,19 @@
  		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
@@ -201,7 +204,7 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -311,6 +420,8 @@
+@@ -311,6 +423,8 @@
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},

--- a/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -6,22 +6,27 @@ Subject: [PATCH] hwmon: pmbus/isl68137: Add support for Renesas RAA228942 and
 
 Add I2C device IDs for Renesas RAA228942 and RAA228943.
 
-At the Linux PMBus hwmon interface level currently supported by this
-driver, these devices are compatible with the existing 2-rail non-TC
-controllers, so devicetree will use fallback compatibles and no
-dedicated OF match entries are needed.
+Both devices use the existing 2-rail non-TC behavior. RAA228943 also
+stores its VOUT OV/UV fault tolerances in vendor DMA registers instead
+of the standard PMBus limit registers. Add a dedicated variant that
+reads the per-page DMA tolerance and returns the absolute fault limit
+as VOUT_COMMAND (VID) plus or minus that tolerance.
+
+The dedicated variant keeps the DMA behavior isolated to RAA228943.
+RAA228942 and all existing devices retain their current behavior.
 
 Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
+Signed-off-by: Vasily Vityukov <vvityukov@nvidia.com>
 ---
- Documentation/hwmon/isl68137.rst | 20 ++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 49 ++++++++++++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 68 insertions(+), 1 deletion(-)
+ Documentation/hwmon/isl68137.rst | 23 +++++++++++++++++++++++
+ drivers/hwmon/pmbus/isl68137.c   | 113 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 135 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
 --- a/Documentation/hwmon/isl68137.rst
 +++ b/Documentation/hwmon/isl68137.rst
-@@ -374,6 +374,26 @@
+@@ -374,6 +374,29 @@
  
        Publicly available (after August 2020 launch) at the Renesas website
  
@@ -45,49 +50,41 @@ index 0e71b22047f8..1a1424dd640f 100644
 +
 +      Provided by Renesas upon request and NDA
 +
++    VOUT over/under-voltage fault limits are derived from the configured VID
++    and per-page tolerances read through the vendor DMA interface.
++
    * Renesas RAA229001
  
      Prefix: 'raa229001'
 diff --git a/drivers/hwmon/pmbus/isl68137.c b/drivers/hwmon/pmbus/isl68137.c
-index 7e53fb1..5e22c38 100644
+index 7e53fb1..a835786 100644
 --- a/drivers/hwmon/pmbus/isl68137.c
 +++ b/drivers/hwmon/pmbus/isl68137.c
-@@ -178,6 +178,48 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
+@@ -21,6 +21,9 @@
+ #define ISL68137_VOUT_AVS	0x30
+ #define RAA_DMPVR2_READ_VMON	0xc8
+ 
++#define RAA228943_DMA_ADDR_REG  0xc7
++#define RAA228943_DMA_DATA_REG  0xc5
++
+ enum chips {
+ 	isl68137,
+ 	isl68220,
+@@ -68,6 +71,7 @@ enum variants {
+ 	raa_dmpvr2_1rail,
+ 	raa_dmpvr2_2rail,
+ 	raa_dmpvr2_2rail_nontc,
++	raa_dmpvr2_2rail_nontc_vidrel,
+ 	raa_dmpvr2_3rail,
+ 	raa_dmpvr2_hv,
+ };
+@@ -178,6 +182,101 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
  	return ret;
  }
  
 +static int raa_dmpvr2_nontc_read_word_data(struct i2c_client *client, int page,
 +					   int phase, int reg)
 +{
-+	const struct i2c_device_id *data = i2c_match_id(raa_dmpvr_id, client);
-+	bool ov = (reg == PMBUS_VOUT_OV_FAULT_LIMIT);
-+
-+	if ((data != NULL) &&
-+	    (!strcmp(data->name, "raa228943")) &&
-+	    ((reg == PMBUS_VOUT_UV_FAULT_LIMIT) || ov)) {
-+		switch (client->addr) {
-+		case 0x66: /* VDD, page 0 */
-+			if (page != 0)
-+				return -EIO;
-+			return ov ? 796 : 590;
-+		case 0x68: /* AVDD PL0, page 0; DVDD PL0, page 1 */
-+		case 0x6c: /* AVDD PL1, page 0; DVDD PL1, page 1 */
-+			if (page == 0)
-+				return ov ? 1170 : 840;
-+			if (page == 1)
-+				return ov ? 770 : 550;
-+			return -EIO;
-+		case 0x6e: /* AVCC, page 0; HVDD, page 1 */
-+			if (page == 0)
-+				return ov ? 1910 : 1692;
-+			if (page == 1)
-+				return ov ? 1270 : 1120;
-+			return -EIO;
-+		default:
-+			return -EIO;
-+		}
-+	}
-+
 +	switch (reg) {
 +	case PMBUS_UT_FAULT_LIMIT:
 +	case PMBUS_UT_WARN_LIMIT:
@@ -98,29 +95,118 @@ index 7e53fb1..5e22c38 100644
 +	}
 +}
 +
++/*
++ * Read a 32-bit vendor-specific DMA register on RAA228943 (Renesas
++ * Gen3.5 indirect access path): write the 16-bit internal address to
++ * RAA228943_DMA_ADDR_REG (LSB first), then read 4 bytes back from
++ * RAA228943_DMA_DATA_REG. Returns the raw 32-bit value (host order,
++ * device returns LSB-first) or a negative errno on failure.
++ */
++static int read_dma_word(struct i2c_client *client, u16 addr)
++{
++	u8 addr_buf[2] = { addr & 0xff, (addr >> 8) & 0xff };
++	u8 data_buf[4];
++	int ret;
++
++	ret = i2c_smbus_write_i2c_block_data(client, RAA228943_DMA_ADDR_REG,
++					     sizeof(addr_buf), addr_buf);
++	if (ret < 0)
++		return ret;
++
++	ret = i2c_smbus_read_i2c_block_data(client, RAA228943_DMA_DATA_REG,
++					    sizeof(data_buf), data_buf);
++	if (ret < 0)
++		return ret;
++	if (ret != sizeof(data_buf))
++		return -EIO;
++
++	return data_buf[0] | (data_buf[1] << 8) |
++		(data_buf[2] << 16) | (data_buf[3] << 24);
++}
++
++/*
++ * RAA228943 only: compute VOUT_OV_FAULT_LIMIT / VOUT_UV_FAULT_LIMIT as
++ * VID +/- tolerance, where VID is PMBUS_VOUT_COMMAND and tolerance is
++ * the 12-bit unsigned value at dma_addr. Both are already expressed in
++ * the same integer 'direct format' units used by this chip for VOUT
++ * (m=1, b=0, R=3, i.e. raw millivolts), so plain integer add/sub gives
++ * a result directly usable as the PMBus word for the caller's reg.
++ */
++static int raa228943_ov_uv_fault_limit(struct i2c_client *client, int page,
++				       u16 dma_addr, bool is_ov_limit)
++{
++	int tol_raw, vid_raw;
++
++	tol_raw = read_dma_word(client, dma_addr);
++	if (tol_raw < 0)
++		return tol_raw;
++	tol_raw &= 0xfff;
++
++	vid_raw = pmbus_read_word_data(client, page, 0xff,
++				       PMBUS_VOUT_COMMAND);
++	if (vid_raw < 0)
++		return vid_raw;
++
++	return is_ov_limit ? (vid_raw + tol_raw) : (vid_raw - tol_raw);
++}
++
++static int raa228943_read_word_data(struct i2c_client *client, int page,
++				    int phase, int reg)
++{
++	u16 addr;
++
++	switch (reg) {
++	case PMBUS_VOUT_OV_FAULT_LIMIT:
++		if (page == 0)
++			addr = 0xea3e;
++		else if (page == 1)
++			addr = 0xeabe;
++		else
++			return -ENODATA;
++		return raa228943_ov_uv_fault_limit(client, page, addr, true);
++	case PMBUS_VOUT_UV_FAULT_LIMIT:
++		if (page == 0)
++			addr = 0xea3d;
++		else if (page == 1)
++			addr = 0xeabd;
++		else
++			return -ENODATA;
++		return raa228943_ov_uv_fault_limit(client, page, addr, false);
++	default:
++		return raa_dmpvr2_nontc_read_word_data(client, page, phase, reg);
++	}
++}
++
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -244,9 +286,12 @@ static int isl68137_probe(struct i2c_client *client)
+@@ -244,9 +343,19 @@ static int isl68137_probe(struct i2c_client *client)
  		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
++		info->func[0] &= ~PMBUS_HAVE_VMON;
++		info->func[0] &= ~PMBUS_HAVE_TEMP3;
++		info->func[1] &= ~PMBUS_HAVE_TEMP3;
++		info->pages = 2;
++		info->read_word_data = raa_dmpvr2_nontc_read_word_data;
++		break;
++	case raa_dmpvr2_2rail_nontc_vidrel:
 +		info->func[0] &= ~PMBUS_HAVE_VMON;
  		info->func[0] &= ~PMBUS_HAVE_TEMP3;
  		info->func[1] &= ~PMBUS_HAVE_TEMP3;
 -		fallthrough;
 +		info->pages = 2;
-+		info->read_word_data = raa_dmpvr2_nontc_read_word_data;
++		info->read_word_data = raa228943_read_word_data;
 +		break;
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -311,6 +356,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
+@@ -311,6 +420,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},
 +	{"raa228942", raa_dmpvr2_2rail_nontc},
-+	{"raa228943", raa_dmpvr2_2rail_nontc},
++	{"raa228943", raa_dmpvr2_2rail_nontc_vidrel},
  	{"raa229001", raa_dmpvr2_2rail},
  	{"raa229004", raa_dmpvr2_2rail},
  	{}

--- a/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -19,8 +19,8 @@ Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 Signed-off-by: Vasily Vityukov <vvityukov@nvidia.com>
 ---
  Documentation/hwmon/isl68137.rst | 23 +++++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 113 +++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 135 insertions(+), 1 deletion(-)
+ drivers/hwmon/pmbus/isl68137.c   | 116 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 138 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
@@ -78,7 +78,7 @@ index 7e53fb1..a835786 100644
  	raa_dmpvr2_3rail,
  	raa_dmpvr2_hv,
  };
-@@ -178,6 +182,101 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
+@@ -178,6 +182,104 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
  	return ret;
  }
  
@@ -99,10 +99,11 @@ index 7e53fb1..a835786 100644
 + * Read a 32-bit vendor-specific DMA register on RAA228943 (Renesas
 + * Gen3.5 indirect access path): write the 16-bit internal address to
 + * RAA228943_DMA_ADDR_REG (LSB first), then read 4 bytes back from
-+ * RAA228943_DMA_DATA_REG. Returns the raw 32-bit value (host order,
-+ * device returns LSB-first) or a negative errno on failure.
++ * RAA228943_DMA_DATA_REG. Stores the raw 32-bit value (host order,
++ * device returns LSB-first) in *val. Returns 0 on success or a
++ * negative errno on failure.
 + */
-+static int read_dma_word(struct i2c_client *client, u16 addr)
++static int read_dma_word(struct i2c_client *client, u16 addr, u32 *val)
 +{
 +	u8 addr_buf[2] = { addr & 0xff, (addr >> 8) & 0xff };
 +	u8 data_buf[4];
@@ -120,8 +121,9 @@ index 7e53fb1..a835786 100644
 +	if (ret != sizeof(data_buf))
 +		return -EIO;
 +
-+	return data_buf[0] | (data_buf[1] << 8) |
-+		(data_buf[2] << 16) | (data_buf[3] << 24);
++	*val = data_buf[0] | ((u32)data_buf[1] << 8) |
++	       ((u32)data_buf[2] << 16) | ((u32)data_buf[3] << 24);
++	return 0;
 +}
 +
 +/*
@@ -135,12 +137,13 @@ index 7e53fb1..a835786 100644
 +static int raa228943_ov_uv_fault_limit(struct i2c_client *client, int page,
 +				       u16 dma_addr, bool is_ov_limit)
 +{
-+	int tol_raw, vid_raw;
++	u32 dma_val;
++	int ret, tol_raw, vid_raw;
 +
-+	tol_raw = read_dma_word(client, dma_addr);
-+	if (tol_raw < 0)
-+		return tol_raw;
-+	tol_raw &= 0xfff;
++	ret = read_dma_word(client, dma_addr, &dma_val);
++	if (ret < 0)
++		return ret;
++	tol_raw = dma_val & 0xfff;
 +
 +	vid_raw = pmbus_read_word_data(client, page, 0xff,
 +				       PMBUS_VOUT_COMMAND);
@@ -180,7 +183,7 @@ index 7e53fb1..a835786 100644
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -244,9 +343,19 @@ static int isl68137_probe(struct i2c_client *client)
+@@ -244,9 +346,19 @@ static int isl68137_probe(struct i2c_client *client)
  		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
@@ -201,7 +204,7 @@ index 7e53fb1..a835786 100644
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -311,6 +420,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
+@@ -311,6 +423,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},


### PR DESCRIPTION
Replace address-specific hardcoded RAA228943 fault limits in the Linux 6.1 and 6.12 isl68137 patches with per-page DMA tolerance reads combined with VOUT_COMMAND. Isolate the behavior in a dedicated RAA228943 variant and document VID-relative limit reporting.


(cherry picked from commit 9634039fa11ccfdc4ba643a8a98e273c0adfd75c)