### PR TITLE
hw-mgmt: sensors: Update sensor configuration files for SN5600 and SN…

### DIFF
--- a/usr/etc/hw-management-sensors/sn5600_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600_sensors.conf
@@ -1,30 +1,10 @@
 ##################################################################################
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Platform specific sensors config for SN5600
 ##################################################################################
 
-# Bus names
-bus "i2c-39" "i2c-1-mux (chan_id 6)"
-
-# Temperature sensors
-chip "mlxsw-i2c-*-48"
-    label temp1 "Ambient ASIC Temp"
-
-chip "tmp102-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air exhaust)"
-chip "adt75-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air exhaust)"
-chip "stts751-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air exhaust)"
-chip "tmp102-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air intake)"
-chip "adt75-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air intake)"
-chip "stts751-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air intake)"
-
-# Power controllers
+# ASIC power controllers
 chip "mp2975-i2c-*-62"
     label in1      "PMIC-1 PSU 13V5 Rail (in1)"
     label in2      "PMIC-1 VDD_M ADJ Rail (out1)"
@@ -74,8 +54,8 @@ chip "mp2975-i2c-*-63"
     label power3   "PMIC-2 VDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in1)"
     label curr2    "PMIC-2 VDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-2 VDD_T1 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-2 VDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-63"
@@ -104,8 +84,8 @@ chip "mp2975-i2c-*-64"
     label power3   "PMIC-3 VDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
     label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-3 VDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-64"
@@ -134,8 +114,8 @@ chip "mp2975-i2c-*-65"
     label power3   "PMIC-4 VDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in1)"
     label curr2    "PMIC-4 VDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-4 VDD_T5 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-4 VDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-65"
@@ -164,8 +144,8 @@ chip "mp2975-i2c-*-66"
     label power3   "PMIC-5 VDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in1)"
     label curr2    "PMIC-5 VDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-5 VDD_T7 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-5 VDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-66"
@@ -194,8 +174,8 @@ chip "mp2975-i2c-*-67"
     label power3   "PMIC-6 DVDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)"
     label curr2    "PMIC-6 DVDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-6 DVDD_T1 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-6 DVDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-67"
@@ -224,8 +204,8 @@ chip "mp2975-i2c-*-68"
     label power3   "PMIC-7 DVDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in1)"
     label curr2    "PMIC-7 DVDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-7 DVDD_T3 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-7 DVDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-68"
@@ -254,8 +234,8 @@ chip "mp2975-i2c-*-69"
     label power3   "PMIC-8 DVDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in1)"
     label curr2    "PMIC-8 DVDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-8 DVDD_T5 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-8 DVDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-69"
@@ -284,8 +264,8 @@ chip "mp2975-i2c-*-6a"
     label power3   "PMIC-9 DVDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in1)"
     label curr2    "PMIC-9 DVDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-9 DVDD_T7 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-9 DVDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-6a"
@@ -314,11 +294,11 @@ chip "mp2975-i2c-*-6c"
     label power3   "PMIC-10 HVDD_T47 Rail Pwr (out2)"
     label curr1    "PMIC-10 13V5 HVDD_T03 HVDD_T47 Rail Curr (in1)"
     label curr2    "PMIC-10 HVDD_T03 Rail Curr (out1)"
-    label curr3    "PMIC-10 HVDD_T47 Rail Curr (out2)"
+    ignore curr3
     ignore curr4
     ignore curr5
     ignore curr6
-    ignore curr7
+    label curr7    "PMIC-10 HVDD_T47 Rail Curr (out2)"
     ignore curr8
     ignore curr9
     ignore curr10
@@ -354,9 +334,9 @@ chip "mp2975-i2c-*-6e"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
     label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    ignore curr3
     ignore curr4
-    ignore curr5
+    label curr5    "PMIC-11 DVDD_M Rail Curr (out2)"
     ignore curr6
 chip "xdpe15284-i2c-*-6e"
     label in1      "PMIC-11 PSU 13V5 Rail (in1)"
@@ -375,7 +355,6 @@ chip "xdpe15284-i2c-*-6e"
     ignore curr6
 
 # Power supplies
-
 chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
@@ -407,36 +386,36 @@ chip "dps460-i2c-*-5a"
 
 # Power converters
 chip "pmbus-i2c-*-10"
-    label in1      	"IBC-1 PWR CONV 54V Rail (in1)"
-    label in2		"IBC-1 13V5 Rail (out)"
+    label in1       "IBC-1 PWR CONV 54V Rail (in1)"
+    label in2       "IBC-1 13V5 Rail (out)"
     ignore in3
