### PR TITLE
hw-mgmt: thermal: SPC1: Add fallback in case if I2C ASIC driver failure

### DIFF
--- a/tests/offline/test_hw_management_chipup_pwm_fail.py
+++ b/tests/offline/test_hw_management_chipup_pwm_fail.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Unit tests for PWM 100% fallback after mlxsw_minimal chipup failure.
+################################################################################
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+HELPERS = ROOT / "usr" / "usr" / "bin" / "hw-management-helpers.sh"
+HW_MGMT_SH = ROOT / "usr" / "usr" / "bin" / "hw-management.sh"
+
+TC_ASIC_PWM = '{"asic_config": {"1": {"pwm_control": true}}}'
+TC_ASIC_PWM_OFF = '{"asic_config": {"1": {"pwm_control": false}}}'
+
+
+def _write_exec(path, text):
+    path.write_text(text)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def _run_pwm_fail_helper(
+    tmp_path,
+    tc_config=None,
+    pwm1=None,
+    asic_index="1",
+    explicit_dev=None,
+    asic_num=None,
+    pci_bus_ids=None,
+    mst_map=None,
+):
+    config_dir = tmp_path / "config"
+    thermal_dir = tmp_path / "thermal"
+    bin_dir = tmp_path / "bin"
+    mst_sysfs = tmp_path / "sys_class_mst"
+    mst_devdir = tmp_path / "dev_mst"
+    config_dir.mkdir(exist_ok=True)
+    thermal_dir.mkdir(exist_ok=True)
+    bin_dir.mkdir(exist_ok=True)
+    mst_sysfs.mkdir(exist_ok=True)
+    mst_devdir.mkdir(exist_ok=True)
+
+    if tc_config is not None:
+        (config_dir / "tc_config.json").write_text(tc_config)
+    if asic_num is not None:
+        (config_dir / "asic_num").write_text("{}\n".format(asic_num))
+    if pci_bus_ids:
+        for idx, bdf in pci_bus_ids.items():
+            (config_dir / "asic{}_pci_bus_id".format(idx)).write_text("{}\n".format(bdf))
+    if pwm1 is not None:
+        (thermal_dir / "pwm1").write_text(str(pwm1))
+
+    if mst_map:
+        pci_root = tmp_path / "pci_devs"
+        pci_root.mkdir(exist_ok=True)
+        for name, bdf in mst_map.items():
+            pci_dev = pci_root / bdf
+            pci_dev.mkdir(exist_ok=True)
+            node = mst_sysfs / name
+            node.mkdir()
+            (node / "device").symlink_to(pci_dev)
+            (mst_devdir / name).write_text("")
+
+    mlxreg_log = tmp_path / "mlxreg.args"
+    _write_exec(
+        bin_dir / "mlxreg",
+        "#!/bin/sh\n"
+        "printf '%s\\n' \"$*\" > \"{log}\"\n"
+        "exit 0\n".format(log=mlxreg_log),
+    )
+
+    if explicit_dev is None and mst_map is None and not pci_bus_ids:
+        explicit_dev = tmp_path / "fake_pciconf0"
+        explicit_dev.write_text("")
+
+    env = os.environ.copy()
+    env["PATH"] = "{}:{}".format(bin_dir, env.get("PATH", ""))
+    env["HW_MGMT_MST_SYSFS"] = str(mst_sysfs)
+    env["HW_MGMT_MST_DEVDIR"] = str(mst_devdir)
+
+    explicit_arg = '"{}"'.format(explicit_dev) if explicit_dev is not None else '""'
+    script = """
+source "{helpers}"
+log_info() {{ :; }}
+log_err() {{ :; }}
+config_path="{config}"
+thermal_path="{thermal}"
+export HW_MGMT_MST_SYSFS="{mst_sysfs}"
+export HW_MGMT_MST_DEVDIR="{mst_devdir}"
+set_asic_pwm_full_speed_on_chipup_fail "{asic_index}" {explicit_arg}
+echo RC:$?
+""".format(
+        helpers=HELPERS,
+        config=config_dir,
+        thermal=thermal_dir,
+        mst_sysfs=mst_sysfs,
+        mst_devdir=mst_devdir,
+        asic_index=asic_index,
+        explicit_arg=explicit_arg,
+    )
+
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        env=env,
+        cwd=str(tmp_path),
+    )
+    return result, mlxreg_log, thermal_dir / "pwm1"
+
+
+def test_chipup_fail_path_passes_failed_asic_index():
+    text = HW_MGMT_SH.read_text()
+    chipup_case = text[text.index("\tchipup)"): text.index("\tchipdown)")]
+    fail_idx = chipup_case.index('log_info "chipup failed for ASIC $asic_index"')
+    success_exit = chipup_case.index("exit 0")
+    assert success_exit < fail_idx
+    assert 'set_asic_pwm_full_speed_on_chipup_fail "$asic_index" "$3"' in chipup_case[fail_idx:]
+    assert "set_asic_pwm_full_speed_on_chipup_fail" not in chipup_case[:fail_idx]
+    helpers = HELPERS.read_text()
+    assert "get_asic_mlxreg_dev()" in helpers
+    assert "_hw_mgmt_normalize_asic_index()" in helpers
+    assert "asic${asic_index}_pci_bus_id" in helpers
+    assert "head -n 1" in helpers
+    # First-pciconf0 fallback is gated to a single ASIC.
+    assert '[ "$asic_num" -eq 1 ]' in helpers
+    assert "pwm_duty_cycle=0xff" in helpers
+
+
+def test_sysfs_pwm_used_when_pwm1_exists(tmp_path):
+    result, mlxreg_log, pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+        pwm1="128",
+    )
+    assert result.returncode == 0
+    assert "RC:0" in result.stdout
+    assert pwm1.read_text().strip() == "255"
+    assert not mlxreg_log.exists()
+
+
+def test_mlxreg_used_when_asic_pwm_and_no_pwm1(tmp_path):
+    result, mlxreg_log, pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+    )
+    assert result.returncode == 0
+    assert "RC:0" in result.stdout
+    assert not pwm1.exists()
+    args = mlxreg_log.read_text()
+    assert "--reg_name MFSC" in args
+    assert "pwm_duty_cycle=0xff" in args
+    assert "--indexes pwm=0x0" in args
+
+
+def test_no_mlxreg_when_pwm_control_disabled(tmp_path):
+    result, mlxreg_log, _pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM_OFF,
+    )
+    assert result.returncode == 0
+    assert "RC:1" in result.stdout
+    assert not mlxreg_log.exists()
+
+
+def test_mlxreg_targets_failed_asic_on_multi_asic(tmp_path):
+    """Chipup of ASIC 2 must program that ASIC's mst node, not the first pciconf0."""
+    result, mlxreg_log, _pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+        asic_index="2",
+        explicit_dev=None,
+        asic_num=2,
+        pci_bus_ids={1: "03:00.0", 2: "05:00.0"},
+        mst_map={
+            "mt_asic1_pciconf0": "0000:03:00.0",
+            "mt_asic2_pciconf0": "0000:05:00.0",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RC:0" in result.stdout
+    args = mlxreg_log.read_text()
+    assert "mt_asic2_pciconf0" in args
+    assert "mt_asic1_pciconf0" not in args
+
+
+def test_mlxreg_uses_pci_bdf_when_mst_sysfs_missing(tmp_path):
+    result, mlxreg_log, _pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+        asic_index="2",
+        explicit_dev=None,
+        asic_num=2,
+        pci_bus_ids={1: "03:00.0", 2: "05:00.0"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RC:0" in result.stdout
+    args = mlxreg_log.read_text()
+    assert "-d 05:00.0" in args
+    assert "03:00.0" not in args
+
+
+def test_multi_asic_without_pci_id_does_not_pick_first_pciconf(tmp_path):
+    result, mlxreg_log, _pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+        asic_index="2",
+        explicit_dev=None,
+        asic_num=2,
+        mst_map={"mt_asic1_pciconf0": "0000:03:00.0"},
+    )
+    assert result.returncode == 0
+    assert "RC:1" in result.stdout
+    assert not mlxreg_log.exists()
+
+
+def test_index_zero_uses_asic1_pci_id(tmp_path):
+    """sxcore calls chipup 0; config files are asic1_pci_bus_id."""
+    result, mlxreg_log, _pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+        asic_index="0",
+        explicit_dev=None,
+        asic_num=1,
+        pci_bus_ids={1: "03:00.0"},
+        mst_map={"mt_asic1_pciconf0": "0000:03:00.0"},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RC:0" in result.stdout
+    args = mlxreg_log.read_text()
+    assert "mt_asic1_pciconf0" in args
+
+
+def test_sxcore_pci_path_with_index_zero_selects_matching_asic(tmp_path):
+    """chipup 0 /sys/.../0000:05:00.0 must program that ASIC, not asic1."""
+    pci_path = tmp_path / "sys" / "devices" / "0000:05:00.0"
+    pci_path.mkdir(parents=True)
+    result, mlxreg_log, _pwm1 = _run_pwm_fail_helper(
+        tmp_path,
+        tc_config=TC_ASIC_PWM,
+        asic_index="0",
+        explicit_dev=pci_path,
+        asic_num=2,
+        pci_bus_ids={1: "03:00.0", 2: "05:00.0"},
+        mst_map={
+            "mt_asic1_pciconf0": "0000:03:00.0",
+            "mt_asic2_pciconf0": "0000:05:00.0",
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    assert "RC:0" in result.stdout
+    args = mlxreg_log.read_text()
+    assert "mt_asic2_pciconf0" in args
+    assert "mt_asic1_pciconf0" not in args

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -1672,3 +1672,184 @@ function set_fan_direction_for_all_fans()
 	done
 	print_function_call "$0" "${FUNCNAME[0]}" "Finished"
 }
+
+# Normalize PCI BDF to bus:dev.func without domain (03:00.0).
+_hw_mgmt_pci_bdf_short()
+{
+	local pci_id="$1"
+
+	pci_id=$(echo "$pci_id" | tr -d '[:space:]')
+	pci_id="${pci_id#0000:}"
+	echo "$pci_id"
+}
+
+# Chipup callers mix 0-based and 1-based indexes. sxcore uses
+# "chipup 0 <pci_path>"; autochipup/hotplug use 1..N. Config files are
+# 1-based (asic1_pci_bus_id). Map 0/empty to 1.
+_hw_mgmt_normalize_asic_index()
+{
+	local idx="${1:-1}"
+
+	if [ -z "$idx" ] || [ "$idx" -eq 0 ] 2>/dev/null; then
+		echo 1
+		return
+	fi
+	echo "$idx"
+}
+
+# Extract a PCI BDF from a chipup argument: BDF, pci-BDF, or sysfs path
+# ending in 0000:bb:dd.f (sxcore passes %S/%p).
+_hw_mgmt_extract_pci_bdf()
+{
+	local arg="$1"
+	local base
+
+	[ -n "$arg" ] || return 1
+	base=$(basename "$arg")
+	base="${base#pci-}"
+	echo "$base" | grep -E -q '^([0-9A-Fa-f]{4}:)?[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f]$' || return 1
+	_hw_mgmt_pci_bdf_short "$base"
+}
+
+# Resolve mlxreg -d target for ASIC index $1 (0- or 1-based).
+# Optional $2: explicit /dev/mst path (tests) or PCI BDF/sysfs path from
+# chipup $3. Match /sys/class/mst to config/asicN_pci_bus_id (1-based) so a
+# multi-ASIC chipup failure programs the ASIC that failed, not the first
+# pciconf0. If no mst node matches, pass the PCI BDF to mlxreg.
+get_asic_mlxreg_dev()
+{
+	local asic_index
+	local arg2="$2"
+	local pci_id pci_short mst_sysfs mst_devdir mst_name pci_link pci_tail extracted
+	local asic_num=1
+	local match=""
+
+	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
+
+	if [ -n "$arg2" ]; then
+		if extracted=$(_hw_mgmt_extract_pci_bdf "$arg2"); then
+			pci_id=$extracted
+			pci_short=$extracted
+		else
+			echo "$arg2"
+			return 0
+		fi
+	fi
+
+	[ -f "$config_path/asic_num" ] && asic_num=$(< "$config_path/asic_num")
+
+	if [ -z "$pci_short" ] && [ -f "$config_path/asic${asic_index}_pci_bus_id" ]; then
+		pci_id=$(_hw_mgmt_pci_bdf_short "$(< "$config_path/asic${asic_index}_pci_bus_id")")
+		pci_short=$pci_id
+	fi
+
+	mst_sysfs="${HW_MGMT_MST_SYSFS:-/sys/class/mst}"
+	mst_devdir="${HW_MGMT_MST_DEVDIR:-/dev/mst}"
+
+	if [ -n "$pci_short" ] && [ -d "$mst_sysfs" ]; then
+		for mst_name in "$mst_sysfs"/*; do
+			[ -e "$mst_name" ] || continue
+			pci_link=$(readlink -f "$mst_name/device" 2>/dev/null)
+			if [ -z "$pci_link" ] && [ -f "$mst_name/uevent" ]; then
+				pci_link=$(sed -n 's/^PCI_SLOT_NAME=//p' "$mst_name/uevent")
+			fi
+			[ -n "$pci_link" ] || continue
+			pci_tail=$(_hw_mgmt_pci_bdf_short "$(basename "$pci_link")")
+			if [ "$pci_tail" = "$pci_short" ]; then
+				match="$mst_devdir/$(basename "$mst_name")"
+				break
+			fi
+		done
+	fi
+
+	if [ -n "$match" ]; then
+		echo "$match"
+		return 0
+	fi
+
+	# mlxreg accepts a PCI BDF when the mst char device is missing.
+	if [ -n "$pci_short" ]; then
+		echo "$pci_id"
+		return 0
+	fi
+
+	# Last resort for a single-ASIC system only. Never pick the first
+	# pciconf0 when more than one ASIC is present.
+	if [ "$asic_num" -eq 1 ]; then
+		match=$(find "$mst_devdir" -maxdepth 1 -name '*_pciconf0' 2>/dev/null | head -n 1)
+		if [ -n "$match" ]; then
+			echo "$match"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+# After mlxsw_minimal chipup has failed, thermal/asic and thermal/pwm1 are
+# typically missing, so thermal control never latches emergency and never
+# calls write_pwm_mlxreg(). Force PWM 100% here:
+# - thermal/pwm1 if it still exists (CPLD or leftover ASIC hwmon)
+# - otherwise MFSC via mlxreg for the failed ASIC when tc_config enables
+#   ASIC PWM control
+# $1: ASIC index from chipup (0- or 1-based; 0 means first ASIC)
+# $2: optional mlxreg device, PCI BDF, or sxcore PCI sysfs path
+set_asic_pwm_full_speed_on_chipup_fail()
+{
+	local asic_index
+	local explicit_dev="$2"
+	local pwm_link="$thermal_path/pwm1"
+	local tc_cfg="$config_path/tc_config.json"
+	local mt_dev=""
+	local mlxreg_rc=0
+	local mst_devdir="${HW_MGMT_MST_DEVDIR:-/dev/mst}"
+
+	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
+
+	if [ -e "$pwm_link" ]; then
+		echo 255 > "$pwm_link"
+		log_info "Set PWM to maximum speed via sysfs after chipup failure."
+		return 0
+	fi
+
+	if [ ! -f "$tc_cfg" ] || ! grep -q '"pwm_control"[[:space:]]*:[[:space:]]*true' "$tc_cfg"; then
+		log_info "Chipup failed and PWM sysfs is missing; ASIC PWM control is not configured."
+		return 1
+	fi
+
+	if ! command -v mlxreg >/dev/null 2>&1; then
+		log_err "mlxreg is not available; cannot set PWM after chipup failure."
+		return 1
+	fi
+
+	if [ -z "$explicit_dev" ] && [ ! -d "$mst_devdir" ] && \
+	   [ -z "${HW_MGMT_MST_DEVDIR:-}" ] && command -v mst >/dev/null 2>&1; then
+		mst start >/dev/null 2>&1
+		sleep 2
+	fi
+
+	mt_dev=$(get_asic_mlxreg_dev "$1" "$explicit_dev")
+	if [ -z "$mt_dev" ]; then
+		log_err "ASIC $asic_index mst/PCI device is not available; cannot set PWM after chipup failure."
+		return 1
+	fi
+
+	# mlxreg prompts for confirmation; same pattern as thermal write_pwm_mlxreg().
+	if command -v timeout >/dev/null 2>&1; then
+		yes | timeout 3 mlxreg -d "$mt_dev" --reg_name MFSC \
+			--indexes pwm=0x0 --set pwm_duty_cycle=0xff >/dev/null 2>&1
+		mlxreg_rc=$?
+	else
+		yes | mlxreg -d "$mt_dev" --reg_name MFSC \
+			--indexes pwm=0x0 --set pwm_duty_cycle=0xff >/dev/null 2>&1
+		mlxreg_rc=$?
+	fi
+
+	if [ "$mlxreg_rc" -ne 0 ]; then
+		log_err "Failed to set PWM to maximum speed via mlxreg after chipup failure (asic=$asic_index dev=$mt_dev rc=$mlxreg_rc)."
+		return 1
+	fi
+
+	log_info "Set PWM to maximum speed via mlxreg after chipup failure (asic=$asic_index dev=$mt_dev)."
+	return 0
+}

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -1083,6 +1083,8 @@ if [ "$1" == "add" ]; then
 		if [ ${minimal_unsupported} -eq 0 ] && [ ! -d /sys/module/mlxsw_minimal ]; then
 			modprobe mlxsw_minimal
 		fi
+		# sxcore uses 0-based ASIC index; chipup maps 0 to asic1_* and
+		# uses $3 (%S/%p PCI path) to identify the failed ASIC.
 		/usr/bin/hw-management.sh chipup 0 "$4/$5"
 		set_asic_ready "$4/$5" 1
 	fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -4419,6 +4419,12 @@ case $ACTION in
 			done
 			stop_chipup_i2c_trace
 			log_info "chipup failed for ASIC $asic_index"
+			# thermal/pwm1 and thermal/asic are not created when
+			# mlxsw_minimal probe fails, so TC will not enforce
+			# full speed. Set PWM 100% on the ASIC that failed
+			# chipup via sysfs or mlxreg MFSC. Pass $3 (PCI path
+			# from sxcore) so index 0 still resolves a target.
+			set_asic_pwm_full_speed_on_chipup_fail "$asic_index" "$3"
 		fi
 	;;
 	chipdown)


### PR DESCRIPTION
This change is only for SPC1 based systems. After mlxsw_minimal chipup fails, thermal sysfs PWM is missing and TC cannot force full speed. Set PWM to 100% via mlxreg MFSC.

The reason of these failures might be HW issue: system before re-spin, bad serial cable. Or in some rare case problem with I2C communication from CPU to SPC1.
In case the problem with the serial cable - the suggestion to replace the cable by cables recommended by Nvidia.

It was agreed on the following SW approach:
In case issue happened after cold reboot - just reboot system again.
In case issue happened after warm reboot - need to change code and set PWM to 100%, so it will stay at full speed with no changes.

Bug #4966961