### PR TITLE
hw-mgmt: scripts:  Preserve TC run state across hw-management restart

### DIFF
--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -16,5 +16,10 @@ TimeoutStopSec=10
 Restart=on-failure
 RestartSec=60s
 
+# Save/clear TC run state for hw-management-start-post.sh.
+# Path must match tc_state_file in hw-management-helpers.sh.
+ExecStartPost=-/bin/rm -f /var/run/.hw-management-tc-state
+ExecStop=-/bin/sh -c 'f=/var/run/.hw-management-tc-state; [ -L "$f" ] && rm -f "$f"; umask 077; printf started > "$f"'
+
 [Install]
 WantedBy=multi-user.target

--- a/doc/man/hw-management-tc.service.8
+++ b/doc/man/hw-management-tc.service.8
@@ -13,11 +13,21 @@ The service supports multiple thermal control versions:
 - TC v2.5: Enhanced thermal control with improved algorithms for newer systems
 
 The service selects the thermal control application from the
-\fItc_version\fR field in \fI/var/run/hw-management/tc_config.json\fR (defaults to v2.0
-when unset). \fBhw-management-start-post.sh\fR aligns the systemd unit to run the
+\fItc_version\fR field in \fI/var/run/hw-management/config/tc_config.json\fR (defaults to
+v2.0 when unset). \fBhw-management-start-post.sh\fR aligns the systemd unit to run the
 matching Python script:
 - /usr/bin/hw_management_thermal_control.py (TC v2.0)
 - /usr/bin/hw_management_thermal_control_2_5.py (TC v2.5)
+
+When the unit is rewritten, it is reloaded and thermal control is restarted shortly after.
+
+.SH STATE ACROSS HW-MANAGEMENT RESTARTS
+On stop, this unit writes "started" to \fI/var/run/.hw-management-tc-state\fR.
+\fBhw-management-start-post.sh\fR restores that state and removes the file.
+Missing or invalid content leaves thermal control unchanged.
+Cleared again on TC start, so a manual restart of this service leaves no marker.
+Honoured only while the unit is enabled; use
+\fBsystemctl disable \-\-now hw\-management\-tc\fR to keep it off.
 .SH OPTIONS
 .TP
 start

--- a/tests/offline/test_hw_management_start_post_tc.py
+++ b/tests/offline/test_hw_management_start_post_tc.py
@@ -51,12 +51,49 @@ fi
 printf '%d %d %d\n' "$tc_should_disable" "$tc_should_enable" "$tc_should_start"
 """
 
-# Mirrors cmd_line build 184-214 (no nohup)
+# Mirrors the state restore, the reload gate and the cmd_line build (no nohup).
+# Prints NONE when the script would leave the TC service alone.
 _BASH_CMD_LINE = r"""
+tc_is_enabled=${TC_IS_EN:-0}
+tc_is_active=${TC_IS_ACT:-0}
+tc_saved_state=${STATE:-}
 tc_should_reload=${R:-0}
 tc_should_disable=${D:-0}
 tc_should_enable=${E:-0}
-tc_should_start=${S:-0}
+
+tc_should_start=$tc_is_active
+tc_should_restart=0
+if [ "$tc_saved_state" = "started" ] && [ "$tc_is_enabled" -eq 1 ]; then
+	tc_should_start=1
+fi
+
+# The SimX branch forces a start regardless of the saved state.
+if [ "${FORCE_START:-0}" -eq 1 ]; then
+	tc_should_start=1
+fi
+
+if [ "$tc_should_reload" -eq 1 ]; then
+	tc_should_restart=1
+	if [ -z "$tc_saved_state" ] && [ "$tc_is_enabled" -eq 1 ]; then
+		tc_should_start=1
+	fi
+fi
+
+tc_action_needed=0
+if [ "$tc_should_reload" -eq 1 ] ||
+   [ "$tc_should_disable" -eq 1 ] ||
+   [ "$tc_should_enable" -eq 1 ] ||
+   [ "$tc_should_restart" -eq 1 ]; then
+	tc_action_needed=1
+elif [ "$tc_should_start" -eq 1 ] && [ "$tc_is_active" -eq 0 ]; then
+	tc_action_needed=1
+fi
+
+if [ "$tc_action_needed" -eq 0 ]; then
+	printf 'NONE\n'
+	exit 0
+fi
+
 cmd_line="sleep 10 &&"
 if [ "$tc_should_reload" -eq 1 ]; then
 	cmd_line="$cmd_line systemctl daemon-reload &&"
