### PR TITLE
hw-mgmt: tc: Replace service-file patching with a launcher script

### DIFF
--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -16,10 +16,5 @@ TimeoutStopSec=10
 Restart=on-failure
 RestartSec=60s
 
-# Save/clear TC run state for hw-management-start-post.sh.
-# Path must match tc_state_file in hw-management-helpers.sh.
-ExecStartPost=-/bin/rm -f /var/run/.hw-management-tc-state
-ExecStop=-/bin/sh -c 'f=/var/run/.hw-management-tc-state; [ -L "$f" ] && rm -f "$f"; umask 077; printf started > "$f"'
-
 [Install]
 WantedBy=multi-user.target

--- a/debian/hw-management.hw-management-tc.service
+++ b/debian/hw-management.hw-management-tc.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Thermal control service (ver 2.0) of Nvidia systems
+Description=Thermal control service (ver x.x) of Nvidia systems
 After=hw-management.service
 Requires=hw-management.service
 PartOf=hw-management.service
@@ -9,8 +9,8 @@ StartLimitIntervalSec=1200
 StartLimitBurst=15
 
 [Service]
-ExecStart=/bin/sh -c "/usr/bin/hw_management_thermal_control.py"
-ExecStop=/bin/kill $MAINPID
+ExecStart=/usr/bin/hw_management_tc_launcher.sh
+ExecStopPost=/usr/bin/hw-management-tc-stop-post.sh
 TimeoutStopSec=10
 
 Restart=on-failure

--- a/doc/man/hw-management-tc.service.8
+++ b/doc/man/hw-management-tc.service.8
@@ -12,12 +12,47 @@ The service supports multiple thermal control versions:
 - TC v2.0: Standard thermal control implementation
 - TC v2.5: Enhanced thermal control with improved algorithms for newer systems
 
-The service selects the thermal control application from the
-\fItc_version\fR field in \fI/var/run/hw-management/tc_config.json\fR (defaults to v2.0
-when unset). \fBhw-management-start-post.sh\fR aligns the systemd unit to run the
-matching Python script:
-- /usr/bin/hw_management_thermal_control.py (TC v2.0)
+The service is started via \fBhw_management_tc_launcher.sh\fR, which reads the
+\fItc_version\fR field from \fI/var/run/hw-management/config/tc_config.json\fR and
+exec()s the matching Python binary directly as the systemd MAINPID:
+- /usr/bin/hw_management_thermal_control.py (TC v2.0, default)
 - /usr/bin/hw_management_thermal_control_2_5.py (TC v2.5)
+
+Version selection happens at each service start; no patching or daemon-reload
+of \fBExecStart\fR is required.  \fItc_config.json\fR is written by
+\fBhw-management.sh\fR (set_config_data) before \fBhw-management.service\fR
+becomes active, so the correct binary is always chosen on the first start.
+
+The launcher also keeps the unit's \fBDescription\fR in sync with the
+selected version (e.g. "... (ver 2.5) ..."), so \fBsystemctl status\fR
+reflects the running version. This edit is metadata only: it patches the
+\fBDescription\fR field in place and runs \fBsystemctl daemon-reload\fR, but
+never touches \fBExecStart\fR, so it cannot race with or affect this unit's
+own running/activating state. It is skipped when the Description already
+matches. Before the launcher's first run, the shipped unit ships a
+"(ver x.x)" placeholder rather than a specific version, since that value
+has not yet been determined for this boot.
+.SH STATE ACROSS HW-MANAGEMENT RESTARTS
+\fBPartOf=hw-management.service\fR propagates a stop or restart of
+\fBhw-management.service\fR to this service, but never a plain start. If
+\fBhw-management.service\fR is stopped and later started as two separate
+operations, an already-enabled TC service would otherwise stay down.
+\fBhw-management-tc-stop-post.sh\fR (ExecStopPost) tells this case apart from
+an operator directly stopping only the TC service by checking whether a
+stop or restart job is queued for \fBhw-management.service\fR at the moment
+TC stops: if one is, TC's stop is part of that same transaction (PartOf=
+cascade) and is marked for restore; if not, the stop is recorded as
+intentional. Because this service has After=hw-management.service, TC is
+always stopped before hw-management.service's own stop job begins, so
+\fBhw-management.service\fR's ActiveState is still "active" at that point
+even during a genuine cascade - a queued job, not ActiveState, is what
+distinguishes the two cases.
+\fBhw-management-start-post.sh\fR schedules a restore on the next
+\fBhw-management.service\fR start when that marker is present, but does not
+consume it or check TC's active state until the restore's usual 10s
+scheduling delay has elapsed. Re-checking at that later point, rather than
+when the delay is scheduled, means an operator action that clears the marker
+during the delay is not silently overridden by an already-stale decision.
 .SH OPTIONS
 .TP
 start

--- a/doc/man/hw-management-tc.service.8
+++ b/doc/man/hw-management-tc.service.8
@@ -13,21 +13,11 @@ The service supports multiple thermal control versions:
 - TC v2.5: Enhanced thermal control with improved algorithms for newer systems
 
 The service selects the thermal control application from the
-\fItc_version\fR field in \fI/var/run/hw-management/config/tc_config.json\fR (defaults to
-v2.0 when unset). \fBhw-management-start-post.sh\fR aligns the systemd unit to run the
+\fItc_version\fR field in \fI/var/run/hw-management/tc_config.json\fR (defaults to v2.0
+when unset). \fBhw-management-start-post.sh\fR aligns the systemd unit to run the
 matching Python script:
 - /usr/bin/hw_management_thermal_control.py (TC v2.0)
 - /usr/bin/hw_management_thermal_control_2_5.py (TC v2.5)
-
-When the unit is rewritten, it is reloaded and thermal control is restarted shortly after.
-
-.SH STATE ACROSS HW-MANAGEMENT RESTARTS
-On stop, this unit writes "started" to \fI/var/run/.hw-management-tc-state\fR.
-\fBhw-management-start-post.sh\fR restores that state and removes the file.
-Missing or invalid content leaves thermal control unchanged.
-Cleared again on TC start, so a manual restart of this service leaves no marker.
-Honoured only while the unit is enabled; use
-\fBsystemctl disable \-\-now hw\-management\-tc\fR to keep it off.
 .SH OPTIONS
 .TP
 start

--- a/rpm/hw-management.spec
+++ b/rpm/hw-management.spec
@@ -128,6 +128,7 @@ install -m 0755 usr/usr/bin/hw-management-power-helper.sh $RPM_BUILD_ROOT/usr/bi
 install -m 0755 usr/usr/bin/hw-management-ps-vpd.sh $RPM_BUILD_ROOT/usr/bin/hw-management-ps-vpd.sh
 install -m 0755 usr/usr/bin/hw-management-ready.sh $RPM_BUILD_ROOT/usr/bin/hw-management-ready.sh
 install -m 0755 usr/usr/bin/hw-management-start-post.sh $RPM_BUILD_ROOT/usr/bin/hw-management-start-post.sh
+install -m 0755 usr/usr/bin/hw-management-tc-stop-post.sh $RPM_BUILD_ROOT/usr/bin/hw-management-tc-stop-post.sh
 install -m 0755 usr/usr/bin/hw-management-thermal-events.sh $RPM_BUILD_ROOT/usr/bin/hw-management-thermal-events.sh
 install -m 0755 usr/usr/bin/hw-management-vpd-parser.py $RPM_BUILD_ROOT/usr/bin/hw-management-vpd-parser.py
 install -m 0755 usr/usr/bin/hw-management-wd.sh $RPM_BUILD_ROOT/usr/bin/hw-management-wd.sh
@@ -141,6 +142,7 @@ install -m 0755 usr/usr/bin/hw_management_thermal_control_2_5.py $RPM_BUILD_ROOT
 install -m 0755 usr/usr/bin/hw_management_thermal_updater.py $RPM_BUILD_ROOT/usr/bin/hw_management_thermal_updater.py
 install -m 0755 usr/usr/bin/hw_management_independent_mode_update.py $RPM_BUILD_ROOT/usr/bin/hw_management_independent_mode_update.py
 install -m 0755 usr/usr/bin/hw_management_dpu_thermal_update.py $RPM_BUILD_ROOT/usr/bin/hw_management_dpu_thermal_update.py
+install -m 0755 usr/usr/bin/hw_management_tc_launcher.sh $RPM_BUILD_ROOT/usr/bin/hw_management_tc_launcher.sh
 install -m 0755 usr/usr/bin/iorw $RPM_BUILD_ROOT/usr/bin/iorw
 install -m 0755 usr/usr/bin/sxd_read_cpld_ver.py $RPM_BUILD_ROOT/usr/bin/sxd_read_cpld_ver.py
 install -m 0755 usr/usr/local/bin/hw-management-process-blacklist.sh $RPM_BUILD_ROOT/usr/local/bin/hw-management-process-blacklist.sh
