### PR TITLE
hw-mgmt: scripts: Add LED software/hardware control owner indication

### DIFF
--- a/Documentation/CHANGELOG_User_Manual.md
+++ b/Documentation/CHANGELOG_User_Manual.md
@@ -7,6 +7,25 @@
 
 ## Change History
 
+### Rev. 3.2.8 - August 25, 2026
+
+#### Added: LED software/hardware control owner
+
+**Affected platforms:** All host platforms (default `led_hw_sw`).
+
+**User manual updates:**
+
+| Area | Change |
+|------|--------|
+| §3.1.60 | **`config/led_control_type`**: optional space-separated `name type` pairs from platform `*_specific()`; exact name or `led_<name>`; glob masks `*` / `?` |
+| §3.16.28 | **`led/led_<name>_control`**: `led_sw`, `led_hw`, or `led_hw_sw` (default if map missing or name unmatched). `fan` and `fan1` are distinct names |
+
+**Validation source:** `usr/usr/bin/hw-management.sh` (`set_config_data()`),
+`usr/usr/bin/hw-management-chassis-events.sh` (`get_led_control_type()`),
+`usr/usr/bin/hw-management-helpers.sh` (`LED_CONTROL_*`).
+
+---
+
 ### Rev. 3.2.7 - August 17, 2026
 
 #### Clarified: `system/asic_pg_fail` platform exception

--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -2,7 +2,7 @@
 
 ![NVIDIA Logo](images/logo.png)
 
-Rev. 3.2.6
+Rev. 3.2.7
 
 ## Table of Contents
 
@@ -75,6 +75,7 @@ Rev. 3.2.6
 | 3.1.57 | Core 0 Temperature ID | 37 |
 | 3.1.58 | Core 1 Temperature ID | 37 |
 | 3.1.59 | Read PDB Hotswap Scale Factor | 37 |
+| 3.1.60 | Read LED Control Type Map | 38 |
 | 3.2 | BIOS Control | 38 |
 | 3.2.1 | BIOS Status | 38 |
 | 3.2.2 | BIOS Start Retry | 38 |
@@ -221,6 +222,7 @@ Rev. 3.2.6
 | 3.16.25 | UID LED Blue Trigger | 83 |
 | 3.16.26 | UID LED Capability | 83 |
 | 3.16.27 | UID LED State | 83 |
+| 3.16.28 | Get LED Control Owner | 83 |
 | 3.17 | Power Control | 84 |
 | 3.17.1 | Get Power Consumption | 84 |
 | 3.17.2 | Get PSU sensor Current + thresholds | 85 |
@@ -407,6 +409,7 @@ Rev. 3.2.6
 
 | Revision | Date | Description |
 |----------|------|-------------|
+| 3.2.7 | August 2026 | §3.1.60 `config/led_control_type` platform LED owner map; §3.16.28 `led/led_<name>_control` (`led_sw` / `led_hw` / `led_hw_sw`); glob masks `*` and `?` |
 | 3.2.6 | June 2026 | §3.1.59 and §3.4 PDB hotswap scale (SN6600_LD / lm5066i); §3.24 AST2700 BMC reset cause tree; §3.25 BMC A2D leakage runtime layout; N6300_LD (HI185) platform notes; §3.18 cpu_shutdown_req hw-mgmt polling note |
 | 3.2.5 | June 2026 | §2.2 HI189 BMC peripheral table; §3.3.7–§3.3.8 BMC EEPROM bodies; §3.20 BMC stack tags and CPU-on-BMC thermal cross-refs; §3.23 BMC status bodies (present, bmc_to_cpu_ctrl, MCTP) |
 | 3.2.4 | June 2026 | Added §2.2 **Host and BMC software stacks**: separate repo paths (`usr/` vs `bmc/usr/`), packages, handlers, and examples; stack notes in §3 intro and §3.20 Thermal |