@@ -64,11 +101,12 @@ fi
 if [ "$tc_should_disable" -eq 1 ]; then
 	cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
 	tc_should_start=0
+	tc_should_restart=0
 elif [ "$tc_should_enable" -eq 1 ]; then
 	cmd_line="$cmd_line systemctl enable hw-management-tc &&"
 fi
 if [ "$tc_should_start" -ne 0 ]; then
-	if [ "$tc_should_reload" -eq 1 ]; then
+	if [ "$tc_should_restart" -eq 1 ]; then
 		cmd_line="$cmd_line systemctl restart hw-management-tc &&"
 	else
 		cmd_line="$cmd_line systemctl start hw-management-tc &&"
@@ -160,25 +198,60 @@ def test_simx_supported_already_enabled_no_enable_flag():
     assert (d, en, st) == (0, 0, 1)
 
 
+def test_systemd_restart_brings_back_tc_that_was_running():
+    """PartOf= or systemctl stop both run ExecStop and leave STATE=started.
+    After hw-management start, TC must be brought back while the unit stays enabled."""
+    s = _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "0"})
+    assert "start hw-management-tc" in s
+
+
+def test_no_saved_state_leaves_inactive_tc_alone():
+    """Missing marker (never written or already consumed): do not start or stop TC."""
+    assert _run_bash_cmdline({"TC_IS_EN": "1", "TC_IS_ACT": "0"}) == "NONE"
+
+
+def test_running_tc_without_unit_change_is_left_alone():
+    assert _run_bash_cmdline({"TC_IS_EN": "1", "TC_IS_ACT": "1"}) == "NONE"
+
+
+def test_saved_state_with_already_active_tc_is_left_alone():
+    """State file only drives start after a systemd stop; if TC is still active, do nothing."""
+    assert (
+        _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "1"}) ==
+        "NONE"
+    )
+
+
+def test_saved_state_ignored_when_unit_is_disabled():
+    assert _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "0"}) == "NONE"
+
+
+def test_version_change_restarts_tc_that_was_running():
+    s = _run_bash_cmdline(
+        {"R": "1", "STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "0"}
+    )
+    assert "daemon-reload" in s and "restart hw-management-tc" in s
+
+
 def test_cmd_line_reload_only():
-    s = _run_bash_cmdline({"R": "1", "D": "0", "E": "0", "S": "0"})
+    s = _run_bash_cmdline({"R": "1", "TC_IS_EN": "0", "TC_IS_ACT": "0"})
     assert "daemon-reload" in s
     assert "restart" not in s and "start hw-management-tc" not in s
 
 
 def test_cmd_line_disable_clears_start():
-    s = _run_bash_cmdline({"R": "0", "D": "1", "E": "0", "S": "1"})
+    s = _run_bash_cmdline({"D": "1", "TC_IS_EN": "1", "TC_IS_ACT": "1"})
     assert "stop hw-management-tc" in s and "disable" in s
     assert "start hw-management-tc" not in s and "restart" not in s
 
 
 def test_cmd_line_reload_with_start_uses_restart():
-    s = _run_bash_cmdline({"R": "1", "D": "0", "E": "0", "S": "1"})
+    s = _run_bash_cmdline({"R": "1", "TC_IS_EN": "1", "TC_IS_ACT": "0"})
     assert "daemon-reload" in s and "restart hw-management-tc" in s
 
 
 def test_cmd_line_enable_and_start():
-    s = _run_bash_cmdline({"R": "0", "D": "0", "E": "1", "S": "1"})
+    s = _run_bash_cmdline({"E": "1", "FORCE_START": "1", "TC_IS_ACT": "0"})
     assert "enable hw-management-tc" in s and "start hw-management-tc" in s
 
 
@@ -193,3 +266,94 @@ def test_start_post_script_documents_bug_and_nohup():
     # Do not auto-enable on TC 2.5 alone: enable only in SimX-supported branch
     assert "if [ $tc_is_enabled -eq 0 ]; then" in text
     assert "tc_should_enable=1" in text
+
+
+def test_unit_path_taken_from_fragment_path():
+    """systemctl status output starts with a warning line once the unit was edited on disk,
+    which broke the previous line/field based parsing of the unit path."""
+    root = Path(__file__).resolve().parents[2]
+    sh = root / "usr" / "usr" / "bin" / "hw-management-start-post.sh"
+    text = sh.read_text()
+    assert "systemctl show -p FragmentPath hw-management-tc.service" in text
+    assert "systemctl status hw-management-tc.service" not in text
+
+
+def test_tc_state_is_saved_on_hw_management_stop_and_restored_on_start():
+    root = Path(__file__).resolve().parents[2]
+    tc_unit = (root / "debian" / "hw-management.hw-management-tc.service").read_text()
+    helpers = (root / "usr" / "usr" / "bin" / "hw-management-helpers.sh").read_text()
+    hw_management = (root / "usr" / "usr" / "bin" / "hw-management.sh").read_text()
+    start_post = (
+        root / "usr" / "usr" / "bin" / "hw-management-start-post.sh"
+    ).read_text()
+
+    assert 'tc_state_file="/var/run/.hw-management-tc-state"' in helpers
+    assert "consume_tc_saved_state()" in helpers
+    assert "save_tc_state_started" not in helpers
+    # Helpers: path near other /run state files; consume after check_tc_is_supported.
+    assert helpers.index("asic_chipup_status=") < helpers.index('tc_state_file="/var/run/.hw-management-tc-state"')
+    assert helpers.index("check_tc_is_supported()") < helpers.index("consume_tc_saved_state()")
+    # Unit: existing ExecStart/ExecStop first; state save/clear after.
+    assert tc_unit.index("ExecStart=/bin/sh") < tc_unit.index("ExecStartPost=-/bin/rm -f /var/run/.hw-management-tc-state")
+    assert tc_unit.index("ExecStop=/bin/kill $MAINPID") < tc_unit.index("umask 077")
+    assert "/var/run/.hw-management-tc-state" in tc_unit
+    # State is saved only from the TC unit ExecStop, not from hw-management.sh.
+    do_stop = hw_management[hw_management.index("do_stop()"): hw_management.index("function find_asic_hwmon_path")]
+    assert "consume_tc_saved_state" not in do_stop
+    assert "tc_state_file" not in do_stop
+    # start-post: existing enable/active checks first; restore after unit align.
+    assert start_post.index("systemctl is-enabled --quiet hw-management-tc.service") < start_post.index(
+        "tc_saved_state=$(consume_tc_saved_state)"
+    )
+    assert start_post.index("tc_should_reload=1") < start_post.index(
+        "tc_saved_state=$(consume_tc_saved_state)"
+    )
+
+
+def test_consume_tc_state_handles_missing_broken_and_symlink(tmp_path):
+    """Missing / garbage / symlink must not restore TC as started."""
+    root = Path(__file__).resolve().parents[2]
+    helpers = root / "usr" / "usr" / "bin" / "hw-management-helpers.sh"
+    state = tmp_path / ".hw-management-tc-state"
+    script = f"""
+source {helpers}
+tc_state_file="{state}"
+printf '%s\\n' "$(consume_tc_saved_state)"
+"""
+
+    # Missing file
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+
+    # Valid started
+    state.write_text("started\n")
+    os.chmod(state, 0o600)
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0
+    assert r.stdout.strip() == "started"
+    assert not state.exists()
+
+    # Broken content
+    state.write_text("garbage\n")
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+    assert not state.exists()
+
+    # Empty / whitespace
+    state.write_text("   \n")
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+    assert not state.exists()
+
+    # Symlink: remove and ignore
+    target = tmp_path / "elsewhere"
+    target.write_text("started\n")
+    state.symlink_to(target)
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0
+    assert r.stdout.strip() == ""
+    assert not state.exists()
+    assert target.read_text() == "started\n"

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -83,6 +83,9 @@ vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
 cpldreg_log_file=/var/log/hw-mgmt-cpldreg.log
 fixup_hook_script=/usr/local/bin/hw-management-fixup.sh
 asic_chipup_status=/run/.asic_chipup_completed
+# TC run state across hw-management stop/start. Outside $hw_management_path
+# (removed on stop). Keep in sync with hw-management-tc.service.
+tc_state_file="/var/run/.hw-management-tc-state"
 
 declare -A psu_fandir_vs_pn=(["00KX1W"]=R ["00MP582"]=F ["00MP592"]=R ["00WT061"]=F \
 ["00WT062"]=R ["00WT199"]=F ["01FT674"]=F ["01FT691"]=F ["01LL976"]=F \
@@ -361,6 +364,27 @@ check_tc_is_supported()
 	else
 		return 1
 	fi
+}
+
+# Read once and remove. Prints "started" or nothing if missing/invalid.
+consume_tc_saved_state()
+{
+	local state=""
+
+	if [ -L "$tc_state_file" ]; then
+		rm -f "$tc_state_file"
+		return
+	fi
+	if [ ! -f "$tc_state_file" ]; then
+		return
+	fi
+	state=$(tr -d '[:space:]' < "$tc_state_file" 2>/dev/null)
+	rm -f "$tc_state_file"
+	case $state in
+		started)
+			printf '%s\n' "$state"
+			;;
+	esac
 }
 
 # This function checks if BMC is supported for current platform

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -132,14 +132,17 @@ if systemctl is-enabled --quiet hw-management-tc.service 2>/dev/null; then
 fi
 # Check if TC service is running.
 tc_should_start=0
