### PR TITLE
hw-mgmt: script: Fix wall-clock dependent timeouts during BMC waits (2 commits)

### DIFF
--- a/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-generate-dump.sh
@@ -68,6 +68,20 @@ readlink_canonical()
 	readlink "$p" 2>/dev/null
 }
 
+# Monotonic seconds since boot (integer). Immune to wall-clock / NTP steps.
+# Echoes empty string if /proc/uptime is unreadable.
+_uptime_sec()
+{
+	local u
+	if ! read -r u _ </proc/uptime 2>/dev/null; then
+		echo ""
+		return 1
+	fi
+	u=${u%%.*}
+	case "$u" in ''|*[!0-9]*) echo ""; return 1 ;; esac
+	echo "$u"
+}
+
 export LOG_TAG="hw-management-bmc-generate-dump"
 # shellcheck source=/dev/null
 source /usr/bin/hw-management-bmc-helpers-common.sh
@@ -289,8 +303,9 @@ run_systemd_analyze_cmd_bg()
 	label=$(basename "$outfile" .txt)
 
 	(
-		local t0=$SECONDS rc elapsed
+		local t0 rc elapsed now
 
+		t0=$(_uptime_sec)
 		log_message info "systemd-analyze ${label}: start"
 		if timeout "$timeout_sec" systemd-analyze "$@" --no-pager >"$outfile" 2>&1; then
 			rc=0
@@ -298,7 +313,12 @@ run_systemd_analyze_cmd_bg()
 			rc=$?
 			log_message warning "systemd-analyze $* failed or timed out"
 		fi
-		elapsed=$((SECONDS - t0))
+		now=$(_uptime_sec)
+		if [ -n "$t0" ] && [ -n "$now" ]; then
+			elapsed=$((now - t0))
+		else
+			elapsed="?"
+		fi
 		if [ "$rc" -eq 0 ]; then
 			log_message info "systemd-analyze ${label}: end (${elapsed}s)"
 		else
@@ -444,19 +464,25 @@ collect_i2c_non_mux()
 	done
 }
 
