### PR TITLE
hw-mgmt: thermal: Add dummy PSU support to TC

### DIFF
--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -2047,6 +2047,7 @@ class psu_fan_sensor(system_device):
         self.prsnt_err_pwm_min = self.get_file_val("config/pwm_min_psu_not_present")
         self.pwm_decode = sys_config.get(CONST.SYS_CONF_FAN_PWM, PSU_PWM_DECODE_DEF)
         self.fan_dir = CONST.C2P
+        self.psu_dummy = False
         self.pwm_last = CONST.PWM_MIN
         self.fault_list_old = []
 
@@ -2066,7 +2067,11 @@ class psu_fan_sensor(system_device):
         @summary: refresh sensor attributes.
         @return None
         """
-        self.fan_dir = self._read_dir()
+        self.psu_dummy = self._get_dummy()
+        if self.psu_dummy:
+            self.fan_dir = CONST.UNKNOWN
+        else:
+            self.fan_dir = self._read_dir()
 
     # ----------------------------------------------------------------------
     def _read_dir(self):
@@ -2110,6 +2115,16 @@ class psu_fan_sensor(system_device):
         return psu_status
 
     # ----------------------------------------------------------------------
+    def _get_dummy(self):
+        """
+        @summary: Check if PSU is dummy
+        @return: Return True if PSU is dummy, False otherwise
+        """
+        if self.check_file("config/{}_is_dummy".format(self.base_file_name)):
+            return True
+        return False
+
+    # ----------------------------------------------------------------------
     def set_pwm(self, pwm):
         """
         @summary: Set PWM level for PSU FAN
@@ -2118,6 +2133,9 @@ class psu_fan_sensor(system_device):
         try:
             present = self.thermal_read_file_int("{0}_pwr_status".format(self.base_file_name))
             if present == 1:
+                self.psu_dummy = self._get_dummy()
+                if self.psu_dummy:
+                    return
                 self.log.info("Write {} PWM {}".format(self.name, pwm))
                 psu_pwm, _, _ = g_get_range_val(self.pwm_decode, pwm)
                 if not psu_pwm:
@@ -2169,23 +2187,29 @@ class psu_fan_sensor(system_device):
         self.pwm = self.pwm_min
         # check if PSU present.
         # if PSU is plugged in then PSU fan missing is not an error
-        psu_status = self._get_status()
-        val_read_file = "thermal/{}".format(self.file_input)
-        if psu_status == 1:
+        if self._get_status() == 1:
+            self.psu_dummy = self._get_dummy()
+            if self.psu_dummy:
+                self.update_value(-1)
+                return
             try:
+                val_read_file = "thermal/{}".format(self.file_input)
                 value = int(self.read_file(val_read_file))
                 self.update_value(value)
                 self.log.debug("{} value {}".format(self.name, self.value))
             except (ValueError, TypeError, OSError, IOError):
                 self.update_value(-1)
+        else:
+            self.update_value(-1)
         return
 
     # ----------------------------------------------------------------------
     def collect_err(self):
         self.clear_fault_list()
+        if self.psu_dummy:
+            return
 
-        psu_status = self._get_status()
-        if psu_status == 0:
+        if self._get_status() == 0:
             self.append_fault(CONST.PRESENT)
 
         # truth table for fan direction