+tc_is_active=0
 if systemctl is-active --quiet hw-management-tc.service; then
 	tc_should_start=1
+	tc_is_active=1
 fi
 
 # Initialize TC service control variables.
 tc_should_enable=0
 tc_should_disable=0
 tc_should_reload=0
+tc_should_restart=0
 
 ## Checking if system doesn't support TC and disable it if it doesn't.
 if check_tc_is_supported; then
@@ -172,11 +175,10 @@ else
 	fi
 fi
 
-# Align hw-management-tc.service on disk with this platform's TC script and version label.
-# The unit is rewritten only when those strings would actually change (avoid needless reload).
-service_file_path=$(systemctl status hw-management-tc.service | grep hw-management-tc.service | sed -n '2p' | awk -F'[();]' '{print $2}')
+# Align TC unit with tc_config.json version; rewrite only when needed.
+service_file_path=$(systemctl show -p FragmentPath hw-management-tc.service 2>/dev/null | cut -d= -f2-)
 if [ -f "$service_file_path" ]; then
-	# TC application (v2.0 vs v2.5) is selected from tc_config.json (tc_version), not SKU.
+	# Select TC app from tc_version in tc_config.json.
 	tc_cfg_json="$config_path/tc_config.json"
 	tc_version="2.0"
 	tc_executable="hw_management_thermal_control.py"