@@ -1944,6 +1947,49 @@ symlinked under each lm5066i PDB hotswap environment node as `*_power1_scale` an
 **Example:**
 ```bash
 cat $bsp_path/config/pdb_hotswap_scale
+```
+
+### Read LED Control Type Map
+
+**Stack:** Host
+
+**Node name:** `$bsp_path/config/led_control_type`
+
+**Description:** Optional platform map of LED name (or glob mask) to control
+owner. Written by `set_config_data()` in `hw-management.sh` when a
+`*_specific()` function sets the `led_control_type` array. Space-separated
+pairs: `name type [name type ...]`.
+
+If the node is absent, or a given LED name is not listed, LED add uses the
+default owner `led_hw_sw` (see §3.16.28).
+
+Name matching (in `hw-management-chassis-events.sh` `get_led_control_type()`):
+
+1. Exact match of the udev LED name (`status`, `fan`, `fan1`) or `led_<name>`.
+   `fan` and `fan1` are different names.
+2. Glob mask: `*` matches any string, `?` matches one character. First matching
+   mask wins. Masks must be quoted in the platform array (`"fan*"`, `"led?"`)
+   so the shell does not expand them.
+3. Otherwise `led_hw_sw`.
+
+**Access:** Read only
+
+**Release version:** 3.2.7
+
+**Arguments:**
+| Name | Data type | Values |
+|------|-----------|--------|
+| name | String | LED name (`fan`, `status`) or mask (`fan*`, `led_psu?`, `led*`) |
+| type | String | `led_sw`, `led_hw`, `led_hw_sw` |
+
+**Platform notes:** Optional. Created only when a platform `*_specific()` function
+sets the `led_control_type` array. Otherwise the node is absent and LED add
+uses `led_hw_sw`.
+
+**Example:**
+```bash
+cat $bsp_path/config/led_control_type
+# fan led_sw psu led_sw status led_sw
 ```
 
 ## BIOS Control
@@ -4667,6 +4713,39 @@ echo 1000 > $bsp_path/led/status_led_delay_off
 **Example:** Set system status LED delay on to 500ms:
 ```bash
 echo 500 > $bsp_path/led/status_led_delay_on
+```
+
+### Get LED Control Owner
+
+**Stack:** Host
+
+**Node name:** `$bsp_path/led/led_<name>_control`
+
+**Description:** Control owner of LED `<name>` (`status`, `fan`, `fan1`, `psu`,
+`uid`, …). Created on LED udev add next to `led_<name>_capability` and
+`led_<name>_state`. Value is resolved from `$bsp_path/config/led_control_type`
+(§3.1.60). Missing map or unmatched name uses `led_hw_sw`.
+
+| Value | Meaning |
+|-------|---------|
+| `led_sw` | Software controlled |
+| `led_hw` | Hardware controlled |
+| `led_hw_sw` | Hardware and software controlled (default) |
+
+**Access:** Read only
+
+**Release version:** 3.2.7
+
+**Arguments:**
+| Name | Data type | Values |
+|------|-----------|--------|
+| name | String | LED type from the udev LED class name |
+| control | String | `led_sw`, `led_hw`, `led_hw_sw` |
+
+**Example:** Get status LED control owner (default when no platform map):
+```bash
+cat $bsp_path/led/led_status_control
+led_hw_sw
 ```
 
 ## Power Control

--- a/tests/shell/spec/hw_management_led_state_conversion_spec.sh
+++ b/tests/shell/spec/hw_management_led_state_conversion_spec.sh
@@ -1,34 +1,36 @@
 #!/bin/bash
-#
+##################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: GPL-2.0-only
+# Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
-# This program is free software; you can redistribute it and/or modify it
-# under the terms and conditions of the GNU General Public License,
-# version 2, as published by the Free Software Foundation.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
 #
-# This program is distributed in the hope it will be useful, but WITHOUT
-# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
-# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-# more details.
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
 #