-    label temp1    	"IBC-1 Temp 1"
+    label temp1     "IBC-1 Temp 1"
     ignore curr1
-    label curr2 	"IBC-1 13V5 Rail Curr (out)"
+    label curr2     "IBC-1 13V5 Rail Curr (out)"
 chip "pmbus-i2c-*-11"
-    label in1      	"IBC-2 PWR CONV 54V Rail (in1)"
-    label in2		"IBC-2 13V5 Rail (out)"
+    label in1       "IBC-2 PWR CONV 54V Rail (in1)"
+    label in2       "IBC-2 13V5 Rail (out)"
     ignore in3
-    label temp1    	"IBC-2 Temp 1"
-    label curr1 	"IBC-2 13V5 Rail Curr (out)"
+    label temp1     "IBC-2 Temp 1"
+    label curr1     "IBC-2 13V5 Rail Curr (out)"
     ignore curr2
 chip "pmbus-i2c-*-13"
-    label in1      	"IBC-3 PWR CONV 54V Rail (in1)"
-    label in2		"IBC-3 13V5 Rail (out)"
+    label in1       "IBC-3 PWR CONV 54V Rail (in1)"
+    label in2       "IBC-3 13V5 Rail (out)"
     ignore in3
-    label temp1    	"IBC-3 Temp 1"
-    label curr1 	"IBC-3 13V5 Rail Curr (out)"
+    label temp1     "IBC-3 Temp 1"
+    label curr1     "IBC-3 13V5 Rail Curr (out)"
     ignore curr2
 chip "pmbus-i2c-*-15"
-    label in1      	"IBC-4 PWR CONV 54V Rail (in1)"
-    label in2		"IBC-4 13V5 Rail (out)"
+    label in1       "IBC-4 PWR CONV 54V Rail (in1)"
+    label in2       "IBC-4 13V5 Rail (out)"
     ignore in3
-    label temp1    	"IBC-4 Temp 1"
-    label curr1 	"IBC-4 13V5 Rail Curr (out)"
+    label temp1     "IBC-4 Temp 1"
+    label curr1     "IBC-4 13V5 Rail Curr (out)"
     ignore curr2
 
-#COMEX CFL
-chip "mp2975-i2c-39-6b"
+# COMEX board power controller
+chip "mp2975-i2c-*-6b"
     label in1 "PMIC-12 PSU 13V5 Rail (vin)"
     label in2 "PMIC-12 COMEX VCORE (out1)"
     label in3 "PMIC-12 COMEX VCCSA (out2)"
@@ -463,21 +442,36 @@ chip "mlxreg_fan-isa-*"
     label fan7 "Chassis Fan Drawer-4 Tach 1"
     label fan8 "Chassis Fan Drawer-4 Tach 2"
 
-# Memory sensors
-bus "i2c-0" "SMBus I801 adapter at efa0"
-chip "jc42-i2c-0-1c"
+# SODIMM temperature sensors
+chip "jc42-i2c-*-1c"
+    label temp1 "SODIMM Temp"
+chip "jc42-i2c-*-1a"
     label temp1 "SODIMM Temp"
 
-chip "jc42-i2c-0-1a"
-    label temp1 "SODIMM Temp"
-
-# PCH
+# PCH temperature sensor
 chip "pch_cannonlake-virtual-*"
     label temp1 "PCH Temp"
 
-# SSD
+# SSD temperature sensor
 chip "drivetemp-*"
     label temp1 "SSD Temp"
 
+# ACPI temperature sensor
 chip "*-acpi-*"
     label temp1 "CPU ACPI temp"
+
+# Fan side temperature sensor
+chip "tmp102-i2c-*-49"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
+chip "adt75-i2c-*-49"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
+chip "stts751-i2c-*-49"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
+
+# Port side temperature sensor
+chip "tmp102-i2c-*-4a"
+    label temp1 "Ambient Port Side Temp (air intake)"
+chip "adt75-i2c-*-4a"
+    label temp1 "Ambient Port Side Temp (air intake)"
+chip "stts751-i2c-*-4a"
+    label temp1 "Ambient Port Side Temp (air intake)"

--- a/usr/etc/hw-management-sensors/sn5600d_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5600d_sensors.conf
@@ -1,30 +1,10 @@
 ##################################################################################
