### PR TITLE
hw-mgmt: script: Fix tc_config init order

### DIFF
--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3967,6 +3967,12 @@ do_start()
 	sleep 1
 	enable_vpd_wp
 	echo 0 > $config_path/events_ready
+
+	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
+		cp $thermal_control_config $config_path/tc_config.json
+	else
+		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
+	fi
 	/usr/bin/hw-management-start-post.sh
 	map_dummy_psus
 
@@ -3982,11 +3988,6 @@ do_start()
 		ln -sf $lm_sensors_config $config_path/lm_sensors_config
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
-	fi
-	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
-		cp $thermal_control_config $config_path/tc_config.json
-	else
-		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
 	/usr/bin/hw-management-exec-parser.sh
 	log_info "Init completed."


### PR DESCRIPTION
Create tc_config.json before start-post TC selection

Description: start-post selects TC 2.0 vs 2.5 from config/tc_config.json,
but do_start() created that file after start-post. TC 2.5 platforms then
defaulted to TC 2.0. Move the copy before calling start-post.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