@@ -234,6 +236,7 @@ chmod 0644 $RPM_BUILD_ROOT/usr/share/man/man8/hw-management.service.8.gz
 %attr(0755, root, root) "/usr/bin/hw-management-ps-vpd.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-ready.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-start-post.sh"
+%attr(0755, root, root) "/usr/bin/hw-management-tc-stop-post.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-thermal-events.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-wd.sh"
 %attr(0755, root, root) "/usr/bin/hw-management.sh"
@@ -253,6 +256,7 @@ chmod 0644 $RPM_BUILD_ROOT/usr/share/man/man8/hw-management.service.8.gz
 %attr(0755, root, root) "/usr/bin/hw_management_thermal_updater.py"
 %attr(0755, root, root) "/usr/bin/hw_management_independent_mode_update.py"
 %attr(0755, root, root) "/usr/bin/hw_management_dpu_thermal_update.py"
+%attr(0755, root, root) "/usr/bin/hw_management_tc_launcher.sh"
 %attr(0755, root, root) "/usr/local/bin/hw-management-process-blacklist.sh"
 %attr(0755, root, root) "/lib/systemd/system/hw-management.service"
 %attr(0755, root, root) "/lib/systemd/system/hw-management-tc.service"

--- a/tests/offline/test_hw_management_start_post_tc.py
+++ b/tests/offline/test_hw_management_start_post_tc.py
@@ -51,49 +51,12 @@ fi
 printf '%d %d %d\n' "$tc_should_disable" "$tc_should_enable" "$tc_should_start"
 """
 
-# Mirrors the state restore, the reload gate and the cmd_line build (no nohup).
-# Prints NONE when the script would leave the TC service alone.
+# Mirrors cmd_line build 184-214 (no nohup)
 _BASH_CMD_LINE = r"""
-tc_is_enabled=${TC_IS_EN:-0}
-tc_is_active=${TC_IS_ACT:-0}
-tc_saved_state=${STATE:-}
 tc_should_reload=${R:-0}
 tc_should_disable=${D:-0}
 tc_should_enable=${E:-0}
-
-tc_should_start=$tc_is_active
-tc_should_restart=0
-if [ "$tc_saved_state" = "started" ] && [ "$tc_is_enabled" -eq 1 ]; then
-	tc_should_start=1
-fi
-
-# The SimX branch forces a start regardless of the saved state.
-if [ "${FORCE_START:-0}" -eq 1 ]; then
-	tc_should_start=1
-fi
-
-if [ "$tc_should_reload" -eq 1 ]; then
-	tc_should_restart=1
-	if [ -z "$tc_saved_state" ] && [ "$tc_is_enabled" -eq 1 ]; then
-		tc_should_start=1
-	fi
-fi
-
-tc_action_needed=0
-if [ "$tc_should_reload" -eq 1 ] ||
-   [ "$tc_should_disable" -eq 1 ] ||
-   [ "$tc_should_enable" -eq 1 ] ||
-   [ "$tc_should_restart" -eq 1 ]; then
-	tc_action_needed=1
-elif [ "$tc_should_start" -eq 1 ] && [ "$tc_is_active" -eq 0 ]; then
-	tc_action_needed=1
-fi
-
-if [ "$tc_action_needed" -eq 0 ]; then
-	printf 'NONE\n'
-	exit 0
-fi
-
+tc_should_start=${S:-0}
 cmd_line="sleep 10 &&"
 if [ "$tc_should_reload" -eq 1 ]; then
 	cmd_line="$cmd_line systemctl daemon-reload &&"
@@ -101,12 +64,11 @@ fi
 if [ "$tc_should_disable" -eq 1 ]; then
 	cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
 	tc_should_start=0
-	tc_should_restart=0
 elif [ "$tc_should_enable" -eq 1 ]; then
 	cmd_line="$cmd_line systemctl enable hw-management-tc &&"
 fi
 if [ "$tc_should_start" -ne 0 ]; then
-	if [ "$tc_should_restart" -eq 1 ]; then
+	if [ "$tc_should_reload" -eq 1 ]; then
 		cmd_line="$cmd_line systemctl restart hw-management-tc &&"
 	else
 		cmd_line="$cmd_line systemctl start hw-management-tc &&"
@@ -200,60 +162,25 @@ def test_simx_supported_already_enabled_no_enable_flag():
     assert (d, en, st) == (0, 0, 1)
 
 
-def test_systemd_restart_brings_back_tc_that_was_running():
-    """PartOf= or systemctl stop both run ExecStop and leave STATE=started.
-    After hw-management start, TC must be brought back while the unit stays enabled."""
-    s = _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "0"})
-    assert "start hw-management-tc" in s
-
-
-def test_no_saved_state_leaves_inactive_tc_alone():
-    """Missing marker (never written or already consumed): do not start or stop TC."""
-    assert _run_bash_cmdline({"TC_IS_EN": "1", "TC_IS_ACT": "0"}) == "NONE"
-
-
-def test_running_tc_without_unit_change_is_left_alone():
-    assert _run_bash_cmdline({"TC_IS_EN": "1", "TC_IS_ACT": "1"}) == "NONE"
-
-
-def test_saved_state_with_already_active_tc_is_left_alone():
-    """State file only drives start after a systemd stop; if TC is still active, do nothing."""
-    assert (
-        _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "1"}) ==
-        "NONE"
-    )
-
-
-def test_saved_state_ignored_when_unit_is_disabled():
-    assert _run_bash_cmdline({"STATE": "started", "TC_IS_EN": "0"}) == "NONE"
-
-
-def test_version_change_restarts_tc_that_was_running():
-    s = _run_bash_cmdline(
-        {"R": "1", "STATE": "started", "TC_IS_EN": "1", "TC_IS_ACT": "0"}
-    )
-    assert "daemon-reload" in s and "restart hw-management-tc" in s
-
-
 def test_cmd_line_reload_only():
-    s = _run_bash_cmdline({"R": "1", "TC_IS_EN": "0", "TC_IS_ACT": "0"})
+    s = _run_bash_cmdline({"R": "1", "D": "0", "E": "0", "S": "0"})
     assert "daemon-reload" in s
     assert "restart" not in s and "start hw-management-tc" not in s
 
 
 def test_cmd_line_disable_clears_start():
-    s = _run_bash_cmdline({"D": "1", "TC_IS_EN": "1", "TC_IS_ACT": "1"})
+    s = _run_bash_cmdline({"R": "0", "D": "1", "E": "0", "S": "1"})
     assert "stop hw-management-tc" in s and "disable" in s
     assert "start hw-management-tc" not in s and "restart" not in s
 
 
 def test_cmd_line_reload_with_start_uses_restart():
-    s = _run_bash_cmdline({"R": "1", "TC_IS_EN": "1", "TC_IS_ACT": "0"})
+    s = _run_bash_cmdline({"R": "1", "D": "0", "E": "0", "S": "1"})
     assert "daemon-reload" in s and "restart hw-management-tc" in s
 
 
 def test_cmd_line_enable_and_start():
-    s = _run_bash_cmdline({"E": "1", "FORCE_START": "1", "TC_IS_ACT": "0"})
+    s = _run_bash_cmdline({"R": "0", "D": "0", "E": "1", "S": "1"})
     assert "enable hw-management-tc" in s and "start hw-management-tc" in s
 
 
@@ -268,94 +195,3 @@ def test_start_post_script_documents_bug_and_nohup():
     # Do not auto-enable on TC 2.5 alone: enable only in SimX-supported branch
     assert "if [ $tc_is_enabled -eq 0 ]; then" in text
     assert "tc_should_enable=1" in text