-# Copyright (c) 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
-# Platform specific sensors config for SN5600
+# Platform specific sensors config for SN5600D
 ##################################################################################
 
-# Bus names
-bus "i2c-39" "i2c-1-mux (chan_id 6)"
-
-# Temperature sensors
-chip "mlxsw-i2c-*-48"
-    label temp1 "Ambient ASIC Temp"
-
-chip "tmp102-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air exhaust)"
-chip "adt75-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air exhaust)"
-chip "stts751-i2c-*-49"
-    label temp1 "Ambient Fan Side Temp (air exhaust)"
-chip "tmp102-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air intake)"
-chip "adt75-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air intake)"
-chip "stts751-i2c-*-4a"
-    label temp1 "Ambient Port Side Temp (air intake)"
-
-# Power controllers
+# ASIC power controllers
 chip "mp2975-i2c-*-62"
     label in1      "PMIC-1 PSU 13V5 Rail (in1)"
     label in2      "PMIC-1 VDD_M ADJ Rail (out1)"
@@ -74,8 +54,8 @@ chip "mp2975-i2c-*-63"
     label power3   "PMIC-2 VDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-2 13V5 VDD_T0 VDD_T1 Rail Curr (in1)"
     label curr2    "PMIC-2 VDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-2 VDD_T1 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-2 VDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-63"
@@ -104,8 +84,8 @@ chip "mp2975-i2c-*-64"
     label power3   "PMIC-3 VDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-3 13V5 VDD_T2 VDD_T3 Rail Curr (in1)"
     label curr2    "PMIC-3 VDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-3 VDD_T3 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-3 VDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-64"
@@ -134,8 +114,8 @@ chip "mp2975-i2c-*-65"
     label power3   "PMIC-4 VDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-4 13V5 VDD_T4 VDD_T5 Rail Curr (in1)"
     label curr2    "PMIC-4 VDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-4 VDD_T5 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-4 VDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-65"
@@ -164,8 +144,8 @@ chip "mp2975-i2c-*-66"
     label power3   "PMIC-5 VDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-5 13V5 VDD_T6 VDD_T7 Rail Curr (in1)"
     label curr2    "PMIC-5 VDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-5 VDD_T7 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-5 VDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-66"
@@ -194,8 +174,8 @@ chip "mp2975-i2c-*-67"
     label power3   "PMIC-6 DVDD_T1 Rail Pwr (out2)"
     label curr1    "PMIC-6 13V5 DVDD_T0 DVDD_T1 Rail Curr (in1)"
     label curr2    "PMIC-6 DVDD_T0 Rail Curr (out1)"
-    label curr3    "PMIC-6 DVDD_T1 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-6 DVDD_T1 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-67"
@@ -224,8 +204,8 @@ chip "mp2975-i2c-*-68"
     label power3   "PMIC-7 DVDD_T3 Rail Pwr (out2)"
     label curr1    "PMIC-7 13V5 DVDD_T2 DVDD_T3 Rail Curr (in1)"
     label curr2    "PMIC-7 DVDD_T2 Rail Curr (out1)"
-    label curr3    "PMIC-7 DVDD_T3 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-7 DVDD_T3 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-68"
@@ -254,8 +234,8 @@ chip "mp2975-i2c-*-69"
     label power3   "PMIC-8 DVDD_T5 Rail Pwr (out2)"
     label curr1    "PMIC-8 13V5 DVDD_T4 DVDD_T5 Rail Curr (in1)"
     label curr2    "PMIC-8 DVDD_T4 Rail Curr (out1)"
-    label curr3    "PMIC-8 DVDD_T5 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-8 DVDD_T5 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-69"
@@ -284,8 +264,8 @@ chip "mp2975-i2c-*-6a"
     label power3   "PMIC-9 DVDD_T7 Rail Pwr (out2)"
     label curr1    "PMIC-9 13V5 DVDD_T6 DVDD_T7 Rail Curr (in1)"
     label curr2    "PMIC-9 DVDD_T6 Rail Curr (out1)"
-    label curr3    "PMIC-9 DVDD_T7 Rail Curr (out2)"
-    ignore curr4
+    ignore curr3
+    label curr4    "PMIC-9 DVDD_T7 Rail Curr (out2)"
     ignore curr5
     ignore curr6
 chip "xdpe15284-i2c-*-6a"
@@ -314,11 +294,11 @@ chip "mp2975-i2c-*-6c"
     label power3   "PMIC-10 HVDD_T47 Rail Pwr (out2)"
     label curr1    "PMIC-10 13V5 HVDD_T03 HVDD_T47 Rail Curr (in1)"
     label curr2    "PMIC-10 HVDD_T03 Rail Curr (out1)"
