### PR TITLE
hw-mgmt: patches: Align MP5926 driver with upstream mainline

### DIFF
--- a/recipes-kernel/linux/linux-6.1/0108-hwmon-pmbus-mp5926-Add-support-for-MP5926-device.patch
+++ b/recipes-kernel/linux/linux-6.1/0108-hwmon-pmbus-mp5926-Add-support-for-MP5926-device.patch
@@ -14,12 +14,12 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
  drivers/hwmon/pmbus/Kconfig  |   9 ++
  drivers/hwmon/pmbus/Makefile |   1 +
- drivers/hwmon/pmbus/mp5926.c | 192 +++++++++++++++++++++++++++++++++++
- 3 files changed, 202 insertions(+)
+ drivers/hwmon/pmbus/mp5926.c | 184 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 194 insertions(+)
  create mode 100644 drivers/hwmon/pmbus/mp5926.c
 
 diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
-index 8e89b058c83c..3d8b428c7401 100644
+index adf45eb..5a85d70 100644
 --- a/drivers/hwmon/pmbus/Kconfig
 +++ b/drivers/hwmon/pmbus/Kconfig
 @@ -363,6 +363,15 @@ config SENSORS_MP5023
@@ -39,7 +39,7 @@ index 8e89b058c83c..3d8b428c7401 100644
  	tristate "Flex PIM4328 and compatibles"
  	help
 diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
-index 8482b69a0b97..598043e94e72 100644
+index c57c9ee..3dc9878 100644
 --- a/drivers/hwmon/pmbus/Makefile
 +++ b/drivers/hwmon/pmbus/Makefile
 @@ -39,6 +39,7 @@ obj-$(CONFIG_SENSORS_MP2891)	+= mp2891.o
@@ -52,17 +52,18 @@ index 8482b69a0b97..598043e94e72 100644
  obj-$(CONFIG_SENSORS_PXE1610)	+= pxe1610.o
 diff --git a/drivers/hwmon/pmbus/mp5926.c b/drivers/hwmon/pmbus/mp5926.c
 new file mode 100644
-index 000000000000..e2f17dc98fd1
+index 0000000..30e59c0
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp5926.c
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,184 @@
 +// SPDX-License-Identifier: GPL-2.0+
-+//
-+// mp5926.c  - pmbus driver for mps mp5926
-+//
-+// Copyright 2025 Monolithic Power Systems, Inc
-+//
-+// Author: Yuxi Wang <Yuxi.Wang@monolithicpower.com>
++/*
++ * mp5926.c  - pmbus driver for mps mp5926
++ *
++ * Copyright 2025 Monolithic Power Systems, Inc
++ *
++ * Author: Yuxi Wang <Yuxi.Wang@monolithicpower.com>
++ */
 +
 +#include <linux/bitfield.h>
 +#include <linux/bits.h>
@@ -72,96 +73,76 @@ index 000000000000..e2f17dc98fd1
 +#include <linux/pmbus.h>
 +#include "pmbus.h"
 +
-+/*Common Register*/
-+#define PAGE		0x01
++#define PAGE	0x01
 +#define EFUSE_CFG	0xCF
 +#define I_SCALE_SEL	0xC6
-+#define MP5926_FUNC	(PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_IIN | PMBUS_HAVE_PIN | \
-+			 PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_INPUT | PMBUS_HAVE_STATUS_TEMP | \
-+			 PMBUS_HAVE_STATUS_VOUT)
++#define MP5926_FUNC	(PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | \
++			PMBUS_HAVE_IIN | PMBUS_HAVE_PIN | \
++			PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_INPUT | \
++			PMBUS_HAVE_STATUS_TEMP | PMBUS_HAVE_STATUS_VOUT)
 +