-
-
-def test_unit_path_taken_from_fragment_path():
-    """systemctl status output starts with a warning line once the unit was edited on disk,
-    which broke the previous line/field based parsing of the unit path."""
-    root = Path(__file__).resolve().parents[2]
-    sh = root / "usr" / "usr" / "bin" / "hw-management-start-post.sh"
-    text = sh.read_text()
-    assert "systemctl show -p FragmentPath hw-management-tc.service" in text
-    assert "systemctl status hw-management-tc.service" not in text
-
-
-def test_tc_state_is_saved_on_hw_management_stop_and_restored_on_start():
-    root = Path(__file__).resolve().parents[2]
-    tc_unit = (root / "debian" / "hw-management.hw-management-tc.service").read_text()
-    helpers = (root / "usr" / "usr" / "bin" / "hw-management-helpers.sh").read_text()
-    hw_management = (root / "usr" / "usr" / "bin" / "hw-management.sh").read_text()
-    start_post = (
-        root / "usr" / "usr" / "bin" / "hw-management-start-post.sh"
-    ).read_text()
-
-    assert 'tc_state_file="/var/run/.hw-management-tc-state"' in helpers
-    assert "consume_tc_saved_state()" in helpers
-    assert "save_tc_state_started" not in helpers
-    # Helpers: path near other /run state files; consume after check_tc_is_supported.
-    assert helpers.index("asic_chipup_status=") < helpers.index('tc_state_file="/var/run/.hw-management-tc-state"')
-    assert helpers.index("check_tc_is_supported()") < helpers.index("consume_tc_saved_state()")
-    # Unit: existing ExecStart/ExecStop first; state save/clear after.
-    assert tc_unit.index("ExecStart=/bin/sh") < tc_unit.index("ExecStartPost=-/bin/rm -f /var/run/.hw-management-tc-state")
-    assert tc_unit.index("ExecStop=/bin/kill $MAINPID") < tc_unit.index("umask 077")
-    assert "/var/run/.hw-management-tc-state" in tc_unit
-    # State is saved only from the TC unit ExecStop, not from hw-management.sh.
-    do_stop = hw_management[hw_management.index("do_stop()"): hw_management.index("function find_asic_hwmon_path")]
-    assert "consume_tc_saved_state" not in do_stop
-    assert "tc_state_file" not in do_stop
-    # start-post: existing enable/active checks first; restore after unit align.
-    assert start_post.index("systemctl is-enabled --quiet hw-management-tc.service") < start_post.index(
-        "tc_saved_state=$(consume_tc_saved_state)"
-    )
-    assert start_post.index("tc_should_reload=1") < start_post.index(
-        "tc_saved_state=$(consume_tc_saved_state)"
-    )
-
-
-def test_consume_tc_state_handles_missing_broken_and_symlink(tmp_path):
-    """Missing / garbage / symlink must not restore TC as started."""
-    root = Path(__file__).resolve().parents[2]
-    helpers = root / "usr" / "usr" / "bin" / "hw-management-helpers.sh"
-    state = tmp_path / ".hw-management-tc-state"
-    script = f"""
-source {helpers}
-tc_state_file="{state}"
-printf '%s\\n' "$(consume_tc_saved_state)"
-"""
-
-    # Missing file
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-
-    # Valid started
-    state.write_text("started\n")
-    os.chmod(state, 0o600)
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == "started"
-    assert not state.exists()
-
-    # Broken content
-    state.write_text("garbage\n")
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-    assert not state.exists()
-
-    # Empty / whitespace
-    state.write_text("   \n")
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-    assert not state.exists()
-
-    # Symlink: remove and ignore
-    target = tmp_path / "elsewhere"
-    target.write_text("started\n")
-    state.symlink_to(target)
-    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
-    assert r.returncode == 0
-    assert r.stdout.strip() == ""
-    assert not state.exists()
-    assert target.read_text() == "started\n"

--- a/tests/offline/test_hw_management_start_post_tc.py
+++ b/tests/offline/test_hw_management_start_post_tc.py
@@ -3,23 +3,23 @@
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
 # Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
-# Unit tests for hw-management-start-post.sh TC service logic
-# (commit f9f543b4c6b5dd42caac5d0c1b8e4aa559566b8d, Bug 4929286).
+# Unit tests for hw-management-start-post.sh TC service logic and
+# hw_management_tc_launcher.sh version selection.
 #
 # Verifies: TC is not auto-enabled on non-SimX; SimX paths set enable/disable
-# flags; deferred cmd_line matches reload/start/stop combinations.
+# flags; deferred cmd_line matches enable/disable combinations; launcher picks
+# the correct Python binary from tc_config.json.
 ################################################################################
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.offline
 
-# Mirrors start-post.sh lines 114-159 (flag computation only)
+# Mirrors start-post.sh TC flag computation (platform/SimX logic only)
 _BASH_TC_FLAGS = r"""
 tc_is_enabled=${TC_IS_EN:-0}
 tc_should_start=0
@@ -51,30 +51,108 @@ fi
 printf '%d %d %d\n' "$tc_should_disable" "$tc_should_enable" "$tc_should_start"
 """
 
-# Mirrors cmd_line build 184-214 (no nohup)
+# Mirrors the simplified cmd_line build in start-post.sh (no nohup). The
+# tc_should_start-only branch defers the marker re-check/consume and the
+# is-active check into the command line itself, so they run when the 10s
+# sleep elapses, not when cmd_line is built - see _BASH_DEFERRED_START.
+# Prints NONE when the script would leave the TC service alone.
 _BASH_CMD_LINE = r"""
-tc_should_reload=${R:-0}
 tc_should_disable=${D:-0}
 tc_should_enable=${E:-0}
 tc_should_start=${S:-0}
-cmd_line="sleep 10 &&"
-if [ "$tc_should_reload" -eq 1 ]; then
-	cmd_line="$cmd_line systemctl daemon-reload &&"
-fi
-if [ "$tc_should_disable" -eq 1 ]; then
-	cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
-	tc_should_start=0
-elif [ "$tc_should_enable" -eq 1 ]; then
-	cmd_line="$cmd_line systemctl enable hw-management-tc &&"
-fi
-if [ "$tc_should_start" -ne 0 ]; then
-	if [ "$tc_should_reload" -eq 1 ]; then
-		cmd_line="$cmd_line systemctl restart hw-management-tc &&"
-	else
-		cmd_line="$cmd_line systemctl start hw-management-tc &&"
+tc_pending_restart_file="$MARKER"
+
+cmd_line=""
+if [ "$tc_should_disable" -eq 1 ] || [ "$tc_should_enable" -eq 1 ] || [ "$tc_should_start" -eq 1 ]; then
+	cmd_line="sleep 10 &&"
+	if [ "$tc_should_disable" -eq 1 ]; then
+		cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
+	elif [ "$tc_should_enable" -eq 1 ]; then
+		cmd_line="$cmd_line systemctl enable hw-management-tc &&"
+		if [ "$tc_should_start" -eq 1 ]; then
+			cmd_line="$cmd_line systemctl start hw-management-tc &&"
+		fi
+	elif [ "$tc_should_start" -eq 1 ]; then
+		cmd_line="$cmd_line if [ -f $tc_pending_restart_file ]; then rm -f $tc_pending_restart_file; if ! systemctl is-active --quiet hw-management-tc.service; then systemctl start hw-management-tc; fi; fi &&"
 	fi
 fi
-printf '%s\n' "$cmd_line"
+
+if [ -z "$cmd_line" ]; then
+	printf 'NONE\n'
+else
+	printf '%s\n' "$cmd_line"
+fi
+"""
+
+# Mirrors the post-PartOf restart-detection added in start-post.sh: an already
+# enabled TC service that is not currently active (hw-management.service was
+# stopped and started separately, so PartOf= propagated only the stop) is
+# scheduled for a restore-check only when hw-management-tc-stop-post.sh
+# recorded that the prior stop was the PartOf= cascade (marker file present),
+# not an operator directly stopping TC. The marker itself is deliberately NOT
+# consumed here - see _BASH_DEFERRED_START - so a stop issued during the
+# scheduling delay is not silently overridden by this early decision.
+_BASH_RESTART_CHECK = r"""
+tc_is_enabled=${TC_IS_EN:-0}
+tc_should_disable=${D:-0}
+tc_should_start=${S:-0}
+tc_pending_restart_file="$MARKER"
+
+if [ "$tc_is_enabled" -eq 1 ] && [ "$tc_should_disable" -eq 0 ] && [ "$tc_should_start" -eq 0 ]; then
+	if [ -f "$tc_pending_restart_file" ]; then
+		tc_should_start=1
+	fi
+fi
+printf '%d %d\n' "$tc_should_start" "$([ -f "$tc_pending_restart_file" ] && echo 1 || echo 0)"
+"""
+
+# Mirrors the deferred re-check embedded in cmd_line for the tc_should_start
+# branch: runs after the 10s scheduling delay, so it sees whatever the marker
+# and TC's active state actually are at that moment, not at decision time.
+_BASH_DEFERRED_START = r"""
+tc_pending_restart_file="$MARKER"
+
+systemctl() {
+	if [ "$1" = "is-active" ]; then
+		return "${ACTIVE_RET:-0}"
+	fi
+	if [ "$1" = "start" ]; then
+		echo STARTED
+	fi
+	return 0
+}
+
+if [ -f "$tc_pending_restart_file" ]; then
+	rm -f "$tc_pending_restart_file"
+	if ! systemctl is-active --quiet hw-management-tc.service; then
+		systemctl start hw-management-tc
+	fi
+fi
+"""
+
+# Mirrors hw-management-tc-stop-post.sh (ExecStopPost hook): decides whether
+# TC's stop was an operator directly stopping TC, or a PartOf= cascade from
+# hw-management.service also stopping/restarting. TC has
+# After=hw-management.service, so on a coordinated stop the parent's own stop
+# job has not even started (ActiveState is still "active") by the time this
+# hook runs - a job queued for the whole transaction is what distinguishes
+# the cascade case, not the parent's current ActiveState.
+_BASH_STOP_POST = r"""
+tc_pending_restart_file="$MARKER"
+
+systemctl() {
+	if [ "$1" = "list-jobs" ]; then
+		printf '%s\n' "$HWMGMT_JOBS_OUTPUT"
+		return 0
+	fi
+	return 0
+}
+
+if systemctl list-jobs --no-legend hw-management.service 2>/dev/null | grep -q .; then
+	touch "$tc_pending_restart_file"
+else
+	rm -f "$tc_pending_restart_file"
+fi
 """
 
 
