### PR TITLE
hw-mgmt: scripts: Fix updater service stop timeout

### DIFF
--- a/debian/hw-management.hw-management-peripheral-updater.service
+++ b/debian/hw-management.hw-management-peripheral-updater.service
@@ -8,9 +8,9 @@ StartLimitIntervalSec=1200
 StartLimitBurst=5
 
 [Service]
-ExecStart=/bin/sh -c "/usr/bin/hw_management_peripheral_updater.py"
-ExecStop=/bin/kill $MAINPID
-TimeoutStopSec=5
+ExecStart=/usr/bin/hw_management_peripheral_updater.py
+# systemd Type=simple already sends SIGTERM to MAINPID on stop
+TimeoutStopSec=15
 
 Restart=on-failure
 RestartSec=10s

--- a/debian/hw-management.hw-management-thermal-updater.service
+++ b/debian/hw-management.hw-management-thermal-updater.service
@@ -8,9 +8,9 @@ StartLimitIntervalSec=1200
 StartLimitBurst=5
 
 [Service]
-ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_updater.py"
-ExecStop=/bin/kill $MAINPID
-TimeoutStopSec=5
+ExecStart=/usr/bin/hw_management_thermal_updater.py
+# systemd Type=simple already sends SIGTERM to MAINPID on stop
+TimeoutStopSec=15
 
 Restart=on-failure
 RestartSec=10s

--- a/usr/usr/bin/hw_management_lib.py
+++ b/usr/usr/bin/hw_management_lib.py
@@ -92,9 +92,17 @@ def atomic_file_write(file_name, value):
         with os.fdopen(fd, 'w', encoding="utf-8") as f:
             f.write("{}".format(value))
         os.replace(f_path_tmp, file_name)  # Atomic on POSIX
-    except Exception as e:
-        os.unlink(f_path_tmp)  # Cleanup on failure
-        raise Exception(f"Error writing {file_name}: {e}")
+    except BaseException as e:
+        try:
+            os.unlink(f_path_tmp)
+        except OSError:
+            pass
+        msg = f"Error writing {file_name}: {e}"
+        if isinstance(e, Exception):
+            raise Exception(msg)
+        # Keep ShutdownRequested/SystemExit/KeyboardInterrupt type so
+        # caller except Exception cannot swallow SIGTERM.
+        raise type(e)(msg) from e
 
 # ----------------------------------------------------------------------
 

--- a/usr/usr/bin/hw_management_peripheral_updater.py
+++ b/usr/usr/bin/hw_management_peripheral_updater.py
@@ -112,6 +112,16 @@ EXIT = threading.Event()
 _sig_condition_name = ""
 
 
+class ShutdownRequested(BaseException):
+    """
+    @summary: Abort the daemon on SIGTERM/SIGINT/SIGHUP.
+
+    Must not subclass Exception: the main-loop safety net would swallow it.
+    Raising from the signal handler prevents CPython PEP 475 from restarting
+    a blocking sysfs read, which can exceed systemd TimeoutStopSec.
+    """
+
+
 def _build_attrib_list():
     """
     Build peripheral configuration dictionary from central platform config.
@@ -527,6 +537,11 @@ def update_peripheral_attr(attr_prop):
                     if "oldval" not in attr_prop.keys() or attr_prop["oldval"] != val:
                         globals()[fn_name](argv, val)
                         attr_prop["oldval"] = val
+                except ShutdownRequested:
+                    raise
+                except InterruptedError:
+                    # SIGTERM during sysfs I/O: do not treat as a normal read error
+                    raise ShutdownRequested()
                 except (OSError, ValueError):
                     # File exists but read error
                     globals()[fn_name](argv, "")
@@ -536,6 +551,11 @@ def update_peripheral_attr(attr_prop):
         else:
             try:
                 globals()[fn_name](argv, None)
+            except ShutdownRequested:
+                raise
+            except InterruptedError:
+                # SIGTERM during sysfs I/O: do not treat as a normal read error
+                raise ShutdownRequested()
             except (OSError, ValueError, KeyError, TypeError):
                 # Catch common errors from dynamically called functions
                 # to prevent daemon crash
@@ -599,14 +619,17 @@ def handle_shutdown(sig, _frame):
     @summary: Handle application signal
     @param sig: Signal number
     @param _frame: Unused frame
+
+    Raise ShutdownRequested so a blocking sysfs read is not restarted
+    (PEP 475) and the process can exit before systemd TimeoutStopSec.
     """
     global _sig_condition_name
     try:
         _sig_condition_name = signal.Signals(sig).name
     except (ValueError, AttributeError):
         _sig_condition_name = str(sig)
