### PR TITLE
hw-mgmt: bmc: align BIOS recovery flash with OpenBMC AST2700

### DIFF
--- a/bmc/FILE_MAPPING.md
+++ b/bmc/FILE_MAPPING.md
@@ -81,7 +81,7 @@ On the target system the **hw-management-bmc** Debian package installs this tree
 | .../bmc-post-boot-cfg/files/bmc-early-i2c-init.sh | usr/usr/bin/ |
 | .../bmc-post-boot-cfg/files/bmc-i2c-slave-setup.sh | usr/usr/bin/ |
 | .../bmc-post-boot-cfg/files/bmc-recovery-handler.sh | usr/usr/bin/ |
-| .../bmc-post-boot-cfg/files/**bios-recovery-flash.sh** | usr/usr/bin/**hw-management-bmc-bios-recovery-flash.sh** |
+| .../meta-ast2700/.../bmc-post-boot-cfg/files/**bios-recovery-flash.sh** (GPIO + **flashrom**; not meta-switch **flashcp**) | usr/usr/bin/**hw-management-bmc-bios-recovery-flash.sh** |
 | .../meta-ast2700/.../bmc-plat-specific-preps.service (script: bmc-plat-specific-preps.sh from spc6) | usr/usr/bin/ |
 | .../spc6-ast2700-a1/.../bmc_ready_common.sh | usr/usr/bin/**hw-management-bmc-ready-common.sh** |
 | .../spc6-ast2700-a1/.../spc6-ast2700-a1-bmc_ready.sh | usr/usr/bin/**hw-management-bmc-ready.sh** (common; not per-HID) |
@@ -140,7 +140,8 @@ cp "$OPENBMC/$S/$A/spc6-ast2700-a1-bmc_ready.sh" bmc/usr/usr/bin/hw-management-b
 # Scripts (expand as needed)
 cp "$OPENBMC/$S/recipes-nvidia/health-monitor/files/"*.sh bmc/usr/usr/bin/
 cp "$OPENBMC/$S/recipes-nvidia/bmc-post-boot-cfg/files/bmc-early-i2c-init.sh" bmc/usr/usr/bin/
-cp "$OPENBMC/$S/recipes-nvidia/bmc-post-boot-cfg/files/bios-recovery-flash.sh" bmc/usr/usr/bin/hw-management-bmc-bios-recovery-flash.sh
+cp "$OPENBMC/$S/meta-ast2700/recipes-nvidia/bmc-post-boot-cfg/files/bios-recovery-flash.sh" \
+  bmc/usr/usr/bin/hw-management-bmc-bios-recovery-flash.sh
 cp "$OPENBMC/$S/recipes-nvidia/bmc-post-boot-cfg/files/hw-management-helpers-common.sh" bmc/usr/usr/bin/hw-management-bmc-helpers-common.sh
 # ... etc.
 ```

--- a/bmc/README.md
+++ b/bmc/README.md
@@ -245,20 +245,20 @@ Documentation and sample data only. Nothing here is required at runtime unless y
 | **`hw-management-bmc-ads7924-read-status.sh`** | Debug — reads ADS7924 **MODECNTRL**, **INTCNTRL** (alarm status/enable), and all four channel data registers (**`i2ctransfer`**, optional **scale**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-max1363-force-alarm.sh`** | From OpenBMC **`max1363_force_alarm.sh`**: debug — programs tight/safe per-channel thresholds so selected channels hit alarm (**`i2ctransfer`**). **`#!/bin/sh`**. |
 | **`hw-management-bmc-max1363-read-status.sh`** | From OpenBMC **`max1363_read_status.sh`**: debug — prints first read bytes / decoded status flags (**`i2ctransfer`**, **`awk`**). **`#!/bin/sh`**. |
-| **`hw-management-bmc-bios-recovery-flash.sh`** | From OpenBMC **`bios-recovery-flash.sh`**: BMC-side host BIOS recovery — writes CPLD **`spi_chnl_select`** then **`flashcp`** to **`spidev`** (default **`/dev/spidev1.0`**). Requires **`mtd-utils`**, hw-management runtime (**`/var/run/hw-management/system/spi_chnl_select`**). **`#!/bin/bash`**. |
+| **`hw-management-bmc-bios-recovery-flash.sh`** | From OpenBMC **meta-ast2700** **`bios-recovery-flash.sh`**: BMC-side host BIOS recovery — power off host if needed, GPIO bank select (**`GP_BMC_REC_SPI_MUX1_SEL`**, **`GP_PROD_CS_FLASH*_EN`**), then **`flashrom`** via **`linux_spi`** (default **`/dev/spidev0.0`**, chip **`MX25U25643G`**). Requires **`flashrom`**, hw-management GPIO/sysfs under **`/var/run/hw-management/system/`**. **`#!/bin/bash`**. |
 | **`hw-management-bmc-get-reset-cause.sh`** | Reset-cause exporter. **Primary (SONiC):** exactly one of **`reset_pwr_cycle`**, **`reset_soft_reboot`**, **`reset_unknown`** at **`bmc/`** root (**v3**: SRST/EXTRST + WDT + ABR; W1C-clear primary bits). Hardware **`reset_*`** under **`bmc/domains/`** (incl. **`reset_abr`**). Source: U-Boot env → **`/proc/cmdline`** → **`devmem`**. |
 | **`hw-management-bmc-show-reset-cause.sh`** | Operator view of reset causes: **`bmc`** (BMC root **`reset_*`** with value 1), **`host`** (**`/var/run/hw-management/system/reset_*`**, same idea as host **`hw-management.sh reset-cause`**), **`bmc-domain`** (**`.../bmc/domains/reset_*`**), **`bmc-raw`** (**`raw_scu*_reset_event_log*`** under the BMC dir). With no arguments, prints all four sections. Overrides: **`BMC_DIR`**, **`BMC_DOMAINS_DIR`**, **`HOST_SYSTEM_DIR`**. **`#!/bin/sh`**. |
 
 ### BIOS recovery flash (`hw-management-bmc-bios-recovery-flash.sh`)
 
-Stand-alone operator tool — **no** **`systemd`** unit; invoke from the shell when you need to program the host BIOS from the BMC while the CPU is unavailable.
+Stand-alone operator tool — **no** **`systemd`** unit; invoke from the shell when you need to program the host BIOS from the BMC while the host CPU is powered off.
 
 | Topic | Notes |
 |-------|--------|
-| **Purpose** | Select the host BIOS SPI path via CPLD (**`spi_chnl_select`**) and copy an image to the **`spidev`** that muxes to that flash (same idea as manual **`echo … > spi_chnl_select`** then **`flashcp`**). |
-| **Prerequisites** | **`mtd-utils`** (**`flashcp`** on **`PATH`**); **`/var/run/hw-management/system/spi_chnl_select`** writable (hw-management / udev has created the **`mlxreg-io`** / sysfs link); **`spidev`** device matches your board (default **`/dev/spidev1.0`** is only valid if the DTS exposes that node for the recovery path). |
-| **Usage** | **`hw-management-bmc-bios-recovery-flash.sh <bios_image> [spidev] [channel]`** — **`channel`** is **`0`** or **`1`** for CPLD mux (default **`1`**). Run with no arguments to print a short usage summary. |
-| **Safety** | Use a verified image and the correct **`spidev`** / channel for your SKU; flashing the wrong device or a bad image can brick the host flash path. |
+| **Purpose** | Select inactive host BIOS SPI bank via GPIO (**`GP_BMC_REC_SPI_MUX1_SEL`**, **`GP_PROD_CS_FLASH0_EN`**, **`GP_PROD_CS_FLASH1_EN`**), write/verify image with **`flashrom`** (`linux_spi`), then restore REC mux default. |
+| **Prerequisites** | **`flashrom`** on **`PATH`**; GPIO/sysfs links under **`/var/run/hw-management/system/`** (incl. **`pwr_down`**); SPI device (default **`/dev/spidev0.0`**). |
+| **Usage** | **`hw-management-bmc-bios-recovery-flash.sh [options] <bios_image>`** — options: **`-d`** spidev, **`-c`** chip name, **`-s`** SPI Hz, **`-m`** mux settle sec, **`-t`** host power-off timeout. **`-h`** for help. |
+| **Safety** | Host must be off (script requests **`pwr_down=1`** if needed). Use a verified image and the correct **`spidev`** / chip for your SKU; flashing the wrong bank or a bad image can brick the host flash path. |
 
 ### Reset-cause policy (`hw-management-bmc-get-reset-cause.sh`)
 
@@ -364,7 +364,7 @@ SONiC BMC images often ship **BusyBox** (`/bin/sh` → **ash**) and may also inc
 | **`hw-management-bmc-generate-dump.sh`** | **bash** | **`#!/bin/bash`**: parallel **`run_collect_bg`** collectors, **`MAX_PARALLEL`**, **`-v`** for **`systemd-analyze`**, **`source`** **`hw-management-bmc-cpld-dump.sh`**, single-pass **`find`** + stride workers for **`/var/run/hw-management`**. **`tar cf - \| gzip -9`**; BusyBox-friendly **`find`** / **`readlink_canonical`**. Needs **`gzip`**, **`bash`**. |
 | **`hw-management-bmc-show-reset-cause.sh`** | Yes | **`#!/bin/sh`**: lists active **`reset_*`** (value 1) or raw SCU lines; no bashisms. |
 | **`hw-management-bmc-get-reset-cause.sh`** | Yes | **`#!/bin/sh`**: SCU read / semantic export. |
-| **`hw-management-bmc-bios-recovery-flash.sh`** | **bash** | **`#!/bin/bash`**, **`set -e`**: **`flashcp`** (**`mtd-utils`**), **`spi_chnl_select`** sysfs. |
+| **`hw-management-bmc-bios-recovery-flash.sh`** | **bash** | **`#!/bin/bash`**, **`set -euo pipefail`**: **`flashrom`** (**`linux_spi`**), GPIO bank select under **`/var/run/hw-management/system/`**. |
 
 If **`/usr/bin/hw-management-bmc-helpers.sh`** is sourced, it is written for bash but parses under BusyBox ash; some code paths use bash-style arithmetic — prefer **`bash`** where the full helper API is used.
 
@@ -633,7 +633,7 @@ CLI tool for host and board power transitions on SONiC BMC. It drives **mlxreg-i
 | meta-nvidia/.../bmc-post-boot-cfg/files/**a2d_leakage_read.sh** | usr/usr/bin/**hw-management-bmc-a2d-leakage-read.sh** |
 | meta-nvidia/.../bmc-post-boot-cfg/files/**max1363_force_alarm.sh** | usr/usr/bin/**hw-management-bmc-max1363-force-alarm.sh** |
 | meta-nvidia/.../bmc-post-boot-cfg/files/**max1363_read_status.sh** | usr/usr/bin/**hw-management-bmc-max1363-read-status.sh** |
-| meta-nvidia/.../bmc-post-boot-cfg/files/**bios-recovery-flash.sh** | usr/usr/bin/**hw-management-bmc-bios-recovery-flash.sh** |
+| meta-nvidia/.../meta-ast2700/.../bmc-post-boot-cfg/files/**bios-recovery-flash.sh** (GPIO + **flashrom**) | usr/usr/bin/**hw-management-bmc-bios-recovery-flash.sh** |
 | meta-nvidia/.../bmc-post-boot-cfg/files/*.sh, spc6-ast2700-a1/.../*.sh, hw-management*.sh, etc. | usr/usr/bin/ |
 | meta-nvidia/meta-switch/recipes-phosphor/**dump**/files/**cpld_dump.sh** + **dump_utils.sh** (partial; see **FILE_MAPPING.md**) | usr/usr/bin/**hw-management-bmc-cpld-dump.sh** |
 | *(SONiC BMC; see **FILE_MAPPING.md** — host analog **`hw-management-generate-dump.sh`**)* | usr/usr/bin/**hw-management-bmc-generate-dump.sh** |

--- a/bmc/copy-from-openbmc.sh
+++ b/bmc/copy-from-openbmc.sh
@@ -10,6 +10,8 @@ S="$OPENBMC/meta-nvidia/meta-switch"
 A="$S/meta-ast2700/meta-spc6-ast2700-a1/recipes-nvidia/bmc-post-boot-cfg/files"
 HM="$S/recipes-nvidia/health-monitor/files"
 BP="$S/recipes-nvidia/bmc-post-boot-cfg/files"
+# AST2700 host BIOS recovery (GPIO mux + flashrom); overrides meta-switch flashcp script
+AST2700_BP="$S/meta-ast2700/recipes-nvidia/bmc-post-boot-cfg/files"
 BD="$(dirname "$0")"   # bmc/
 NIC="$S/meta-ast2700/recipes-nvidia/nvidia-internal-network-config/files"
 
@@ -101,11 +103,19 @@ chmod +x "$BD/usr/usr/bin/hw-management-bmc-json-parser.sh"
 cp "$A/hw-management-helpers-common.sh" "$BD/usr/usr/bin/hw-management-bmc-helpers-common.sh"
 chmod +x "$BD/usr/usr/bin/hw-management-bmc-helpers-common.sh"
 # A2D leakage reader + MAX1363 debug (meta-switch bmc-post-boot-cfg/files; not spc6-only tree)
-for f in "$BP/a2d_leakage_read.sh" "$BP/bios-recovery-flash.sh" "$BP/max1363_force_alarm.sh" "$BP/max1363_read_status.sh"; do
+for f in "$BP/a2d_leakage_read.sh" "$BP/max1363_force_alarm.sh" "$BP/max1363_read_status.sh"; do
 	dest=$(openbmc_script_dest "$(basename "$f")")
 	cp "$f" "$BD/usr/usr/bin/$dest"
 	chmod +x "$BD/usr/usr/bin/$dest"
 done
+# BIOS recovery: AST2700 GPIO bank select + flashrom (meta-ast2700), not meta-switch flashcp
+if [ -f "$AST2700_BP/bios-recovery-flash.sh" ]; then
+	dest=$(openbmc_script_dest "bios-recovery-flash.sh")
+	cp "$AST2700_BP/bios-recovery-flash.sh" "$BD/usr/usr/bin/$dest"
+	chmod +x "$BD/usr/usr/bin/$dest"
+else
+	echo "copy-from-openbmc: skip bios-recovery (missing $AST2700_BP/bios-recovery-flash.sh)" >&2
+fi
 # Scripts that already have hw-management in name
 for f in "$A/hw-management.sh" "$A/hw-management-devtree-check.sh" "$A/hw-management-devtree.sh" "$A/hw-management-helpers.sh"; do
 	dest=$(openbmc_script_dest "$(basename "$f")")

--- a/bmc/usr/usr/bin/hw-management-bmc-bios-recovery-flash.sh
+++ b/bmc/usr/usr/bin/hw-management-bmc-bios-recovery-flash.sh
@@ -8,9 +8,9 @@
 # modification, are permitted provided that the following conditions are met:
 #
 # 1. Redistributions of source code must retain the above copyright
-#    notice, this list of conditions, and the following disclaimer.
+#    notice, this list of conditions and the following disclaimer.
 # 2. Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions, and the following disclaimer in the
+#    notice, this list of conditions and the following disclaimer in the
 #    documentation and/or other materials provided with the distribution.
 # 3. Neither the names of the copyright holders nor the names of its
 #    contributors may be used to endorse or promote products derived from
@@ -33,78 +33,462 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ################################################################################
-# BMC-side host BIOS recovery flash (when CPU is not available).
-# Selects SPI channel via CPLD (spi_chnl_select) then flashes using flashcp.
+# Origin: OpenBMC meta-ast2700 bmc-post-boot-cfg bios-recovery-flash.sh
 #
-# Origin: OpenBMC meta-nvidia bmc-post-boot-cfg bios-recovery-flash.sh
+# BMC-side host BIOS recovery flash (host CPU must be powered off).
 #
-# Prerequisites on BMC:
-#   - hw-management provides /var/run/hw-management/system/spi_chnl_select
-#   - spidev for host BIOS path (DTS: spidev on the bus behind CPLD mux)
-#   - mtd-utils (flashcp)
+# Prerequisites:
+#   - hw-management: /var/run/hw-management/system/*
+#   - /dev/spidev0.0, flashrom with linux_spi
 #
 # Usage:
-#   hw-management-bmc-bios-recovery-flash.sh <bios_image> [spidev] [channel]
+#   hw-management-bmc-bios-recovery-flash.sh [options] <bios_image>
 #
-# Examples:
-#   hw-management-bmc-bios-recovery-flash.sh /tmp/bios.rom
-#   hw-management-bmc-bios-recovery-flash.sh /tmp/bios.rom /dev/spidev1.0
-#   hw-management-bmc-bios-recovery-flash.sh /tmp/bios.rom /dev/spidev1.0 1
+# Options:
+#   -d <path>    SPI device (default: /dev/spidev0.0)
+#   -c <name>    flashrom chip name (default: MX25U25643G)
+#   -s <hz>      SPI clock speed (default: 50000000)
+#   -m <sec>     GPIO mux settle time (default: 10)
+#   -t <sec>     Host power-off wait timeout (default: 30)
+#   -h           Show help
 #
-# Manual flow:
-#   echo 1 > /var/run/hw-management/system/spi_chnl_select
-#   flashcp /path/to/bios.rom /dev/spidev1.0
+# Colors: enabled on TTY; set NO_COLOR=1 to disable.
 ################################################################################
 
-set -e
+set -euo pipefail
 
-SPI_CHNL_SELECT="/var/run/hw-management/system/spi_chnl_select"
-DEFAULT_SPIDEV="/dev/spidev1.0"
-DEFAULT_CHANNEL="1"
+HW_MGMT="/var/run/hw-management/system"
+
+# Reserved; CPLD channel select not used yet.
+SPI_CHNL_SELECT="${HW_MGMT}/spi_chnl_select"
+
+GP_REC="${HW_MGMT}/GP_BMC_REC_SPI_MUX1_SEL"
+GP_CS0="${HW_MGMT}/GP_PROD_CS_FLASH0_EN"
+GP_CS1="${HW_MGMT}/GP_PROD_CS_FLASH1_EN"
+
+PWR_DOWN="${HW_MGMT}/pwr_down"
+
+DEFAULT_SPIDEV="/dev/spidev0.0"
+DEFAULT_FLASH_CHIP="MX25U25643G"
+DEFAULT_SPISPEED="50000000"
+DEFAULT_MUX_SETTLE_SEC=1
+DEFAULT_HOST_PWR_OFF_TIMEOUT=30
+
+GPIO_SETUP_DONE=0
+
+SPIDEV="$DEFAULT_SPIDEV"
+FLASH_CHIP="$DEFAULT_FLASH_CHIP"
+SPI_SPEED="$DEFAULT_SPISPEED"
+MUX_SETTLE_SEC="$DEFAULT_MUX_SETTLE_SEC"
+HOST_PWR_OFF_TIMEOUT="$DEFAULT_HOST_PWR_OFF_TIMEOUT"
+IMAGE=""
+
+STEP_NUM=0
+STEP_TOTAL=7
+
+# Colors (disabled when not a TTY or NO_COLOR is set)
+USE_COLOR=0
+C_RESET=""
+C_BOLD=""
+C_DIM=""
+C_RED=""
+C_GREEN=""
+C_YELLOW=""
+C_CYAN=""
+C_BLUE=""
+C_MAGENTA=""
+
+color_init() {
+	if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+		USE_COLOR=1
+		C_RESET=$'\033[0m'
+		C_BOLD=$'\033[1m'
+		C_DIM=$'\033[2m'
+		C_RED=$'\033[31m'
+		C_GREEN=$'\033[32m'
+		C_YELLOW=$'\033[33m'
+		C_CYAN=$'\033[36m'
+		C_BLUE=$'\033[34m'
+		C_MAGENTA=$'\033[35m'
+	fi
+}
 
 usage() {
-	echo "Usage: $0 <bios_image> [spidev] [channel]"
-	echo "  bios_image  Path to BIOS image to flash"
-	echo "  spidev      SPI device (default: $DEFAULT_SPIDEV)"
-	echo "  channel     CPLD SPI channel selection 0 or 1 (default: $DEFAULT_CHANNEL)"
-	echo ""
-	echo "BMC recovery: run on BMC when host CPU is not available."
+	cat <<EOF
+${C_BOLD}Usage:${C_RESET} $0 [options] <bios_image>
+
+Flash host BIOS from BMC via SPI recovery path (GPIO bank select).
+
+${C_BOLD}Options:${C_RESET}
+  ${C_CYAN}-d${C_RESET} <path>    SPI device (default: ${DEFAULT_SPIDEV})
+  ${C_CYAN}-c${C_RESET} <name>    flashrom chip name (default: ${DEFAULT_FLASH_CHIP})
+  ${C_CYAN}-s${C_RESET} <hz>      SPI clock speed (default: ${DEFAULT_SPISPEED})
+  ${C_CYAN}-m${C_RESET} <sec>     GPIO mux settle time (default: ${DEFAULT_MUX_SETTLE_SEC})
+  ${C_CYAN}-t${C_RESET} <sec>     Host power-off wait timeout (default: ${DEFAULT_HOST_PWR_OFF_TIMEOUT})
+  ${C_CYAN}-h${C_RESET}           Show this help
+
+Host power: uses ${PWR_DOWN} (0=on, 1=off).
+EOF
 	exit 1
 }
 
-if [ $# -lt 1 ]; then
-	usage
-fi
+parse_args() {
+	local opt
 
-IMAGE="$1"
-SPIDEV="${2:-$DEFAULT_SPIDEV}"
-CHANNEL="${3:-$DEFAULT_CHANNEL}"
+	OPTIND=1
+	while getopts ":d:c:s:m:t:h" opt; do
+		case "$opt" in
+		d) SPIDEV="$OPTARG" ;;
+		c) FLASH_CHIP="$OPTARG" ;;
+		s) SPI_SPEED="$OPTARG" ;;
+		m) MUX_SETTLE_SEC="$OPTARG" ;;
+		t) HOST_PWR_OFF_TIMEOUT="$OPTARG" ;;
+		h) usage ;;
+		\?) die "Unknown option: -${OPTARG} (use -h for help)" ;;
+		:) die "Option -${OPTARG} requires an argument" ;;
+		esac
+	done
+	shift $((OPTIND - 1))
 
-if [ ! -f "$IMAGE" ]; then
-	echo "Error: BIOS image not found: $IMAGE"
+	if [ $# -lt 1 ]; then
+		usage
+	fi
+	if [ $# -gt 1 ]; then
+		die "Unexpected extra arguments: $*"
+	fi
+
+	IMAGE="$1"
+}
+
+print_rule() {
+	printf '%s\n' "${C_DIM}------------------------------------------------------------------------${C_RESET}"
+}
+
+print_banner() {
+	echo ""
+	printf '%s\n' "${C_BOLD}${C_CYAN}  BIOS Recovery Flash (BMC SPI)${C_RESET}"
+	print_rule
+}
+
+print_config() {
+	log_kv "Image" "$IMAGE"
+	log_kv "SPI device" "$SPIDEV"
+	log_kv "Flash chip" "$FLASH_CHIP"
+	log_kv "SPI speed" "${SPI_SPEED} Hz"
+	log_kv "Mux settle" "${MUX_SETTLE_SEC} s"
+	log_kv "Power-off timeout" "${HOST_PWR_OFF_TIMEOUT} s"
+	print_rule
+}
+
+log_step() {
+	STEP_NUM=$((STEP_NUM + 1))
+	echo ""
+	printf '%s\n' \
+		"${C_BOLD}${C_BLUE}[${STEP_NUM}/${STEP_TOTAL}]${C_RESET} ${C_BOLD}$*${C_RESET}"
+}
+
+log_info() {
+	printf '  %s %s\n' "${C_DIM}>>${C_RESET}" "$*"
+}
+
+log_kv() {
+	local key="$1"
+	local value="$2"
+	printf '  %s %-18s %s%s%s\n' \
+		"${C_DIM}>>${C_RESET}" "${key}:" "${C_CYAN}${value}${C_RESET}"
+}
+
+log_ok() {
+	printf '  %s %s%s%s\n' \
+		"${C_GREEN}[OK]${C_RESET}" "${C_GREEN}" "$*" "${C_RESET}"
+}
+
+log_warn() {
+	printf '  %s %s%s%s\n' \
+		"${C_YELLOW}[!!]${C_RESET}" "${C_YELLOW}" "$*" "${C_RESET}"
+}
+
+log_fail() {
+	printf '%s %s%s%s\n' \
+		"${C_RED}[FAIL]${C_RESET}" "${C_BOLD}${C_RED}" "$*" "${C_RESET}" >&2
+}
+
+log_cmd() {
+	printf '  %s %s\n' "${C_MAGENTA}\$${C_RESET}" "${C_DIM}$*${C_RESET}"
+}
+
+log_gpio() {
+	local name="$1"
+	local value="$2"
+	printf '  %s %-28s %s%s%s\n' \
+		"${C_DIM}>>${C_RESET}" "${name}:" "${C_YELLOW}${value}${C_RESET}"
+}
+
+die() {
+	echo "" >&2
+	log_fail "$*"
+	echo "" >&2
 	exit 1
-fi
+}
 
-if [ ! -w "$SPI_CHNL_SELECT" ]; then
-	echo "Error: Cannot write SPI channel select: $SPI_CHNL_SELECT"
-	echo "       (hw-management must be running and expose spi_chnl_select)"
-	exit 1
-fi
+print_done() {
+	echo ""
+	print_rule
+	printf '%s\n' "${C_BOLD}${C_GREEN}  BIOS recovery flash completed successfully${C_RESET}"
+	print_rule
+	echo ""
+}
 
-if [ ! -w "$SPIDEV" ]; then
-	echo "Error: SPI device not writable: $SPIDEV"
-	exit 1
-fi
+require_file() {
+	local path="$1"
+	local desc="$2"
+	if [ ! -e "$path" ]; then
+		die "${desc} not found: ${path}"
+	fi
+	if [ ! -w "$path" ] && [ ! -r "$path" ]; then
+		die "${desc} not accessible: ${path}"
+	fi
+}
 
-if ! command -v flashcp >/dev/null 2>&1; then
-	echo "Error: flashcp not found (install mtd-utils)"
-	exit 1
-fi
+write_gpio() {
+	local path="$1"
+	local value="$2"
+	local name="$3"
+	require_file "$path" "$name"
+	echo "$value" > "$path"
+	log_gpio "$name" "$(cat "$path")"
+}
 
-echo "Selecting SPI channel $CHANNEL (host BIOS flash)"
-echo "$CHANNEL" > "$SPI_CHNL_SELECT"
+# Return 0 if host power is on, 1 if off.
+host_power_is_on() {
+	local pwr_down_val
 
-echo "Flashing $IMAGE to $SPIDEV"
-flashcp -v "$IMAGE" "$SPIDEV"
+	if [ ! -r "$PWR_DOWN" ]; then
+		die "Cannot read host power state: ${PWR_DOWN}"
+	fi
 
-echo "Done."
+	pwr_down_val=$(cat "$PWR_DOWN")
+	# pwr_down=0 -> host on, pwr_down=1 -> host off
+	[ "$pwr_down_val" = "0" ]
+}
+
+host_power_off() {
+	if [ ! -w "$PWR_DOWN" ]; then
+		return 1
+	fi
+	echo 1 > "$PWR_DOWN"
+	return 0
+}
+
+wait_host_power_off() {
+	local timeout="$1"
+	local remaining="$timeout"
+
+	log_info "Waiting for host power off (timeout ${timeout}s)"
+
+	while [ "$remaining" -gt 0 ]; do
+		if ! host_power_is_on; then
+			echo ""
+			log_ok "pwr_down=$(cat "$PWR_DOWN") (host off)"
+			return 0
+		fi
+		printf '\r  %s power off countdown: %s%2d%s s remaining   ' \
+			"${C_YELLOW}[..]${C_RESET}" \
+			"${C_BOLD}${C_YELLOW}" "$remaining" "${C_RESET}"
+		sleep 1
+		remaining=$((remaining - 1))
+	done
+	echo ""
+	log_fail "power off countdown timed out"
+	return 1
+}
+
+ensure_host_powered_off() {
+	log_step "Check host power state"
+
+	log_kv "pwr_down" "$(cat "$PWR_DOWN") (0=on, 1=off)"
+
+	if host_power_is_on; then
+		log_warn "Host is powered on; requesting power off"
+		host_power_off || die "Cannot write ${PWR_DOWN}"
+		wait_host_power_off "$HOST_PWR_OFF_TIMEOUT" ||
+			die "Host still powered on after ${HOST_PWR_OFF_TIMEOUT}s"
+	else
+		log_ok "Host is already powered off"
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# Inactive flash bank selection (wiki: 0x252d bit5, 0x2535 bit4).
+# Temporarily always bank1 until CPLD/active-image read is validated.
+# ---------------------------------------------------------------------------
+get_inactive_flash_bank() {
+	# local active_byte active_bit
+
+	# Read active flash from CPLD page 0x25 offset 0x2d (bit 5):
+	#   0x0e -> flash 0 active,  0x2e -> flash 1 active
+	# active_byte=$(i2ctransfer -f -y 14 w2@0x31 0x25 0x2d r1 2>/dev/null || echo "")
+	# active_bit=$((active_byte & 0x20))
+	# if [ "$active_bit" -eq 0 ]; then
+	#	echo 1
+	# else
+	#	echo 0
+	# fi
+
+	echo 1
+}
+
+select_spi_bank() {
+	local bank="$1"
+
+	log_step "Select SPI flash bank ${bank}"
+	log_kv "Bank" "${bank} (GPIO CS routing)"
+
+	case "$bank" in
+	0)
+		write_gpio "$GP_REC" 1 "GP_BMC_REC_SPI_MUX1_SEL"
+		write_gpio "$GP_CS0" 1 "GP_PROD_CS_FLASH0_EN"
+		write_gpio "$GP_CS1" 0 "GP_PROD_CS_FLASH1_EN"
+		;;
+	1)
+		write_gpio "$GP_REC" 1 "GP_BMC_REC_SPI_MUX1_SEL"
+		write_gpio "$GP_CS0" 0 "GP_PROD_CS_FLASH0_EN"
+		write_gpio "$GP_CS1" 1 "GP_PROD_CS_FLASH1_EN"
+		;;
+	*)
+		die "Invalid flash bank: ${bank} (expected 0 or 1)"
+		;;
+	esac
+
+	GPIO_SETUP_DONE=1
+
+	if [ "$MUX_SETTLE_SEC" -gt 0 ]; then
+		log_info "Mux settle delay ${MUX_SETTLE_SEC}s ..."
+		sleep "$MUX_SETTLE_SEC"
+		log_ok "Mux settle complete"
+	fi
+}
+
+restore_spi_mux_default() {
+	log_step "Restore REC SPI mux default"
+
+	if [ -w "$GP_REC" ]; then
+		echo 0 > "$GP_REC"
+		log_gpio "GP_BMC_REC_SPI_MUX1_SEL" "$(cat "$GP_REC")"
+	else
+		log_warn "GP_BMC_REC_SPI_MUX1_SEL not writable; skip"
+	fi
+	GPIO_SETUP_DONE=0
+}
+
+# ---------------------------------------------------------------------------
+# Switch active BIOS bank for next boot (wiki: set bit6 in 0x2535 -> 0x47).
+# Disabled until validated on this platform.
+# ---------------------------------------------------------------------------
+switch_active_flash_bank() {
+	:
+	# local safe
+
+	# log_step "Switch active BIOS bank for next boot"
+	# safe=$(i2ctransfer -f -y 14 w2@0x31 0x25 0x35 r1)
+	# log_info "SAFE_BIOS before: 0x$(printf '%02x' "$safe")"
+	# i2ctransfer -f -y 14 w3@0x31 0x25 0x35 0x47
+	# safe=$(i2ctransfer -f -y 14 w2@0x31 0x25 0x35 r1)
+	# log_info "SAFE_BIOS after:  0x$(printf '%02x' "$safe")"
+	# log_ok "bios_image_invert requested"
+}
+
+cleanup() {
+	if [ "$GPIO_SETUP_DONE" -eq 1 ]; then
+		echo 0 > "$GP_REC" 2>/dev/null || true
+	fi
+}
+
+trap cleanup EXIT
+
+flashrom_prog() {
+	echo "linux_spi:dev=${SPIDEV},spispeed=${SPI_SPEED}"
+}
+
+verify_image_file() {
+	log_step "Verify BIOS image file"
+
+	if [ ! -f "$IMAGE" ]; then
+		die "BIOS image not found: ${IMAGE}"
+	fi
+
+	log_ok "Image: ${IMAGE} ($(stat -c '%s' "$IMAGE") bytes)"
+}
+
+run_flashrom() {
+	local action="$1"
+	local action_flag="$2"
+	local prog
+
+	prog=$(flashrom_prog)
+
+	log_cmd "flashrom -p ${prog} -c ${FLASH_CHIP} ${action_flag} ${IMAGE} --progress"
+	echo ""
+	flashrom -p "$prog" -c "$FLASH_CHIP" "$action_flag" "$IMAGE" --progress
+	echo ""
+	log_ok "flashrom ${action} completed"
+}
+
+run_flashrom_write() {
+	log_step "Flash BIOS image"
+	log_kv "Device" "$SPIDEV"
+	log_kv "Chip" "$FLASH_CHIP"
+	log_kv "Speed" "${SPI_SPEED} Hz"
+	run_flashrom "write" "-w"
+}
+
+verify_flash_contents() {
+	log_step "Verify flash contents"
+	log_kv "Reference" "$IMAGE"
+	run_flashrom "verify" "-v"
+}
+
+preflight() {
+	log_step "Preflight checks"
+
+	if ! command -v flashrom >/dev/null 2>&1; then
+		die "flashrom not found"
+	fi
+
+	require_file "$PWR_DOWN" "pwr_down"
+	require_file "$GP_REC" "GP_BMC_REC_SPI_MUX1_SEL"
+	require_file "$GP_CS0" "GP_PROD_CS_FLASH0_EN"
+	require_file "$GP_CS1" "GP_PROD_CS_FLASH1_EN"
+
+	if [ ! -c "$SPIDEV" ]; then
+		die "SPI device not accessible: ${SPIDEV}"
+	fi
+
+	log_ok "GPIO, pwr_down, and SPI paths present"
+}
+
+main() {
+	local bank
+
+	color_init
+	parse_args "$@"
+
+	print_banner
+	print_config
+
+	preflight
+	ensure_host_powered_off
+
+	bank=$(get_inactive_flash_bank)
+	select_spi_bank "$bank"
+	verify_image_file
+	run_flashrom_write
+	verify_flash_contents
+	restore_spi_mux_default
+	switch_active_flash_bank
+
+	trap - EXIT
+	print_done
+}
+
+main "$@"

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Description: Thermal control and chassis management for Nvidia systems (host)
 Package: hw-management-bmc
 Architecture: any
 Build-Profiles: <!pkg.hw-mgmt.cpu-only>
-Depends: ${misc:Depends}, systemd, udev
+Depends: ${misc:Depends}, systemd, udev, flashrom
 Description: Hardware management and chassis services for Nvidia BMC (SONiC BMC)
  This package provides BMC-side scripts, systemd units, udev rules,
  and platform-specific config (e.g. HI189 / SPC6 AST2700) for use


### PR DESCRIPTION
Replace CPLD/flashcp recovery with GPIO bank select + flashrom,
matching meta-nvidia/meta-switch/meta-ast2700/.../bios-recovery-flash.sh.
Depend on flashrom so SonicBMC lazy install stages the arm64 package.