-+static int mp5926_read_word_data(struct i2c_client *client, int page, int phase, int reg)
-+{
-+	int ret;
-+	s16 exponent;
-+	s32 mantissa;
-+	s64 val;
-+
-+	switch (reg) {
-+	case PMBUS_READ_VIN...PMBUS_READ_VCAP:
-+	case PMBUS_READ_IOUT...PMBUS_READ_TEMPERATURE_1:
-+	case PMBUS_READ_PIN:
-+	case PMBUS_STATUS_WORD:
-+		ret = -ENODATA;
-+		break;
-+	case PMBUS_READ_VOUT:
-+		/* The Vout format used by the chip is linear11 and not linear16.
-+		 * So we transform the value into the direct format defined by PMBus.
-+		 */
-+		ret = i2c_smbus_read_word_data(client, EFUSE_CFG);
-+		if (ret < 0)
-+			return ret;
-+		if (ret & BIT(12)) {
-+			ret = i2c_smbus_read_word_data(client, PMBUS_READ_VOUT);
-+			if (ret < 0)
-+				return ret;
-+			exponent = ((s16)ret) >> 11;
-+			mantissa = ((s16)((ret & 0x7ff) << 5)) >> 5;
-+			val = mantissa * 1000;
-+			if (exponent >= 0)
-+				val <<= exponent;
-+			else
-+				val >>= -exponent;
-+			return div_s64(val * 10 + 313L, 625L);
-+		}
-+		ret = -ENODATA;
-+		break;
-+	default:
-+		ret = -EINVAL;
-+		break;
-+	}
-+
-+	return ret;
-+}
-+
-+static int mp5926_read_byte_data(struct i2c_client *client, int page, int reg)
-+{
-+	int ret;
-+
-+	switch (reg) {
-+	case PMBUS_STATUS_BYTE:
-+	case PMBUS_STATUS_VOUT:
-+	case PMBUS_STATUS_INPUT:
-+	case PMBUS_STATUS_TEMPERATURE:
-+	case PMBUS_STATUS_CML:
-+	case PMBUS_STATUS_MFR_SPECIFIC:
-+		ret = -ENODATA;
-+		break;
-+	default:
-+		ret = -EINVAL;
-+		break;
-+	}
-+	return ret;
-+}
-+
-+static struct pmbus_driver_info mp5926_info_linear = {
-+	.pages = PAGE,
-+	.format[PSC_VOLTAGE_IN] = linear,
-+	.format[PSC_CURRENT_IN] = linear,
-+	.format[PSC_VOLTAGE_OUT] = direct,
-+	.format[PSC_TEMPERATURE] = linear,
-+	.format[PSC_POWER] = linear,
-+
-+	.m[PSC_VOLTAGE_OUT] = 16,
-+	.b[PSC_VOLTAGE_OUT] = 0,
-+	.R[PSC_VOLTAGE_OUT] = 0,
-+
-+	.read_word_data = mp5926_read_word_data,
-+	.read_byte_data = mp5926_read_byte_data,
-+	.func[0] = MP5926_FUNC,
++struct mp5926_data {
++	struct pmbus_driver_info info;
++	u8 vout_mode;
++	u8 vout_linear_exponent;
 +};
 +
-+static struct pmbus_driver_info mp5926_info_direct = {
++#define to_mp5926_data(x)  container_of(x, struct mp5926_data, info)
++
++static int mp5926_read_byte_data(struct i2c_client *client, int page,
++				 int reg)
++{
++	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
++	struct mp5926_data *data = to_mp5926_data(info);
++	int ret;
++
++	switch (reg) {
++	case PMBUS_VOUT_MODE:
++		if (data->vout_mode == linear) {
++			/*
++			 * The VOUT format used by the chip is linear11,
++			 * not linear16. Report that VOUT is in linear mode
++			 * and return exponent value extracted while probing
++			 * the chip.
++			 */
++			return data->vout_linear_exponent;
++		}
++		return PB_VOUT_MODE_DIRECT;
++	default:
++		ret = -ENODATA;
++		break;
++	}
++	return ret;
++}
++
++static int mp5926_read_word_data(struct i2c_client *client, int page, int phase,
++				 int reg)
++{
++	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
++	struct mp5926_data *data = to_mp5926_data(info);
++	int ret;
++
++	switch (reg) {
++	case PMBUS_READ_VOUT:
++		ret = pmbus_read_word_data(client, page, phase, reg);
++		if (ret < 0)
++			return ret;
++		/*
++		 * Because the VOUT format used by the chip is linear11 and not
++		 * linear16, we disregard bits[15:11]. The exponent is reported
++		 * as part of the VOUT_MODE command.
++		 */
++		if (data->vout_mode == linear)
++			ret = ((s16)((ret & 0x7ff) << 5)) >> 5;
++		break;
++	default:
++		ret = -ENODATA;
++		break;
++	}
++	return ret;
++}
++
++static struct pmbus_driver_info mp5926_info = {
 +	.pages = PAGE,
 +	.format[PSC_VOLTAGE_IN] = direct,
 +	.format[PSC_CURRENT_IN] = direct,
@@ -183,7 +164,7 @@ index 000000000000..e2f17dc98fd1
 +
 +	.m[PSC_TEMPERATURE] = 4,
 +	.b[PSC_TEMPERATURE] = 0,
-+	.R[PSC_TEMPERATURE] = 3,
++	.R[PSC_TEMPERATURE] = 0,
 +
 +	.m[PSC_POWER] = 25,
 +	.b[PSC_POWER] = 0,
@@ -196,35 +177,46 @@ index 000000000000..e2f17dc98fd1
 +
 +static int mp5926_probe(struct i2c_client *client)
 +{
++	struct mp5926_data *data;
++	struct pmbus_driver_info *info;
 +	int ret;
 +
-+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_READ_BYTE_DATA |
-+				     I2C_FUNC_SMBUS_BLOCK_DATA))
-+		return -ENODEV;
++	data = devm_kzalloc(&client->dev, sizeof(struct mp5926_data),
++			    GFP_KERNEL);
++	if (!data)
++		return -ENOMEM;
 +
++	memcpy(&data->info, &mp5926_info, sizeof(*info));
++	info = &data->info;
 +	ret = i2c_smbus_read_word_data(client, EFUSE_CFG);
-+
 +	if (ret < 0)
 +		return ret;
-+
 +	if (ret & BIT(12)) {
-+		ret = pmbus_do_probe(client, &mp5926_info_linear);
++		data->vout_mode = linear;
++		data->info.format[PSC_VOLTAGE_IN] = linear;
++		data->info.format[PSC_CURRENT_IN] = linear;
++		data->info.format[PSC_VOLTAGE_OUT] = linear;
++		data->info.format[PSC_TEMPERATURE] = linear;
++		data->info.format[PSC_POWER] = linear;
++		ret = i2c_smbus_read_word_data(client, PMBUS_READ_VOUT);
++		if (ret < 0)
++			return dev_err_probe(&client->dev, ret, "Can't get vout exponent.");
++		data->vout_linear_exponent = (u8)((ret >> 11) & 0x1f);
 +	} else {
++		data->vout_mode = direct;
 +		ret = i2c_smbus_read_word_data(client, I_SCALE_SEL);
 +		if (ret < 0)
 +			return ret;
 +		if (ret & BIT(6))
-+			mp5926_info_direct.m[PSC_CURRENT_IN] = 4;
-+		ret = pmbus_do_probe(client, &mp5926_info_direct);
++			data->info.m[PSC_CURRENT_IN] = 4;
 +	}
-+	if (!ret)
-+		dev_info(&client->dev, "%s chip found\n", client->name);
-+	return ret;
++
++	return pmbus_do_probe(client, info);
 +}
 +
 +static const struct i2c_device_id mp5926_id[] = {
-+	{ "mp5926", 0 },
-+	{}
++	{ .name = "mp5926", .driver_data = 0 },
++	{ }
 +};
 +MODULE_DEVICE_TABLE(i2c, mp5926_id);
 +
@@ -245,9 +237,8 @@ index 000000000000..e2f17dc98fd1
 +
 +module_i2c_driver(mp5926_driver);
 +MODULE_AUTHOR("Yuxi Wang <Yuxi.Wang@monolithicpower.com>");
-+MODULE_DESCRIPTION("MPS MP5926 HWMON driver");
++MODULE_DESCRIPTION("MPS MP5926 pmbus driver");
 +MODULE_LICENSE("GPL");
 +MODULE_IMPORT_NS(PMBUS);
 -- 
 2.34.1
-

--- a/recipes-kernel/linux/linux-6.12/0057-hwmon-pmbus-mp5926-Add-support-for-MP5926-device.patch
+++ b/recipes-kernel/linux/linux-6.12/0057-hwmon-pmbus-mp5926-Add-support-for-MP5926-device.patch
@@ -13,12 +13,12 @@ Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
  drivers/hwmon/pmbus/Kconfig  |   9 ++
  drivers/hwmon/pmbus/Makefile |   1 +
- drivers/hwmon/pmbus/mp5926.c | 192 +++++++++++++++++++++++++++++++++++++++++++
- 3 files changed, 202 insertions(+)
+ drivers/hwmon/pmbus/mp5926.c | 184 +++++++++++++++++++++++++++++++++++
+ 3 files changed, 194 insertions(+)
  create mode 100644 drivers/hwmon/pmbus/mp5926.c
 
 diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
-index 946613e..08c9e7b 100644
+index ac86dba..5ddb715 100644
 --- a/drivers/hwmon/pmbus/Kconfig
 +++ b/drivers/hwmon/pmbus/Kconfig
 @@ -426,6 +426,15 @@ config SENSORS_MP5920
@@ -38,7 +38,7 @@ index 946613e..08c9e7b 100644
  	tristate "MPS MP5990"
  	help
 diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
-index c716461..1a641d9 100644
+index abcb3dd..9ebd052 100644
 --- a/drivers/hwmon/pmbus/Makefile
 +++ b/drivers/hwmon/pmbus/Makefile
 @@ -45,6 +45,7 @@ obj-$(CONFIG_SENSORS_MP2975)	+= mp2975.o
@@ -51,17 +51,18 @@ index c716461..1a641d9 100644
  obj-$(CONFIG_SENSORS_MPQ7932)	+= mpq7932.o
 diff --git a/drivers/hwmon/pmbus/mp5926.c b/drivers/hwmon/pmbus/mp5926.c
 new file mode 100644
-index 00000000..626d945
+index 0000000..e66701b
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/mp5926.c
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,184 @@
 +// SPDX-License-Identifier: GPL-2.0+
-+//
-+// mp5926.c  - pmbus driver for mps mp5926
-+//
-+// Copyright 2025 Monolithic Power Systems, Inc
-+//
-+// Author: Yuxi Wang <Yuxi.Wang@monolithicpower.com>
++/*
++ * mp5926.c  - pmbus driver for mps mp5926
++ *
++ * Copyright 2025 Monolithic Power Systems, Inc
++ *
++ * Author: Yuxi Wang <Yuxi.Wang@monolithicpower.com>
++ */
 +
 +#include <linux/bitfield.h>
 +#include <linux/bits.h>
@@ -71,96 +72,76 @@ index 00000000..626d945
 +#include <linux/pmbus.h>
 +#include "pmbus.h"
 +
-+/*Common Register*/
-+#define PAGE		0x01
++#define PAGE	0x01
 +#define EFUSE_CFG	0xCF
 +#define I_SCALE_SEL	0xC6
-+#define MP5926_FUNC	(PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | PMBUS_HAVE_IIN | PMBUS_HAVE_PIN | \
-+			 PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_INPUT | PMBUS_HAVE_STATUS_TEMP | \
-+			 PMBUS_HAVE_STATUS_VOUT)
++#define MP5926_FUNC	(PMBUS_HAVE_VIN | PMBUS_HAVE_VOUT | \
++			PMBUS_HAVE_IIN | PMBUS_HAVE_PIN | \
++			PMBUS_HAVE_TEMP | PMBUS_HAVE_STATUS_INPUT | \
++			PMBUS_HAVE_STATUS_TEMP | PMBUS_HAVE_STATUS_VOUT)
 +
