### PR TITLE
hw-mgmt: tc: Replace service-file patching with a launcher script

### DIFF
--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Thermal control service (ver 2.0) of Nvidia systems
+Description=Thermal control service of Nvidia systems
 After=hw-management.service
 Requires=hw-management.service
 PartOf=hw-management.service
@@ -9,17 +9,11 @@ StartLimitIntervalSec=1200
 StartLimitBurst=15
 
 [Service]
-ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_control.py"
-ExecStop=/bin/kill $MAINPID
+ExecStart=/usr/bin/hw_management_tc_launcher.sh
 TimeoutStopSec=10
 
 Restart=on-failure
 RestartSec=60s
-
-# Save/clear TC run state for hw-management-start-post.sh.
-# Path must match tc_state_file in hw-management-helpers.sh.
-ExecStartPost=-/bin/rm -f /var/run/.hw-management-tc-state
-ExecStop=-/bin/sh -c 'f=/var/run/.hw-management-tc-state; [ -L "$f" ] && rm -f "$f"; umask 077; printf started > "$f"'
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/man/hw-management-tc.service.8
+++ b/doc/man/hw-management-tc.service.8
@@ -12,22 +12,16 @@ The service supports multiple thermal control versions:
 - TC v2.0: Standard thermal control implementation
 - TC v2.5: Enhanced thermal control with improved algorithms for newer systems
 
-The service selects the thermal control application from the
-\fItc_version\fR field in \fI/var/run/hw-management/config/tc_config.json\fR (defaults to
-v2.0 when unset). \fBhw-management-start-post.sh\fR aligns the systemd unit to run the
-matching Python script:
-- /usr/bin/hw_management_thermal_control.py (TC v2.0)
+The service is started via \fBhw_management_tc_launcher.sh\fR, which reads the
+\fItc_version\fR field from \fI/var/run/hw-management/config/tc_config.json\fR and
+exec()s the matching Python binary directly as the systemd MAINPID:
+- /usr/bin/hw_management_thermal_control.py (TC v2.0, default)
 - /usr/bin/hw_management_thermal_control_2_5.py (TC v2.5)
 
-When the unit is rewritten, it is reloaded and thermal control is restarted shortly after.
-
-.SH STATE ACROSS HW-MANAGEMENT RESTARTS
-On stop, this unit writes "started" to \fI/var/run/.hw-management-tc-state\fR.
-\fBhw-management-start-post.sh\fR restores that state and removes the file.
-Missing or invalid content leaves thermal control unchanged.
-Cleared again on TC start, so a manual restart of this service leaves no marker.
-Honoured only while the unit is enabled; use
-\fBsystemctl disable \-\-now hw\-management\-tc\fR to keep it off.
+Version selection happens at each service start; no service file patching or
+daemon-reload is required.  \fItc_config.json\fR is written by
+\fBhw-management.sh\fR (set_config_data) before \fBhw-management.service\fR
+becomes active, so the correct binary is always chosen on the first start.
 .SH OPTIONS
 .TP
 start

--- a/tests/offline/test_hw_management_start_post_tc.py
+++ b/tests/offline/test_hw_management_start_post_tc.py
@@ -3,23 +3,23 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
-# Unit tests for hw-management-start-post.sh TC service logic
-# (commit f9f543b4c6b5dd42caac5d0c1b8e4aa559566b8d, Bug 4929286).
+# Unit tests for hw-management-start-post.sh TC service logic and
+# hw_management_tc_launcher.sh version selection.
 #
 # Verifies: TC is not auto-enabled on non-SimX; SimX paths set enable/disable
-# flags; deferred cmd_line matches reload/start/stop combinations.
+# flags; deferred cmd_line matches enable/disable combinations; launcher picks
+# the correct Python binary from tc_config.json.
 ################################################################################
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.offline
 
-# Mirrors start-post.sh lines 114-159 (flag computation only)
+# Mirrors start-post.sh TC flag computation (platform/SimX logic only)
 _BASH_TC_FLAGS = r"""
 tc_is_enabled=${TC_IS_EN:-0}
 tc_should_start=0
@@ -51,68 +51,31 @@ fi
 printf '%d %d %d\n' "$tc_should_disable" "$tc_should_enable" "$tc_should_start"
 """
 