-
-################################################################################
-# ShellSpec tests for hw-management-led-state-conversion.sh
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 #
-# This script tests LED state conversion logic which reads LED control files
-# and determines the current LED state (color, blinking, etc.)
-#
-# Test Coverage:
-# - LED state detection (on, off, blinking)
-# - Color parsing (red, green, amber, blue, etc.)
-# - Blink detection (delay_on, delay_off)
-# - File parsing and state conversion
-################################################################################
 
 Describe 'hw-management-led-state-conversion.sh'
     
@@ -105,7 +107,7 @@ check_led_blink()
 
 for CURR_FILE in "${FNAMES[@]}"
 do
-    if echo "$CURR_FILE" | (grep -q '_state\|_capability') ; then
+    if echo "$CURR_FILE" | (grep -q '_state\|_capability\|_control') ; then
         continue
     fi
     COLOR=$(echo "$CURR_FILE" | cut -d_ -f3)
@@ -293,6 +295,7 @@ WRAPPER_EOF
         It 'ignores _state and _capability files'
             create_led_file "${LED_NAME}_state" "some_state"
             create_led_file "${LED_NAME}_capability" "capability_info"
+            create_led_file "${LED_NAME}_control" "led_hw_sw"
             create_led_file "${LED_NAME}_red" "255"
             
             When call run_led_conversion

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -689,6 +689,77 @@ function handle_hotplug_event()
 	esac
 }
 
