### PR TITLE
hw-mgmt: tools: Read mp2975/mp2974 DPC model/rev from page 1

### DIFF
--- a/usr/usr/bin/hw-management-read-vr-model-version.sh
+++ b/usr/usr/bin/hw-management-read-vr-model-version.sh
@@ -74,7 +74,9 @@ get_device_registers()
             echo "0x55 0x43 1 1"
             ;;
         mp2975|mp2974)
-            echo "0xba 0xbb 0 0"
+            # DPC_MODEL_ID / DPC_REVISION_ID live on page 1 (same as
+            # hw-management-dpc-update.sh defaults DPC_*_PAGE=1).
+            echo "0xba 0xbb 1 1"
             ;;
         xdpe1a2g7b)
             # Block read exposes a leading byte before the 16-bit MFR value.


### PR DESCRIPTION
hw-management-read-vr-model-version.sh used PMBus page 0 for 0xBA/0xBB on mp2975/mp2974, so --show reported wrong Model/Revision (e.g. 0x0000 on SN5600D HI174). Programmed DPC IDs are on page 1, matching hw-management-dpc-update.sh DPC_*_PAGE defaults.

BUG: #5191603