### PR TITLE
hw-mgmt: sensors: Add hot-swap power and current scaling factor for N…

### DIFF
--- a/usr/etc/hw-management-sensors/n51xxld_sensors_labels.json
+++ b/usr/etc/hw-management-sensors/n51xxld_sensors_labels.json
@@ -856,6 +856,8 @@
 		"drivetemp" : "SSD+Temp"
 	},
 	"labels_scale_HI176_rev1_array" : {
+		"pdb_hotswap1_power1" : "3.401",
+		"pdb_hotswap1_curr1"  : "3.401"
 	},
 	"labels_HI177_alternatives" : {
 		"pwr_conv1": {


### PR DESCRIPTION
…55XX_LD

Add current and power scaling factor for hot-swap controller on N55XX_LD platforms. This is to create the scale nodes under hw-management UI folder.

Bug: 5225682