### PR TITLE
hw-mgmt: script: Fix wall-clock dependent timeouts during BMC/VR waits

### DIFF
--- a/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
@@ -68,6 +68,20 @@ readlink_canonical()
 	readlink "$p" 2>/dev/null
 }
 
+# Monotonic seconds since boot (integer). Immune to wall-clock / NTP steps.
+# Echoes empty string if /proc/uptime is unreadable.
+_uptime_sec()
+{
+	local u
+	if ! read -r u _ </proc/uptime 2>/dev/null; then
+		echo ""
+		return 1
+	fi
+	u=${u%%.*}
+	case "$u" in ''|*[!0-9]*) echo ""; return 1 ;; esac
+	echo "$u"
+}
+
 export LOG_TAG="hw-management-bmc-generate-dump"
 # shellcheck source=/dev/null
 source /usr/bin/hw-management-bmc-helpers-common.sh
@@ -292,8 +306,9 @@ run_systemd_analyze_cmd_bg()
 	label=$(basename "$outfile" .txt)
 
 	(
-		local t0=$SECONDS rc elapsed
+		local t0 rc elapsed now
 
+		t0=$(_uptime_sec)
 		log_message info "systemd-analyze ${label}: start"
 		if timeout "$timeout_sec" systemd-analyze "$@" --no-pager >"$outfile" 2>&1; then
 			rc=0
@@ -301,7 +316,12 @@ run_systemd_analyze_cmd_bg()
 			rc=$?
 			log_message warning "systemd-analyze $* failed or timed out"
 		fi
-		elapsed=$((SECONDS - t0))
+		now=$(_uptime_sec)
+		if [ -n "$t0" ] && [ -n "$now" ]; then
+			elapsed=$((now - t0))
+		else
+			elapsed="?"
+		fi
 		if [ "$rc" -eq 0 ]; then
 			log_message info "systemd-analyze ${label}: end (${elapsed}s)"
 		else
@@ -479,19 +499,25 @@ collect_i2c_non_mux()
 	done
 }
 
