### PR TITLE
hw-mgmt: bmc: Disable ABR watchdog heartbeat service by default

### DIFF
--- a/debian/hw-management-bmc.postinst
+++ b/debian/hw-management-bmc.postinst
@@ -91,14 +91,9 @@ case "$1" in
                 # leaves HW-MGMT unstarted.  Suppress systemctl chatter on
                 # success (>/dev/null 2>&1); real failures hit the WARNING below.
                 #
-                #   wd-heartbeat        stop-gap ABR-watchdog heartbeat to Bali
-                #                       (Caliptra) over MCTP.  Independent of the
-                #                       init chain; ordered After=boot-complete so
-                #                       it only heartbeats once the BMC has booted.
-                #                       No-ops (exit 0) when disabled in
-                #                       /etc/hw-management-bmc-wd-heartbeat.conf or
-                #                       when mctp-client is absent, so listing it
-                #                       here is safe on images without MCTP tooling.
+                # wd-heartbeat is intentionally omitted: packaged disabled
+                # (dh_systemd_enable --no-enable). Start only when explicitly
+                # enabled for ABR-fused production systems.
                 #
                 if ! systemctl start --no-block \
                         hw-management-bmc-boot-complete.service \
@@ -106,7 +101,6 @@ case "$1" in
                         hw-management-bmc-i2c-slave-setup.service \
                         hw-management-bmc-recovery-handler.service \
                         hw-management-bmc-reset-cause-logger.service \
-                        hw-management-bmc-wd-heartbeat.service \
                         >/dev/null 2>&1; then
                     echo "WARNING: hw-management-bmc.postinst: failed to queue HW-MGMT BMC startup; package configure will continue, but HW-MGMT will only come up on the next reboot" >&2
                 fi

--- a/debian/rules
+++ b/debian/rules
@@ -168,7 +168,12 @@ ifeq ($(with_bmc),1)
 		hw-management-bmc-health-monitor.service \
 		hw-management-bmc-reset-cause-logger.service \
 		hw-management-bmc-i2c-slave-setup.service \
-		hw-management-bmc-recovery-handler.service \
+		hw-management-bmc-recovery-handler.service
+	# ABR watchdog heartbeat: installed but disabled by default (same
+	# pattern as host hw-management-sync). Enable manually when OTP is
+	# fused / ABR must be serviced: systemctl enable --now ...
+	# Positional arg keeps this call from walking every BMC unit.
+	dh_systemd_enable --no-enable -phw-management-bmc \
 		hw-management-bmc-wd-heartbeat.service
 endif
 


### PR DESCRIPTION
Motivation
hw-management-bmc-wd-heartbeat was added as a stop-gap to service the AST2700 ABR watchdog over MCTP (f8ba502). The watchdog is armed only when the OTP fuse is programmed, so enabling the service by default is unnecessary on unfused / lab systems and can start mctpd / mctpirot0 work that is not required.

Solution
Package hw-management-bmc-wd-heartbeat.service disabled by default, matching the host hw-management-sync pattern:
  - debian/rules: drop it from the dh_systemd_enable allow-list; add a separate dh_systemd_enable --no-enable for this unit.
  - debian/hw-management-bmc.postinst: omit it from the fresh-install systemctl start --no-block list. The unit, script, and conf remain installed. Operators enable when ABR must be serviced:
  systemctl enable --now hw-management-bmc-wd-heartbeat.service

BUG: #5200030


(cherry picked from commit 83e5d7e00a7028e4f03a6f32d3bc69d789e6de66)