### PR TITLE
hw-mgmt: scripts: Align VR DPC flash with OpenBMC shared logic

### DIFF
--- a/usr/usr/bin/hw-management-read-vr-model-version.sh
+++ b/usr/usr/bin/hw-management-read-vr-model-version.sh
@@ -104,24 +104,18 @@ log_message()
     echo "[$level] $message"
 }
 
-# Run i2cset without eval (argv only). Optional first arg: expected exit code.
+# Safe i2c command execution with error checking (argv only; no eval).
 i2c_cmd()
 {
     local expected_exit=0
-    local exit_code
 
-    if [[ "${1:-}" =~ ^[0-9]+$ ]] && [[ $# -gt 1 ]]; then
-        expected_exit="$1"
-        shift
+    if [[ "$1" == "--expect" ]]; then
+        expected_exit="$2"
+        shift 2
     fi
 
-    if [[ "$1" != "i2cset" ]]; then
-        return 1
-    fi
-    shift
-
-    i2cset "$@" >/dev/null 2>&1
-    exit_code=$?
+    "$@" >/dev/null 2>&1
+    local exit_code=$?
 
     if [[ $exit_code -ne $expected_exit ]]; then
         return $exit_code
@@ -168,7 +162,7 @@ get_model()
     local byte_offset="${5:-0}"
 
     # Set page to model ID page
-    if ! i2c_cmd 0 i2cset -y -f "$bus" "$dev_addr" "$PAGE_REG" "$model_page"; then
+    if ! i2c_cmd i2cset -y -f "$bus" "$dev_addr" "$PAGE_REG" "$model_page"; then
         return 1
     fi
 
@@ -193,7 +187,7 @@ get_revision()
     local byte_offset="${5:-0}"
 
     # Set page to revision ID page
-    if ! i2c_cmd 0 i2cset -y -f "$bus" "$dev_addr" "$PAGE_REG" "$rev_page"; then
+    if ! i2c_cmd i2cset -y -f "$bus" "$dev_addr" "$PAGE_REG" "$rev_page"; then
         return 1
     fi
 

--- a/usr/usr/bin/hw-management-vr-dpc-infineon-update.sh
+++ b/usr/usr/bin/hw-management-vr-dpc-infineon-update.sh
@@ -608,6 +608,10 @@ read_otp_dword_hex() {
     line=$(i2c_rw_wrapper "$bus" "$addr" 5 0 "$MFR_REG_READ") || return 1
     line=$(echo "$line" | sed 's/0x//g')
     read -r _d0 _d1 _d2 _d3 _d4 <<< "$line"
+    if (( 16#${_d0:-0} != 4 )); then
+        log_error "read_otp_dword_hex: expected block length 0x04, got 0x${_d0:-??}"
+        return 1
+    fi
     line="$_d1 $_d2 $_d3 $_d4"
     if [ "${USE_I2C_PEC:-0}" -eq 1 ]; then
         log_debug "read DWORD: $line # PEC"
@@ -852,16 +856,17 @@ rebind_driver_if_unbound() {
     fi
     if echo "$DRIVER_UNBIND_DEVID" > "$bind_file"; then
         log_info "Driver $DRIVER_UNBIND_NAME rebound to $DRIVER_UNBIND_DEVID"
-    else
-        log_warn "Rebind of $DRIVER_UNBIND_NAME to $DRIVER_UNBIND_DEVID failed (device may need more time or power cycle)"
-        local bus addr
-        bus="${DRIVER_UNBIND_DEVID%-*}"
-        addr="0x${DRIVER_UNBIND_DEVID##*-}"
-        diagnose_rebind_id_regs "$bus" "$addr"
+        DRIVER_UNBIND_DEVID=""
+        DRIVER_UNBIND_NAME=""
+        return 0
     fi
-    DRIVER_UNBIND_DEVID=""
-    DRIVER_UNBIND_NAME=""
-    return 0
+
+    log_warn "Rebind of $DRIVER_UNBIND_NAME to $DRIVER_UNBIND_DEVID failed (device may need more time or power cycle)"
+    local bus addr
+    bus="${DRIVER_UNBIND_DEVID%-*}"
+    addr="0x${DRIVER_UNBIND_DEVID##*-}"
+    diagnose_rebind_id_regs "$bus" "$addr"
+    return 1
 }
 
 # Save unbound device info to state file (for 'rebind' mode in a separate run).
@@ -880,10 +885,12 @@ rebind_driver_from_state_file() {
     [ -f "$UNBIND_STATE_FILE" ] || return 1
     DRIVER_UNBIND_DEVID=$(sed -n '1p' "$UNBIND_STATE_FILE" 2>/dev/null)
     DRIVER_UNBIND_NAME=$(sed -n '2p' "$UNBIND_STATE_FILE" 2>/dev/null)
-    rm -f "$UNBIND_STATE_FILE" 2>/dev/null
     [ -n "$DRIVER_UNBIND_DEVID" ] && [ -n "$DRIVER_UNBIND_NAME" ] || return 1
-    rebind_driver_if_unbound
-    return 0
+    if rebind_driver_if_unbound; then
+        rm -f "$UNBIND_STATE_FILE" 2>/dev/null
+        return 0
+    fi
+    return 1
 }
 
 # Read device identification (uses block read for MFR_* so output matches 'info')
@@ -1850,15 +1857,21 @@ reset_device() {
 # Main programming sequence
 program_device() {
     local flash_file artifact_dir=""
+    local wp_cleared=0
+
+    _program_device_restore_wp() {
+        if [ "${wp_cleared:-0}" -eq 1 ]; then
+            enable_write_protect || log_warn "Failed to re-enable write protect on exit"
+            wp_cleared=0
+        fi
+    }
+    trap '_program_device_restore_wp' RETURN
 
     log_info "Starting programming sequence for $CONFIG_FILE"
     log_info "Target: I2C bus $I2C_BUS, address $DEVICE_ADDR"
 
     detect_device || return 1
     read_device_id || return 1
-    clear_faults || return 1
-    disable_write_protect || return 1
-    check_otp_space || return 1
 
     # Full .txt/.mic only (no -s): skip entire flash if GUI "Configuration Checksum" matches device total CRC (AN001 GET_CRC HC=0).
     if [[ "$CONFIG_FILE" =~ \.(txt|mic)$ ]] && [ -z "$FLASH_SECTION_HC" ]; then
@@ -1909,6 +1922,12 @@ program_device() {
             fi
         fi
     fi
+
+    clear_faults || return 1
+    check_otp_space || return 1
+
+    disable_write_protect || return 1
+    wp_cleared=1
 
     # .txt/.mic: upload each section individually (AN001 Section 6 - avoid device buffer overrun)
     # .bin: single scratchpad write + upload
@@ -2042,6 +2061,7 @@ program_device() {
     enable_write_protect || {
         return 1
     }
+    wp_cleared=0
 
     # XDPE1A2G7 family: after OTP programming the device may not ACK OPERATION reset
     # or MFR_ID/MODEL/REVISION immediately. Do not fail the script (batch JSON flashes

--- a/usr/usr/bin/hw-management-vr-dpc-renesas-update.sh
+++ b/usr/usr/bin/hw-management-vr-dpc-renesas-update.sh
@@ -1380,6 +1380,14 @@ check_file() {
             log_error "record $reccount (line $lineno): malformed (need >=4 bytes): $s"; errs=$((errs + 1)); continue
         fi
 
+        local declared_len=$((16#${s:2:2}))
+        local actual_len=$((nbytes - 2))
+        if [ "$declared_len" -ne "$actual_len" ]; then
+            log_error "record $reccount (line $lineno): declared length $declared_len does not match payload length $actual_len: $s"
+            errs=$((errs + 1))
+            continue
+        fi
+
         # Per-line CRC8 integrity: the last byte is CRC8 (poly 0x07, init 0) over the payload
         # bytes[2..(end-1)] = the I2C bytes (addr8, cmd, data) WITHOUT the rectype/length framing.
         # A single changed byte (accidental corruption or tampering) breaks its line's CRC here.

--- a/usr/usr/bin/hw-management-vr-dpc-update-all.sh
+++ b/usr/usr/bin/hw-management-vr-dpc-update-all.sh
@@ -403,6 +403,11 @@ process_json_config()
         return 1
     fi
 
+    if ! validate_json_config "$json_file"; then
+        log_message "err" "Aborting batch update because the JSON configuration is invalid"
+        return 1
+    fi
+
     local total_devices=0
     local successful_updates=0
     local failed_updates=0

--- a/usr/usr/bin/hw-management-vr-dpc-update.sh
+++ b/usr/usr/bin/hw-management-vr-dpc-update.sh
@@ -95,7 +95,7 @@ show_help()
 	echo "PARAMETERS:"
 	echo "  i2c_bus        I2C bus number (e.g., 0, 1, 2) - MANDATORY"
 	echo "  device_name    Device name (e.g., mp2888, mp2974, xdpe152, xdpe122) - MANDATORY"
-	echo "  hid            Hardware ID (e.g., hid180) or 0 for manual files - MANDATORY"
+	echo "  hid            Hardware ID (hid180, hi180/HI180) or 0 for manual files - MANDATORY"
 	echo "  csv_file       CSV file containing register configuration data - OPTIONAL"
 	echo "                 Format: device_addr,cmd_code,wr,p0_name,p0_byte,p0_val,..."
 	echo "  crc_file       File containing expected CRC checksum values - OPTIONAL"
@@ -321,9 +321,17 @@ validate_inputs()
 		error_exit "Invalid device name format: $DEVICE_NAME"
 	fi
 
-	# Validate HID format (allow "0" for manual file specification).
-	if [[ "$HID" != "0" ]] && [[ ! "$HID" =~ ^hid[0-9]{3}$ ]]; then
-		error_exit "Invalid HID format: $HID (expected hidXXX where XXX are 3 digits, or 0 for manual files)"
+	# Normalize HID: JSON / update-all use HI180|hi180; firmware paths use hid180.
+	# Allow "0" for fully manual file specification.
+	if [[ "$HID" != "0" ]]; then
+		HID=$(echo "$HID" | tr '[:upper:]' '[:lower:]')
+		if [[ "$HID" =~ ^hid[0-9]{3}$ ]]; then
+			:
+		elif [[ "$HID" =~ ^hi[0-9]{3}$ ]]; then
+			HID="hid${HID#hi}"
+		else
+			error_exit "Invalid HID format: $3 (expected hidXXX, hiXXX/HIXXX, or 0 for manual files)"
+		fi
 	fi
 
 	# Auto-discover missing files (skip if HID is "0").
@@ -356,28 +364,14 @@ validate_inputs()
 	log_info "Input validation passed"
 }
 
-# Run i2cset without eval (argv only). Optional first arg: expected exit code.
+# Run i2c tools without eval (argv only). Callers always expect exit 0.
 i2c_cmd()
 {
-	local expected_exit=0
-	local exit_code
+	"$@"
+	local exit_code=$?
 
-	if [[ "${1:-}" =~ ^[0-9]+$ ]] && [[ $# -gt 1 ]]; then
-		expected_exit="$1"
-		shift
-	fi
-
-	if [[ "$1" != "i2cset" ]]; then
-		log_info "Warning: unsupported i2c command: $1"
-		return 1
-	fi
-	shift
-
-	i2cset "$@"
-	exit_code=$?
-
-	if [[ $exit_code -ne $expected_exit ]]; then
-		log_info "Warning: i2cset failed (exit $exit_code): i2cset $*"
+	if [[ $exit_code -ne 0 ]]; then
+		log_info "Warning: i2c command failed: $* (exit code: $exit_code)"
 		return $exit_code
 	fi
 
@@ -402,15 +396,15 @@ store_user()
 	log_info "Storing user settings..."
 
 	# Remove write protect from page 0.
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "0x00" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "0x00" || return 1
 	sleep 0.1
-	i2c_cmd 0 i2cset -f -y "$I2C_BUS" "$dev_addr" "$WRITE_PROTECT" "$WP_VAL" bp || return 1
+	i2c_cmd i2cset -f -y "$I2C_BUS" "$dev_addr" "$WRITE_PROTECT" "$WP_VAL" bp || return 1
 
 	# Clear fault and store user from page 1.
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "0x01" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "0x01" || return 1
 	sleep 1
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$CLEAR_FAULT" "0x00" || return 1
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$STORE_OFFSET" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$CLEAR_FAULT" "0x00" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$STORE_OFFSET" || return 1
 	sleep 0.1
 
 	log_info "User settings stored successfully"
@@ -421,7 +415,7 @@ read_crc_from_device()
 	log_info "Reading CRC from device..."
 
 	# Read CRC from 0xAB (MFR_CRC_NORMAL_CODE) and 0xAD (MFR_CRC_MULTI_CONFIG) from page 1.
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "0x01" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "0x01" || return 1
 
 	CRC_READ[0]=$(i2cget -y -f "$I2C_BUS" "$dev_addr" "$MFR_CRC_NORMAL_CODE" w 2>/dev/null)
 	CRC_READ[1]=$(i2cget -y -f "$I2C_BUS" "$dev_addr" "$MFR_CRC_MULTI_CONFIG" w 2>/dev/null)
@@ -431,13 +425,13 @@ read_crc_from_device()
 
 get_model()
 {
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$DPC_MODEL_ID_PAGE" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$DPC_MODEL_ID_PAGE" || return 1
 	i2cget -y -f "$I2C_BUS" "$dev_addr" "$DPC_MODEL_ID" w
 }
 
 get_revision()
 {
-	i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$DPC_REVISION_ID_PAGE" || return 1
+	i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$DPC_REVISION_ID_PAGE" || return 1
 	i2cget -y -f "$I2C_BUS" "$dev_addr" "$DPC_REVISION_ID" w
 }
 
@@ -476,20 +470,35 @@ hex_word_to_int()
 	echo $((16#$h))
 }
 
+# Config page / PAGE2_MAX_REG may be decimal or 0x-hex; do not treat decimal as hex.
+cfg_to_int()
+{
+	local v="${1,,}"
+	if [[ "$v" =~ ^0x[0-9a-f]+$ ]]; then
+		echo $((16#${v#0x}))
+	elif [[ "$v" =~ ^[0-9]+$ ]]; then
+		echo $((10#$v))
+	else
+		return 1
+	fi
+}
+
 validate_revisions()
 {
 	log_info "Validating device revisions..."
 
 	local model
 	local revision
+	local rev_page
 
 	model=$(get_model) || error_exit "Failed to get model"
 	revision=$(get_revision) || error_exit "Failed to get revision"
+	rev_page="$(cfg_to_int "$DPC_REVISION_ID_PAGE")" || error_exit "Invalid DPC_REVISION_ID_PAGE '$DPC_REVISION_ID_PAGE'"
 
 	log_info "Device model: $model, revision: $revision"
 
-	# Parse input file: skip header, process each line until revision field.
-	tail -n +2 "$CSV_FILE" | while IFS=, read -r dev_addr cmd_code wr \
+	# Process substitution (not a pipe) so return exits this function, not a subshell.
+	while IFS=, read -r dev_addr cmd_code wr \
 		p0_name p0_byte p0_val \
 		p1_name p1_byte p1_val \
 		p2_name p2_byte p2_val
@@ -509,7 +518,7 @@ validate_revisions()
 
 			cmd_code=$(echo "$cmd_code" | tr '[:upper:]' '[:lower:]')
 
-			if [[ "$page" == "$DPC_REVISION_ID_PAGE" ]] && [[ "$cmd_code" == "$DPC_REVISION_ID" ]]; then
+			if (( page == rev_page )) && [[ "$cmd_code" == "$DPC_REVISION_ID" ]]; then
 				local rev_n val_n
 				val="$(_csv_hex_val_normalize "$val")" || {
 					log_info "Invalid package revision CSV value (must be 0x + 1..4 hex digits): '$val'"
@@ -526,7 +535,7 @@ validate_revisions()
 				fi
 			fi
 		done
-	done
+	done < <(tail -n +2 "$CSV_FILE")
 
 	log_info "Revision validation completed"
 }
@@ -590,6 +599,13 @@ compare_and_flash_device()
 		return 1
 	}
 
+	local page2_max
+	page2_max="$(cfg_to_int "$PAGE2_MAX_REG")" || {
+		log_info "Invalid PAGE2_MAX_REG '$PAGE2_MAX_REG'"
+		rm -f "$temp_file" "$err_file"
+		return 1
+	}
+
 	# Skip header, process each line.
 	tail -n +2 "$CSV_FILE" | while IFS=, read -r dev_addr cmd_code wr \
 		p0_name p0_byte p0_val \
@@ -638,7 +654,7 @@ compare_and_flash_device()
 				echo "1" >> "$err_file"
 				continue
 			fi
-			if ! i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$page"; then
+			if ! i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$page"; then
 				log_info "Failed to select page $page before read at $dev_addr $cmd_code name $name"
 				echo "1" >> "$err_file"
 				continue
@@ -676,7 +692,7 @@ compare_and_flash_device()
 						skip_wp=1
 					fi
 				fi
-				if [[ "$page" == "2" ]] && (( 16#${cmd_code#0x} > 16#${PAGE2_MAX_REG#0x} )); then
+				if [[ "$page" == "2" ]] && (( 16#${cmd_code#0x} > page2_max )); then
 					skip_p2=1
 				fi
 				if [[ $skip_wp -eq 1 || $skip_p2 -eq 1 ]]; then
@@ -687,7 +703,7 @@ compare_and_flash_device()
 				log_info "Mismatch at bus $I2C_BUS $dev_addr $cmd_code page $page name $name: read $read_val, expected $val"
 
 				# Set page and fix mismatch.
-				if ! i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$page"; then
+				if ! i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$PAGE" "$page"; then
 					log_info "Failed to select page $page for $dev_addr $cmd_code name $name"
 					echo "1" >> "$err_file"
 					continue
@@ -695,14 +711,14 @@ compare_and_flash_device()
 
 				local new_val
 				if [[ "$byte" == "2" ]]; then
-					if ! i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$cmd_code" "$val" w; then
+					if ! i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$cmd_code" "$val" w; then
 						log_info "Failed to write $val (word) to $dev_addr $cmd_code page $page name $name"
 						echo "1" >> "$err_file"
 						continue
 					fi
 					new_val=$(i2cget -y -f "$I2C_BUS" "$dev_addr" "$cmd_code" w 2>/dev/null)
 				elif [[ "$byte" == "1" ]]; then
-					if ! i2c_cmd 0 i2cset -y -f "$I2C_BUS" "$dev_addr" "$cmd_code" "$val"; then
+					if ! i2c_cmd i2cset -y -f "$I2C_BUS" "$dev_addr" "$cmd_code" "$val"; then
 						log_info "Failed to write $val to $dev_addr $cmd_code page $page name $name"
 						echo "1" >> "$err_file"
 						continue


### PR DESCRIPTION
Drop the unused i2c_cmd expected-exit 0 argument and run i2cset via argv.
Accept HI###/hi### HID. Compare DPC_REVISION_ID_PAGE and PAGE2_MAX_REG
with cfg_to_int so decimal config values are not parsed as hex.
Read the CSV revision field via process substitution so a failed gate actually aborts.
Restore Infineon write-protect on early exit; skip or confirm before clearing WP.
Abort batch update if JSON validation fails.