### PR TITLE
hwmgmt: tools: fix review comments on Renesas DPC update

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,13 +26,18 @@ updater. Use it for Renesas Gen3.5 `.hex` files with an explicit I2C bus and
 device address:
 
 ```sh
+hw-management-vr-dpc-renesas-update.sh checkfile -f <file.hex>
 hw-management-vr-dpc-renesas-update.sh verify -b <bus> -a <addr> -f <file.hex>
 hw-management-vr-dpc-renesas-update.sh flash -y -b <bus> -a <addr> -f <file.hex>
 ```
 
-`verify` is read-only and checks the target device ID plus the live
-`CONFIG_CRC`; `flash` programs the configuration and skips an already
-programmed device unless forced by the updater options.
+`checkfile` validates a `.hex` offline (header, record structure, per-line
+CRC8) with no device access. `verify` is read-only and checks the target
+device ID plus the live `CONFIG_CRC`. `flash` runs the same offline checks
+as `checkfile` before any I2C write, then programs the configuration and
+skips an already programmed device unless forced (`-F`, `-r N`, or
+`-r max`). Use `-F` to override failed file validation as well (writes a
+bad file anyway; use with care).
 
 ### Renesas DPC model and revision
 
@@ -75,10 +80,14 @@ hardware by **bus + I2C address**, then compares **`DeviceType`**:
 | Live device type differs from JSON entry | **Skip** (vendor mismatch; no flash) |
 | Types match, model/revision match package | **Skip** (up-to-date; no flash) |
 | Types match, model/revision differ | **Update** that device |
+| Types match, model/revision match, **`--force`** | **Update** anyway (reflash) |
 
 On a Renesas-only system with a combined MPS+Renesas tarball, MPS entries
 are skipped and Renesas entries are updated only when needed. **`--verify`**
 reports **`SKIP_VND`**, **`OK`**, **`DIFF`**, etc. per entry.
+**`--force`** still skips vendor-mismatch and missing-hardware entries; it
+only bypasses the up-to-date skip so matched model/revision devices are
+reflashed.
 
 Manual check on target:
 

--- a/usr/usr/bin/hw-management-dpc-update.sh
+++ b/usr/usr/bin/hw-management-dpc-update.sh
@@ -823,10 +823,13 @@ apply_cmd() {
           continue
           ;;
         UP_TO_DATE)
-          info "Skipping device[$i] (up-to-date): Type=$device_type Bus=$bus Addr=${lookup_addr:-} model=$DPC_ENTRY_CUR_MODEL rev=$DPC_ENTRY_CUR_REV"
-          skip=$((skip + 1))
-          i=$((i + 1))
-          continue
+          if [[ $skip_identical -eq 1 ]]; then
+            info "Skipping device[$i] (up-to-date): Type=$device_type Bus=$bus Addr=${lookup_addr:-} model=$DPC_ENTRY_CUR_MODEL rev=$DPC_ENTRY_CUR_REV"
+            skip=$((skip + 1))
+            i=$((i + 1))
+            continue
+          fi
+          info "Forcing update for device[$i] (already up-to-date): Type=$device_type Bus=$bus Addr=${lookup_addr:-} model=$DPC_ENTRY_CUR_MODEL rev=$DPC_ENTRY_CUR_REV"
           ;;
         NO_TARGET)
           info "WARN: device[$i] could not parse target model/revision; attempting update"

--- a/usr/usr/bin/hw-management-vr-dpc-renesas-update.sh
+++ b/usr/usr/bin/hw-management-vr-dpc-renesas-update.sh
@@ -177,7 +177,10 @@ FLASH OPTIONS:
   -F              Force. Overrides these safety stops: (1) already-programmed device (normally
                   skipped to avoid wasting an NVM save); (2) unreadable NVM saves counter
                   (normally aborts, since room/verification cannot be confirmed); (3) unsupported
-                  .hex record type (normally aborts; with -F the record is skipped). Each real
+                  .hex record type (normally aborts; with -F the record is skipped); (4) failed
+                  offline file validation, i.e. the same checks as 'checkfile' — record
+                  structure, declared lengths and per-line CRC8 — which flash runs before any
+                  write (normally aborts; with -F a corrupted file is flashed anyway). Each real
                   flash consumes one NVM save. Use with care.
   -y              Non-interactive: skip the "Continue?" confirmation prompt (for batch use).
   -P0 | -P1       SMBus PEC on/off for i2ctransfer helpers (default: OFF)
@@ -1478,6 +1481,20 @@ flash_with_redundancy() {
     local rep=${REDUNDANCY:-1}
     [ "$rep" -lt 1 ] 2>/dev/null && rep=1
     local until_full=${REPEAT_UNTIL_FULL:-0}
+
+    # Validate the file OFFLINE before touching the device. program_device only checks a
+    # minimum byte count per record, so a corrupted payload, wrong encoded length, or bad
+    # trailing CRC8 would otherwise be written to the regulator and consume an NVM save.
+    if ! check_file; then
+        if [ "$DRY_RUN" -eq 1 ]; then
+            log_warn "File validation FAILED. Dry-run: continuing (no writes)."
+        elif [ "${FORCE_FLASH:-0}" -eq 1 ]; then
+            log_warn "File validation FAILED. Overridden by -F (force): writing a corrupted configuration."
+        else
+            log_error "File validation FAILED for $CONFIG_FILE: refusing to flash. Run 'checkfile' for details, or use -F to override."
+            return 1
+        fi
+    fi
 
     # Pre-flight ONCE: detect, verify file<->device, report version/CONFIG_CRC, idempotency.
     preflight_check || return 1


### PR DESCRIPTION
Make hw-management-dpc-update.sh reflash UP_TO_DATE devices when --force is set, instead of skipping them inside run_update_from_json. Run check_file() in the Renesas flash path before any device write so corrupted HEX payloads, lengths, or CRC8 cannot consume an NVM save. Document both behaviors in examples/README.md.


(cherry picked from commit dee94db782078bd97716b3c1587ab996cf4105e5)