-# Mirrors the state restore, the reload gate and the cmd_line build (no nohup).
+# Mirrors the simplified cmd_line build in start-post.sh (no nohup).
 # Prints NONE when the script would leave the TC service alone.
 _BASH_CMD_LINE = r"""
-tc_is_enabled=${TC_IS_EN:-0}
-tc_is_active=${TC_IS_ACT:-0}
-tc_saved_state=${STATE:-}
-tc_should_reload=${R:-0}
 tc_should_disable=${D:-0}
 tc_should_enable=${E:-0}
+tc_should_start=${S:-0}
 
-tc_should_start=$tc_is_active
-tc_should_restart=0
-if [ "$tc_saved_state" = "started" ] && [ "$tc_is_enabled" -eq 1 ]; then
-	tc_should_start=1
-fi
-
-# The SimX branch forces a start regardless of the saved state.
-if [ "${FORCE_START:-0}" -eq 1 ]; then
-	tc_should_start=1
-fi
-
-if [ "$tc_should_reload" -eq 1 ]; then
-	tc_should_restart=1
-	if [ -z "$tc_saved_state" ] && [ "$tc_is_enabled" -eq 1 ]; then
-		tc_should_start=1
+cmd_line=""
+if [ "$tc_should_disable" -eq 1 ] || [ "$tc_should_enable" -eq 1 ]; then
+	cmd_line="sleep 10 &&"
+	if [ "$tc_should_disable" -eq 1 ]; then
+		cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
+	elif [ "$tc_should_enable" -eq 1 ]; then
+		cmd_line="$cmd_line systemctl enable hw-management-tc &&"
+		if [ "$tc_should_start" -eq 1 ]; then
+			cmd_line="$cmd_line systemctl start hw-management-tc &&"
+		fi
 	fi
 fi
 
-tc_action_needed=0
-if [ "$tc_should_reload" -eq 1 ] ||
-   [ "$tc_should_disable" -eq 1 ] ||
-   [ "$tc_should_enable" -eq 1 ] ||
-   [ "$tc_should_restart" -eq 1 ]; then
-	tc_action_needed=1
-elif [ "$tc_should_start" -eq 1 ] && [ "$tc_is_active" -eq 0 ]; then
-	tc_action_needed=1
-fi
-
-if [ "$tc_action_needed" -eq 0 ]; then
+if [ -z "$cmd_line" ]; then
 	printf 'NONE\n'
-	exit 0
+else
+	printf '%s\n' "$cmd_line"
 fi
-
-cmd_line="sleep 10 &&"
-if [ "$tc_should_reload" -eq 1 ]; then
-	cmd_line="$cmd_line systemctl daemon-reload &&"
-fi
-if [ "$tc_should_disable" -eq 1 ]; then
-	cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
-	tc_should_start=0
-	tc_should_restart=0
-elif [ "$tc_should_enable" -eq 1 ]; then
-	cmd_line="$cmd_line systemctl enable hw-management-tc &&"
-fi
-if [ "$tc_should_start" -ne 0 ]; then
-	if [ "$tc_should_restart" -eq 1 ]; then
-		cmd_line="$cmd_line systemctl restart hw-management-tc &&"
-	else
-		cmd_line="$cmd_line systemctl start hw-management-tc &&"
-	fi
-fi
-printf '%s\n' "$cmd_line"
 """
 
 
@@ -144,6 +107,37 @@ def _run_bash_cmdline(env):
     assert r.returncode == 0, r.stderr
     return r.stdout.strip()
 
+
+def _run_launcher(tc_config_content, tmp_path):
+    """Run launcher version-selection logic; return '2_5' or '2_0'."""
+    cfg = tmp_path / "tc_config.json"
+    if tc_config_content is not None:
+        cfg.write_text(tc_config_content)
+        cfg_path = str(cfg)
+    else:
+        cfg_path = "/nonexistent/tc_config.json"
+
+    script = rf"""
+tc_cfg="{cfg_path}"
+tc_ver=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$tc_cfg" 2>/dev/null \
+         | head -n1 | cut -d'"' -f4)
+case $tc_ver in
+    2.5|2.5.*)
+        printf '2_5\n'
+        ;;
+    *)
+        printf '2_0\n'
+        ;;
+esac
+"""
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Platform / SimX flag tests
+# ---------------------------------------------------------------------------
 
 def test_tc_not_supported_disables():
     """check_tc_is_supported returns 0 -> platform_support 0 -> disable."""
