### PR TITLE
hw-mgmt: thermal: SN2201: Change module PWM calculation formula

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
@@ -32,7 +32,9 @@
 	"dev_parameters" : {
 		"asic\\d*":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":70},
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 20, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!95000", "poll_time": 3, "sensor_read_error":70},
-		"module\\d+":     {"pwm_min": 20, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
+		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "val_max_clamp": 65000, "poll_time": 20,
+						   "reg_extra_param": {"increase_step" : 5, "decrease_step": 0.1, "Iterm_down_trh": -10,
+                                         	   "val_up_trh" : 1, "val_down_trh": 3, "range": 3}},
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
 		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
 		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60}


### PR DESCRIPTION
Updated tc_config for msn2201_M (busbar). Fans Capping at 60% to reduce
noise.

FR : 4964410

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
