### PR TITLE
hw-mgmt: add i2c_swb_bus and SWB cartridge CPLD dump

### DIFF
--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -1614,6 +1614,43 @@ used for internal purposes
 
 **Example:** 
 
+### I2C SWB Bus
+
+**Node name:** `$bsp_path/config/i2c_swb_bus`
+
+**Description:** Absolute I2C adapter number for the switch-board (SWB) CPLD
+used for cartridge identity registers (rack id, topology id, tray id, slot id)
+at slave address `0x31`. Platform-specific (for example HI176 CPU bus 18,
+HI180 CPU bus 53). Created from platform.json `variables.i2c_swb_bus` or from
+legacy `*_specific()` init. Used by `hw-management-generate-dump.sh` to
+produce archive member `cpld_swb_cartridge_dump` when the node exists
+(rack_id 13 bytes + ASCII, topology/tray/slot).
+
+**Access:** Read only
+
+**Release version:** 
+
+**Arguments:**
+| Name | Data type | Values |
+|------|-----------|--------|
+|      | Integer | Bus number |
+
+**Example:** 
+```bash
+cat $bsp_path/config/i2c_swb_bus
+53
+```
+
+Example `cpld_swb_cartridge_dump` (from `/tmp/hw-mgmt-dump.tar.gz`):
+```text
+i2c_swb_bus=53 addr=0x31
+rack_id: 0x31 0x38 0x32 0x34 0x32 0x32 0x35 0x34 0x31 0x30 0x30 0x31 0x33
+rack_id_ascii: 1824225410013
+topology_id: 0x00
+tray_id: 0x00
+slot_id: 0x01
+```
+
 ### LM Sensors Configuration
 
 **Node name:** `$bsp_path/config/lm_sensors_config`

--- a/examples/README.md
+++ b/examples/README.md
@@ -123,3 +123,22 @@ optional COMEx named-bus offsets. Use **`base_tables`**, **`dynamic_tables`**, o
 inline **`base_connect`** / **`dynamic_connect`** only when devtree is absent.
 **`named_busses_table`** (shell-array reference) and inline **`named_busses`**
 are mutually exclusive. Mistyped values abort boot.
+
+In **`variables`**, optional **`i2c_swb_bus`** is the absolute I2C adapter for
+the switch-board (SWB) CPLD (cartridge identity @ **`0x31`**). When set, it is
+written to **`/var/run/hw-management/config/i2c_swb_bus`**. Host
+**`hw-management-generate-dump.sh`** uses that node (when present) to collect
+**`cpld_swb_cartridge_dump`** inside **`/tmp/hw-mgmt-dump.tar.gz`**. Legacy
+platforms may set the same config file from **`*_specific()`** (for example
+HI176 CPU **`18`**, HI180 CPU **`53`**).
+
+Example **`cpld_swb_cartridge_dump`** contents (HI180 CPU, bus 53):
+
+```text
+i2c_swb_bus=53 addr=0x31
+rack_id: 0x31 0x38 0x32 0x34 0x32 0x32 0x35 0x34 0x31 0x30 0x30 0x31 0x33
+rack_id_ascii: 1824225410013
+topology_id: 0x00
+tray_id: 0x00
+slot_id: 0x01
+```

--- a/examples/hw-management-platform-example.json
+++ b/examples/hw-management-platform-example.json
@@ -46,6 +46,8 @@
         "leakage_rope_count": 0,
         "i2c_comex_mon_bus_default": 23,
         "i2c_bus_def_off_eeprom_cpu": 24,
+        "_comment_i2c_swb_bus": "SWB CPLD abs bus; HI176 CPU=18 BMC=23; HI180 CPU=53 BMC=23",
+        "i2c_swb_bus": 18,
         "lm_sensors_config": "/etc/hw-management-sensors/example_sensors.conf",
         "lm_sensors_labels": "/etc/hw-management-sensors/example_sensors_labels.json",
         "thermal_control_config": "/etc/hw-management-thermal/tc_config_not_supported.json",

--- a/usr/usr/bin/hw-management-generate-dump.sh
+++ b/usr/usr/bin/hw-management-generate-dump.sh
@@ -59,6 +59,52 @@ dump_cmd () {
 	fi
 }
 