@@ -94,9 +172,10 @@ def _run_bash_flags(env):
     return int(parts[0]), int(parts[1]), int(parts[2])
 
 
-def _run_bash_cmdline(env):
+def _run_bash_cmdline(env, marker="/nonexistent/pending"):
     e = os.environ.copy()
     e.update({k: str(v) for k, v in env.items()})
+    e["MARKER"] = str(marker)
     r = subprocess.run(
         ["bash", "-e", "-c", _BASH_CMD_LINE],
         env=e,
@@ -108,6 +187,147 @@ def _run_bash_cmdline(env):
     assert r.returncode == 0, r.stderr
     return r.stdout.strip()
 
+
+def _run_deferred_start(marker, active_ret):
+    e = os.environ.copy()
+    e["MARKER"] = str(marker)
+    e["ACTIVE_RET"] = "0" if active_ret else "1"
+    r = subprocess.run(
+        ["bash", "-e", "-c", _BASH_DEFERRED_START],
+        env=e,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        timeout=5,
+    )
+    assert r.returncode == 0, r.stderr
+    return "STARTED" in r.stdout
+
+
+def _run_restart_check(env, marker):
+    e = os.environ.copy()
+    e.update({k: str(v) for k, v in env.items()})
+    e["MARKER"] = str(marker)
+    r = subprocess.run(
+        ["bash", "-e", "-c", _BASH_RESTART_CHECK],
+        env=e,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        timeout=5,
+    )
+    assert r.returncode == 0, r.stderr
+    should_start, marker_left = r.stdout.strip().split()
+    return int(should_start), int(marker_left)
+
+
+def _run_stop_post(parent_job_queued, marker):
+    e = os.environ.copy()
+    e["MARKER"] = str(marker)
+    e["HWMGMT_JOBS_OUTPUT"] = (
+        "1234 hw-management.service stop waiting" if parent_job_queued else ""
+    )
+    r = subprocess.run(
+        ["bash", "-e", "-c", _BASH_STOP_POST],
+        env=e,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        timeout=5,
+    )
+    assert r.returncode == 0, r.stderr
+
+
+def _run_launcher(tc_config_content, tmp_path):
+    """Run launcher version-selection logic; return '2_5' or '2_0'."""
+    cfg = tmp_path / "tc_config.json"
+    if tc_config_content is not None:
+        cfg.write_text(tc_config_content)
+        cfg_path = str(cfg)
+    else:
+        cfg_path = "/nonexistent/tc_config.json"
+
+    script = rf"""
+tc_cfg="{cfg_path}"
+tc_ver=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$tc_cfg" 2>/dev/null \
+         | head -n1 | cut -d'"' -f4)
+case $tc_ver in
+    2.5|2.5.*)
+        printf '2_5\n'
+        ;;
+    *)
+        printf '2_0\n'
+        ;;
+esac
+"""
+    r = subprocess.run(["bash", "-e", "-c", script], capture_output=True, text=True, timeout=5)
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+def _run_launcher_desc_patch(tc_config_content, initial_desc, tmp_path):
+    """Run launcher version-selection + Description-patch logic against a fake
+    unit file and a stubbed systemctl. Returns (bin_tag, final_desc, reload_calls)."""
+    cfg = tmp_path / "tc_config.json"
+    if tc_config_content is not None:
+        cfg.write_text(tc_config_content)
+        cfg_path = str(cfg)
+    else:
+        cfg_path = "/nonexistent/tc_config.json"
+
+    unit = tmp_path / "hw-management-tc.service"
+    unit.write_text(f"[Unit]\nDescription={initial_desc}\nAfter=hw-management.service\n")
+
+    reload_log = tmp_path / "reload.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "systemctl"
+    stub.write_text(f'#!/bin/sh\necho "$*" >> "{reload_log}"\n')
+    stub.chmod(0o755)
+
+    script = rf"""
+tc_cfg="{cfg_path}"
+unit_path="{unit}"
+
+tc_ver=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$tc_cfg" 2>/dev/null \
+         | head -n1 | cut -d'"' -f4)
+
+case $tc_ver in
+    2.5|2.5.*)
+        tc_ver_label=2.5
+        tc_bin=/usr/bin/hw_management_thermal_control_2_5.py
+        ;;
+    *)
+        tc_ver_label=2.0
+        tc_bin=/usr/bin/hw_management_thermal_control.py
+        ;;
+esac
+
+desc="Thermal control service (ver $tc_ver_label) of Nvidia systems"
+if ! grep -qF "Description=$desc" "$unit_path"; then
+    sed -i "s/^Description=.*/Description=$desc/" "$unit_path"
+    systemctl daemon-reload
+fi
+"""
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    r = subprocess.run(
+        ["bash", "-e", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        env=env,
+    )
+    assert r.returncode == 0, r.stderr
+
+    final_desc = [line for line in unit.read_text().splitlines() if line.startswith("Description=")][0]
+    reload_calls = reload_log.read_text().splitlines() if reload_log.exists() else []
+    return final_desc, reload_calls
+
+
+# ---------------------------------------------------------------------------
+# Platform / SimX flag tests
+# ---------------------------------------------------------------------------
 
 def test_tc_not_supported_disables():
     """check_tc_is_supported returns 0 -> platform_support 0 -> disable."""
@@ -162,27 +382,154 @@ def test_simx_supported_already_enabled_no_enable_flag():
     assert (d, en, st) == (0, 0, 1)
 
 
-def test_cmd_line_reload_only():
-    s = _run_bash_cmdline({"R": "1", "D": "0", "E": "0", "S": "0"})
-    assert "daemon-reload" in s
-    assert "restart" not in s and "start hw-management-tc" not in s
+# ---------------------------------------------------------------------------
+# cmd_line builder tests
+# ---------------------------------------------------------------------------
+
+def test_no_action_needed_returns_none():
+    """No disable/enable → nothing to do."""
+    assert _run_bash_cmdline({}) == "NONE"
 
 
-def test_cmd_line_disable_clears_start():
-    s = _run_bash_cmdline({"R": "0", "D": "1", "E": "0", "S": "1"})
-    assert "stop hw-management-tc" in s and "disable" in s
-    assert "start hw-management-tc" not in s and "restart" not in s
-
-
-def test_cmd_line_reload_with_start_uses_restart():
-    s = _run_bash_cmdline({"R": "1", "D": "0", "E": "0", "S": "1"})
-    assert "daemon-reload" in s and "restart hw-management-tc" in s
+def test_cmd_line_disable():
+    s = _run_bash_cmdline({"D": "1"})
+    assert "stop hw-management-tc" in s and "disable hw-management-tc" in s
+    assert "start hw-management-tc" not in s and "enable" not in s
 
 
 def test_cmd_line_enable_and_start():
-    s = _run_bash_cmdline({"R": "0", "D": "0", "E": "1", "S": "1"})
+    s = _run_bash_cmdline({"E": "1", "S": "1"})
     assert "enable hw-management-tc" in s and "start hw-management-tc" in s
 
+
+def test_cmd_line_enable_without_start():
+    s = _run_bash_cmdline({"E": "1", "S": "0"})
+    assert "enable hw-management-tc" in s
+    assert "start hw-management-tc" not in s
+
+
+def test_cmd_line_start_only(tmp_path):
+    """Already-enabled TC that just needs restarting: the deferred re-check
+    block is scheduled, no enable/disable."""
+    marker = tmp_path / "pending"
+    s = _run_bash_cmdline({"S": "1"}, marker=marker)
+    assert "start hw-management-tc" in s
+    assert str(marker) in s
+    assert "enable hw-management-tc" not in s and "disable hw-management-tc" not in s
+
+
+def test_cmd_line_no_action_ignores_marker():
+    """Marker presence alone (without S=1) must not trigger scheduling."""
+    assert _run_bash_cmdline({}) == "NONE"
+
+
+# ---------------------------------------------------------------------------
+# PartOf= start-propagation restart-detection tests
+# ---------------------------------------------------------------------------
+# tc_should_start is only scheduled here - the marker is deliberately left
+# untouched (not consumed, no is-active check) so an operator's action during
+# the 10s scheduling delay can still take effect; see the deferred-start
+# tests below for the actual consume/start logic.
+
+def test_restart_flagged_when_marker_present(tmp_path):
+    """Marker present (PartOf= cascade recorded by stop-post): schedule a
+    restore-check, and leave the marker in place for the deferred re-check."""
+    marker = tmp_path / "pending"
+    marker.touch()
+    should_start, marker_left = _run_restart_check({"TC_IS_EN": "1", "D": "0", "S": "0"}, marker)
+    assert (should_start, marker_left) == (1, 1)
+
+
+def test_restart_not_flagged_when_marker_absent():
+    """No marker (no stop-post ran, or last stop was operator-intentional):
+    do not schedule a restore even though TC is enabled and inactive."""
+    should_start, marker_left = _run_restart_check(
+        {"TC_IS_EN": "1", "D": "0", "S": "0"}, "/nonexistent/pending"
+    )
+    assert (should_start, marker_left) == (0, 0)
+
+
+def test_restart_not_flagged_when_not_enabled(tmp_path):
+    marker = tmp_path / "pending"
+    marker.touch()
+    should_start, marker_left = _run_restart_check({"TC_IS_EN": "0", "D": "0", "S": "0"}, marker)
+    assert (should_start, marker_left) == (0, 1)
+
+
+def test_restart_not_flagged_when_disabling(tmp_path):
+    marker = tmp_path / "pending"
+    marker.touch()
+    should_start, marker_left = _run_restart_check({"TC_IS_EN": "1", "D": "1", "S": "0"}, marker)
+    assert (should_start, marker_left) == (0, 1)
+
+
+def test_restart_not_double_flagged_when_already_starting(tmp_path):
+    marker = tmp_path / "pending"
+    marker.touch()
+    should_start, marker_left = _run_restart_check({"TC_IS_EN": "1", "D": "0", "S": "1"}, marker)
+    assert (should_start, marker_left) == (1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Deferred restore re-check tests (embedded in cmd_line, runs after the 10s
+# scheduling delay - this is what actually consumes the marker and starts TC)
+# ---------------------------------------------------------------------------
+
+def test_deferred_start_starts_and_consumes_marker_when_still_pending(tmp_path):
+    marker = tmp_path / "pending"
+    marker.touch()
+    assert _run_deferred_start(marker, active_ret=False) is True
+    assert not marker.exists()
+
+
+def test_deferred_start_does_nothing_when_marker_no_longer_present(tmp_path):
+    """The key race fix: if something consumed/removed the marker during the
+    10s scheduling delay (e.g. a fresh stop-post run), the deferred re-check
+    must not start TC - it must not rely on the decision made 10s earlier."""
+    marker = tmp_path / "pending"
+    assert _run_deferred_start(marker, active_ret=False) is False
+
+
+def test_deferred_start_skips_start_when_already_active(tmp_path):
+    """Marker present but TC is already active by execution time: consume the
+    marker (cleanup) but do not issue a redundant start."""
+    marker = tmp_path / "pending"
+    marker.touch()
+    assert _run_deferred_start(marker, active_ret=True) is False
+    assert not marker.exists()
+
+
+# ---------------------------------------------------------------------------
+# hw-management-tc-stop-post.sh (ExecStopPost) tests
+# ---------------------------------------------------------------------------
+
+def test_stop_post_clears_marker_when_no_parent_job_queued(tmp_path):
+    """Operator directly stops TC, no stop/restart job queued for
+    hw-management.service: treat as intentional, clear any stale marker."""
+    marker = tmp_path / "pending"
+    marker.touch()
+    _run_stop_post(parent_job_queued=False, marker=marker)
+    assert not marker.exists()
+
+
+def test_stop_post_sets_marker_when_parent_job_queued(tmp_path):
+    """A stop/restart job is queued for hw-management.service (it has not
+    started yet due to After= ordering, so it's still "active"): TC's stop
+    is the PartOf= cascade, mark it for restore on the next start."""
+    marker = tmp_path / "pending"
+    _run_stop_post(parent_job_queued=True, marker=marker)
+    assert marker.exists()
+
+
+def test_stop_post_no_marker_stays_absent_when_no_parent_job_queued(tmp_path):
+    marker = tmp_path / "pending"
+    _run_stop_post(parent_job_queued=False, marker=marker)
+    assert not marker.exists()
+
+
+# ---------------------------------------------------------------------------
+# start-post.sh structural checks
+# ---------------------------------------------------------------------------
 
 def test_start_post_script_documents_bug_and_nohup():
     """Regression: script uses deferred nohup bash -c for TC actions."""
@@ -195,3 +542,174 @@ def test_start_post_script_documents_bug_and_nohup():
     # Do not auto-enable on TC 2.5 alone: enable only in SimX-supported branch
     assert "if [ $tc_is_enabled -eq 0 ]; then" in text
     assert "tc_should_enable=1" in text
+
+
+def test_start_post_no_longer_patches_service_file():
+    """start-post.sh must not sed-patch the TC unit file."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw-management-start-post.sh").read_text()
+    assert "sed_edit_executable" not in text
+    assert "FragmentPath" not in text
+    assert "daemon-reload" not in text
+    assert "consume_tc_saved_state" not in text
+
+
+def test_start_post_restarts_enabled_but_inactive_tc():
+    """start-post.sh must restart an already-enabled TC left inactive by a
+    separate hw-management.service stop+start (PartOf= only propagates stop),
+    gated on the marker written by hw-management-tc-stop-post.sh."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw-management-start-post.sh").read_text()
+    assert "systemctl is-active --quiet hw-management-tc.service" in text
+    assert "tc_should_start=1" in text
+    assert "tc_pending_restart_file" in text
+
+
+def test_start_post_defers_marker_consumption_past_the_scheduling_delay():
+    """Regression for the marker-consumed-too-early race: the decision-time
+    block (before the 10s deferral) must not remove the marker or check
+    is-active itself - only the deferred cmd_line block (which runs after the
+    delay) may do that, so a stop issued during the delay is not overridden."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw-management-start-post.sh").read_text()
+    decision_block = text.split("# Build and execute the command line")[0]
+    assert "rm -f" not in decision_block
+    assert "is-active" not in decision_block
+    assert 'rm -f $tc_pending_restart_file' in text
+
+
+def test_stop_post_script_distinguishes_operator_stop_from_cascade():
+    """hw-management-tc-stop-post.sh must check for a queued job on the
+    parent, not its ActiveState, to tell an operator-initiated TC stop apart
+    from a PartOf= cascade: TC has After=hw-management.service, so the
+    parent's own stop job has not started (still "active") by the time this
+    hook runs even during a genuine cascade."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw-management-tc-stop-post.sh").read_text()
+    assert "systemctl list-jobs --no-legend hw-management.service" in text
+    assert "systemctl is-active" not in text
+    assert 'rm -f "$tc_pending_restart_file"' in text
+    assert 'touch "$tc_pending_restart_file"' in text
+
+
+def test_helpers_define_shared_pending_restart_marker():
+    """The marker path must be defined once and shared by both scripts."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw-management-helpers.sh").read_text()
+    assert "tc_pending_restart_file=/var/run/.hw-management-tc-pending-restart" in text
+
+
+def test_service_file_wires_stop_post_hook():
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "debian" / "hw-management.hw-management-tc.service").read_text()
+    assert "ExecStopPost=/usr/bin/hw-management-tc-stop-post.sh" in text
+
+
+# ---------------------------------------------------------------------------
+# RPM packaging tests
+# ---------------------------------------------------------------------------
+
+def test_rpm_spec_packages_tc_launcher():
+    """The launcher script must be installed and listed in %files, or
+    hw-management-tc.service's ExecStart is missing on RPM-based installs."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "rpm" / "hw-management.spec").read_text()
+    assert "usr/usr/bin/hw_management_tc_launcher.sh" in text
+    assert '"/usr/bin/hw_management_tc_launcher.sh"' in text
+
+
+def test_rpm_spec_packages_tc_stop_post():
+    """The ExecStopPost hook must be installed and listed in %files, or
+    hw-management-tc.service's ExecStopPost is missing on RPM-based installs."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "rpm" / "hw-management.spec").read_text()
+    assert "usr/usr/bin/hw-management-tc-stop-post.sh" in text
+    assert '"/usr/bin/hw-management-tc-stop-post.sh"' in text
+
+
+# ---------------------------------------------------------------------------
+# Launcher version selection tests
+# ---------------------------------------------------------------------------
+
+def test_launcher_selects_v25_binary(tmp_path):
+    assert _run_launcher('{"tc_version": "2.5"}', tmp_path) == "2_5"
+
+
+def test_launcher_selects_v25_for_subversion(tmp_path):
+    assert _run_launcher('{"tc_version": "2.5.1"}', tmp_path) == "2_5"
+
+
+def test_launcher_selects_v20_explicitly(tmp_path):
+    assert _run_launcher('{"tc_version": "2.0"}', tmp_path) == "2_0"
+
+
+def test_launcher_defaults_to_v20_when_config_missing(tmp_path):
+    assert _run_launcher(None, tmp_path) == "2_0"
+
+
+def test_launcher_defaults_to_v20_for_unknown_version(tmp_path):
+    assert _run_launcher('{"tc_version": "3.0"}', tmp_path) == "2_0"
+
+
+def test_launcher_uses_exec_so_python_is_mainpid():
+    """The launcher must exec the Python binary so Python becomes the systemd MAINPID."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw_management_tc_launcher.sh").read_text()
+    assert "tc_bin=/usr/bin/hw_management_thermal_control_2_5.py" in text
+    assert "tc_bin=/usr/bin/hw_management_thermal_control.py" in text
+    assert 'exec "$tc_bin"' in text
+    # Must not use sh -c wrapper
+    assert "/bin/sh -c" not in text
+
+
+# ---------------------------------------------------------------------------
+# Launcher Description-patch tests
+# ---------------------------------------------------------------------------
+
+def test_launcher_patches_description_to_v25(tmp_path):
+    final_desc, reload_calls = _run_launcher_desc_patch(
+        '{"tc_version": "2.5"}', "Thermal control service (ver x.x) of Nvidia systems", tmp_path
+    )
+    assert final_desc == "Description=Thermal control service (ver 2.5) of Nvidia systems"
+    assert reload_calls == ["daemon-reload"]
+
+
+def test_launcher_patches_description_to_v20(tmp_path):
+    final_desc, reload_calls = _run_launcher_desc_patch(
+        None, "Thermal control service (ver x.x) of Nvidia systems", tmp_path
+    )
+    assert final_desc == "Description=Thermal control service (ver 2.0) of Nvidia systems"
+    assert reload_calls == ["daemon-reload"]
+
+
+def test_launcher_skips_reload_when_description_already_current(tmp_path):
+    final_desc, reload_calls = _run_launcher_desc_patch(
+        '{"tc_version": "2.0"}', "Thermal control service (ver 2.0) of Nvidia systems", tmp_path
+    )
+    assert final_desc == "Description=Thermal control service (ver 2.0) of Nvidia systems"
+    assert reload_calls == []
+
+
+def test_launcher_repatches_description_on_version_change(tmp_path):
+    """A prior boot's stale (ver 2.0) must be corrected once tc_config.json says 2.5."""
+    final_desc, reload_calls = _run_launcher_desc_patch(
+        '{"tc_version": "2.5"}', "Thermal control service (ver 2.0) of Nvidia systems", tmp_path
+    )
+    assert final_desc == "Description=Thermal control service (ver 2.5) of Nvidia systems"
+    assert reload_calls == ["daemon-reload"]
+
+
+def test_launcher_hardcodes_unit_path():
+    """The install location is fixed by debhelper convention (debian/hw-management.hw-management-tc.service
+    -> package hw-management -> /lib/systemd/system/hw-management-tc.service); no runtime lookup needed."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "usr" / "usr" / "bin" / "hw_management_tc_launcher.sh").read_text()
+    assert "unit_path=/lib/systemd/system/hw-management-tc.service" in text
+
+
+def test_service_file_ships_unpatched_version_placeholder():
+    """Before the launcher's first run, the shipped Description must not claim a
+    specific version it hasn't verified (e.g. a stale/wrong 'ver 2.0')."""
+    root = Path(__file__).resolve().parents[2]
+    text = (root / "debian" / "hw-management.hw-management-tc.service").read_text()
+    assert "Description=Thermal control service (ver x.x) of Nvidia systems" in text

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -48,6 +48,13 @@ fw_path=$hw_management_path/firmware
 bin_path=$hw_management_path/bin
 dynamic_boards_path=$config_path/dynamic_boards
 udev_ready=$hw_management_path/.udev_ready
+
+# Marker written by hw-management-tc.service's ExecStopPost (hw-management-tc-stop-post.sh)
+# when TC's stop was propagated from hw-management.service via PartOf=, as opposed to an
+# operator directly stopping the TC service. Consumed once by hw-management-start-post.sh
+# to decide whether to restore TC's run state. Lives outside $hw_management_path because
+# hw-management.sh's do_stop() removes that whole tree on stop.
+tc_pending_restart_file=/var/run/.hw-management-tc-pending-restart
 LOCKFILE="/var/run/hw-management-chassis.lock"
 if [ -d /sys/devices/virtual/dmi/id ]; then
 	board_type_file=/sys/devices/virtual/dmi/id/board_name

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -83,9 +83,6 @@ vm_vpd_path="/etc/hw-management-virtual/$vm_sku"
 cpldreg_log_file=/var/log/hw-mgmt-cpldreg.log
 fixup_hook_script=/usr/local/bin/hw-management-fixup.sh
 asic_chipup_status=/run/.asic_chipup_completed
-# TC run state across hw-management stop/start. Outside $hw_management_path
-# (removed on stop). Keep in sync with hw-management-tc.service.
-tc_state_file="/var/run/.hw-management-tc-state"
 
 declare -A psu_fandir_vs_pn=(["00KX1W"]=R ["00MP582"]=F ["00MP592"]=R ["00WT061"]=F \
 ["00WT062"]=R ["00WT199"]=F ["01FT674"]=F ["01FT691"]=F ["01LL976"]=F \
@@ -364,27 +361,6 @@ check_tc_is_supported()
 	else
 		return 1
 	fi
-}
-
-# Read once and remove. Prints "started" or nothing if missing/invalid.
-consume_tc_saved_state()
-{
-	local state=""
-
-	if [ -L "$tc_state_file" ]; then
-		rm -f "$tc_state_file"
-		return
-	fi
-	if [ ! -f "$tc_state_file" ]; then
-		return
-	fi
-	state=$(tr -d '[:space:]' < "$tc_state_file" 2>/dev/null)
-	rm -f "$tc_state_file"
-	case $state in
-		started)
-			printf '%s\n' "$state"
-			;;
-	esac
 }
 
 # This function checks if BMC is supported for current platform

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -132,17 +132,14 @@ if systemctl is-enabled --quiet hw-management-tc.service 2>/dev/null; then
 fi
 # Check if TC service is running.
 tc_should_start=0
