### PR TITLE
hw-mgmt: SPC1: Asic control - introduce degrade mode

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -130,6 +130,12 @@ sn66xx_reset_attr_num=14
 n61xx_reset_attr_num=17
 q3401_reset_attr_num=17
 chipup_retry_count=3
+# When the mlxsw_minimal I2C probe permanently fails on legacy SPC1 systems,
+# still account the ASIC in asic_chipup_completed / asics_init_done so that OS
+# services gated on these attributes (SONiC pmon) can come up. FAN speed is not
+# touched in this flow and stays at the hardware default (100%).
+# Enabled only for VMOD0001/0002/003/0004/0005/0009 in set_config_data().
+chipup_degraded_mode_default=0
 
 # Set FAN speed tolerance based on spec +-30%
 fan_speed_tolerance=30
@@ -3222,6 +3228,15 @@ set_config_data()
 	echo 35 > $config_path/thermal_delay
 	echo $chipup_delay_default > $config_path/chipup_delay
 	echo 0 > $config_path/chipdown_delay
+	case $board_type in
+	VMOD0001|VMOD0002|VMOD003|VMOD0004|VMOD0005|VMOD0009)
+		echo 1 > $config_path/chipup_degraded_mode
+		;;
+	*)
+		echo $chipup_degraded_mode_default > $config_path/chipup_degraded_mode
+		;;
+	esac
+	echo 0 > $config_path/asic_chipup_degraded
 	echo $hotplug_psus > $config_path/hotplug_psus
 	echo $hotplug_pwrs > $config_path/hotplug_pwrs
 	echo $hotplug_pdbs > $config_path/hotplug_pdbs
@@ -4026,6 +4041,92 @@ function find_asic_hwmon_path()
 	return 0
 }
 
+# Number of ASICs currently counted in asic_chipup_completed without a working
+# mlxsw_minimal instance behind them.
+get_asic_chipup_degraded()
+{
+	local degraded=0
+
+	[ -f "$config_path/asic_chipup_degraded" ] && degraded=$(< $config_path/asic_chipup_degraded)
+	echo "$degraded"
+}
+
+# Normalize ASIC index from chipup/sxcore callers to config file numbering.
+# sxcore may pass 0; config files use asic1_ready, asic2_ready, ...
+normalize_asic_index()
+{
+	local asic_index=$1
+
+	if [ -z "$asic_index" ] || [ "$asic_index" -eq 0 ]; then
+		echo 1
+	else
+		echo "$asic_index"
+	fi
+}
+
+# Set ASIC ready state in config for NOS services that gate on asic*_ready.
+# $1 - ASIC index (0-based sxcore index or 1-based chipup index)
+# $2 - ready state (0 or 1)
+set_asic_ready_by_index()
+{
+	local asic_index
+	local asic_id
+	local state=$2
+
+	asic_index=$(normalize_asic_index "$1")
+	asic_id=$asic_index
+	echo "$state" > "$config_path/asic${asic_id}_ready"
+	if [ "$asic_id" -eq 1 ]; then
+		echo "$state" > "$config_path/asic_ready"
+	fi
+}
+
+# Count one ASIC as "chipup completed" although its I2C driver never probed.
+# Services which are gated on asic_chipup_completed / asics_init_done (SONiC
+# pmon) can then start, at the cost of losing ASIC and port temperatures, fan
+# tachometers and PWM control for that ASIC. PWM is intentionally not written
+# here: without mlxsw_minimal nothing overrides the hardware default of 100%.
+# $1 - ASIC index
+set_asic_chipup_degraded()
+{
+	local asic_index=$1
+	local degraded_mode=0
+
+	[ -f "$config_path/chipup_degraded_mode" ] && degraded_mode=$(< $config_path/chipup_degraded_mode)
+	if [ "$degraded_mode" -ne 1 ]; then
+		return 1
+	fi
+
+	log_err "I2C communication problem with ASIC $asic_index on $sku: mlxsw_minimal driver is not connected"
+	log_err "ASIC $asic_index on $sku reported as initialized in degraded mode: ASIC and port temperatures, fan tachometers and PWM control are not available, FAN speed stays at hardware default (100%)"
+
+	lock_service_state_change
+	[ -f "$config_path/asic_chipup_completed" ] || echo 0 > "$config_path"/asic_chipup_completed
+	[ -f "$config_path/asics_init_done" ] || echo 0 > "$config_path"/asics_init_done
+	[ -f "$config_path/asic_chipup_degraded" ] || echo 0 > "$config_path"/asic_chipup_degraded
+	change_file_counter "$config_path"/asic_chipup_degraded 1
+	set_asic_ready_by_index "$asic_index" 1
+	unlock_service_state_change_update_and_match "$config_path"/asic_chipup_completed 1 \
+		"$config_path"/asic_num "$config_path"/asics_init_done
+	return 0
+}
+
+# Roll back one degraded-mode entry, so that a later successful chipup or a
+# chipdown does not double count asic_chipup_completed.
+clear_asic_chipup_degraded()
+{
+	lock_service_state_change
+	if [ "$(get_asic_chipup_degraded)" -le 0 ]; then
+		unlock_service_state_change
+		return 0
+	fi
+
+	log_info "Leaving ASIC chipup degraded mode"
+	change_file_counter "$config_path"/asic_chipup_degraded -1
+	unlock_service_state_change_update_and_match "$config_path"/asic_chipup_completed -1 \
+		"$config_path"/asic_num "$config_path"/asics_init_done
+}
+
 do_chip_up_down()
 {
 	local action=$1
@@ -4243,7 +4344,9 @@ case $ACTION in
 		do_start
 		# In SPC1/SPC2 switches that uses minimal driver, re-storing the state
 		# of asic chipup for the restart scenario.
-		check_asic_chipup_status && do_chip_up_down 1 1
+		if check_asic_chipup_status; then
+			do_chip_up_down 1 1 || set_asic_chipup_degraded 1
+		fi
 	;;
 	stop)
 		if [ -d /var/run/hw-management ]; then