-+static int mp5926_read_word_data(struct i2c_client *client, int page, int phase, int reg)
-+{
-+	int ret;
-+	s16 exponent;
-+	s32 mantissa;
-+	s64 val;
-+
-+	switch (reg) {
-+	case PMBUS_READ_VIN...PMBUS_READ_VCAP:
-+	case PMBUS_READ_IOUT...PMBUS_READ_TEMPERATURE_1:
-+	case PMBUS_READ_PIN:
-+	case PMBUS_STATUS_WORD:
-+		ret = -ENODATA;
-+		break;
-+	case PMBUS_READ_VOUT:
-+		/* The Vout format used by the chip is linear11 and not linear16.
-+		 * So we transform the value into the direct format defined by PMBus.
-+		 */
-+		ret = i2c_smbus_read_word_data(client, EFUSE_CFG);
-+		if (ret < 0)
-+			return ret;
-+		if (ret & BIT(12)) {
-+			ret = i2c_smbus_read_word_data(client, PMBUS_READ_VOUT);
-+			if (ret < 0)
-+				return ret;
-+			exponent = ((s16)ret) >> 11;
-+			mantissa = ((s16)((ret & 0x7ff) << 5)) >> 5;
-+			val = mantissa * 1000;
-+			if (exponent >= 0)
-+				val <<= exponent;
-+			else
-+				val >>= -exponent;
-+			return div_s64(val * 10 + 313L, 625L);
-+		}
-+		ret = -ENODATA;
-+		break;
-+	default:
-+		ret = -EINVAL;
-+		break;
-+	}
-+
-+	return ret;
-+}
-+
-+static int mp5926_read_byte_data(struct i2c_client *client, int page, int reg)
-+{
-+	int ret;
-+
-+	switch (reg) {
-+	case PMBUS_STATUS_BYTE:
-+	case PMBUS_STATUS_VOUT:
-+	case PMBUS_STATUS_INPUT:
-+	case PMBUS_STATUS_TEMPERATURE:
-+	case PMBUS_STATUS_CML:
-+	case PMBUS_STATUS_MFR_SPECIFIC:
-+		ret = -ENODATA;
-+		break;
-+	default:
-+		ret = -EINVAL;
-+		break;
-+	}
-+	return ret;
-+}
-+
-+static struct pmbus_driver_info mp5926_info_linear = {
-+	.pages = PAGE,
-+	.format[PSC_VOLTAGE_IN] = linear,
-+	.format[PSC_CURRENT_IN] = linear,
-+	.format[PSC_VOLTAGE_OUT] = direct,
-+	.format[PSC_TEMPERATURE] = linear,
-+	.format[PSC_POWER] = linear,
-+
-+	.m[PSC_VOLTAGE_OUT] = 16,
-+	.b[PSC_VOLTAGE_OUT] = 0,
-+	.R[PSC_VOLTAGE_OUT] = 0,
-+
-+	.read_word_data = mp5926_read_word_data,
-+	.read_byte_data = mp5926_read_byte_data,
-+	.func[0] = MP5926_FUNC,
++struct mp5926_data {
++	struct pmbus_driver_info info;
++	u8 vout_mode;
++	u8 vout_linear_exponent;
 +};
 +
-+static struct pmbus_driver_info mp5926_info_direct = {
++#define to_mp5926_data(x)  container_of(x, struct mp5926_data, info)
++
++static int mp5926_read_byte_data(struct i2c_client *client, int page,
++				 int reg)
++{
++	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
++	struct mp5926_data *data = to_mp5926_data(info);
++	int ret;
++
++	switch (reg) {
++	case PMBUS_VOUT_MODE:
++		if (data->vout_mode == linear) {
++			/*
++			 * The VOUT format used by the chip is linear11,
++			 * not linear16. Report that VOUT is in linear mode
++			 * and return exponent value extracted while probing
++			 * the chip.
++			 */
++			return data->vout_linear_exponent;
++		}
++		return PB_VOUT_MODE_DIRECT;
++	default:
++		ret = -ENODATA;
++		break;
++	}
++	return ret;
++}
++
++static int mp5926_read_word_data(struct i2c_client *client, int page, int phase,
++				 int reg)
++{
++	const struct pmbus_driver_info *info = pmbus_get_driver_info(client);
++	struct mp5926_data *data = to_mp5926_data(info);
++	int ret;
++
++	switch (reg) {
++	case PMBUS_READ_VOUT:
++		ret = pmbus_read_word_data(client, page, phase, reg);
++		if (ret < 0)
++			return ret;
++		/*
++		 * Because the VOUT format used by the chip is linear11 and not
++		 * linear16, we disregard bits[15:11]. The exponent is reported
++		 * as part of the VOUT_MODE command.
++		 */
++		if (data->vout_mode == linear)
++			ret = ((s16)((ret & 0x7ff) << 5)) >> 5;
++		break;
++	default:
++		ret = -ENODATA;
++		break;
++	}
++	return ret;
++}
++
++static struct pmbus_driver_info mp5926_info = {
 +	.pages = PAGE,
 +	.format[PSC_VOLTAGE_IN] = direct,
 +	.format[PSC_CURRENT_IN] = direct,
@@ -182,7 +163,7 @@ index 00000000..626d945
 +
 +	.m[PSC_TEMPERATURE] = 4,
 +	.b[PSC_TEMPERATURE] = 0,
-+	.R[PSC_TEMPERATURE] = 3,
++	.R[PSC_TEMPERATURE] = 0,
 +
 +	.m[PSC_POWER] = 25,
 +	.b[PSC_POWER] = 0,
@@ -195,35 +176,46 @@ index 00000000..626d945
 +
 +static int mp5926_probe(struct i2c_client *client)
 +{
++	struct mp5926_data *data;
++	struct pmbus_driver_info *info;
 +	int ret;
 +
-+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_READ_BYTE_DATA |
-+				     I2C_FUNC_SMBUS_BLOCK_DATA))
-+		return -ENODEV;
++	data = devm_kzalloc(&client->dev, sizeof(struct mp5926_data),
++			    GFP_KERNEL);
++	if (!data)
++		return -ENOMEM;
 +
++	memcpy(&data->info, &mp5926_info, sizeof(*info));
++	info = &data->info;
 +	ret = i2c_smbus_read_word_data(client, EFUSE_CFG);
-+
 +	if (ret < 0)
 +		return ret;
-+
 +	if (ret & BIT(12)) {
-+		ret = pmbus_do_probe(client, &mp5926_info_linear);
++		data->vout_mode = linear;
++		data->info.format[PSC_VOLTAGE_IN] = linear;
++		data->info.format[PSC_CURRENT_IN] = linear;
++		data->info.format[PSC_VOLTAGE_OUT] = linear;
++		data->info.format[PSC_TEMPERATURE] = linear;
++		data->info.format[PSC_POWER] = linear;
++		ret = i2c_smbus_read_word_data(client, PMBUS_READ_VOUT);
++		if (ret < 0)
++			return dev_err_probe(&client->dev, ret, "Can't get vout exponent.");
++		data->vout_linear_exponent = (u8)((ret >> 11) & 0x1f);
 +	} else {
++		data->vout_mode = direct;
 +		ret = i2c_smbus_read_word_data(client, I_SCALE_SEL);
 +		if (ret < 0)
 +			return ret;
 +		if (ret & BIT(6))
-+			mp5926_info_direct.m[PSC_CURRENT_IN] = 4;
-+		ret = pmbus_do_probe(client, &mp5926_info_direct);
++			data->info.m[PSC_CURRENT_IN] = 4;
 +	}
-+	if (!ret)
-+		dev_info(&client->dev, "%s chip found\n", client->name);
-+	return ret;
++
++	return pmbus_do_probe(client, info);
 +}
 +
 +static const struct i2c_device_id mp5926_id[] = {
-+	{ "mp5926", 0 },
-+	{}
++	{ .name = "mp5926", .driver_data = 0 },
++	{ }
 +};
 +MODULE_DEVICE_TABLE(i2c, mp5926_id);
 +
@@ -244,9 +236,8 @@ index 00000000..626d945
 +
 +module_i2c_driver(mp5926_driver);
 +MODULE_AUTHOR("Yuxi Wang <Yuxi.Wang@monolithicpower.com>");
-+MODULE_DESCRIPTION("MPS MP5926 HWMON driver");
++MODULE_DESCRIPTION("MPS MP5926 pmbus driver");
 +MODULE_LICENSE("GPL");
 +MODULE_IMPORT_NS(PMBUS);
 -- 
 2.8.4
-


### PR DESCRIPTION
Sync the 6.1 and 6.12 MP5926 backports with the upstream Linux 7.0+ driver (VOUT via pmbus_read_word_data and cached VOUT_MODE exponent) and regenerate Kconfig/Makefile hunks so they apply cleanly on 6.1.123 and 6.12.41.