-tc_is_active=0
 if systemctl is-active --quiet hw-management-tc.service; then
 	tc_should_start=1
-	tc_is_active=1
 fi
 
 # Initialize TC service control variables.
 tc_should_enable=0
 tc_should_disable=0
 tc_should_reload=0
-tc_should_restart=0
 
 ## Checking if system doesn't support TC and disable it if it doesn't.
 if check_tc_is_supported; then
@@ -175,10 +172,11 @@ else
 	fi
 fi
 
-# Align TC unit with tc_config.json version; rewrite only when needed.
-service_file_path=$(systemctl show -p FragmentPath hw-management-tc.service 2>/dev/null | cut -d= -f2-)
+# Align hw-management-tc.service on disk with this platform's TC script and version label.
+# The unit is rewritten only when those strings would actually change (avoid needless reload).
+service_file_path=$(systemctl status hw-management-tc.service | grep hw-management-tc.service | sed -n '2p' | awk -F'[();]' '{print $2}')
 if [ -f "$service_file_path" ]; then
-	# Select TC app from tc_version in tc_config.json.
+	# TC application (v2.0 vs v2.5) is selected from tc_config.json (tc_version), not SKU.
 	tc_cfg_json="$config_path/tc_config.json"
 	tc_version="2.0"
 	tc_executable="hw_management_thermal_control.py"
