### PR TITLE
hw-mgmt: bmc: fix mlxreg-io .bit for multi-bit CPLD fields in nvsw-bm…

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
+++ b/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
@@ -4162,7 +4162,7 @@ index 000000000..9f4c94f5d
 +		.label = "bios_status",
 +		.reg = NVSW_REG_GPCOM0_OFFSET,
 +		.mask = GENMASK(3, 1),
-+		.bit = 3,
++		.bit = 2,
 +		.mode = 0444,
 +	},
 +	{
@@ -4522,7 +4522,7 @@ index 000000000..9f4c94f5d
 +		.label = "cpu_spi_ctrl",
 +		.reg = NVSW_REG_GP5_OFFSET,
 +		.mask = GENMASK(4, 2),
-+		.bit = 4,
++		.bit = 3,
 +		.mode = 0644,
 +	},
 +	{
@@ -4801,7 +4801,7 @@ index 000000000..9f4c94f5d
 +		.label = "bios_status",
 +		.reg = NVSW_REG_GPCOM0_OFFSET,
 +		.mask = GENMASK(3, 1),
-+		.bit = 3,
++		.bit = 2,
 +		.mode = 0444,
 +	},
 +	{
@@ -5353,7 +5353,7 @@ index 000000000..9f4c94f5d
 +		.label = "cpu_spi_ctrl",
 +		.reg = NVSW_REG_GP5_OFFSET,
 +		.mask = GENMASK(4, 2),
-+		.bit = 4,
++		.bit = 3,
 +		.mode = 0644,
 +	},
 +	{
@@ -5747,7 +5747,7 @@ index 000000000..9f4c94f5d
 +		.label = "bios_status_ro",
 +		.reg = NVSW_REG_GPCOM0_OFFSET,
 +		.mask = GENMASK(3, 1),
-+		.bit = 3,
++		.bit = 2,
 +		.mode = 0444,
 +	},
 +	{
@@ -6088,7 +6088,7 @@ index 000000000..9f4c94f5d
 +		.label = "bios_status",
 +		.reg = NVSW_REG_SAFE_BIOS_OFFSET,
 +		.mask = GENMASK(2, 0),
-+		.bit = 2,
++		.bit = 1,
 +		.mode = 0644,
 +	},
 +	{
@@ -6161,7 +6161,7 @@ index 000000000..9f4c94f5d
 +		.label = "cpu_spi_ctrl",
 +		.reg = NVSW_REG_GP5_OFFSET,
 +		.mask = GENMASK(4, 2),
-+		.bit = 4,
++		.bit = 3,
 +		.mode = 0644,
 +	},
 +	{
@@ -6211,7 +6211,7 @@ index 000000000..9f4c94f5d
 +		.label = "psu_qty",
 +		.reg = NVSW_REG_SYS_CPBLTY0,
 +		.mask = GENMASK(3, 0),
-+		.bit = 3,
++		.bit = 1,
 +		.mode = 0444,
 +	},
 +	{
@@ -6316,7 +6316,7 @@ index 000000000..9f4c94f5d
 +		.label = "bios_status_ro",
 +		.reg = NVSW_REG_GPCOM0_OFFSET,
 +		.mask = GENMASK(3, 1),
-+		.bit = 3,
++		.bit = 2,
 +		.mode = 0444,
 +	},
 +	{
@@ -6645,7 +6645,7 @@ index 000000000..9f4c94f5d
 +		.label = "bios_status",
 +		.reg = NVSW_REG_SAFE_BIOS_OFFSET,
 +		.mask = GENMASK(2, 0),
-+		.bit = 2,
++		.bit = 1,
 +		.mode = 0644,
 +	},
 +	{
@@ -6718,7 +6718,7 @@ index 000000000..9f4c94f5d
 +		.label = "cpu_spi_ctrl",
 +		.reg = NVSW_REG_GP5_OFFSET,
 +		.mask = GENMASK(4, 2),
-+		.bit = 4,
++		.bit = 3,
 +		.mode = 0644,
 +	},
 +	{
@@ -6750,14 +6750,14 @@ index 000000000..9f4c94f5d
 +		.label = "asic_clk_brd_hw_id",
 +		.reg = NVSW_REG_CONFIG1_OFFSET,
 +		.mask = GENMASK(2, 0),
-+		.bit = 2,
++		.bit = 1,
 +		.mode = 0444,
 +	},
 +	{
 +		.label = "config1",
 +		.reg = NVSW_REG_CONFIG1_OFFSET,
 +		.mask = GENMASK(7, 3),
-+		.bit = 7,
++		.bit = 4,
 +		.mode = 0444,
 +	},
 +	{
@@ -8291,7 +8291,7 @@ index 000000000..6fb8cf07a
 +		.label = "bios_status",
 +		.reg = NVSW_REG_GPCOM0_OFFSET,
 +		.mask = GENMASK(3, 1),
-+		.bit = 3,
++		.bit = 2,
 +		.mode = 0444,
 +	},
 +	{


### PR DESCRIPTION
…c patch

mlxreg-io treats .bit as the 1-based LSB of the field (shift by bit-1), not the MSB of GENMASK(hi,lo). bios_status, bios_status_ro, cpu_spi_ctrl, psu_qty, asic_clk_brd_hw_id and config1 entries used the high bit, shifting the corresponding sysfs values.

Mirrors OpenBMC commit 349d5452785a7ded904b62b225fc7a6ea8836912.