### PR TITLE
hw-mgmt: scripts: Fix fan direction debounce races on hotplug

### DIFF
--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -1740,7 +1740,7 @@ C2P
 
 **Node name:** `$bsp_path/config/fan_dir_eeprom`
 
-**Description:** Enables fan direction detection from EEPROM. Set to "1" for systems that support fan direction detection via EEPROM.
+**Description:** Enables fan direction detection from EEPROM. Set to "1" for systems that support fan direction detection via EEPROM. On these systems, each fan drawer direction (`thermal/fan<index>_dir`) is taken from the fan module EEPROM VPD. When the fan is removed, the corresponding `fan<index>_dir` attribute may also be removed. See [Read Fan Direction](#read-fan-direction).
 
 **Access:** Read only
 
@@ -6246,22 +6246,29 @@ cat $bsp_path/thermal/fan1_speed_tolerance
 
 ### Read Fan Direction
 
-**Node name:** `$bsp_path/thermal/fan<index>_direction`
+**Node name:** `$bsp_path/thermal/fan<index>_dir`
 
-**Description:** Read fan<index> direction
+**Description:** Read fan drawer `<index>` airflow direction.
 
 **Access:** Read only
 
 **Release version:** 1.0
 
-**Arguments:**
-| Name | Data type | Values |
-|------|-----------|--------|
-| fan | Integer |  |
+**Values:**
+| Value | Meaning |
+|------|---------|
+| 0 | Reverse (C2P) |
+| 1 | Forward (P2C) |
+| 2 | Direction cannot be determined (fan missing, or fan present but direction debounce failed) |
+
+**Notes:**
+- If the fan is not present (`thermal/fan<index>_status` is 0), `fan<index>_dir` is irrelevant and must be ignored by consumers.
+- On systems that report direction via CPLD (`system/fan_dir`), a remove event keeps `fan<index>_dir` present and sets it to `2`.
+- On systems with fan-module EEPROM direction detection (`config/fan_dir_eeprom`), direction is taken from EEPROM VPD data. When the fan (and its EEPROM) is removed, `fan<index>_dir` may also be removed.
 
 **Example:** Read fan1 direction:
 ```bash
-cat $bsp_path/thermal/fan1_direction
+cat $bsp_path/thermal/fan1_dir
 ```
 ### Read Fan Status
 

--- a/Documentation/Thermal_Monitoring_for_NVIDIA_Systems_with_third_party_OS.md
+++ b/Documentation/Thermal_Monitoring_for_NVIDIA_Systems_with_third_party_OS.md
@@ -947,7 +947,7 @@ journalctl -u hw-management-tc --since "1 hour ago"
 | `/environment/fan2_input` | Fan 2 speed | 3000 RPM | Secondary fan |
 | `/config/fan_min` | Minimum fan speed | 25% | Configuration |
 | `/config/fan_max` | Maximum fan speed | 100% | Configuration |
-| `/thermal/fan1_dir` | Fan 1 direction | 1 | 1=forward, 0=reverse |
+| `/thermal/fan1_dir` | Fan 1 direction | 1 | 0=reverse (C2P), 1=forward (P2C), 2=undetectable (missing or debounce failed). Ignore if fan not present. EEPROM-based systems may remove the attribute on fan removal. |
 
 #### Thermal Zones
 

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -551,9 +551,7 @@ function handle_hotplug_fan_event()
 		;;
 	esac
 
-	if [ "$event" -eq 1 ]; then
-		set_fan_direction "$attribute" "$event"
-	fi
+	set_fan_direction "$attribute" "$event"
 }
 
 function handle_hotplug_dpu_event()

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -119,7 +119,9 @@ declare -A sys_fandir_vs_pn=(["00MP584"]=F ["00MP594"]=R ["00MP593"]=R \
 
 base_cpu_bus_offset=10
 max_tachos=20
-fan_debounce_timeout_ms=2000
+fan_debounce_timeout_ms=750
+fan_debounce_poll_ms=50
+fan_dir_lock_file="/var/run/hw-management-fan-dir.lock"
 i2c_asic_bus_default=2
 i2c_asic2_bus_default=3
 i2c_bus_min=1
@@ -1408,6 +1410,94 @@ print_function_call() {
 		"$argument" >> "$LOG_FILE"
 }
 
+# Check fan presence. fanX_status is linked to the CPLD hotplug attribute, so
+# it always reflects the current state, unlike the cached hotplug event.
+#
+# $1 - "$attribute" (fan1, fan2, ...)
+# Return: 0 if the fan is present or presence can't be read, 1 if it is removed
+function is_fan_present()
+{
+	local attribute="$1"
+	local status_file="$thermal_path/${attribute}_status"
+	local status
+
+	if [ ! -e "$status_file" ]; then
+		return 0
+	fi
+	status=$(< "$status_file")
+	if [[ ! "$status" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+	[ "$status" -ne 0 ]
+}
+
+# Allocate a new fan direction generation for a fan.
+# Each presence event gets its own generation, so a debounce started by an
+# older event can detect that it was superseded and leave fanX_dir alone.
+#
+# $1 - "$attribute" (fan1, fan2, ...)
+# Return: allocated generation on stdout
+function fan_dir_generation_new()
+{
+	local attribute="$1"
+	local gen_file="$hw_management_path/.${attribute}_dir_generation"
+	local generation
+
+	(
+		/usr/bin/flock -x 9
+		generation=0
+		if [ -f "$gen_file" ]; then
+			generation=$(< "$gen_file")
+		fi
+		if [[ ! "$generation" =~ ^[0-9]+$ ]]; then
+			generation=0
+		fi
+		generation=$((generation + 1))
+		echo "$generation" > "$gen_file"
+		echo "$generation"
+	) 9>>"$fan_dir_lock_file"
+}
+
+# Check whether the caller still owns the last fan direction generation.
+#
+# $1 - "$attribute" (fan1, fan2, ...)
+# $2 - "$generation" obtained from fan_dir_generation_new
+# Return: 0 if the generation is still the current one, 1 otherwise
+function fan_dir_generation_is_current()
+{
+	local attribute="$1"
+	local generation="$2"
+	local gen_file="$hw_management_path/.${attribute}_dir_generation"
+
+	if [ ! -f "$gen_file" ]; then
+		return 1
+	fi
+	[ "$(< "$gen_file")_" == "${generation}_" ]
+}
+
+# Store fan direction, unless a newer presence event was registered meanwhile.
+#
+# $1 - "$attribute" (fan1, fan2, ...)
+# $2 - "$fan_direction" (0 - Reverse, 1 - Forward, 2 - unknown)
+# $3 - "$generation" obtained from fan_dir_generation_new
+# Return: None
+function set_fan_dir_attr()
+{
+	local attribute="$1"
+	local fan_direction="$2"
+	local generation="$3"
+
+	(
+		/usr/bin/flock -x 9
+		if fan_dir_generation_is_current "$attribute" "$generation"; then
+			echo "$fan_direction" > "$thermal_path/${attribute}_dir"
+		else
+			print_function_call "$0" "${FUNCNAME[0]}" \
+				"$attribute gen:$generation superseded, dir:$fan_direction dropped"
+		fi
+	) 9>>"$fan_dir_lock_file"
+}
+
 # Set fan direction for a single fan
 #
 # Input parameters:
@@ -1428,12 +1518,30 @@ function set_fan_direction()
 	local fan_dir_old
 	local fan_index
 	local fan_direction
+	local generation
+	local __t0 __t1 __elapsed_ms
 
+	__t0=$(date +%s%3N 2>/dev/null || date +%s)
 	print_function_call "$0" "${FUNCNAME[0]}" "attr:$attribute evt:$event entering..."
 	case $attribute in
 	fan*)
+		# fanN: N must be a positive integer (1-based); becomes bit (N-1) in fan_dir.
+		fan_index=${attribute#fan}
+		if [ -z "$fan_index" ] || [[ ! "$fan_index" =~ ^[0-9]+$ ]] || [ "$fan_index" -le 0 ]; then
+			return
+		fi
+		fan_index=$((fan_index - 1))
+
+		# Invalidate a debounce which may still be running for this fan on
+		# behalf of a previous event: the last event is the one which decides.
+		generation=$(fan_dir_generation_new "$attribute")
+
 		if [ "$event" -eq 0 ]; then
-			echo 2 > "$thermal_path/${attribute}_dir"
+			set_fan_dir_attr "$attribute" 2 "$generation"
+			__t1=$(date +%s%3N 2>/dev/null || date +%s)
+			__elapsed_ms=$((__t1 - __t0))
+			print_function_call "$0" "${FUNCNAME[0]}" \
+				"attr:$attribute evt:$event exiting... elapsed_ms:$__elapsed_ms"
 			return
 		fi
 		if [ -f "$config_path/fan_dir_eeprom" ]; then
@@ -1460,28 +1568,36 @@ function set_fan_direction()
 				fan_dir_old=$fan_dir
 				fan_debounce_counter=0
 			fi
-			fan_debounce_timer=$((fan_debounce_timer - 200))
-			sleep 0.2
+			fan_debounce_timer=$((fan_debounce_timer - fan_debounce_poll_ms))
+			# Sleep duration must track fan_debounce_poll_ms (was hardcoded 0.2).
+			sleep "$(awk -v ms="$fan_debounce_poll_ms" 'BEGIN { printf "%.3f", ms / 1000 }')"
+			if ! fan_dir_generation_is_current "$attribute" "$generation"; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"$attribute gen:$generation superseded by a newer event, aborting debounce"
+				return
+			fi
 			fan_dir=$(< "$system_path/fan_dir")
 		done
 
-		# fanN: N must be a positive integer (1-based); becomes bit (N-1) in fan_dir.
-		fan_index=${attribute#fan}
-		if [ -z "$fan_index" ] || [[ ! "$fan_index" =~ ^[0-9]+$ ]] || [ "$fan_index" -le 0 ]; then
-			return
-		fi
-		fan_index=$((fan_index - 1))
-
 		#  Debounce is not success. Set fan dir as not recognized value "2".
-		if [ ! -z "$fan_debounce_timer" ] && [ "$fan_debounce_timer" -le 0 ]; then
+		if (("$fan_debounce_counter" < 2)); then
 			fan_direction=2
 		else
 			# fan_dir is an integer bitfield; one bit per fan direction.
 			fan_direction=$(( (fan_dir >> fan_index) & 1 ))
 		fi
+
+		# fan_dir bits are not cleared on removal, so a stable bitfield alone
+		# does not prove the fan is still in the slot.
+		if ! is_fan_present "$attribute"; then
+			fan_direction=2
+		fi
 		print_function_call "$0" "${FUNCNAME[0]}" "$attribute $event. Debounce timer left: $fan_debounce_timer ms, fan_dir: $fan_dir, fan_index: $fan_index, fan_direction: $fan_direction"
-		echo "$fan_direction" > "$thermal_path/${attribute}_dir"
-		print_function_call "$0" "${FUNCNAME[0]}" "attr:$attribute evt:$event exiting..."
+		set_fan_dir_attr "$attribute" "$fan_direction" "$generation"
+		__t1=$(date +%s%3N 2>/dev/null || date +%s)
+		__elapsed_ms=$((__t1 - __t0))
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"attr:$attribute evt:$event exiting... elapsed_ms:$__elapsed_ms"
 	;;
 	*)
 		;;


### PR DESCRIPTION
hw-mgmt: scripts: Fix fan direction debounce races on hotplug

Issue: Fan direction (fanX_dir) could be wrong or stale during rapid
fan hotplug / presence events.

RC: Debounce for an older event could still complete and write fanX_dir
after a newer event. Also, fan_dir bitfield bits are not cleared on
removal, so a stable reading alone could report direction for an
absent fan. Debounce success was tied to timer expiry rather than
confirmed stable samples.

Fix: Assign a generation per presence event with flock; abort or drop
writes when superseded. Re-check fanX_status before committing
direction. Require fan_debounce_counter >= 2 for a valid direction.
Shorten debounce to 750 ms and poll every 50 ms.

Bug: 5082250

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