@@ -196,16 +194,19 @@ if [ -f "$service_file_path" ]; then
 		esac
 	fi
 
+	# 1) Substitutions we would apply to the unit (TC executable basename and "ver X.Y" marker).
 	sed_edit_executable="s/hw_management_thermal_control_2_5\.py/$tc_executable/g;s/hw_management_thermal_control\.py/$tc_executable/g"
 	sed_edit_version="s/ver [0-9][0-9.]*/ver $tc_version/g"
 
-	# Rewrite only if content would change.
+	# 2) Rewrite only if disk and "sed output" differ. cmp compares the file to stdin (-);
+	#    stdin is the unit text after the two sed rules (no temp file).
 	tc_unit_needs_update=1
 	if sed -e "$sed_edit_executable" -e "$sed_edit_version" -- "$service_file_path" |
 		cmp -s -- "$service_file_path" -; then
 		tc_unit_needs_update=0
 	fi
 
+	# 3) Apply the same two edits in place only when needed.
 	if [ "$tc_unit_needs_update" -eq 1 ]; then
 		sed -i -e "$sed_edit_executable" -e "$sed_edit_version" "$service_file_path"
 		log_info "Thermal Control service updated. Reload it in 10 seconds"
@@ -213,31 +214,10 @@ if [ -f "$service_file_path" ]; then
 	fi
 fi
 