@@ -198,62 +192,35 @@ def test_simx_supported_already_enabled_no_enable_flag():
     assert (d, en, st) == (0, 0, 1)
 
 
-def test_systemd_restart_brings_back_tc_that_was_running():
-    """PartOf= or systemctl stop both run ExecStop and leave STATE=started.
-    After hw-management start, TC must be brought back while the unit stays enabled."""
-    s = _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "0"})
-    assert "start hw-management-tc" in s
+# ---------------------------------------------------------------------------
+# cmd_line builder tests
+# ---------------------------------------------------------------------------
+
+def test_no_action_needed_returns_none():
+    """No disable/enable → nothing to do."""
+    assert _run_bash_cmdline({}) == "NONE"
 
 
-def test_no_saved_state_leaves_inactive_tc_alone():
-    """Missing marker (never written or already consumed): do not start or stop TC."""
-    assert _run_bash_cmdline({"TC_IS_EN": "1", "TC_IS_ACT": "0"}) == "NONE"
-
-
-def test_running_tc_without_unit_change_is_left_alone():
-    assert _run_bash_cmdline({"TC_IS_EN": "1", "TC_IS_ACT": "1"}) == "NONE"
-
-
-def test_saved_state_with_already_active_tc_is_left_alone():
-    """State file only drives start after a systemd stop; if TC is still active, do nothing."""
-    assert (
-        _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "1"}) ==
-        "NONE"
-    )
-
-
-def test_saved_state_ignored_when_unit_is_disabled():
-    assert _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "0"}) == "NONE"
-
-
-def test_version_change_restarts_tc_that_was_running():
-    s = _run_bash_cmdline(
-        {"R": "1", "STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "0"}
-    )
-    assert "daemon-reload" in s and "restart hw-management-tc" in s
-
-
-def test_cmd_line_reload_only():
-    s = _run_bash_cmdline({"R": "1", "TC_IS_EN": "0", "TC_IS_ACT": "0"})
-    assert "daemon-reload" in s
-    assert "restart" not in s and "start hw-management-tc" not in s
-
-
-def test_cmd_line_disable_clears_start():
-    s = _run_bash_cmdline({"D": "1", "TC_IS_EN": "1", "TC_IS_ACT": "1"})
-    assert "stop hw-management-tc" in s and "disable" in s
-    assert "start hw-management-tc" not in s and "restart" not in s
-
-
-def test_cmd_line_reload_with_start_uses_restart():
-    s = _run_bash_cmdline({"R": "1", "TC_IS_EN": "1", "TC_IS_ACT": "0"})
-    assert "daemon-reload" in s and "restart hw-management-tc" in s
+def test_cmd_line_disable():
+    s = _run_bash_cmdline({"D": "1"})
+    assert "stop hw-management-tc" in s and "disable hw-management-tc" in s
+    assert "start hw-management-tc" not in s and "enable" not in s
 
 
 def test_cmd_line_enable_and_start():
-    s = _run_bash_cmdline({"E": "1", "FORCE_START": "1", "TC_IS_ACT": "0"})
+    s = _run_bash_cmdline({"E": "1", "S": "1"})
     assert "enable hw-management-tc" in s and "start hw-management-tc" in s
 
+
+def test_cmd_line_enable_without_start():
+    s = _run_bash_cmdline({"E": "1", "S": "0"})
+    assert "enable hw-management-tc" in s
+    assert "start hw-management-tc" not in s
+
+
+# ---------------------------------------------------------------------------
+# start-post.sh structural checks
+# ---------------------------------------------------------------------------
 
 def test_start_post_script_documents_bug_and_nohup():
     """Regression: script uses deferred nohup bash -c for TC actions."""
@@ -268,92 +235,45 @@ def test_start_post_script_documents_bug_and_nohup():
     assert "tc_should_enable=1" in text
 
 
-def test_unit_path_taken_from_fragment_path():
-    """systemctl status output starts with a warning line once the unit was edited on disk,
-    which broke the previous line/field based parsing of the unit path."""
+def test_start_post_no_longer_patches_service_file():
+    """start-post.sh must not sed-patch the TC unit file."""
     root = Path(__file__).resolve().parents[2]
-    sh = root / "usr" / "usr" / "bin" / "hw-management-start-post.sh"
-    text = sh.read_text()
-    assert "systemctl show -p FragmentPath hw-management-tc.service" in text
-    assert "systemctl status hw-management-tc.service" not in text
+    text = (root / "usr" / "usr" / "bin" / "hw-management-start-post.sh").read_text()
+    assert "sed_edit_executable" not in text
+    assert "FragmentPath" not in text
+    assert "daemon-reload" not in text
+    assert "consume_tc_saved_state" not in text
 
 
-def test_tc_state_is_saved_on_hw_management_stop_and_restored_on_start():
+# ---------------------------------------------------------------------------
+# Launcher version selection tests
+# ---------------------------------------------------------------------------
+
+def test_launcher_selects_v25_binary(tmp_path):
+    assert _run_launcher('{"tc_version": "2.5"}', tmp_path) == "2_5"
+
+
+def test_launcher_selects_v25_for_subversion(tmp_path):
+    assert _run_launcher('{"tc_version": "2.5.1"}', tmp_path) == "2_5"
+
+
+def test_launcher_selects_v20_explicitly(tmp_path):
+    assert _run_launcher('{"tc_version": "2.0"}', tmp_path) == "2_0"
+
+
+def test_launcher_defaults_to_v20_when_config_missing(tmp_path):
+    assert _run_launcher(None, tmp_path) == "2_0"
+
+
+def test_launcher_defaults_to_v20_for_unknown_version(tmp_path):
+    assert _run_launcher('{"tc_version": "3.0"}', tmp_path) == "2_0"
+
+
+def test_launcher_uses_exec_so_python_is_mainpid():
+    """The launcher must exec the Python binary so Python becomes the systemd MAINPID."""
     root = Path(__file__).resolve().parents[2]
-    tc_unit = (root / "debian" / "hw-management.hw-management-tc.service").read_text()
-    helpers = (root / "usr" / "usr" / "bin" / "hw-management-helpers.sh").read_text()
-    hw_management = (root / "usr" / "usr" / "bin" / "hw-management.sh").read_text()
-    start_post = (
-        root / "usr" / "usr" / "bin" / "hw-management-start-post.sh"
-    ).read_text()
-
-    assert 'tc_state_file="/var/run/.hw-management-tc-state"' in helpers
-    assert "consume_tc_saved_state()" in helpers
-    assert "save_tc_state_started" not in helpers
-    # Helpers: path near other /run state files; consume after check_tc_is_supported.
-    assert helpers.index("asic_chipup_status=") < helpers.index('tc_state_file="/var/run/.hw-management-tc-state"')
-    assert helpers.index("check_tc_is_supported()") < helpers.index("consume_tc_saved_state()")
-    # Unit: existing ExecStart/ExecStop first; state save/clear after.
-    assert tc_unit.index("ExecStart=/bin/sh") < tc_unit.index("ExecStartPost=-/bin/rm -f /var/run/.hw-management-tc-state")
-    assert tc_unit.index("ExecStop=/bin/kill $MAINPID") < tc_unit.index("umask 077")
-    assert "/var/run/.hw-management-tc-state" in tc_unit
-    # State is saved only from the TC unit ExecStop, not from hw-management.sh.
-    do_stop = hw_management[hw_management.index("do_stop()"): hw_management.index("function find_asic_hwmon_path")]
-    assert "consume_tc_saved_state" not in do_stop
-    assert "tc_state_file" not in do_stop
-    # start-post: existing enable/active checks first; restore after unit align.
-    assert start_post.index("systemctl is-enabled --quiet hw-management-tc.service") < start_post.index(
-        "tc_saved_state=$(consume_tc_saved_state)"
-    )
-    assert start_post.index("tc_should_reload=1") < start_post.index(
-        "tc_saved_state=$(consume_tc_saved_state)"
-    )
-
-
-def test_consume_tc_state_handles_missing_broken_and_symlink(tmp_path):
-    """Missing / garbage / symlink must not restore TC as started."""
-    root = Path(__file__).resolve().parents[2]
-    helpers = root / "usr" / "usr" / "bin" / "hw-management-helpers.sh"
-    state = tmp_path / ".hw-management-tc-state"
-    script = f"""
-source {helpers}
-tc_state_file="{state}"
-printf '%s\\n' "$(consume_tc_saved_state)"
-"""
-
-    # Missing file
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-
-    # Valid started
-    state.write_text("started\n")
-    os.chmod(state, 0o600)
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == "started"
-    assert not state.exists()
-
-    # Broken content
-    state.write_text("garbage\n")
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-    assert not state.exists()
-
-    # Empty / whitespace
-    state.write_text("   \n")
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-    assert not state.exists()
-
-    # Symlink: remove and ignore
-    target = tmp_path / "elsewhere"
-    target.write_text("started\n")
-    state.symlink_to(target)
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-    assert not state.exists()
-    assert target.read_text() == "started\n"
+    text = (root / "usr" / "usr" / "bin" / "hw_management_tc_launcher.sh").read_text()
+    assert "exec /usr/bin/hw_management_thermal_control_2_5.py" in text
+    assert "exec /usr/bin/hw_management_thermal_control.py" in text
+    # Must not use sh -c wrapper
+    assert "/bin/sh -c" not in text

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -83,9 +83,6 @@ vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
 cpldreg_log_file=/var/log/hw-mgmt-cpldreg.log
 fixup_hook_script=/usr/local/bin/hw-management-fixup.sh
 asic_chipup_status=/run/.asic_chipup_completed
-# TC run state across hw-management stop/start. Outside $hw_management_path
-# (removed on stop). Keep in sync with hw-management-tc.service.
-tc_state_file="/var/run/.hw-management-tc-state"
 
 declare -A psu_fandir_vs_pn=(["00KX1W"]=R ["00MP582"]=F ["00MP592"]=R ["00WT061"]=F \
 ["00WT062"]=R ["00WT199"]=F ["01FT674"]=F ["01FT691"]=F ["01LL976"]=F \
@@ -364,27 +361,6 @@ check_tc_is_supported()
 	else
 		return 1
 	fi
-}
-
-# Read once and remove. Prints "started" or nothing if missing/invalid.
-consume_tc_saved_state()
-{
-	local state=""
-
-	if [ -L "$tc_state_file" ]; then
-		rm -f "$tc_state_file"
-		return
-	fi
-	if [ ! -f "$tc_state_file" ]; then
-		return
-	fi
-	state=$(tr -d '[:space:]' < "$tc_state_file" 2>/dev/null)
-	rm -f "$tc_state_file"
-	case $state in
-		started)
-			printf '%s\n' "$state"
-			;;
-	esac
 }
 
 # This function checks if BMC is supported for current platform

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -35,20 +35,6 @@
 # hw-management script that is executed at the end of hw-management start.
 source hw-management-helpers.sh
 
