### PR TITLE
hw-mgmt: bmc: HI189: align leak ChnlNames with Channels type

### DIFF
--- a/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
+++ b/bmc/usr/etc/HI189/hw-management-bmc-a2d-leakage-config.json
@@ -3,8 +3,8 @@
         "Name": "Mngm_ADC0",
         "NumChnl": 2,
         "ChnlNames": [
-            "Mngm_ADC0_Ch1_Embedded_0",
-            "Mngm_ADC0_Ch2_Flex_1"
+            "Mngm_ADC0_Ch1_Flex_0",
+            "Mngm_ADC0_Ch2_Embedded_1"
         ],
         "Device": [
             {
@@ -112,8 +112,8 @@
                     }
                 ],
                 "Channels": [
-                    { "Id": 1, "Type": "flex", "CfgReg": "0x0a", "CfgRegVal": "0x60 0x54" },
-                    { "Id": 2, "Type": "embedded", "CfgReg": "0x0c", "CfgRegVal": "0x43 0x3c" }
+                    { "Id": 1, "Type": "flex", "CfgReg": "0x0a", "CfgRegVal": "0x43 0x3c" },
+                    { "Id": 2, "Type": "embedded", "CfgReg": "0x0c", "CfgRegVal": "0x60 0x54" }
                 ],
                 "CfgRegVal_comment": "ADS7924 window comparator is programmed PER CHANNEL (not per device): each Channels[] entry sets CfgReg = that input's Upper-Limit register (ULRn = 0x0a + 2*(Id-1); LLRn follows at CfgReg+1) and CfgRegVal = \"0xUL 0xLL\" 8-bit codes (code = volts/Scale, 12-bit, >>4). UL derived from the type NormalMax, LL from NormalMin."
             }
@@ -123,8 +123,8 @@
         "Name": "Swb_ADC0",
         "NumChnl": 2,
         "ChnlNames": [
-            "Swb_ADC0_Ch1_Embedded_0",
-            "Swb_ADC0_Ch4_Flex_1"
+            "Swb_ADC0_Ch1_Flex_0",
+            "Swb_ADC0_Ch4_Embedded_1"
         ],
         "Device": [
             {
@@ -232,8 +232,8 @@
                     }
                 ],
                 "Channels": [
-                    { "Id": 1, "Type": "flex", "CfgReg": "0x0a", "CfgRegVal": "0x60 0x54" },
-                    { "Id": 4, "Type": "embedded", "CfgReg": "0x10", "CfgRegVal": "0x43 0x3c" }
+                    { "Id": 1, "Type": "flex", "CfgReg": "0x0a", "CfgRegVal": "0x43 0x3c" },
+                    { "Id": 4, "Type": "embedded", "CfgReg": "0x10", "CfgRegVal": "0x60 0x54" }
                 ],
                 "CfgRegVal_comment": "ADS7924 window comparator is programmed PER CHANNEL (not per device): each Channels[] entry sets CfgReg = that input's Upper-Limit register (ULRn = 0x0a + 2*(Id-1); LLRn follows at CfgReg+1) and CfgRegVal = \"0xUL 0xLL\" 8-bit codes (code = volts/Scale, 12-bit, >>4). UL derived from the type NormalMax, LL from NormalMin."
             }


### PR DESCRIPTION
Backport of the ChnlNames / ADS7924 window fix from 782f4930 (#2665) for Redmine #5203178.
On V.7.0070.1000_BR, Channels[].Type was already ch1=flex / ch2|ch4=embedded (Leak Sensor spreadsheet),
but ChnlNames still said Embedded/Flex and ADS7924 CfgRegVal windows were swapped,
so runtime channel_name disagreed with type.

BUG: #5203178