-# Restore TC state saved on hw-management stop. Missing/invalid => leave as-is.
-tc_saved_state=$(consume_tc_saved_state)
-if [ "$tc_saved_state" = "started" ] && [ $tc_is_enabled -eq 1 ]; then
-	tc_should_start=1
-fi
-# Unit rewrite requires restart; with no saved state, fall back to enabled.
-if [ $tc_should_reload -eq 1 ]; then
-	tc_should_restart=1
-	if [ -z "$tc_saved_state" ] && [ $tc_is_enabled -eq 1 ]; then
-		tc_should_start=1
-	fi
-fi
-
 # Build and execute the command line for TC service control only when there is something to do.
-tc_action_needed=0
-if [ $tc_should_reload -eq 1 ] ||
-   [ $tc_should_disable -eq 1 ] ||
-   [ $tc_should_enable -eq 1 ] ||
-   [ $tc_should_restart -eq 1 ]; then
-	tc_action_needed=1
-elif [ $tc_should_start -eq 1 ] && [ $tc_is_active -eq 0 ]; then
-	tc_action_needed=1
-fi
-
-if [ $tc_action_needed -eq 1 ]; then
+if [ $tc_should_reload -eq 1 ] || 
+   [ $tc_should_disable -eq 1 ] || 
+   [ $tc_should_enable -eq 1 ]; then
 	cmd_line="sleep 10 &&"
 
 	# Reload the systemd daemon if needed.
@@ -250,7 +230,6 @@ if [ $tc_action_needed -eq 1 ]; then
 		cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
 		# TC service should not be started.
 		tc_should_start=0
-		tc_should_restart=0
 	elif [ $tc_should_enable -eq 1 ]; then
 		# TC service should be enabled.
 		cmd_line="$cmd_line systemctl enable hw-management-tc &&"
@@ -258,7 +237,7 @@ if [ $tc_action_needed -eq 1 ]; then
 
 	# Start TC service if needed.
 	if [ $tc_should_start -ne 0 ]; then
-		if [ $tc_should_restart -eq 1 ]; then
+		if [ $tc_should_reload -eq 1 ]; then
 			# TC service should be restarted in case of reload.
 			cmd_line="$cmd_line systemctl restart hw-management-tc &&"
 		else

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -35,20 +35,6 @@
 # hw-management script that is executed at the end of hw-management start.
 source hw-management-helpers.sh
 
-# Read tc_version value from a tc_config.json path (grep-based). Prints 2.0 when missing or unreadable.
-get_tc_version()
-{
-	local json_path="$1"
-	local v
-
-	[ -f "$json_path" ] || {
-		echo "2.0"
-		return
-	}
-	v=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$json_path" 2>/dev/null | head -n1 | cut -d'"' -f4)
-	echo "${v:-2.0}"
-}
-
 # Local constants and paths.
 CPLD3_VER_DEF="0"
  
@@ -125,21 +111,16 @@ case $sku in
 		# Do nothing
 esac
 
-# Check if TC service is enabled (unit enabled at boot) and if it is currently running.
+# Check if TC service is enabled (unit enabled at boot).
 tc_is_enabled=0
 if systemctl is-enabled --quiet hw-management-tc.service 2>/dev/null; then
 	tc_is_enabled=1
-fi
-# Check if TC service is running.
-tc_should_start=0
-if systemctl is-active --quiet hw-management-tc.service; then
-	tc_should_start=1
 fi
 
 # Initialize TC service control variables.
 tc_should_enable=0
 tc_should_disable=0
-tc_should_reload=0
+tc_should_start=0
 
 ## Checking if system doesn't support TC and disable it if it doesn't.
 if check_tc_is_supported; then
@@ -157,7 +138,6 @@ else
 				logger -t hw-management -p daemon.notice "Stopping and disabling hw-management-tc on SimX"
 				# TC service should be stopped and disabled.
 				tc_should_disable=1
-				tc_should_start=0
 			fi
 		else
 			# If TC is supported in SimX.
@@ -170,85 +150,50 @@ else
 			fi
 		fi
 	fi
-fi
 
-# Align hw-management-tc.service on disk with this platform's TC script and version label.
-# The unit is rewritten only when those strings would actually change (avoid needless reload).
-service_file_path=$(systemctl status hw-management-tc.service | grep hw-management-tc.service | sed -n '2p' | awk -F'[();]' '{print $2}')
-if [ -f "$service_file_path" ]; then
-	# TC application (v2.0 vs v2.5) is selected from tc_config.json (tc_version), not SKU.
-	tc_cfg_json="$config_path/tc_config.json"
-	tc_version="2.0"
-	tc_executable="hw_management_thermal_control.py"
-	if [ -f "$tc_cfg_json" ]; then
-		tc_ver_raw=$(get_tc_version "$tc_cfg_json")
-		case $tc_ver_raw in
-			2.5|2.5.*)
-				tc_version="2.5"
-				tc_executable="hw_management_thermal_control_2_5.py"
-				;;
-			*)
-				tc_version="2.0"
-				tc_executable="hw_management_thermal_control.py"
-				;;
-		esac
-	fi
-
-	# 1) Substitutions we would apply to the unit (TC executable basename and "ver X.Y" marker).
-	sed_edit_executable="s/hw_management_thermal_control_2_5\.py/$tc_executable/g;s/hw_management_thermal_control\.py/$tc_executable/g"
-	sed_edit_version="s/ver [0-9][0-9.]*/ver $tc_version/g"
-
-	# 2) Rewrite only if disk and "sed output" differ. cmp compares the file to stdin (-);
-	#    stdin is the unit text after the two sed rules (no temp file).
-	tc_unit_needs_update=1
-	if sed -e "$sed_edit_executable" -e "$sed_edit_version" -- "$service_file_path" |
-		cmp -s -- "$service_file_path" -; then
-		tc_unit_needs_update=0
-	fi
-
-	# 3) Apply the same two edits in place only when needed.
-	if [ "$tc_unit_needs_update" -eq 1 ]; then
-		sed -i -e "$sed_edit_executable" -e "$sed_edit_version" "$service_file_path"
-		log_info "Thermal Control service updated. Reload it in 10 seconds"
-		tc_should_reload=1
+	# PartOf=hw-management.service only propagates stop/restart of hw-management-tc.service,
+	# not start. If hw-management.service was stopped and later started separately (rather
+	# than restarted), an already-enabled TC service is left inactive. Schedule a restore
+	# below, but only when hw-management-tc-stop-post.sh recorded that the prior stop was
+	# this PartOf= cascade rather than an operator directly stopping TC - see
+	# tc_pending_restart_file in hw-management-helpers.sh. The marker is re-checked (and
+	# consumed) at actual start time, not here, since the start itself runs after a 10s
+	# deferral below: consuming it this early would let an operator's stop issued during
+	# that window be silently overridden by our own stale decision.
+	if [ $tc_is_enabled -eq 1 ] && [ $tc_should_disable -eq 0 ] && [ $tc_should_start -eq 0 ]; then
+		if [ -f "$tc_pending_restart_file" ]; then
+			log_info "Thermal Control restore scheduled after hw-management restart."
+			tc_should_start=1
+		fi
 	fi
 fi
 
 # Build and execute the command line for TC service control only when there is something to do.
-if [ $tc_should_reload -eq 1 ] || 
-   [ $tc_should_disable -eq 1 ] || 
-   [ $tc_should_enable -eq 1 ]; then
+if [ $tc_should_disable -eq 1 ] || [ $tc_should_enable -eq 1 ] || [ $tc_should_start -eq 1 ]; then
 	cmd_line="sleep 10 &&"
-
-	# Reload the systemd daemon if needed.
-	if [ $tc_should_reload -eq 1 ]; then
-		cmd_line="$cmd_line systemctl daemon-reload &&"
-	fi
 
 	# Disable TC service if needed.
 	if [ $tc_should_disable -eq 1 ]; then
 		cmd_line="$cmd_line systemctl stop hw-management-tc && systemctl disable hw-management-tc &&"
