### PR TITLE
hw-mgmt: patches: Keep RAA228943 DMA data separate from errno

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.1/0112-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -19,8 +19,8 @@ Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 Signed-off-by: Vasily Vityukov <vvityukov@nvidia.com>
 ---
  Documentation/hwmon/isl68137.rst | 23 +++++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 113 +++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 135 insertions(+), 1 deletion(-)
+ drivers/hwmon/pmbus/isl68137.c   | 116 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 138 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
@@ -78,7 +78,7 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
  	raa_dmpvr2_3rail,
  	raa_dmpvr2_hv,
  };
-@@ -178,6 +182,101 @@
+@@ -178,6 +182,104 @@
  	return ret;
  }
  
@@ -99,10 +99,11 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
 + * Read a 32-bit vendor-specific DMA register on RAA228943 (Renesas
 + * Gen3.5 indirect access path): write the 16-bit internal address to
 + * RAA228943_DMA_ADDR_REG (LSB first), then read 4 bytes back from
-+ * RAA228943_DMA_DATA_REG. Returns the raw 32-bit value (host order,
-+ * device returns LSB-first) or a negative errno on failure.
++ * RAA228943_DMA_DATA_REG. Stores the raw 32-bit value (host order,
++ * device returns LSB-first) in *val. Returns 0 on success or a
++ * negative errno on failure.
 + */
-+static int read_dma_word(struct i2c_client *client, u16 addr)
++static int read_dma_word(struct i2c_client *client, u16 addr, u32 *val)
 +{
 +	u8 addr_buf[2] = { addr & 0xff, (addr >> 8) & 0xff };
 +	u8 data_buf[4];
@@ -120,8 +121,9 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
 +	if (ret != sizeof(data_buf))
 +		return -EIO;
 +
-+	return data_buf[0] | (data_buf[1] << 8) |
-+		(data_buf[2] << 16) | (data_buf[3] << 24);
++	*val = data_buf[0] | ((u32)data_buf[1] << 8) |
++	       ((u32)data_buf[2] << 16) | ((u32)data_buf[3] << 24);
++	return 0;
 +}
 +
 +/*
@@ -135,12 +137,13 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
 +static int raa228943_ov_uv_fault_limit(struct i2c_client *client, int page,
 +				       u16 dma_addr, bool is_ov_limit)
 +{
-+	int tol_raw, vid_raw;
++	u32 dma_val;
++	int ret, tol_raw, vid_raw;
 +
-+	tol_raw = read_dma_word(client, dma_addr);
-+	if (tol_raw < 0)
-+		return tol_raw;
-+	tol_raw &= 0xfff;
++	ret = read_dma_word(client, dma_addr, &dma_val);
++	if (ret < 0)
++		return ret;
++	tol_raw = dma_val & 0xfff;
 +
 +	vid_raw = pmbus_read_word_data(client, page, 0xff,
 +				       PMBUS_VOUT_COMMAND);
@@ -180,7 +183,7 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -244,9 +343,19 @@
+@@ -244,9 +346,19 @@
  		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
@@ -201,7 +204,7 @@ index 1a8caff1ac5f..fb794c42b3f2 100644
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -311,6 +420,8 @@
+@@ -311,6 +423,8 @@
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},

--- a/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
+++ b/recipes-kernel/linux/linux-6.12/0064-hwmon-pmbus-isl68137-Add-support-for-Renesas-RAA2289.patch
@@ -19,8 +19,8 @@ Signed-off-by: Dawei Liu <dawei.liu.jy@renesas.com>
 Signed-off-by: Vasily Vityukov <vvityukov@nvidia.com>
 ---
  Documentation/hwmon/isl68137.rst | 23 +++++++++++++++++++++++
- drivers/hwmon/pmbus/isl68137.c   | 113 +++++++++++++++++++++++++++++++++++++++-
- 2 files changed, 135 insertions(+), 1 deletion(-)
+ drivers/hwmon/pmbus/isl68137.c   | 116 +++++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 138 insertions(+), 1 deletion(-)
 
 diff --git a/Documentation/hwmon/isl68137.rst b/Documentation/hwmon/isl68137.rst
 index 0e71b22047f8..1a1424dd640f 100644
@@ -78,7 +78,7 @@ index 7e53fb1..a835786 100644
  	raa_dmpvr2_3rail,
  	raa_dmpvr2_hv,
  };
-@@ -178,6 +182,101 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
+@@ -178,6 +182,104 @@ static int raa_dmpvr2_read_word_data(struct i2c_client *client, int page,
  	return ret;
  }
  
@@ -99,10 +99,11 @@ index 7e53fb1..a835786 100644
 + * Read a 32-bit vendor-specific DMA register on RAA228943 (Renesas
 + * Gen3.5 indirect access path): write the 16-bit internal address to
 + * RAA228943_DMA_ADDR_REG (LSB first), then read 4 bytes back from
-+ * RAA228943_DMA_DATA_REG. Returns the raw 32-bit value (host order,
-+ * device returns LSB-first) or a negative errno on failure.
++ * RAA228943_DMA_DATA_REG. Stores the raw 32-bit value (host order,
++ * device returns LSB-first) in *val. Returns 0 on success or a
++ * negative errno on failure.
 + */
