### PR TITLE
hw-mgmt: thermal: Fix PWM stuck high after tacho error recovery

### DIFF
--- a/tests/offline/test_hw_management_fan_validate_rpm.py
+++ b/tests/offline/test_hw_management_fan_validate_rpm.py
@@ -151,6 +151,24 @@ def test_validate_rpm_read_pwm_mismatch_uses_cached_false(module_name, tc_mod, t
 
 
 @pytest.mark.parametrize("tacho_idx", [1, 2])
+def test_validate_rpm_pwm_quantization_clears_cached_fault_2_5(tacho_idx):
+    """2.5 float PWM round-trip (50 vs 50.2) is settled; trend can clear a cached tacho fault."""
+    import hw_management_thermal_control_2_5 as tc25
+
+    with patch.object(tc25, "current_milli_time", return_value=1_000_000):
+        h = _ValidateRpmHarness(
+            read_pwm_val=50.2,
+            pwm_set=50,
+            rpm_relax_ts=0,
+            fan_tacho_state=False,
+            rpm_read=_EXPECTED_RPM_AT_PWM_50,
+            tacho_idx=tacho_idx,
+        )
+        assert tc25.fan_sensor._validate_rpm(h) is True
+        assert h.fan_tacho_state is True
+
+
+@pytest.mark.parametrize("tacho_idx", [1, 2])
 @pytest.mark.parametrize("module_name,tc_mod", _modules())
 def test_validate_rpm_stabilized_speed_ok(module_name, tc_mod, tacho_idx):
     with patch.object(tc_mod, "current_milli_time", return_value=1_000_000):

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -2998,7 +2998,7 @@ class fan_sensor(system_device):
             False: PWM read error; or fan speed abnormal (out of range or
                    wrong vs calculated); or PWM stabilized but speed wrong.
             Previous state (cached fan_tacho_state): when PWM not yet
-            stabilized (relax time not elapsed or read PWM != set PWM) —
+            stabilized (relax time not elapsed or |read PWM - set PWM| >= 1) —
             applies only to the trend check (step 2). Out-of-range RPM (step 1)
             is an immediate fault and does not use the cache during stabilisation.
         """
@@ -3046,7 +3046,10 @@ class fan_sensor(system_device):
              # 2. Check fan trend
             if pwm_curr >= pwm_min:
                 # if FAN speed stabilized after the last change
-                if self.rpm_relax_timestamp <= current_milli_time() and pwm_curr == self.pwm_set:
+                # PWM sysfs is 0..255; percent round-trip can differ by <1%
+                # (65.0 -> 166/255 -> 65.1). Exact == never becomes true after a
+                # tacho-fault PWM bump, so the cached fault would stick forever.
+                if self.rpm_relax_timestamp <= current_milli_time() and abs(pwm_curr - self.pwm_set) < 1:
                     # calculate speed
                     slope = float(fan_param["slope"])
                     b = rpm_max - slope * CONST.PWM_MAX


### PR DESCRIPTION
Issue: After a simulated fan tacho error, PWM correctly rose to the
fan_err.tacho dmin (65%). After restoring the real tacho sysfs, PWM
stayed at 65% and never recovered. Seen with TC 2.5.

RC: TC 2.5 stores PWM as float percent after a 0..255 sysfs round-trip,
so read PWM can differ from set PWM by <1% (65.0 -> 166/255 -> 65.1).
_validate_rpm required exact pwm_curr == pwm_set to treat speed as
settled. After the tacho-fault PWM bump that equality never became
true, so the cached tacho fault stuck and PWM stayed high.

Fix: Treat PWM as settled when |read-set| < 1. Add a unit test that a
50 vs 50.2 mismatch can still clear a cached tacho fault.

Bug: 5232793

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