-# Run a collector in a background subshell; log start/end and wall time (journal + stderr).
+# Run a collector in a background subshell; log start/end and elapsed time (journal + stderr).
 run_collect_bg()
 {
 	local name=$1
 	shift
 
 	(
-		local t0=$SECONDS rc elapsed
+		local t0 rc elapsed now
 
+		t0=$(_uptime_sec)
 		log_message info "collect ${name}: start"
 		"$@"
 		rc=$?
-		elapsed=$((SECONDS - t0))
+		now=$(_uptime_sec)
+		if [ -n "$t0" ] && [ -n "$now" ]; then
+			elapsed=$((now - t0))
+		else
+			elapsed="?"
+		fi
 		if [ "$rc" -eq 0 ]; then
 			log_message info "collect ${name}: end (${elapsed}s)"
 		else
@@ -500,7 +526,7 @@ if ! command -v gzip >/dev/null 2>&1; then
 	rm -rf "$DUMP_FOLDER"
 	exit 1
 fi
-archive_t0=$SECONDS
+archive_t0=$(_uptime_sec)
 log_message info "archive: start"
 set -o pipefail 2>/dev/null || true
 if ! tar cf - -C "$DUMP_FOLDER" . | gzip -9 >"$OUTPUT_TAR"; then
@@ -509,7 +535,12 @@ if ! tar cf - -C "$DUMP_FOLDER" . | gzip -9 >"$OUTPUT_TAR"; then
 	exit 1
 fi
 set +o pipefail 2>/dev/null || true
-log_message info "archive: end ($((SECONDS - archive_t0))s)"
+archive_now=$(_uptime_sec)
+if [ -n "$archive_t0" ] && [ -n "$archive_now" ]; then
+	log_message info "archive: end ($((archive_now - archive_t0))s)"
+else
+	log_message info "archive: end"
+fi
 
 rm -rf "$DUMP_FOLDER"
 log_message info "BMC dump created: $OUTPUT_TAR"

--- a/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-ready-common.sh
@@ -60,12 +60,27 @@ fi
 G_ETHER_HOST_ADDR="${G_ETHER_HOST_ADDR:-46:44:8a:c8:7f:bf}"
 G_ETHER_DEV_ADDR="${G_ETHER_DEV_ADDR:-46:44:8a:c8:7f:bd}"
 
+# Monotonic seconds since boot (integer). Immune to wall-clock / NTP steps.
+# Echoes empty string if /proc/uptime is unreadable.
+_uptime_sec()
+{
+	local u
+	if ! read -r u _ </proc/uptime 2>/dev/null; then
+		echo ""
+		return 1
+	fi
+	u=${u%%.*}
+	case "$u" in ''|*[!0-9]*) echo ""; return 1 ;; esac
+	echo "$u"
+}
+
 #######################################
 # Wait for GP_STBY_PG (BMC standby-ready) via sysfs GPIO value file.
 # Uses global BMC_STBY_READY (path to the value file), set in
 # bmc_init_sysfs_gpio() from hw-management-bmc-gpio-set.sh before this runs.
+# Timeout uses /proc/uptime (monotonic) so wall-clock steps do not affect it.
 # ARGUMENTS:
-#   $1 timeout (seconds, default 10) — max wall time to wait
+#   $1 timeout (seconds, default 10) — max wait time
 #   $2 interval (seconds, default 1) — sleep between polls
 # RETURN:
 #   0 if the value reads 1 within the timeout
@@ -75,7 +90,15 @@ wait_bmc_standby_ready()
 {
 	local timeout_sec=${1:-10}
 	local interval_secs=${2:-1}
-	local start_time=$EPOCHSECONDS
+	local start_uptime now_uptime elapsed
+	local ready_status
+
+	start_uptime=$(_uptime_sec)
+	if [ -z "$start_uptime" ]; then
+		echo "[ERROR] /proc/uptime unreadable; cannot enforce BMC standby timeout"
+		sleep "$interval_secs"
+		return 1
+	fi
 
 	if [ -z "${BMC_STBY_READY:-}" ] || [ ! -r "$BMC_STBY_READY" ]; then
 		echo "[ERROR] BMC_STBY_READY is not set or not readable: ${BMC_STBY_READY:-<unset>}"
@@ -86,7 +109,6 @@ wait_bmc_standby_ready()
 	echo "Expecting $BMC_STBY_READY set HIGH"
 
 	while true; do
-		local ready_status
 		read -r ready_status < "$BMC_STBY_READY" || true
 		ready_status="${ready_status//$'\r'/}"
 
@@ -95,13 +117,20 @@ wait_bmc_standby_ready()
 			return 0
 		fi
 
-		echo "Waiting for BMC standby ready signal, elapsed $((EPOCHSECONDS - start_time))s"
-		sleep "$interval_secs"
+		now_uptime=$(_uptime_sec)
+		if [ -z "$now_uptime" ]; then
+			echo "[ERROR] /proc/uptime unreadable while waiting for BMC standby ready"
+			sleep "$interval_secs"
+			return 1
+		fi
+		elapsed=$((now_uptime - start_uptime))
 
-		if ((EPOCHSECONDS - start_time >= timeout_sec)); then
+		echo "Waiting for BMC standby ready signal, elapsed ${elapsed}s"
+		if ((elapsed >= timeout_sec)); then
 			echo "[ERROR] BMC standby not ready in ${timeout_sec} secs"
 			return 1
 		fi
+		sleep "$interval_secs"
 	done
 }
 

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3959,6 +3959,12 @@ do_start()
 	sleep 1
 	enable_vpd_wp
 	echo 0 > $config_path/events_ready
+
+	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
+		cp $thermal_control_config $config_path/tc_config.json
+	else
+		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
+	fi
 	/usr/bin/hw-management-start-post.sh
 	map_dummy_psus
 
@@ -3974,11 +3980,6 @@ do_start()
 		ln -sf $lm_sensors_config $config_path/lm_sensors_config
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
-	fi
-	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
-		cp $thermal_control_config $config_path/tc_config.json
-	else
-		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
 	/usr/bin/hw-management-exec-parser.sh
 	log_info "Init completed."


### PR DESCRIPTION
- hw-mgmt: script: Fix tc_config init order
- hw-mgmt: script: Fix wall-clock dependent timeouts during BMC waits