-    label curr3    "PMIC-10 HVDD_T47 Rail Curr (out2)"
+    ignore curr3
     ignore curr4
     ignore curr5
     ignore curr6
-    ignore curr7
+    label curr7    "PMIC-10 HVDD_T47 Rail Curr (out2)"
     ignore curr8
     ignore curr9
     ignore curr10
@@ -354,9 +334,9 @@ chip "mp2975-i2c-*-6e"
     label power3   "PMIC-11 DVDD_M Rail Pwr (out2)"
     label curr1    "PMIC-11 13V5 VDDSCC DVDD_M Rail Curr (in1)"
     label curr2    "PMIC-11 VDDSCC Rail Curr (out1)"
-    label curr3    "PMIC-11 DVDD_M Rail Curr (out2)"
+    ignore curr3
     ignore curr4
-    ignore curr5
+    label curr5    "PMIC-11 DVDD_M Rail Curr (out2)"
     ignore curr6
 chip "xdpe15284-i2c-*-6e"
     label in1      "PMIC-11 PSU 13V5 Rail (in1)"
@@ -375,7 +355,6 @@ chip "xdpe15284-i2c-*-6e"
     ignore curr6
 
 # Power supplies
-
 chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
@@ -405,60 +384,55 @@ chip "dps460-i2c-*-5a"
     label curr1 "PSU-2(R) 220V Rail Curr (in)"
     label curr2 "PSU-2(R) 54V Rail Curr (out)"
 
-# PDB board
-bus "i2c-4" "i2c-1-mux (chan_id 6)"
-	# Hot-swap
-	chip "lm5066i-i2c-*-12"
-	    label in1       "HSC1 VinDC Volt (in)"
-	    label in3       "HSC1 Vout Volt (out)"
-	    ignore in2
-	    label power1    "HSC1 VinDC Pwr (in)"
-	    label curr1     "HSC1 VinDC Curr (in)"
-	    label temp1     "HSC1 Temp"
+# PDB board hot-swap controllers
+chip "lm5066i-i2c-*-12"
+    label in1       "HSC1 VinDC Volt (in)"
+    label in3       "HSC1 Vout Volt (out)"
+    ignore in2
+    label power1    "HSC1 VinDC Pwr (in)"
+    label curr1     "HSC1 VinDC Curr (in)"
+    label temp1     "HSC1 Temp"
+chip "lm5066i-i2c-*-14"
+    label in1       "HSC2 VinDC Volt (in)"
+    label in3       "HSC2 Vout Volt (out)"
+    ignore in2
+    label power1    "HSC2 VinDC Pwr (in)"
+    label curr1     "HSC2 VinDC Curr (in)"
+    label temp1     "HSC2 Temp"
 
-	chip "lm5066i-i2c-*-14"
-	    label in1       "HSC2 VinDC Volt (in)"
-	    label in3       "HSC2 Vout Volt (out)"
-	    ignore in2
-	    label power1    "HSC2 VinDC Pwr (in)"
-	    label curr1     "HSC2 VinDC Curr (in)"
-	    label temp1     "HSC2 Temp"
+# PDB board power converter
+chip "raa228000-i2c-*-61"
+    label in1       "PWR_CONV1 VinDC Volt (in)"
+    ignore in2
+    label in3       "PWR_CONV1 Vout Volt (out)"
+    label power1  	"PWR_CONV1 VinDC Pwr (in)"
+    label power2	"PWR_CONV1 VoutDC Pwr (out)"
+    label curr1		"PWR_CONV1 Curr Curr (in)"
+    label curr2     "PWR_CONV1 Curr Curr (out)"
+    label temp1		"PWR_CONV1 Temp1"
+    label temp2     "PWR_CONV1 Temp2"
+    ignore temp3
+chip "raa228004-i2c-*-61"
+    label in1       "PWR_CONV1 VinDC Volt (in)"
+    ignore in2
+    label in3       "PWR_CONV1 Vout Volt (out)"
+    label power1  	"PWR_CONV1 VinDC Pwr (in)"
+    label power2	"PWR_CONV1 VoutDC Pwr (out)"
+    label curr1		"PWR_CONV1 Curr Curr (in)"
+    label curr2     "PWR_CONV1 Curr Curr (out)"
+    label temp1		"PWR_CONV1 Temp1"
+    label temp2     "PWR_CONV1 Temp2"
+    ignore temp3
 