-# Read tc_version value from a tc_config.json path (grep-based). Prints 2.0 when missing or unreadable.
-get_tc_version()
-{
-	local json_path="$1"
-	local v
-
-	[ -f "$json_path" ] || {
-		echo "2.0"
-		return
-	}
-	v=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$json_path" 2>/dev/null | head -n1 | cut -d'"' -f4)
-	echo "${v:-2.0}"
-}
-
 # Local constants and paths.
 CPLD3_VER_DEF="0"
  
@@ -125,24 +111,16 @@ case $sku in
 		# Do nothing
 esac
 
-# Check if TC service is enabled (unit enabled at boot) and if it is currently running.
+# Check if TC service is enabled (unit enabled at boot).
 tc_is_enabled=0
 if systemctl is-enabled --quiet hw-management-tc.service 2>/dev/null; then
 	tc_is_enabled=1
-fi
-# Check if TC service is running.
-tc_should_start=0
-tc_is_active=0
-if systemctl is-active --quiet hw-management-tc.service; then
-	tc_should_start=1
-	tc_is_active=1
 fi
 
 # Initialize TC service control variables.
 tc_should_enable=0
 tc_should_disable=0
-tc_should_reload=0
-tc_should_restart=0
+tc_should_start=0
 
 ## Checking if system doesn't support TC and disable it if it doesn't.
 if check_tc_is_supported; then