@@ -2200,7 +2224,7 @@ class psu_fan_sensor(system_device):
         #  UNKNOWN P2C        False
         #  UNKNOWN UNKNOWN    False
         if (self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or \
-           (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
+            (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
             self.append_fault(CONST.DIRECTION)
 
         if self.fread_err.check_err():
@@ -2214,11 +2238,10 @@ class psu_fan_sensor(system_device):
         pwm_new = self.pwm
         fault_list = self.get_fault_list_filtered()
         self.fault_list_old = self.fault_list[:]
-        psu_status = self._get_status()
 
         if CONST.PRESENT in fault_list:
             # PSU status error. Calculating pwm based on dmin information
-            self.log.info("{} psu_status {}".format(self.name, psu_status))
+            self.log.info("{} psu_status {}".format(self.name, self._get_status()))
             # do not update pwm if error in "masked" list
             if CONST.PRESENT not in self.mask_fault_list:
                 if self.prsnt_err_pwm_min:
@@ -2260,16 +2283,22 @@ class psu_fan_sensor(system_device):
         """
         @summary: returning info about device state.
         """
-        if self.value == -1:
-            value = "N/A"
-        else:
-            value = self.value
-        return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
-                                                                         value,
-                                                                         self.fan_dir,
+        if self.psu_dummy:
+            return "\"{}\" dummy psu, faults:[{}] tz_pwm: {}, {}".format(self.name,
                                                                          self.get_fault_list_str(),
                                                                          self.pwm,
                                                                          self.state)
+        else:
+            if self.value == -1:
+                value = "N/A"
+            else:
+                value = self.value
+            return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
+                                                                             value,
+                                                                             self.fan_dir,
+                                                                             self.get_fault_list_str(),
+                                                                             self.pwm,
+                                                                             self.state)
 
 
 class fan_sensor(system_device):

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2417,6 +2417,7 @@ class psu_fan_sensor(system_device):
         self.prsnt_err_pwm_min = self.get_file_val("config/pwm_min_psu_not_present")
         self.pwm_decode = sys_config.get(CONST.SYS_CONF_FAN_PWM, PSU_PWM_DECODE_DEF)
         self.fan_dir = CONST.C2P
+        self.psu_dummy = False
         self.pwm_last = CONST.PWM_MIN
         self.fault_list_old = []
 
@@ -2437,7 +2438,11 @@ class psu_fan_sensor(system_device):
         @summary: refresh sensor attributes.
         @return None
         """
-        self.fan_dir = self._read_dir()
+        self.psu_dummy = self._get_dummy()
+        if self.psu_dummy:
+            self.fan_dir = CONST.UNKNOWN
+        else:
+            self.fan_dir = self._read_dir()
 
     # ----------------------------------------------------------------------
     def _read_dir(self):
@@ -2481,6 +2486,16 @@ class psu_fan_sensor(system_device):
         return psu_status
 
     # ----------------------------------------------------------------------
+    def _get_dummy(self):
+        """
+        @summary: Check if PSU is dummy
+        @return: Return True if PSU is dummy, False otherwise
+        """
+        if self.check_file("config/{}_is_dummy".format(self.base_file_name)):
+            return True
+        return False
+
+    # ----------------------------------------------------------------------
     def set_pwm(self, pwm):
         """
         @summary: Set PWM level for PSU FAN
@@ -2489,6 +2504,9 @@ class psu_fan_sensor(system_device):
         try:
             present = self.thermal_read_file_int("{0}_pwr_status".format(self.base_file_name))
             if present == 1:
+                self.psu_dummy = self._get_dummy()
+                if self.psu_dummy:
+                    return
                 self.log.info("Write {} PWM {}".format(self.name, pwm))
                 psu_pwm, _, _ = g_get_range_val(self.pwm_decode, round(pwm))
                 if not psu_pwm:
@@ -2540,23 +2558,29 @@ class psu_fan_sensor(system_device):
         self.pwm = self.pwm_min
         # check if PSU present.
         # if PSU is plugged in then PSU fan missing is not an error
-        psu_status = self._get_status()
-        val_read_file = "thermal/{}".format(self.file_input)
-        if psu_status == 1:
+        if self._get_status() == 1:
+            self.psu_dummy = self._get_dummy()
+            if self.psu_dummy:
+                self.update_value(-1)
+                return
             try:
+                val_read_file = "thermal/{}".format(self.file_input)
                 value = int(self.read_file(val_read_file))
                 self.update_value(value)
                 self.log.debug("{} value {}".format(self.name, self.value))
             except (ValueError, TypeError, OSError, IOError):
                 self.update_value(-1)
+        else:
+            self.update_value(-1)
         return
 
     # ----------------------------------------------------------------------
     def collect_err(self):
         self.clear_fault_list()
+        if self.psu_dummy:
+            return
 
-        psu_status = self._get_status()
-        if psu_status == 0:
+        if self._get_status() == 0:
             self.append_fault(CONST.PRESENT)
 
         # truth table for fan direction
@@ -2571,7 +2595,7 @@ class psu_fan_sensor(system_device):
         #  UNKNOWN P2C        False
         #  UNKNOWN UNKNOWN    False
         if (self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or \
-           (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
+            (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
             self.append_fault(CONST.DIRECTION)
 
         if self.fread_err.check_err():
@@ -2585,11 +2609,10 @@ class psu_fan_sensor(system_device):
         pwm_new = self.pwm
         fault_list = self.get_fault_list_filtered()
         self.fault_list_old = self.fault_list[:]
-        psu_status = self._get_status()
 
         if CONST.PRESENT in fault_list:
             # PSU status error. Calculating pwm based on dmin information
-            self.log.info("{} psu_status {}".format(self.name, psu_status))
+            self.log.info("{} psu_status {}".format(self.name, self._get_status()))
             # do not update pwm if error in "masked" list
             if CONST.PRESENT not in self.mask_fault_list:
                 if self.prsnt_err_pwm_min:
@@ -2631,16 +2654,22 @@ class psu_fan_sensor(system_device):
         """
         @summary: returning info about device state.
         """
-        if self.value == -1:
-            value = "N/A"
-        else:
-            value = int(self.value)
-        return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
-                                                                         value,
-                                                                         self.fan_dir,
+        if self.psu_dummy:
+            return "\"{}\" dummy psu, faults:[{}] tz_pwm: {}, {}".format(self.name,
                                                                          self.get_fault_list_str(),
                                                                          g_safe_round(self.pwm, 1),
                                                                          self.state)
+        else:
+            if self.value == -1:
+                value = "N/A"
+            else:
+                value = int(self.value)
+            return "\"{}\" rpm:{}, dir:{} faults:[{}] tz_pwm: {}, {}".format(self.name,
+                                                                             value,
+                                                                             self.fan_dir,
+                                                                             self.get_fault_list_str(),
+                                                                             g_safe_round(self.pwm, 1),
+                                                                             self.state)
 
 
 class fan_sensor(system_device):


### PR DESCRIPTION
iDummy PSU slots are present without a real I2C device
(config/psuN_is_dummy). Treat them as non-faulting in
thermal control: skip RPM reads, fan and PWM i2c writes,
suppress present faults, keep fan direction unknown, and
report them as dummy in TC status.

Bug: 4931230

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