-
     EXIT.set()
+    raise ShutdownRequested()
 
 # ----------------------------------------------------------------------
 
@@ -679,38 +702,60 @@ def main():
     for attr in sys_attr:
         init_attr(attr)
 
-    signal.signal(signal.SIGTERM, handle_shutdown)
-    signal.signal(signal.SIGINT, handle_shutdown)
-    signal.signal(signal.SIGHUP, handle_shutdown)
     EXIT.clear()
+    try:
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            signal.signal(sig, handle_shutdown)
+            # Disable SA_RESTART so EINTR is not retried on blocking sysfs reads
+            signal.siginterrupt(sig, True)
 
-    LOGGER.notice("hw-management-peripheral-updater: start main loop")
-    while not EXIT.is_set():
-        try:
-            for attr in sys_attr:
-                update_peripheral_attr(attr)
+        LOGGER.notice("hw-management-peripheral-updater: start main loop")
+        while not EXIT.is_set():
             try:
-                log_level_filename = os.path.join(CONST.HW_MGMT_FOLDER_DEF, CONST.LOG_LEVEL_FILENAME)
-                if os.path.isfile(log_level_filename):
-                    with open(log_level_filename, 'r', encoding="utf-8") as f:
-                        log_level = f.read().rstrip('\n')
-                        log_level = int(log_level)
-                        LOGGER.set_loglevel(log_level)
-            except (OSError, ValueError):
-                # Expected errors when reading/parsing log level file
-                # These are non-critical, just skip and continue
-                pass
-        except Exception as e:
-            # Safety net: catch any unexpected exceptions to keep daemon alive
-            LOGGER.error("Unexpected error in main loop: {}".format(e))
-            LOGGER.notice(traceback.format_exc())
-            # Continue running despite error
+                for attr in sys_attr:
+                    if EXIT.is_set():
+                        break
+                    update_peripheral_attr(attr)
+                try:
+                    log_level_filename = os.path.join(CONST.HW_MGMT_FOLDER_DEF, CONST.LOG_LEVEL_FILENAME)
+                    if os.path.isfile(log_level_filename):
+                        with open(log_level_filename, 'r', encoding="utf-8") as f:
+                            log_level = f.read().rstrip('\n')
+                            log_level = int(log_level)
+                            LOGGER.set_loglevel(log_level)
+                except InterruptedError:
+                    raise ShutdownRequested()
+                except (OSError, ValueError):
+                    # Expected errors when reading/parsing log level file
+                    # These are non-critical, just skip and continue
+                    pass
+            except ShutdownRequested:
+                raise
+            except Exception as e:
+                # Safety net: catch any unexpected exceptions to keep daemon alive
+                LOGGER.error("Unexpected error in main loop: {}".format(e))
+                LOGGER.notice(traceback.format_exc())
+                # Continue running despite error
 
-        exit_wait(EXIT, 1)
+            exit_wait(EXIT, 1)
+    except ShutdownRequested:
+        pass
 
-    LOGGER.notice("hw-management-peripheral-updater: stopped main loop ({})".format(_sig_condition_name))
+    try:
+        LOGGER.notice("hw-management-peripheral-updater: stopped main loop ({})".format(_sig_condition_name))
+    except ShutdownRequested:
+        pass
+    finally:
+        try:
+            for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                signal.signal(sig, signal.SIG_DFL)
+        except ShutdownRequested:
+            pass
     return
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except ShutdownRequested:
+        pass

--- a/usr/usr/bin/hw_management_thermal_updater.py
+++ b/usr/usr/bin/hw_management_thermal_updater.py
@@ -164,6 +164,16 @@ LOGGER = None
 EXIT = threading.Event()
 _sig_condition_name = ""
 
+
+class ShutdownRequested(BaseException):
+    """
+    @summary: Abort the daemon on SIGTERM/SIGINT/SIGHUP.
+
+    Must not subclass Exception: the main-loop safety net would swallow it.
+    Raising from the signal handler prevents CPython PEP 475 from restarting
+    a blocking sysfs read, which can exceed systemd TimeoutStopSec.
+    """
+
 # ----------------------------------------------------------------------
 
 
@@ -501,6 +511,11 @@ def update_thermal_attr(attr_prop):
 
         try:
             globals()[fn_name](argv, None)
+        except ShutdownRequested:
+            raise
+        except InterruptedError:
+            # SIGTERM during sysfs I/O: do not treat as a normal read error
+            raise ShutdownRequested()
         except (OSError, ValueError, KeyError, TypeError):
             # Catch common errors from dynamically called functions
             # to prevent daemon crash