@@ -4270,6 +4373,10 @@ case $ACTION in
 			asic_chipup_rc=1
 			asic_index="$2"
 			chipup_trace_attempt=1
+
+			# Drop any accounting left by a previous degraded run before
+			# retrying, so this run counts the ASIC exactly once.
+			clear_asic_chipup_degraded
 
 			# Rotate the trace log at invocation start so all retries within one
 			# chipup run stay in the same file (rotation at the end could split
@@ -4315,10 +4422,12 @@ case $ACTION in
 			done
 			stop_chipup_i2c_trace
 			log_info "chipup failed for ASIC $asic_index"
+			set_asic_chipup_degraded "$asic_index"
 		fi
 	;;
 	chipdown)
 		if [ -d /var/run/hw-management ]; then
+			clear_asic_chipup_degraded
 			do_chip_up_down 0 "$2" "$3"
 		fi
 	;;
@@ -4355,7 +4464,9 @@ case $ACTION in
 		do_start
 		# In SPC1/SPC2 switches that uses minimal driver, re-storing the state
 		# of asic chipup for the restart scenario.
-		check_asic_chipup_status && do_chip_up_down 1 1
+		if check_asic_chipup_status; then
+			do_chip_up_down 1 1 || set_asic_chipup_degraded 1
+		fi
 	;;
 	reset-cause)
 		for f in $system_path/reset_*;

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -3342,6 +3342,13 @@ class ThermalManagement(hw_management_file_op):
             self.max_tachos = int(self.read_file("config/max_tachos"))
             self.log.info("Fan tacho:{}".format(self.max_tachos))
         except (ValueError, TypeError, OSError, IOError):
+            if self.is_asic_chipup_degraded():
+                # Exit cleanly so systemd does not restart-loop: without the ASIC
+                # I2C driver there is no PWM/tacho interface to control and FANs
+                # keep running at the hardware default speed.
+                self.log.error("ASIC chipup degraded: no FAN tacho/PWM interface. "
+                               "Thermal control is not started, FANs stay at hardware default speed.", repeat=1)
+                sys.exit(0)
             self.log.error("Missing max tachos config.", repeat=1)
             sys.exit(1)
         # Find ASIC pci device fio
@@ -3881,6 +3888,15 @@ class ThermalManagement(hw_management_file_op):
         """
         val = get_dict_val_by_path(self.sys_config, [CONST.SYS_CONF_ASIC_PARAM, "1", "fan_control"])
         return str2bool(val)
+
+    def is_asic_chipup_degraded(self):
+        """
+        @summary: checking if hw-management counted the ASIC as chipup completed
+        while the mlxsw_minimal I2C driver failed to probe. In this state the
+        ASIC-attached PWM, tacho and temperature interfaces do not exist and FANs
+        run at the hardware default speed.
+        """
+        return self.get_file_val("config/asic_chipup_degraded", 0) > 0
 
     # ----------------------------------------------------------------------
     def is_fan_tacho_init(self):

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -3726,6 +3726,13 @@ class ThermalManagement(hw_management_file_op):
             self.max_tachos = int(self.read_file("config/max_tachos"))
             self.log.info("Fan tacho:{}".format(self.max_tachos))
         except (ValueError, TypeError, OSError, IOError):
+            if self.is_asic_chipup_degraded():
+                # Exit cleanly so systemd does not restart-loop: without the ASIC
+                # I2C driver there is no PWM/tacho interface to control and FANs
+                # keep running at the hardware default speed.
+                self.log.error("ASIC chipup degraded: no FAN tacho/PWM interface. "
+                               "Thermal control is not started, FANs stay at hardware default speed.", repeat=1)
+                sys.exit(0)
             self.log.error("Missing max tachos config.", repeat=1)
             sys.exit(1)
         # Find ASIC pci device fio
@@ -4318,6 +4325,15 @@ class ThermalManagement(hw_management_file_op):
         """
         val = get_dict_val_by_path(self.sys_config, [CONST.SYS_CONF_ASIC_PARAM, "1", "fan_control"])
         return str2bool(val)
+
+    def is_asic_chipup_degraded(self):
+        """
+        @summary: checking if hw-management counted the ASIC as chipup completed
+        while the mlxsw_minimal I2C driver failed to probe. In this state the
+        ASIC-attached PWM, tacho and temperature interfaces do not exist and FANs
+        run at the hardware default speed.
+        """
+        return self.get_file_val("config/asic_chipup_degraded", 0) > 0
 
     # ----------------------------------------------------------------------
     def is_fan_tacho_init(self):


### PR DESCRIPTION
When mlxsw_minimal fails to probe on legacy SPC1 boards (VMOD0001/0002/003/0004/0005/0009), asic_chipup_completed stays 0 and SONiC pmon never starts.

After chipup retries are exhausted, count the ASIC as initialized anyway so NOS can come up. Record the state in asic_chipup_degraded for BSP bookkeeping and TC.

Do not write PWM: with no mlxsw_minimal attached, fans remain at the hardware default (100%). Thermal control exits cleanly instead of restart-looping on missing max_tachos. Other platforms keep the previous behavior.