-		# TC service should not be started.
-		tc_should_start=0
 	elif [ $tc_should_enable -eq 1 ]; then
 		# TC service should be enabled.
 		cmd_line="$cmd_line systemctl enable hw-management-tc &&"
-	fi
-
-	# Start TC service if needed.
-	if [ $tc_should_start -ne 0 ]; then
-		if [ $tc_should_reload -eq 1 ]; then
-			# TC service should be restarted in case of reload.
-			cmd_line="$cmd_line systemctl restart hw-management-tc &&"
-		else
+		if [ $tc_should_start -eq 1 ]; then
 			# TC service should be started.
 			cmd_line="$cmd_line systemctl start hw-management-tc &&"
 		fi
+	elif [ $tc_should_start -eq 1 ]; then
+		# TC service is already enabled and was inactive with a pending-restart marker
+		# at decision time. Re-check (and consume) the marker here, once the 10s
+		# deferral below has elapsed, so a stop issued by an operator during that
+		# window - which would remove the marker via hw-management-tc-stop-post.sh -
+		# is not silently overridden by this stale scheduling decision.
+		cmd_line="$cmd_line if [ -f $tc_pending_restart_file ]; then rm -f $tc_pending_restart_file; if ! systemctl is-active --quiet hw-management-tc.service; then systemctl start hw-management-tc; fi; fi &&"
 	fi
 
 	# Run the command line in the background and log the output to /dev/null.
 	# it is necessary because on SIMX, hw-mgmt tries to start the TC service during initialization.
-	# However, the TC service has a strong dependency: 
+	# However, the TC service has a strong dependency:
 	# Requires=hw-management.service. This means the TC service cannot start
 	# before hw-mgmt starts. But hw-mgmt attempts to start TC earlier. In this
 	# case, neither hw-mgmt nor TC will complete initialization.

--- a/usr/usr/bin/hw-management-tc-stop-post.sh
+++ b/usr/usr/bin/hw-management-tc-stop-post.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# hw-management-tc.service ExecStopPost hook.
+#
+# Records whether hw-management-tc.service's stop was propagated from
+# hw-management.service stopping/restarting (PartOf=hw-management.service), as
+# opposed to an operator directly stopping only the TC service.
+#
+# hw-management-tc.service has After=hw-management.service, so on a
+# coordinated stop systemd stops TC *before* hw-management.service's own stop
+# job even begins (shutdown order is the reverse of startup order). That means
+# hw-management.service's ActiveState is still "active" at this point in a
+# genuine PartOf= cascade too, so is-active cannot tell the two cases apart.
+# A stop/restart job for hw-management.service is queued for the whole
+# transaction immediately, though, even while it is blocked waiting on this
+# ordering constraint - so check for a pending job instead:
+# - job queued for hw-management.service     -> this stop is part of that same
+#   transaction (PartOf= cascade); mark it so hw-management-start-post.sh can
+#   restore TC on the next start, since PartOf= only propagates stop/restart,
+#   never a plain start.
+# - no job queued for hw-management.service  -> TC was stopped on its own
+#   (operator intent); clear any stale marker so a later, unrelated
+#   hw-management restart does not resurrect TC against the operator's wishes.
+source hw-management-helpers.sh
+
+if systemctl list-jobs --no-legend hw-management.service 2>/dev/null | grep -q .; then
+	touch "$tc_pending_restart_file"
+else
+	rm -f "$tc_pending_restart_file"
+fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3315,7 +3315,7 @@ set_config_data()
 	else
 		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
-	if [ -f $thermal_control_configs_path/tc_config_user.json ]; then
+	if [ -v $thermal_control_configs_path/tc_config_user.json ]; then
 		cp $thermal_control_configs_path/tc_config_user.json $config_path/tc_config_user.json
 	fi
 	[ -f "$config_path/asic_num" ] && asic_num=$(< $config_path/asic_num)
@@ -4089,6 +4089,11 @@ do_start()
 		ln -sf $lm_sensors_config $config_path/lm_sensors_config
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
+	fi
+	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
+		cp $thermal_control_config $config_path/tc_config.json
+	else
+		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
 	/usr/bin/hw-management-exec-parser.sh
 	log_info "Init completed."

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3315,7 +3315,7 @@ set_config_data()
 	else
 		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
-	if [ -v $thermal_control_configs_path/tc_config_user.json ]; then
+	if [ -f $thermal_control_configs_path/tc_config_user.json ]; then
 		cp $thermal_control_configs_path/tc_config_user.json $config_path/tc_config_user.json
 	fi
 	[ -f "$config_path/asic_num" ] && asic_num=$(< $config_path/asic_num)
@@ -4089,11 +4089,6 @@ do_start()
 		ln -sf $lm_sensors_config $config_path/lm_sensors_config
 	else
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
-	fi
-	if [ -v "thermal_control_config" ] && [ -f $thermal_control_config ]; then
-		cp $thermal_control_config $config_path/tc_config.json
-	else
-		cp $thermal_control_configs_path/tc_config_not_supported.json $config_path/tc_config.json
 	fi
 	/usr/bin/hw-management-exec-parser.sh
 	log_info "Init completed."

--- a/usr/usr/bin/hw_management_tc_launcher.sh
+++ b/usr/usr/bin/hw_management_tc_launcher.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# Alternatively, this software may be distributed under the terms of the
+# GNU General Public License ("GPL") version 2 as published by the Free
+# Software Foundation.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Thermal control launcher: read tc_version from tc_config.json and exec the
+# matching Python binary.  "exec" replaces this shell process so Python becomes
+# the systemd MAINPID directly — no sh wrapper, no ExecStop needed.
+#
+# tc_config.json is written by hw-management.sh (set_config_data) before
+# hw-management.service becomes active, so the file is always present when
+# this launcher is called (hw-management-tc.service has After=hw-management.service).
+# Defaults to v2.0 when the file is absent or tc_version is unrecognised.
+
+tc_cfg=/var/run/hw-management/config/tc_config.json
+unit_path=/lib/systemd/system/hw-management-tc.service
+
+tc_ver=$(grep -o '"tc_version"[[:space:]]*:[[:space:]]*"[^"]*"' "$tc_cfg" 2>/dev/null \
+         | head -n1 | cut -d'"' -f4)
+
+case $tc_ver in
+    2.5|2.5.*)
+        tc_ver_label=2.5
+        tc_bin=/usr/bin/hw_management_thermal_control_2_5.py
+        ;;
+    *)
+        tc_ver_label=2.0
+        tc_bin=/usr/bin/hw_management_thermal_control.py
+        ;;
+esac
+
+# Keep the unit's Description in sync with the selected version, matching the
+# pre-launcher format ("... (ver X.Y) ..."), so `systemctl status` still shows
+# it. Description is metadata only: daemon-reload picks up the edit without
+# touching this unit's running/activating state, unlike patching ExecStart.
+desc="Thermal control service (ver $tc_ver_label) of Nvidia systems"
+if ! grep -qF "Description=$desc" "$unit_path"; then
+    sed -i "s/^Description=.*/Description=$desc/" "$unit_path"
+    systemctl daemon-reload
+fi
+
+exec "$tc_bin"


### PR DESCRIPTION
Reverts 8f04e45f (Preserve TC run state across hw-management restart) and fixes the root cause properly.

Problem: hw-management-tc.service shipped a hardcoded v2.0 ExecStart. hw-management-start-post.sh patched the unit file on every boot and scheduled a daemon-reload + restart to pick up the new binary.  The state-file mechanism in 8f04e45f worked around the resulting races but left the design ownership wrong: hw-management was deciding which TC binary to run instead of the TC service itself.

Fix: introduce hw_management_tc_launcher.sh as ExecStart.  The launcher reads tc_version from tc_config.json (written by set_config_data before hw-management.service becomes active) and exec()s the matching Python binary directly, making Python the systemd MAINPID.  Because the right binary is chosen on every start, no unit-file patching, daemon-reload, or restart is needed.

Changes:
- hw-management-tc.service: ExecStart -> launcher; drop ExecStop kill wrapper and state-file ExecStartPost/ExecStop hooks
- hw_management_tc_launcher.sh: new launcher (exec, not sh -c)
- hw-management-start-post.sh: remove get_tc_version(), service-file sed patching, FragmentPath lookup, consume_tc_saved_state() call, tc_should_reload/restart/is_active variables and daemon-reload step
- hw-management-helpers.sh: remove tc_state_file and consume_tc_saved_state()
- hw-management-tc.service.8: document launcher approach
- test_hw_management_start_post_tc.py: replace state-file and reload tests with launcher version-selection tests (17 tests, all pass)

Bug: 5200160