### PR TITLE
hw-mgmt: patches: Fix formatting of Realtek PHY 6.12 patch 0063

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0063-reset-phy-using-polling-function-not-register-write.patch
+++ b/recipes-kernel/linux/linux-6.12/0063-reset-phy-using-polling-function-not-register-write.patch
@@ -1,7 +1,8 @@
 From d380e09439f8576e4a89dd1f5c32850ce1c14d62 Mon Sep 17 00:00:00 2001
 From: Vadim Pasternak <vadimp@nvidia.com>
 Date: Thu, 2 Apr 2026 12:24:00 +0300
-Subject: [PATCH BMC Realtek PHY 1/1] net: phy: realtek: reset PHY via polling, not direct register write
+Subject: [PATCH] net: phy: realtek: reset PHY via polling, not direct register
+ write
 
 When resetting the Realtek PHY, the driver previously triggered the
 reset by writing the reset bit directly to a PHY register and continued
@@ -16,9 +17,10 @@ completed before returning. This closes the timing window between the
 reset request and the subsequent PHY access.
 
 Signed-off-by: Mohammad Abu Gazala <mabugazala@nvidia.com>
+Signed-off-by: Vadim Pasternak <vadimp@nvidia.com>
 ---
- drivers/net/phy/realtek.c | 115 +++++++++++++++++++++++++++++++++++++-
- 1 file changed, 114 insertions(+), 1 deletion(-)
+ drivers/net/phy/realtek.c | 124 ++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 123 insertions(+), 1 deletion(-)
 
 diff --git a/drivers/net/phy/realtek.c b/drivers/net/phy/realtek.c
 index 8ce5705a..b05e150d 100644
@@ -37,15 +39,17 @@ index 8ce5705a..b05e150d 100644
  #define RTL8211F_ALDPS_PLL_OFF			BIT(1)
  #define RTL8211F_ALDPS_ENABLE			BIT(2)
  #define RTL8211F_ALDPS_XTAL_OFF			BIT(12)
-@@ -120,6 +126,26 @@ static int rtl821x_write_page(struct phy_device *phydev, int page)
+@@ -120,6 +126,28 @@ static int rtl821x_write_page(struct phy_device *phydev, int page)
  	return __phy_write(phydev, RTL821x_PAGE_SELECT, page);
  }
  
 +#ifdef CONFIG_REALTEK_600MV_DRIVE_STRENGTH
-+static void set_600mv_drive_strength(struct phy_device *phydev){
++static void set_600mv_drive_strength(struct phy_device *phydev)
++{
 +	int ret;
 +	struct device *dev = &phydev->mdio.dev;
-+	dev_info(dev, "Writing drive strength indirect \n");
++
++	dev_info(dev, "Writing drive strength indirect\n");
 +	rtl821x_write_page(phydev, 0xa43);
 +	ret = __phy_write(phydev, 0x1b, 0xdcd0);
 +	rtl821x_write_page(phydev, 0xa43);
@@ -64,7 +68,7 @@ index 8ce5705a..b05e150d 100644
  static int rtl821x_probe(struct phy_device *phydev)
  {
  	struct device *dev = &phydev->mdio.dev;
-@@ -156,7 +182,9 @@ static int rtl821x_probe(struct phy_device *phydev)
+@@ -156,7 +184,9 @@ static int rtl821x_probe(struct phy_device *phydev)
  	}
  
  	phydev->priv = priv;
@@ -75,57 +79,63 @@ index 8ce5705a..b05e150d 100644
  	return 0;
  }
  
-@@ -409,6 +437,49 @@ static int rtl8211f_config_init(struct phy_device *phydev)
+@@ -409,6 +439,55 @@ static int rtl8211f_config_init(struct phy_device *phydev)
  		return 0;
  	}
  
 +#ifdef CONFIG_RTL_RGMII_SGMII_3809
-+    /* RTL8211F SGMII to RGMII MODE verification - NVIDIA BMC */
++	/* RTL8211F SGMII to RGMII MODE verification - NVIDIA BMC */
 +	ret = phy_read_paged(phydev, 0xd40, 0x10);
