### PR TITLE
hw-mgmt: scripts: Add bash completion for hw-management.sh

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Profiles: <!pkg.hw-mgmt.bmc-only>
 Depends: ${misc:Depends}, ${shlibs:Depends}, ${dist:Depends}, lsb-base (>= 3.0-6),
  python2.7 | python3, python3-psutil, xxd, libiio-utils, dmidecode, i2c-tools, tpm2-tools,
  awk, gzip, logrotate, jq
+Suggests: bash-completion
 Description: Thermal control and chassis management for Nvidia systems (host)
  This package supports Nvidia switches family for chassis
  management and thermal control on the host CPU.

--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,8 @@ ifeq ($(with_host),1)
 	cp usr/usr/local/bin/* debian/$(pname)/usr/local/bin
 	dh_installdirs -p$(pname) etc/logrotate.d
 	cp usr/etc/logrotate.d/* debian/$(pname)/etc/logrotate.d
+	dh_installdirs -p$(pname) etc/bash_completion.d
+	cp usr/etc/bash_completion.d/* debian/$(pname)/etc/bash_completion.d
 ifeq ($(DEB_HOST_ARCH),arm64)
 	rm -f  debian/$(pname)/usr/bin/iorw_lpc
 	mv debian/$(pname)/usr/bin/iorw_bf3.sh debian/$(pname)/usr/bin/iorw

--- a/usr/etc/bash_completion.d/hw-management.sh
+++ b/usr/etc/bash_completion.d/hw-management.sh
@@ -1,0 +1,62 @@
+# bash completion for hw-management.sh                     -*- shell-script -*-
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Do not use set -euo pipefail here: this file is sourced into the user shell.
+
+_hw_management()
+{
+	local cur cword cmds
+
+	cmds="start stop chipup chipdown chipupen chipupdis thermsuspend thermresume restart force-reload reset-cause"
+
+	if declare -F _init_completion >/dev/null 2>&1; then
+		_init_completion || return
+	else
+		COMPREPLY=()
+		cur="${COMP_WORDS[COMP_CWORD]}"
+		cword=$COMP_CWORD
+	fi
+
+	# Only the first argument (action name). Extra args are not completed.
+	if [[ $cword -eq 1 ]]; then
+		COMPREPLY=( $(compgen -W "$cmds" -- "$cur") )
+		return 0
+	fi
+
+	COMPREPLY=()
+	return 0
+} &&
+complete -F _hw_management hw-management.sh
+
+# ex: filetype=sh


### PR DESCRIPTION
Operators typing hw-management.sh on the switch have to remember
action names (start, stop, chipup, chipdown, ...). Add a bash
completion drop-in under /etc/bash_completion.d/ so Tab completes
those actions and, for chipup/chipdown, ASIC index and PCI bus id.

Install the file from Debian packaging. Suggest bash-completion
so the drop-in is sourced.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
