### PR TITLE
hw-mgmt: patches: Fix CPLD register name in BMC platform driver

### DIFF
--- a/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
+++ b/recipes-kernel/linux/linux-6.12/0046-platform-mellanox-nvsw-bmc-Add-system-control-and-mo.patch
@@ -5599,7 +5599,7 @@ index 000000000..9f4c94f5d
 +	},
 +	{
 +		.label = "cpld9_pn",
-+		.reg = NVSW_REG_CPLD9B_PN_OFFSET,
++		.reg = NVSW_REG_CPLD9_PN_OFFSET,
 +		.bit = GENMASK(15, 0),
 +		.mode = 0444,
 +		.regnum = 2,


### PR DESCRIPTION
Commit 85ad6a69ce2bd63ecd31d6cbc2b0770c6b93bd3c renamed NVSW_REG_CPLD9B_PN_OFFSET to NVSW_REG_CPLD9_PN_OFFSET but failed to update NVSW_REG_CPLD9B_PN_OFFSET reference in the BMC driver. This patch fixes the problem.