-# Run a collector in a background subshell; log start/end and wall time (journal + stderr).
+# Run a collector in a background subshell; log start/end and elapsed time (journal + stderr).
 run_collect_bg()
 {
 	local name=$1
 	shift
 
 	(
-		local t0=$SECONDS rc elapsed
+		local t0 rc elapsed now
 
+		t0=$(_uptime_sec)
 		log_message info "collect ${name}: start"
 		"$@"
 		rc=$?
-		elapsed=$((SECONDS - t0))
+		now=$(_uptime_sec)
+		if [ -n "$t0" ] && [ -n "$now" ]; then
+			elapsed=$((now - t0))
+		else
+			elapsed="?"
+		fi
 		if [ "$rc" -eq 0 ]; then
 			log_message info "collect ${name}: end (${elapsed}s)"
 		else
@@ -536,7 +562,7 @@ if ! command -v gzip >/dev/null 2>&1; then
 	rm -rf "$DUMP_FOLDER"
 	exit 1
 fi
-archive_t0=$SECONDS
+archive_t0=$(_uptime_sec)
 log_message info "archive: start"
 set -o pipefail 2>/dev/null || true
 if ! tar cf - -C "$DUMP_FOLDER" . | gzip -9 >"$OUTPUT_TAR"; then
@@ -545,7 +571,12 @@ if ! tar cf - -C "$DUMP_FOLDER" . | gzip -9 >"$OUTPUT_TAR"; then
 	exit 1
 fi
 set +o pipefail 2>/dev/null || true
-log_message info "archive: end ($((SECONDS - archive_t0))s)"
+archive_now=$(_uptime_sec)
+if [ -n "$archive_t0" ] && [ -n "$archive_now" ]; then
+	log_message info "archive: end ($((archive_now - archive_t0))s)"
+else
+	log_message info "archive: end"
+fi
 
 rm -rf "$DUMP_FOLDER"
 log_message info "BMC dump created: $OUTPUT_TAR"

--- a/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
@@ -64,8 +64,9 @@ G_ETHER_DEV_ADDR="${G_ETHER_DEV_ADDR:-46:44:8a:c8:7f:bd}"
 # Wait for GP_STBY_PG (BMC standby-ready) via sysfs GPIO value file.
 # Uses global BMC_STBY_READY (path to the value file), set in
 # bmc_init_sysfs_gpio() from hw-management-bmc-gpio-set.sh before this runs.
+# Timeout uses /proc/uptime (monotonic) so wall-clock steps do not affect it.
 # ARGUMENTS:
-#   $1 timeout (seconds, default 10) — max wall time to wait
+#   $1 timeout (seconds, default 10) — max wait time
 #   $2 interval (seconds, default 1) — sleep between polls
 # RETURN:
 #   0 if the value reads 1 within the timeout
@@ -75,7 +76,11 @@ wait_bmc_standby_ready()
 {
 	local timeout_sec=${1:-10}
 	local interval_secs=${2:-1}
-	local start_time=$EPOCHSECONDS
+	local start_uptime now_uptime elapsed
+	local ready_status
+
+	read -r start_uptime _ </proc/uptime
+	start_uptime=${start_uptime%%.*}
 
 	if [ -z "${BMC_STBY_READY:-}" ] || [ ! -r "$BMC_STBY_READY" ]; then
 		echo "[ERROR] BMC_STBY_READY is not set or not readable: ${BMC_STBY_READY:-<unset>}"
@@ -86,7 +91,6 @@ wait_bmc_standby_ready()
 	echo "Expecting $BMC_STBY_READY set HIGH"
 
 	while true; do
-		local ready_status
 		read -r ready_status < "$BMC_STBY_READY" || true
 		ready_status="${ready_status//$'\r'/}"
 
@@ -95,10 +99,16 @@ wait_bmc_standby_ready()
 			return 0
 		fi
 
-		echo "Waiting for BMC standby ready signal, elapsed $((EPOCHSECONDS - start_time))s"
+		read -r now_uptime _ </proc/uptime
+		now_uptime=${now_uptime%%.*}
+		elapsed=$((now_uptime - start_uptime))
+
+		echo "Waiting for BMC standby ready signal, elapsed ${elapsed}s"
 		sleep "$interval_secs"
 
-		if ((EPOCHSECONDS - start_time >= timeout_sec)); then
+		read -r now_uptime _ </proc/uptime
+		now_uptime=${now_uptime%%.*}
+		if ((now_uptime - start_uptime >= timeout_sec)); then
 			echo "[ERROR] BMC standby not ready in ${timeout_sec} secs"
 			return 1
 		fi

--- a/usr/usr/bin/hw-management-vr-dpc-renesas-update.sh
+++ b/usr/usr/bin/hw-management-vr-dpc-renesas-update.sh
@@ -72,9 +72,8 @@ I2C_XFER_FLAGS="-y"
 I2C_MAX_RETRY=${I2C_MAX_RETRY:-3}
 I2C_RETRY_DELAY=${I2C_RETRY_DELAY:-0.05}
 
-# Poll timeout (record type 0x11). Uses a deterministic iteration budget instead of
-# wall-clock: `date +%s%3N` has no %N on BusyBox and would otherwise disable the timeout,
-# allowing an infinite poll on a stuck device.
+# Poll timeout (record type 0x11). Time budget from /proc/uptime (monotonic) plus an
+# iteration-count backstop so a stuck device cannot poll forever if uptime is unreadable.
 POLL_MAX_MS=${POLL_MAX_MS:-2000}
 POLL_INTERVAL_MS=${POLL_INTERVAL_MS:-50}
 
@@ -789,9 +788,9 @@ execute_poll_line() {
     [ -n "$MASK_U32" ] && bitmask=$(and_u32_hex "$bitmask" "$MASK_U32")
 
     # Timeout is BusyBox-robust and enforced two independent ways so the poll can never
-    # loop forever, regardless of `date`/`sleep` capabilities:
-    #   1) wall-clock in whole SECONDS via `date +%s` (BusyBox supports %s, just not %N);
-    #   2) an iteration-count backstop, used when `date +%s` is unusable.
+    # loop forever, regardless of wall-clock/`sleep` capabilities:
+    #   1) monotonic whole seconds via /proc/uptime (immune to date/NTP steps);
+    #   2) an iteration-count backstop, used when /proc/uptime is unreadable.
     # Sub-second pacing is best-effort (_sleep_frac): if BusyBox cannot fractional-sleep,
     # the loop simply polls faster (more I2C reads) but stays bounded by (1)/(2).
     local interval_ms=${POLL_INTERVAL_MS:-50}
@@ -802,11 +801,16 @@ execute_poll_line() {
     local timeout_s=$(( ( ${POLL_MAX_MS:-2000} + 999 ) / 1000 ))   # ceil to whole seconds
     [ "$timeout_s" -ge 1 ] || timeout_s=1
     # Backstop: generous so it never ends BEFORE timeout_s when sleeps are skipped
-    # (fast spin), but still finite if `date` is broken. ~POLL_MAX_MS/ms + 100k margin.
+    # (fast spin), but still finite if uptime is unreadable. ~POLL_MAX_MS/ms + 100k margin.
     local iter_cap=$(( ${POLL_MAX_MS:-2000} / interval_ms + 100000 ))
 
-    local start_s; start_s=$(date +%s 2>/dev/null)
-    case "$start_s" in ''|*[!0-9]*) start_s="" ;; esac
+    local start_s=""
+    if read -r start_s _ </proc/uptime 2>/dev/null; then
+        start_s=${start_s%%.*}
+        case "$start_s" in ''|*[!0-9]*) start_s="" ;; esac
+    else
+        start_s=""
+    fi
 
     local iter=0
     while : ; do
@@ -831,9 +835,14 @@ execute_poll_line() {
 
         # ---- stop conditions ----
         if [ -n "$start_s" ]; then
-            local now_s; now_s=$(date +%s 2>/dev/null)
-            case "$now_s" in ''|*[!0-9]*) now_s="$start_s" ;; esac
-            [ $(( now_s - start_s )) -ge "$timeout_s" ] && break
+            local now_s=""
+            if read -r now_s _ </proc/uptime 2>/dev/null; then
+                now_s=${now_s%%.*}
+                case "$now_s" in ''|*[!0-9]*) now_s="" ;; esac
+            else
+                now_s=""
+            fi
+            [ -n "$now_s" ] && [ $(( now_s - start_s )) -ge "$timeout_s" ] && break
         fi
         [ "$iter" -ge "$iter_cap" ] && break
 


### PR DESCRIPTION
Issue description:
BMC standby-ready wait (and related VR poll / dump timing) could hang
or time out early if NTP/manual clock steps occurred during the wait.

RootCause:
Timeout used wall-clock time (EPOCHSECONDS / date +%s / $SECONDS).

Fix:
Switch timeout/elapsed timing to /proc/uptime.

Bug: 5189244

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