+# Resolve LED control type for $1 (udev LED name, e.g. status, uid, fan1).
+# Reads $config_path/led_control_type pairs: "status led_hw uid led_sw fan* led_hw".
+# Exact name or led_<name> first. Then glob masks (* any string, ? one char).
+# fan and fan1 stay different unless a mask like fan* is used. Else LED_CONTROL_HW_SW.
+# parameters:
+# $1 - LED name (e.g. status, uid, fan1)
+# returns:
+# LED control type (e.g. led_hw, led_sw, led_hw_sw)
+function get_led_control_type()
+{
+	local led_name="$1"
+	local -a led_ctrl_map
+	local i
+	local entry
+	local val
+	local match
+
+	if [ ! -f "$config_path"/led_control_type ]; then
+		echo "$LED_CONTROL_HW_SW"
+		return
+	fi
+
+	# noglob: keep * and ? as mask chars, not pathname expansion.
+	set -f
+	led_ctrl_map=($(< "$config_path"/led_control_type))
+	set +f
+
+	# Exact name first so "fan" does not apply to "fan1".
+	for ((i=0; i<${#led_ctrl_map[@]}; i+=2)); do
+		entry="${led_ctrl_map[i]}"
+		val="${led_ctrl_map[i+1]}"
+		if [ "$entry" = "$led_name" ] || [ "$entry" = "led_${led_name}" ]; then
+			case "$val" in
+			"$LED_CONTROL_SW"|"$LED_CONTROL_HW"|"$LED_CONTROL_HW_SW")
+				echo "$val"
+				return
+				;;
+			esac
+		fi
+	done
+
+	# Glob masks: * any string, ? one character. First matching mask wins.
+	for ((i=0; i<${#led_ctrl_map[@]}; i+=2)); do
+		entry="${led_ctrl_map[i]}"
+		val="${led_ctrl_map[i+1]}"
+		case "$entry" in
+		*[\*\?]*)
+			match=0
+			case "$led_name" in
+			$entry) match=1 ;;
+			esac
+			if [ "$match" -eq 0 ]; then
+				case "led_${led_name}" in
+				$entry) match=1 ;;
+				esac
+			fi
+			if [ "$match" -eq 1 ]; then
+				case "$val" in
+				"$LED_CONTROL_SW"|"$LED_CONTROL_HW"|"$LED_CONTROL_HW_SW")
+					echo "$val"
+					return
+					;;
+				esac
+			fi
+			;;
+		esac
+	done
+
+	echo "$LED_CONTROL_HW_SW"
+}
+
 function handle_fantray_led_event()
 {
 	local fan_idx
@@ -1064,6 +1135,9 @@ if [ "$1" == "add" ]; then
 			capability=$(< $led_path/led_"$name"_capability)
 			capability="${capability} ${color} ${color}_blink"
 			echo "$capability" > $led_path/led_"$name"_capability
+		fi
+		if [ ! -f $led_path/led_"$name"_control ]; then
+			get_led_control_type "$name" > $led_path/led_"$name"_control
 		fi
 		unlock_service_state_change
 		$led_path/led_"$name"_state
@@ -1531,6 +1605,9 @@ else
 	fi
 	if [ -f $led_path/led_"$name"_capability ]; then
 		rm -f $led_path/led_"$name"_capability
+	fi
+	if [ -f $led_path/led_"$name"_control ]; then
+		rm -f $led_path/led_"$name"_control
 	fi
 	if [ "$2" == "regio" ]; then
 		# Detect if it belongs to line card or to main board or to dpu.

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -158,6 +158,20 @@ amd_snw_i2c_sodimm_dev=/sys/devices/platform/AMDI0010:02
 n5110_mctp_bus="0"
 n5110_mctp_addr="1040"
 
+
+# Optional per-LED-type control map, saved as space-separated pairs in
+# $config_path/led_control_type: "name type [name type ...]".
+# Name may be exact (fan, led_status) or a glob mask (fan*, led_psu?).
+# Example in *_specific(): led_control_type=(status "$LED_CONTROL_HW" "fan*" "$LED_CONTROL_SW")
+# Quote masks ("fan*", "led?") so the shell does not expand them.
+# Unset map or missing LED name uses LED_CONTROL_HW_SW.
+
+# LED control owner. Written to led/led_<name>_control.
+# Platform *_specific() may set led_control_type=(name type ...) pairs.
+LED_CONTROL_SW="led_sw"
+LED_CONTROL_HW="led_hw"
+LED_CONTROL_HW_SW="led_hw_sw"
+
 # hw-mngmt-sysfs-monitor GLOBALS
 SYSFS_MONITOR_TIMEOUT=20 # Total Sysfs T/O.
 SYSFS_MONITOR_DELAY=1 # Internal delay for Sysfs monitor loop to free CPU.

--- a/usr/usr/bin/hw-management-led-state-conversion.sh
+++ b/usr/usr/bin/hw-management-led-state-conversion.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ##################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2018-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -68,7 +68,7 @@ check_led_blink()
 
 for CURR_FILE in "${FNAMES[@]}"
 do
-	if echo "$CURR_FILE" | (grep -q '_state\|_capability') ; then
+	if echo "$CURR_FILE" | (grep -q '_state\|_capability\|_control') ; then
 		continue
 	fi
 	COLOR=$(echo "$CURR_FILE" | cut -d_ -f3)

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3310,6 +3310,9 @@ set_config_data()
 	echo $hotplug_linecards > $config_path/hotplug_linecards
 	echo $fan_speed_tolerance > $config_path/fan_speed_tolerance
 	echo $leakage_count > $config_path/leakage_counter
+	if [ "${#led_control_type[@]}" -gt 0 ]; then
+		echo "${led_control_type[@]}" > "$config_path"/led_control_type
+	fi
 	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
 		cp $thermal_control_config $config_path/tc_config.json
 	else


### PR DESCRIPTION
Userspace needs to know whether a chassis LED is controlled by software,
hardware, or both.

Expose the LED control owner through:
./led/led_<name>_control

The LED owner can optionally be defined in config/led_control_type.

The default owner is led_hw_sw.

Possible options:

led_sw - LED state is controlled by the OS from userspace.
led_hw - LED state is automatically controlled by the hardware (CPLD)
state machine.
led_hw_sw - LED state is automatically controlled by the hardware, but
can also be controlled by userspace.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