-	# PDB pwr_conv
-    chip "raa228000-i2c-*-61"
-	    label in1       "PWR_CONV1 VinDC Volt (in)"
-	    ignore in2
-	    label in3       "PWR_CONV1 Vout Volt (out)"
-	    label power1  	"PWR_CONV1 VinDC Pwr (in)"
-	    label power2	"PWR_CONV1 VoutDC Pwr (out)"
-	    label curr1		"PWR_CONV1 Curr Curr (in)"
-	    label curr2     "PWR_CONV1 Curr Curr (out)"
-	    label temp1		"PWR_CONV1 Temp1"
-	    label temp2     "PWR_CONV1 Temp2"
-	    ignore temp3
-
-    chip "raa228004-i2c-*-61"
-	    label in1       "PWR_CONV1 VinDC Volt (in)"
-	    ignore in2
-	    label in3       "PWR_CONV1 Vout Volt (out)"
-	    label power1  	"PWR_CONV1 VinDC Pwr (in)"
-	    label power2	"PWR_CONV1 VoutDC Pwr (out)"
-	    label curr1		"PWR_CONV1 Curr Curr (in)"
-	    label curr2     "PWR_CONV1 Curr Curr (out)"
-	    label temp1		"PWR_CONV1 Temp1"
-	    label temp2     "PWR_CONV1 Temp2"
-	    ignore temp3
-
-    # PDB temperature sensors
-    chip "tmp451-i2c-*-4c"
-    	label temp1 "PDB MOS Temp"
-    	ignore temp2
-
-    chip "tmp1075-i2c-*-4e"
-        label temp1 "PDB Intel Ambiant Temp"
+# PDB board temperature sensors
+chip "tmp451-i2c-*-4c"
+    label temp1 "PDB MOS Temp"
+    ignore temp2
+chip "tmp1075-i2c-*-4e"
+    label temp1 "PDB Intel Ambiant Temp"
   
-#COMEX CFL
-chip "mp2975-i2c-39-6b"
+# COMEX board power controller
+chip "mp2975-i2c-*-6b"
     label in1 "PMIC-12 PSU 13V5 Rail (vin)"
     label in2 "PMIC-12 COMEX VCORE (out1)"
     label in3 "PMIC-12 COMEX VCCSA (out2)"
@@ -485,21 +459,36 @@ chip "mlxreg_fan-isa-*"
     label fan7 "Chassis Fan Drawer-4 Tach 1"
     label fan8 "Chassis Fan Drawer-4 Tach 2"
 
-# Memory sensors
-bus "i2c-0" "SMBus I801 adapter at efa0"
-chip "jc42-i2c-0-1c"
+# SODIMM temperature sensors
+chip "jc42-i2c-*-1c"
+    label temp1 "SODIMM Temp"
+chip "jc42-i2c-*-1a"
     label temp1 "SODIMM Temp"
 
-chip "jc42-i2c-0-1a"
-    label temp1 "SODIMM Temp"
-
-# PCH
+# PCH temperature sensor
 chip "pch_cannonlake-virtual-*"
     label temp1 "PCH Temp"
 
-# SSD
+# SSD temperature sensor
 chip "drivetemp-*"
     label temp1 "SSD Temp"
 
+# ACPI temperature sensor
 chip "*-acpi-*"
     label temp1 "CPU ACPI temp"
+
+# Fan side temperature sensor
+chip "tmp102-i2c-*-49"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
+chip "adt75-i2c-*-49"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
+chip "stts751-i2c-*-49"
+    label temp1 "Ambient Fan Side Temp (air exhaust)"
+
+# Port side temperature sensor
+chip "tmp102-i2c-*-4a"
+    label temp1 "Ambient Port Side Temp (air intake)"
+chip "adt75-i2c-*-4a"
+    label temp1 "Ambient Port Side Temp (air intake)"
+chip "stts751-i2c-*-4a"
+    label temp1 "Ambient Port Side Temp (air intake)"


### PR DESCRIPTION
…5600D

This commit makes the following changes:

1. Fixes out2 current line mapping for several MP2975 ASIC power controllers
2. Keeps corresponding XDPE15284 mappings unmodified, since these alternative
    controllers were not deployed on real systems
3. Fixes whitespace issues, headers and comments
4. Removes redundant I2C bus definitions
5. Removes redundant ASIC temperature sensor definition


Bug: 5176781