@@ -514,6 +529,9 @@ def handle_shutdown(sig, _frame):
     @summary: Handle application signal
     @param sig: Signal
     @param _frame: Unused frame
+
+    Raise ShutdownRequested so a blocking sx_core sysfs read is not restarted
+    (PEP 475) and the process can exit before systemd TimeoutStopSec.
     """
     global _sig_condition_name
     try:
@@ -521,6 +539,7 @@ def handle_shutdown(sig, _frame):
     except (ValueError, AttributeError):
         _sig_condition_name = str(sig)
     EXIT.set()
+    raise ShutdownRequested()
 
 # ----------------------------------------------------------------------
 
@@ -584,38 +603,58 @@ def main():
             break
 
     EXIT.clear()
-    signal.signal(signal.SIGTERM, handle_shutdown)
-    signal.signal(signal.SIGINT, handle_shutdown)
-    signal.signal(signal.SIGHUP, handle_shutdown)
+    try:
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            signal.signal(sig, handle_shutdown)
+            # Disable SA_RESTART so EINTR is not retried on sx_core sysfs reads
+            signal.siginterrupt(sig, True)
 
-    LOGGER.notice("hw-management-thermal-updater: start main loop")
-    while not EXIT.is_set():
-        try:
-            for attr in thermal_attr:
-                if EXIT.is_set():
-                    break
-                update_thermal_attr(attr)
+        LOGGER.notice("hw-management-thermal-updater: start main loop")
+        while not EXIT.is_set():
             try:
-                log_level_filename = os.path.join(CONST.HW_MGMT_FOLDER_DEF, CONST.LOG_LEVEL_FILENAME)
-                if os.path.isfile(log_level_filename):
-                    with open(log_level_filename, 'r', encoding="utf-8") as f:
-                        log_level = f.read().rstrip('\n')
-                        log_level = int(log_level)
-                        LOGGER.set_loglevel(log_level)
-            except (OSError, ValueError):
-                # Expected errors when reading/parsing log level file
-                # These are non-critical, just skip and continue
-                pass
-        except Exception as e:
-            # Safety net: catch any unexpected exceptions to keep daemon alive
-            LOGGER.error("Unexpected error in main loop: {}".format(e))
-            LOGGER.notice(traceback.format_exc())
-            # Continue running despite error
+                for attr in thermal_attr:
+                    if EXIT.is_set():
+                        break
+                    update_thermal_attr(attr)
+                try:
+                    log_level_filename = os.path.join(CONST.HW_MGMT_FOLDER_DEF, CONST.LOG_LEVEL_FILENAME)
+                    if os.path.isfile(log_level_filename):
+                        with open(log_level_filename, 'r', encoding="utf-8") as f:
+                            log_level = f.read().rstrip('\n')
+                            log_level = int(log_level)
+                            LOGGER.set_loglevel(log_level)
+                except InterruptedError:
+                    raise ShutdownRequested()
+                except (OSError, ValueError):
+                    # Expected errors when reading/parsing log level file
+                    # These are non-critical, just skip and continue
+                    pass
+            except ShutdownRequested:
+                raise
+            except Exception as e:
+                # Safety net: catch any unexpected exceptions to keep daemon alive
+                LOGGER.error("Unexpected error in main loop: {}".format(e))
+                LOGGER.notice(traceback.format_exc())
+                # Continue running despite error
 
-        exit_wait(EXIT, 1)
+            exit_wait(EXIT, 1)
+    except ShutdownRequested:
+        pass
 
-    LOGGER.notice("hw-management-thermal-updater: stopped main loop ({})".format(_sig_condition_name))
+    try:
+        LOGGER.notice("hw-management-thermal-updater: stopped main loop ({})".format(_sig_condition_name))
+    except ShutdownRequested:
+        pass
+    finally:
+        try:
+            for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+                signal.signal(sig, signal.SIG_DFL)
+        except ShutdownRequested:
+            pass
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except ShutdownRequested:
+        pass


### PR DESCRIPTION
Issue: hw-management-thermal-updater.service failed with
result 'timeout' (SIGKILL after stop-sigterm).

RC: CPython PEP 475 restarted blocking sx_core sysfs reads, so SIGTERM
did not take effect within TimeoutStopSec=5. MAINPID was also a sh -c
wrapper, and InterruptedError was treated as a normal read error.

Fix: Raise ShutdownRequested from the signal handler, do not swallow
InterruptedError, ExecStart the Python process as MAINPID, and raise
TimeoutStopSec to 15s. atomic_file_write cleans tmp files on shutdown
without wrapping it as Exception.

bug: 5221586
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