-+static int read_dma_word(struct i2c_client *client, u16 addr)
++static int read_dma_word(struct i2c_client *client, u16 addr, u32 *val)
 +{
 +	u8 addr_buf[2] = { addr & 0xff, (addr >> 8) & 0xff };
 +	u8 data_buf[4];
@@ -120,8 +121,9 @@ index 7e53fb1..a835786 100644
 +	if (ret != sizeof(data_buf))
 +		return -EIO;
 +
-+	return data_buf[0] | (data_buf[1] << 8) |
-+		(data_buf[2] << 16) | (data_buf[3] << 24);
++	*val = data_buf[0] | ((u32)data_buf[1] << 8) |
++	       ((u32)data_buf[2] << 16) | ((u32)data_buf[3] << 24);
++	return 0;
 +}
 +
 +/*
@@ -135,12 +137,13 @@ index 7e53fb1..a835786 100644
 +static int raa228943_ov_uv_fault_limit(struct i2c_client *client, int page,
 +				       u16 dma_addr, bool is_ov_limit)
 +{
-+	int tol_raw, vid_raw;
++	u32 dma_val;
++	int ret, tol_raw, vid_raw;
 +
-+	tol_raw = read_dma_word(client, dma_addr);
-+	if (tol_raw < 0)
-+		return tol_raw;
-+	tol_raw &= 0xfff;
++	ret = read_dma_word(client, dma_addr, &dma_val);
++	if (ret < 0)
++		return ret;
++	tol_raw = dma_val & 0xfff;
 +
 +	vid_raw = pmbus_read_word_data(client, page, 0xff,
 +				       PMBUS_VOUT_COMMAND);
@@ -180,7 +183,7 @@ index 7e53fb1..a835786 100644
  static struct pmbus_driver_info raa_dmpvr_info = {
  	.pages = 3,
  	.format[PSC_VOLTAGE_IN] = direct,
-@@ -244,9 +343,19 @@ static int isl68137_probe(struct i2c_client *client)
+@@ -244,9 +346,19 @@ static int isl68137_probe(struct i2c_client *client)
  		info->read_word_data = raa_dmpvr2_read_word_data;
  		break;
  	case raa_dmpvr2_2rail_nontc:
@@ -201,7 +204,7 @@ index 7e53fb1..a835786 100644
  	case raa_dmpvr2_2rail:
  		info->pages = 2;
  		info->read_word_data = raa_dmpvr2_read_word_data;
-@@ -311,6 +420,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
+@@ -311,6 +423,8 @@ static const struct i2c_device_id raa_dmpvr_id[] = {
  	{"raa228004", raa_dmpvr2_hv},
  	{"raa228006", raa_dmpvr2_hv},
  	{"raa228228", raa_dmpvr2_2rail_nontc},


### PR DESCRIPTION
Change read_dma_word() in the Linux 6.1 and 6.12 isl68137 Renesas patches to return I2C status through the return value and store the 32-bit DMA payload in a u32 out-parameter, so bit 31 set cannot be treated as an error before the 12-bit OV/UV tolerance is extracted.


(cherry picked from commit fb3a9a9cbc01f3691da6b8613819be6249807205)