### PR TITLE
hw-mgmt: thermal: SN2201: Fans clapping at 60% to reduce noise

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
@@ -3,7 +3,7 @@
 	"tc_version": "2.5",
 	"dmin" : {
 		"C2P": {
-			"untrusted": {"-127:20": 30, "21:25": 40, "26:30": 50, "31:35": 60, "36:40": 70, "41:120": 80},
+			"untrusted": {"-127:20": 30, "21:25": 40, "26:30": 50, "31:120": 60},
 			"fan_err": {
 				"tacho": {"-127:120": 50},
 				"present": {"-127:120": 50},
@@ -12,7 +12,7 @@
 			"sensor_read_error" : {"-127:120": 50}
 		},
 		"P2C": {
-			"untrusted":{"-127:15": 30, "16:20": 40, "21:25": 50, "26:30": 60, "31:35": 70, "36:40": 80, "41:120": 90},
+			"untrusted":{"-127:15": 30, "16:20": 40, "21:25": 50, "26:120": 60},
 			"fan_err": {
 				"tacho": {"-127:120": 50},
 				"present": {"-127:120": 50},
@@ -30,12 +30,12 @@
 			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}}
 	},
 	"dev_parameters" : {
-		"asic\\d*":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":70},
-		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 20, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!95000", "poll_time": 3, "sensor_read_error":70},
-		"module\\d+":     {"pwm_min": 20, "pwm_max" : 100, "val_min":60000, "val_max":80000, "poll_time": 20},
+		"asic\\d*":           {"pwm_min": 20, "pwm_max" : 60, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":70},
+		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 20, "pwm_max" : 60,  "val_min": "!70000", "val_max": "!95000", "poll_time": 3, "sensor_read_error":70},
+		"module\\d+":     {"pwm_min": 20, "pwm_max" : 60, "val_min":60000, "val_max":80000, "poll_time": 20},
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},
-		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 100, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
-		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 70, "val_min": "!70000", "val_max": "!95000", "poll_time": 60}
+		"voltmon\\d+_temp": {"pwm_min": 20, "pwm_max": 60, "val_min": "!85000", "val_max": "!125000",  "poll_time": 60},
+		"sodimm\\d_temp" :{"pwm_min": 20, "pwm_max" : 60, "val_min": "!70000", "val_max": "!95000", "poll_time": 60}
 	},
 	"asic_config" : {"1":  {"bus" : 2, "addr" : "0048", "pwm_control": true, "fan_control": true}},
 	"sensor_list" : ["asic1", "cpu", "drwr1", "drwr2", "drwr3", "drwr4", "sensor_amb", "sodimm1", "voltmon2"]


### PR DESCRIPTION
Updated tc_config for msn2201_M (busbar). Fans Capping at 60% to reduce
noise.

FR : 4964410

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