@@ -194,19 +196,16 @@ if [ -f "$service_file_path" ]; then
 		esac
 	fi
 
-	# 1) Substitutions we would apply to the unit (TC executable basename and "ver X.Y" marker).
 	sed_edit_executable="s/hw_management_thermal_control_2_5\.py/$tc_executable/g;s/hw_management_thermal_control\.py/$tc_executable/g"
 	sed_edit_version="s/ver [0-9][0-9.]*/ver $tc_version/g"
 
-	# 2) Rewrite only if disk and "sed output" differ. cmp compares the file to stdin (-);
-	#    stdin is the unit text after the two sed rules (no temp file).
+	# Rewrite only if content would change.
 	tc_unit_needs_update=1
 	if sed -e "$sed_edit_executable" -e "$sed_edit_version" -- "$service_file_path" |
 		cmp -s -- "$service_file_path" -; then
 		tc_unit_needs_update=0
 	fi
 
-	# 3) Apply the same two edits in place only when needed.
 	if [ "$tc_unit_needs_update" -eq 1 ]; then
 		sed -i -e "$sed_edit_executable" -e "$sed_edit_version" "$service_file_path"
 		log_info "Thermal Control service updated. Reload it in 10 seconds"
@@ -214,10 +213,31 @@ if [ -f "$service_file_path" ]; then
 	fi
 fi
 