@@ -160,7 +138,6 @@ else
 				logger -t hw-management -p daemon.notice "Stopping and disabling hw-management-tc on SimX"
 				# TC service should be stopped and disabled.
 				tc_should_disable=1
-				tc_should_start=0
 			fi
 		else
 			# If TC is supported in SimX.
@@ -175,93 +152,17 @@ else
 	fi
 fi
 
-# Align TC unit with tc_config.json version; rewrite only when needed.
-service_file_path=$(systemctl show -p FragmentPath hw-management-tc.service 2>/dev/null | cut -d= -f2-)
-if [ -f "$service_file_path" ]; then
-	# Select TC app from tc_version in tc_config.json.
-	tc_cfg_json="$config_path/tc_config.json"
-	tc_version="2.0"
-	tc_executable="hw_management_thermal_control.py"
-	if [ -f "$tc_cfg_json" ]; then
-		tc_ver_raw=$(get_tc_version "$tc_cfg_json")
-		case $tc_ver_raw in
-			2.5|2.5.*)
-				tc_version="2.5"
-				tc_executable="hw_management_thermal_control_2_5.py"
-				;;
-			*)
-				tc_version="2.0"
-				tc_executable="hw_management_thermal_control.py"
-				;;
-		esac
-	fi
-
-	sed_edit_executable="s/hw_management_thermal_control_2_5\.py/$tc_executable/g;s/hw_management_thermal_control\.py/$tc_executable/g"
-	sed_edit_version="s/ver [0-9][0-9.]*/ver $tc_version/g"
-
-	# Rewrite only if content would change.
-	tc_unit_needs_update=1
-	if sed -e "$sed_edit_executable" -e "$sed_edit_version" -- "$service_file_path" |
-		cmp -s -- "$service_file_path" -; then
-		tc_unit_needs_update=0
-	fi
-
-	if [ "$tc_unit_needs_update" -eq 1 ]; then
-		sed -i -e "$sed_edit_executable" -e "$sed_edit_version" "$service_file_path"
-		log_info "Thermal Control service updated. Reload it in 10 seconds"
-		tc_should_reload=1
-	fi
-fi
-
-# Restore TC state saved on hw-management stop. Missing/invalid => leave as-is.
-tc_saved_state=$(consume_tc_saved_state)
-if [ "$tc_saved_state" = "started" ] && [ $tc_is_enabled -eq 1 ]; then
-	tc_should_start=1
-fi
-# Unit rewrite requires restart; with no saved state, fall back to enabled.
-if [ $tc_should_reload -eq 1 ]; then
-	tc_should_restart=1
-	if [ -z "$tc_saved_state" ] && [ $tc_is_enabled -eq 1 ]; then
-		tc_should_start=1
-	fi
-fi
-
 # Build and execute the command line for TC service control only when there is something to do.
