### PR TITLE
hw-mgmt: scripts: Change the location of label dictionary

### DIFF
--- a/usr/usr/bin/hw-management-labels-maker.sh
+++ b/usr/usr/bin/hw-management-labels-maker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ########################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,6 +35,7 @@ source hw-management-helpers.sh
 set -x
 sku=$(< $sku_file)
 ui_path=$hw_management_path/ui 
+cache_path=$hw_management_path/.cache
 
 # Obtain label file (/var/run/hw-management/config/lm_sensors_labels).
 json_file=$hw_management_path/config/lm_sensors_labels
@@ -44,8 +45,9 @@ if [ ! -f $json_file ]; then
 fi
 
 # Check if the dictionary has already been loaded
-if [ ! -f "/tmp/sensor_labels_dictionary.pkl" ]; then
+if [ ! -f "$cache_path/sensor_labels_dictionary.pkl" ]; then
 	lock_service_state_change
+	mkdir -p "$cache_path"
 	# Call the Python program to load the JSON file and store the dictionary
 	hw_management_parse_labels.py --json_file "$json_file" --sku "$sku" 
 	unlock_service_state_change

--- a/usr/usr/bin/hw_management_parse_labels.py
+++ b/usr/usr/bin/hw_management_parse_labels.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 #
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2023-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: GPL-2.0-only
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@ import pickle
 import re
 
 HW_MGMT_PATH = "/var/run/hw-management/"
+HW_MGMT_CACHE = f"{HW_MGMT_PATH}.cache/"
 
 
 def load_json(json_file):
@@ -101,7 +102,7 @@ def retrieve_value(dictionary, label, key):
 def main():
     parser = argparse.ArgumentParser(description='JSON Dictionary')
     parser.add_argument('--json_file', help='Path to JSON file')
-    parser.add_argument('--dictionary_file', default='/tmp/sensor_labels_dictionary.pkl', help='Path to dictionary file')
+    parser.add_argument('--dictionary_file', default=f"{HW_MGMT_CACHE}sensor_labels_dictionary.pkl", help='Path to dictionary file')
     parser.add_argument('--get_value', action='store_true', help='Retrieve value for a given key')
     parser.add_argument('--label', help='Label section in the json file')
     parser.add_argument('--key', help='Key for value retrieval')


### PR DESCRIPTION
Python's pickle module can execute arbitrary code
during deserialization by crafting objects with
`__reduce__` methods. Any local user or compromised container/process can write a malicious pickle file to this default path. When the hw-management service (running as root) subsequently calls this script
with `--get_value`, it will deserialize the
attacker-controlled pickle file and execute arbitrary code with root privileges.

To prevent this issue, moving the dictionary cache under /var/run/hw-management/cache/, where only root user will have the write permission.

Bug #5054893