-+	if(ret < 0) {
++	if (ret < 0) {
 +		dev_err(dev, "Failed to read Mode Selection\n");
 +		return ret;
 +	}
 +
 +	ret = ret & RTL8211F_MODE_SEL;
 +
-+	if (ret == RTL8211F_SGMII_RGMII_PM || ret == RTL8211F_SGMII_RGMII_MP) {
-+
-+		/* Force hardware straps 3'b100, SGMII(PHY Side) to RGMII(MAC Side) for NVIDIA BMC*/
-+		ret = phy_modify_paged_changed(phydev, 0xd40, 0x10, RTL8211F_MODE_SEL, RTL8211F_SGMII_RGMII_PM);
-+		if(ret < 0) {
-+			dev_err(dev, "Failed to update the Mode selection \n");
++	if (ret == RTL8211F_SGMII_RGMII_PM ||
++	    ret == RTL8211F_SGMII_RGMII_MP) {
++		/* Force hardware straps 3'b100, SGMII(PHY Side) to
++		 * RGMII(MAC Side) for NVIDIA BMC
++		 */
++		ret = phy_modify_paged_changed(phydev, 0xd40, 0x10,
++					       RTL8211F_MODE_SEL,
++					       RTL8211F_SGMII_RGMII_PM);
++		if (ret < 0) {
++			dev_err(dev, "Failed to update the Mode selection\n");
 +			return ret;
 +		}
 +
 +		ret = genphy_soft_reset(phydev);
-+		if(ret < 0) {
-+			dev_err(dev, "Failed to reset PHY \n");
++		if (ret < 0) {
++			dev_err(dev, "Failed to reset PHY\n");
 +			return ret;
 +		}
 +
 +		/* SGMII ANAR (SGMII Auto-Negotiation Advertising Register) */
-+		/*Link status : set to 1 , Duplex Mode : Full Duplex*/
-+		ret = phy_modify_paged_changed(phydev, 0xd08, 0x10, BIT(3) | BIT(2), BIT(3) | BIT(2));
-+		if(ret < 0) {
-+			dev_err(dev, "Failed to update the Link & Duplex \n");
++		/* Link status: set to 1, Duplex Mode: Full Duplex */
++		ret = phy_modify_paged_changed(phydev, 0xd08, 0x10,
++					       BIT(3) | BIT(2),
++					       BIT(3) | BIT(2));
++		if (ret < 0) {
++			dev_err(dev, "Failed to update the Link & Duplex\n");
 +			return ret;
 +		}
 +
-+		/* Speed : 1000Mbps */
-+		ret = phy_modify_paged_changed(phydev, 0xd08, 0x10, BIT(1) | BIT(0), 0x2);
-+		if(ret < 0){
-+			dev_err(dev, "Failed to update the Speed \n");
++		/* Speed: 1000Mbps */
++		ret = phy_modify_paged_changed(phydev, 0xd08, 0x10,
++					       BIT(1) | BIT(0), 0x2);
++		if (ret < 0) {
++			dev_err(dev, "Failed to update the Speed\n");
 +			return ret;
 +		}
-+
 +	}
 +#endif
 +
  	ret = phy_modify_paged_changed(phydev, 0xd08, 0x11, RTL8211F_TX_DELAY,
  				       val_txdly);
  	if (ret < 0) {
-@@ -687,6 +758,44 @@ static void rtlgen_decode_speed(struct phy_device *phydev, int val)
+@@ -687,6 +766,45 @@ static void rtlgen_decode_speed(struct phy_device *phydev, int val)
  	}
  }
  
@@ -138,26 +148,27 @@ index 8ce5705a..b05e150d 100644
 +
 +	/* RTL8211F SGMII to RGMII MODE verification - NVIDIA BMC */
 +	ret = phy_read_paged(phydev, 0xd40, 0x10);
-+	if(ret < 0) {
++	if (ret < 0) {
 +		dev_err(&phydev->mdio.dev, "Failed to read Mode Selection\n");
 +		return ret;
 +	}
 +
 +	ret = ret & RTL8211F_MODE_SEL;
 +
-+	if (ret == RTL8211F_SGMII_RGMII_PM || ret == RTL8211F_SGMII_RGMII_MP) {
-+
++	if (ret == RTL8211F_SGMII_RGMII_PM ||
++	    ret == RTL8211F_SGMII_RGMII_MP) {
 +		/* Check Link status */
 +		ret = phy_read_paged(phydev, 0xdcf, 0x15);
 +		if (ret < 0) {
-+			dev_err(&phydev->mdio.dev,"failed to read  link status \n");
++			dev_err(&phydev->mdio.dev,
++				"failed to read link status\n");
 +			return ret;
 +		}
 +		/* Link is Up */
-+		if (ret &  BIT(4)) {
++		if (ret & BIT(4)) {
 +			phydev->link = 1;
 +			phydev->speed = 1000;
-+			phydev->duplex=DUPLEX_FULL;
++			phydev->duplex = DUPLEX_FULL;
 +		}
 +	} else {
 +		return rtlgen_read_status(phydev);
@@ -170,7 +181,7 @@ index 8ce5705a..b05e150d 100644
  static int rtlgen_read_status(struct phy_device *phydev)
  {
  	int ret, val;
-@@ -1338,7 +1447,11 @@ static struct phy_driver realtek_drvs[] = {
+@@ -1338,7 +1456,11 @@ static struct phy_driver realtek_drvs[] = {
  		.name		= "RTL8211F Gigabit Ethernet",
  		.probe		= rtl821x_probe,
  		.config_init	= &rtl8211f_config_init,
@@ -184,4 +195,3 @@ index 8ce5705a..b05e150d 100644
  		.suspend	= rtl821x_suspend,
 -- 
 2.34.1
-


### PR DESCRIPTION
Normalize the linux-6.12 Realtek PHY reset patch Subject to [PATCH], apply kernel coding style to the embedded hunks, refresh hunk stats, and add the missing author Signed-off-by so strict checkpatch is clean.