-tc_action_needed=0
-if [ $tc_should_reload -eq 1 ] ||
-   [ $tc_should_disable -eq 1 ] ||
-   [ $tc_should_enable -eq 1 ] ||
-   [ $tc_should_restart -eq 1 ]; then
-	tc_action_needed=1
-elif [ $tc_should_start -eq 1 ] && [ $tc_is_active -eq 0 ]; then
-	tc_action_needed=1
-fi
-
-if [ $tc_action_needed -eq 1 ]; then
+if [ $tc_should_disable -eq 1 ] || [ $tc_should_enable -eq 1 ]; then
 	cmd_line="sleep 10 &&"
-
-	# Reload the systemd daemon if needed.
-	if [ $tc_should_reload -eq 1 ]; then
-		cmd_line="$cmd_line systemctl daemon-reload &&"
-	fi
 
 	# Disable TC service if needed.
 	if [ $tc_should_disable -eq 1 ]; then
 		cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
-		# TC service should not be started.
-		tc_should_start=0
-		tc_should_restart=0
 	elif [ $tc_should_enable -eq 1 ]; then
 		# TC service should be enabled.
 		cmd_line="$cmd_line systemctl enable hw-management-tc &&"
-	fi
-
-	# Start TC service if needed.
-	if [ $tc_should_start -ne 0 ]; then
-		if [ $tc_should_restart -eq 1 ]; then
-			# TC service should be restarted in case of reload.
-			cmd_line="$cmd_line systemctl restart hw-management-tc &&"
-		else
+		if [ $tc_should_start -eq 1 ]; then
 			# TC service should be started.
 			cmd_line="$cmd_line systemctl start hw-management-tc &&"
 		fi