+# SWB CPLD cartridge identity (CPU). Gated by config/i2c_swb_bus.
+# Registers match BMC Swb* offsets: MSB 0x10, rack/topo/tray/slot.
+# Mux ownership is assumed already set (CPU); do not touch bmc_to_cpu_ctrl.
+dump_cpld_swb_cartridge () {
+	i2c_swb_bus_file="${HW_MGMT_FOLDER}/config/i2c_swb_bus"
+	out="${DUMP_FOLDER}/cpld_swb_cartridge_dump"
+
+	[ -f "$i2c_swb_bus_file" ] || return 0
+	[ -x "$(command -v i2ctransfer)" ] || return 0
+
+	swb_bus=$(cat "$i2c_swb_bus_file")
+	case "$swb_bus" in
+	''|*[!0-9]*)
+		echo "invalid i2c_swb_bus='${swb_bus}'" > "$out"
+		return 0
+		;;
+	esac
+
+	timeout 10 sh -c '
+		bus="$1"
+		out="$2"
+		{
+			echo "i2c_swb_bus=${bus} addr=0x31"
+			rack_hex=$(i2ctransfer -f -y "$bus" w2@0x31 0x10 0x00 r13)
+			echo "rack_id: $rack_hex"
+			printf "rack_id_ascii: "
+			for tok in $rack_hex; do
+				h=${tok#0x}
+				c=$(printf "%d" "0x$h" 2>/dev/null) || c=0
+				if [ "$c" -ge 32 ] && [ "$c" -le 126 ]; then
+					printf "%b" "\\$(printf "%03o" "$c")"
+				else
+					printf "."
+				fi
+			done
+			printf "\n"
+			printf "topology_id: "
+			i2ctransfer -f -y "$bus" w2@0x31 0x10 0x10 r1
+			printf "tray_id: "
+			i2ctransfer -f -y "$bus" w2@0x31 0x10 0x11 r1
+			printf "slot_id: "
+			i2ctransfer -f -y "$bus" w2@0x31 0x10 0x12 r1
+		} > "$out" 2>&1
+	' sh "$swb_bus" "$out"
+}
+
 rm -rf "$DUMP_FOLDER"
 mkdir -p "$DUMP_FOLDER"
 
@@ -134,6 +180,7 @@ dump_cmd "cat ${REGMAP_FILE} 2>/dev/null" "cpld_dump" "5"
 dump_cmd "dpkg -l | grep hw-management" "hw-management_version" "5"
 dump_cmd "systemctl status hw-management* --no-pager" "hw-management_svc_status" "5"
 dump_cmd "ip addr" "ip_addr" "5"
+dump_cpld_swb_cartridge
 
 # Kill all the leftout child processes before creating the dump archive
 pkill -P "$dump_process_pid" 2>/dev/null || true

--- a/usr/usr/bin/hw-management-platform-json.sh
+++ b/usr/usr/bin/hw-management-platform-json.sh
@@ -39,6 +39,7 @@ PLATFORM_JSON_NUMERIC_VARS=(
 	hotplug_pwrs
 	i2c_bus_def_off_eeprom_cpu
 	i2c_comex_mon_bus_default
+	i2c_swb_bus
 	leakage_count
 	leakage_rope_count
 	max_tachos
@@ -651,6 +652,9 @@ platform_json_apply_variables()
 			fi
 			if [ "$key" = "cpld_num" ]; then
 				platform_json_write_config_key "cpld_num" "$val" || return 1
+			fi
+			if [ "$key" = "i2c_swb_bus" ]; then
+				platform_json_write_config_key "i2c_swb_bus" "$val" || return 1
 			fi
 		fi
 	done

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -2621,6 +2621,7 @@ n51xxld_specific()
 		HI176)	# gb300
 			max_tachos=0
 			echo 0 > $config_path/fan_drwr_num
+			echo 18 > $config_path/i2c_swb_bus
 			thermal_control_config="$thermal_control_configs_path/tc_config_not_supported.json"
 			lm_sensors_config="$lm_sensors_configs_path/n5500ld_sensors.conf"
 			leakage_count=2
@@ -2692,6 +2693,7 @@ n61xxld_specific()
 		echo 1 > $config_path/global_wp_wait_step
 		echo 20 > $config_path/global_wp_timeout
 		echo 0 > $config_path/i2c_bus_offset
+		echo 53 > $config_path/i2c_swb_bus
 		lm_sensors_config="$lm_sensors_configs_path/n61xxld_sensors.conf"
 		thermal_control_config="$thermal_control_configs_path/tc_config_not_supported.json"
 


### PR DESCRIPTION
Write /var/run/hw-management/config/i2c_swb_bus from n5110ld/n61xxld_specific and platform.json variables.
CPU dump reads rack/topology/tray/slot via i2ctransfer.