### PR TITLE
hw-mgmt: docs: Note asic_pg_fail is absent on SN5610 and SN5640

### DIFF
--- a/Documentation/CHANGELOG_User_Manual.md
+++ b/Documentation/CHANGELOG_User_Manual.md
@@ -1,11 +1,25 @@
 # User Manual Changelog
 
 **Document:** Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md  
-**Last Updated:** June 30, 2026
+**Last Updated:** August 17, 2026
 
 ---
 
 ## Change History
+
+### Rev. 3.2.7 - August 17, 2026
+
+#### Clarified: `system/asic_pg_fail` platform exception
+
+**Affected platforms:** SN6600_LD (HI193), SN6800_LD (HI187/HI188), SN6810_LD (HI183).
+
+**User manual updates:**
+
+| Area | Change |
+|------|--------|
+| §3.18.54 | **`system/asic_pg_fail`**: noted that this API does not exist on SN6600_LD, SN6800_LD, and SN6810_LD; removed SN66XX_LD from the applicability note |
+
+---
 
 ### Rev. 3.2.6 - June 30, 2026
 

--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -5625,8 +5625,9 @@ cat $bsp_path/system/cartridge1
 
 **Description:** Get ASIC power good failure status. Indicates power sequencing failure on the ASIC.
 
-Note: This attribute is for multi-ASIC systems (SN58XX_LD family, N61XX_LD family, SN66XX_LD family).
+Note: This attribute is for multi-ASIC systems (SN58XX_LD family, N61XX_LD family).
 N6100_LD has 4 ASICs with individual failure tracking.
+Exception: This API does not exist on SN6600_LD, SN6800_LD, and SN6810_LD systems.
 
 **Access:** Read only
 


### PR DESCRIPTION
Clarify that system/asic_pg_fail does not exist on SN5610 and SN5640. Record the change in the user manual changelog as Rev. 3.2.7.

Bug: #5029697

Signed-off-by: Abraham Coifman <acoifman@nvidia.com>