@@ -269,7 +170,7 @@ if [ $tc_action_needed -eq 1 ]; then
 
 	# Run the command line in the background and log the output to /dev/null.
 	# it is necessary because on SIMX, hw-mgmt tries to start the TC service during initialization.
-	# However, the TC service has a strong dependency: 
+	# However, the TC service has a strong dependency:
 	# Requires=hw-management.service. This means the TC service cannot start
 	# before hw-mgmt starts. But hw-mgmt attempts to start TC earlier. In this
 	# case, neither hw-mgmt nor TC will complete initialization.

--- a/usr/usr/bin/hw_management_tc_launcher.sh
+++ b/usr/usr/bin/hw_management_tc_launcher.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Thermal control launcher: read tc_version from tc_config.json and exec the
+# matching Python binary.  "exec" replaces this shell process so Python becomes
+# the systemd MAINPID directly — no sh wrapper, no ExecStop needed.
+#
+# tc_config.json is written by hw-management.sh (set_config_data) before
+# hw-management.service becomes active, so the file is always present when
+# this launcher is called (hw-management-tc.service has After=hw-management.service).
+# Defaults to v2.0 when the file is absent or tc_version is unrecognised.
+
+tc_cfg=/var/run/hw-management/config/tc_config.json
+
+tc_ver=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$tc_cfg" 2>/dev/null \
+         | head -n1 | cut -d'"' -f4)
+
+case $tc_ver in
+    2.5|2.5.*)
+        exec /usr/bin/hw_management_thermal_control_2_5.py
+        ;;
+    *)
+        exec /usr/bin/hw_management_thermal_control.py
+        ;;
+esac


### PR DESCRIPTION
Reverts 8f04e45f (Preserve TC run state across hw-management restart) and fixes the root cause properly.

Problem: hw-management-tc.service shipped a hardcoded v2.0 ExecStart. hw-management-start-post.sh patched the unit file on every boot and scheduled a daemon-reload + restart to pick up the new binary.  The state-file mechanism in 8f04e45f worked around the resulting races but left the design ownership wrong: hw-management was deciding which TC binary to run instead of the TC service itself.

Fix: introduce hw_management_tc_launcher.sh as ExecStart.  The launcher reads tc_version from tc_config.json (written by set_config_data before hw-management.service becomes active) and exec()s the matching Python binary directly, making Python the systemd MAINPID.  Because the right binary is chosen on every start, no unit-file patching, daemon-reload, or restart is needed.

Changes:
- hw-management-tc.service: ExecStart -> launcher; drop ExecStop kill wrapper and state-file ExecStartPost/ExecStop hooks
- hw_management_tc_launcher.sh: new launcher (exec, not sh -c)
- hw-management-start-post.sh: remove get_tc_version(), service-file sed patching, FragmentPath lookup, consume_tc_saved_state() call, tc_should_reload/restart/is_active variables and daemon-reload step
- hw-management-helpers.sh: remove tc_state_file and consume_tc_saved_state()
- hw-management-tc.service.8: document launcher approach
- test_hw_management_start_post_tc.py: replace state-file and reload tests with launcher version-selection tests (17 tests, all pass)

Bug: 5200160