+# Restore TC state saved on hw-management stop. Missing/invalid => leave as-is.
+tc_saved_state=$(consume_tc_saved_state)
+if [ "$tc_saved_state" = "started" ] && [ $tc_is_enabled -eq 1 ]; then
+	tc_should_start=1
+fi
+# Unit rewrite requires restart; with no saved state, fall back to enabled.
+if [ $tc_should_reload -eq 1 ]; then
+	tc_should_restart=1
+	if [ -z "$tc_saved_state" ] && [ $tc_is_enabled -eq 1 ]; then
+		tc_should_start=1
+	fi
+fi
+
 # Build and execute the command line for TC service control only when there is something to do.
-if [ $tc_should_reload -eq 1 ] || 
-   [ $tc_should_disable -eq 1 ] || 
-   [ $tc_should_enable -eq 1 ]; then
+tc_action_needed=0
+if [ $tc_should_reload -eq 1 ] ||
+   [ $tc_should_disable -eq 1 ] ||
+   [ $tc_should_enable -eq 1 ] ||
+   [ $tc_should_restart -eq 1 ]; then
+	tc_action_needed=1
+elif [ $tc_should_start -eq 1 ] && [ $tc_is_active -eq 0 ]; then
+	tc_action_needed=1
+fi
+
+if [ $tc_action_needed -eq 1 ]; then
 	cmd_line="sleep 10 &&"
 
 	# Reload the systemd daemon if needed.
@@ -230,6 +250,7 @@ if [ $tc_should_reload -eq 1 ] ||
 		cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
 		# TC service should not be started.
 		tc_should_start=0
+		tc_should_restart=0
 	elif [ $tc_should_enable -eq 1 ]; then
 		# TC service should be enabled.
 		cmd_line="$cmd_line systemctl enable hw-management-tc &&"
@@ -237,7 +258,7 @@ if [ $tc_should_reload -eq 1 ] ||
 
 	# Start TC service if needed.
 	if [ $tc_should_start -ne 0 ]; then
-		if [ $tc_should_reload -eq 1 ]; then
+		if [ $tc_should_restart -eq 1 ]; then
 			# TC service should be restarted in case of reload.
 			cmd_line="$cmd_line systemctl restart hw-management-tc &&"
 		else

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3226,7 +3226,7 @@ set_config_data()
 	else
 		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
-	if [ -v $thermal_control_configs_path/tc_config_user.json ]; then
+	if [ -f $thermal_control_configs_path/tc_config_user.json ]; then
 		cp $thermal_control_configs_path/tc_config_user.json $config_path/tc_config_user.json
 	fi
 	[ -f "$config_path/asic_num" ] && asic_num=$(< $config_path/asic_num)
@@ -3974,11 +3974,6 @@ do_start()
 		ln -sf $lm_sensors_config $config_path/lm_sensors_config
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
-	fi
-	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
-		cp $thermal_control_config $config_path/tc_config.json
-	else
-		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
 	/usr/bin/hw-management-exec-parser.sh
 	log_info "Init completed."


### PR DESCRIPTION
Description: After restarting hw-management, thermal control stayed on
the previous version because PartOf= stops TC before start-post can see it
was active, and unit-path parsing from systemctl status failed once systemd
warned the unit had changed on disk. Save "started" to

/var/run/.hw-management-tc-state on TC stop (and on direct hw-management.sh
stop), restore it in start-post, and resolve the unit via FragmentPath.

Bug: 5200160

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
