### PR TITLE
hw-mgmt: kernel: 6.12: Amend commit text

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0001-mctp-driver-net-Extend-MCTP-support.patch
+++ b/recipes-kernel/linux/linux-6.12/0001-mctp-driver-net-Extend-MCTP-support.patch
@@ -3,7 +3,15 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 18:26:40 +0300
 Subject: [PATCH 6.12 1/5] mctp: driver: net: Extend MCTP support.
 
-Add support for MCTP over SPI, VRoT.
+Extend the in-kernel MCTP stack with additional transports and the
+supporting infrastructure used by NVIDIA BMC platforms.
+
+This adds new MCTP transport backends, including MCTP over SPI and the
+NVIDIA OP-TEE VRoT transport, together with their headers and the
+associated Kconfig and Makefile entries. It also adds infrastructure
+shared by the transports: MCTP tracepoints, transport statistics, and
+error-injection helpers (I2C/SPI/USB/socket) used for testing, and
+extends the core MCTP routing, device and socket code accordingly.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0002-mctp-aspeed-IRoT-Add-initial-support.patch
+++ b/recipes-kernel/linux/linux-6.12/0002-mctp-aspeed-IRoT-Add-initial-support.patch
@@ -3,7 +3,14 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 11:31:35 +0300
 Subject: [PATCH 6.12 2/5] mctp: aspeed: IRoT: Add initial support
 
-Add support for MCTP over IRoT.
+Add initial support for NVIDIA's Internal Root of Trust (IRoT) on the
+Aspeed AST27xx BMC, exposed as an MCTP transport over the hardware
+mailbox.
+
+A new CONFIG_NVIDIA_AST27XX_IROT option (depends on ARCH_ASPEED) builds
+the nvidia-ast27xx-irot driver, which creates an MCTP network device for
+a BMC device-tree node compatible with "nvidia,ast27xx,irot" (for
+example mctpirot0).
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0003-mctp-driver-net-Add-global-APIs-for-MCTP.patch
+++ b/recipes-kernel/linux/linux-6.12/0003-mctp-driver-net-Add-global-APIs-for-MCTP.patch
@@ -3,6 +3,12 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 18:29:00 +0300
 Subject: [PATCH 6.12 3/5] mctp: driver: net: Add global APIs for MCTP
 
+Export the MCTP transport tracepoints (mctp_transport_tx,
+mctp_transport_rx and mctp_transport_error) via
+EXPORT_TRACEPOINT_SYMBOL_GPL() so that MCTP transport drivers built as
+loadable modules can emit them, and add the missing
+MODULE_LICENSE("GPL") to the MCTP I2C error-injection module.
+
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
  drivers/net/mctp/mctp-i2c-error-inject.c | 2 ++

--- a/recipes-kernel/linux/linux-6.12/0004-mctp-driver-net-Fix-MCTP-over-VDM-PCIe.patch
+++ b/recipes-kernel/linux/linux-6.12/0004-mctp-driver-net-Fix-MCTP-over-VDM-PCIe.patch
@@ -3,7 +3,17 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 14:37:56 +0300
 Subject: [PATCH 6.12 4/5] mctp: driver: net: Fix MCTP over VDM/PCIe
 
-Add fixes for MCTP over VDM/PCIe (option MCTP_TRANSPORT_PCIE_VDM).
+Fix two issues in the MCTP over VDM/PCIe transport
+(CONFIG_MCTP_TRANSPORT_PCIE_VDM):
+
+- mctp-pcie-vdm.c was missing MODULE_LICENSE() and MODULE_DESCRIPTION(),
+  which causes a module taint/warning when the transport is built and
+  loaded as a module. Add both.
+- The header guarded its declarations with
+  "#ifdef CONFIG_MCTP_TRANSPORT_PCIE_VDM", which does not handle the
+  option being built as a module (=m). Include <linux/kconfig.h> and use
+  IS_ENABLED() so the declarations are visible in both built-in and
+  module configurations.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0005-mctp-driver-net-Fix-MCTP-over-USB.patch
+++ b/recipes-kernel/linux/linux-6.12/0005-mctp-driver-net-Fix-MCTP-over-USB.patch
@@ -3,7 +3,14 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Sun, 10 May 2026 18:58:36 +0300
 Subject: [PATCH 6.12 5/5] mctp: driver: net: Fix MCTP over USB
 
-Add fixes for MCTP over USB (option MCTP_TRANSPORT_USB).
+Fix and extend the MCTP over USB transport (CONFIG_MCTP_TRANSPORT_USB).
+
+This reworks the USB TX error statistics so that errors which cannot be
+attributed to a single destination EID (for example batched transfers)
+are accounted under a dedicated unknown-EID bucket rather than a
+specific EID, removes a stale Makefile reference to a USB
+error-injection object, and adds a USB gadget function (f_mctp) so the
+device side can expose an MCTP-over-USB interface.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---

--- a/recipes-kernel/linux/linux-6.12/0007-JTAG-Aspeed-Fix-kernel-configuration.patch
+++ b/recipes-kernel/linux/linux-6.12/0007-JTAG-Aspeed-Fix-kernel-configuration.patch
@@ -3,7 +3,16 @@ From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 23 Apr 2026 21:40:40 +0300
 Subject: [PATCH 6.12 1/1] JTAG: Aspeed: Fix kernel configuration
 
-Change Kconfig and Makefile.
+The JTAG subsystem was not properly wired into the kernel build:
+drivers/jtag/Kconfig was not sourced from the top-level drivers/Kconfig,
+so its configuration options were not exposed in menuconfig, and
+drivers/Makefile descended into drivers/jtag/ only when
+CONFIG_JTAG_ASPEED was set instead of for the generic CONFIG_JTAG
+option.
+
+Source drivers/jtag/Kconfig from drivers/Kconfig so the JTAG options
+become selectable, and build drivers/jtag/ based on CONFIG_JTAG so the
+subsystem is compiled whenever JTAG support is enabled.
 
 Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---


### PR DESCRIPTION
Modify commits text for the patches:
- 0001-mctp-driver-net-Extend-MCTP-support.patch
- 0002-mctp-aspeed-IRoT-Add-initial-support.patch
- 0003-mctp-driver-net-Add-global-APIs-for-MCTP.patch
- 0004-mctp-driver-net-Fix-MCTP-over-VDM-PCIe.patch
- 0005-mctp-driver-net-Fix-MCTP-over-USB.patch
- 0007-JTAG-Aspeed-Fix-kernel-configuration.patch