### PR TITLE
hw-mgmt: scripts: Fix PSU EEPROM parsing on systems without PSU VPD

### DIFF
--- a/usr/usr/bin/hw-management-ps-vpd.sh
+++ b/usr/usr/bin/hw-management-ps-vpd.sh
@@ -2,7 +2,7 @@
 
 ##################################################################################
 # SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
-# Copyright (c) 2020-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -276,8 +276,6 @@ fi
 
 function read_pmbus_ps_vpd ( )
 {
-	read_pmbus_ps_vpd_pointer
-
 	#MFR NAME
 	#read block len
 	len=$(pmbus_read "${MFR_NAME_ADDR}" 1)
@@ -292,6 +290,7 @@ function read_pmbus_ps_vpd ( )
 
 	echo -ne '\n' >> "$VPD_OUTPUT_FILE"
 
+	read_pmbus_ps_vpd_pointer
 	calc_crc16 "${VPD_POINTER[@]:1}"
 
 	i=0

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -956,7 +956,7 @@ if [ "$1" == "add" ]; then
 		hw-management-ps-vpd.sh --BUS_ID "$bus" --I2C_ADDR 0x"$ps_ctrl_addr" --dump --VPD_OUTPUT_FILE $eeprom_path/"$psu_name"_vpd
 		if [ $? -ne 0 ]; then
 			# PS EEPROM VPD.
-			hw-management-parse-eeprom.sh --conv --eeprom_path $eeprom_path/"$psu_name"_info > $eeprom_path/"$psu_name"_vpd
+			hw-management-parse-eeprom.sh --conv --eeprom_path $eeprom_path/"$psu_name"_info >> $eeprom_path/"$psu_name"_vpd
 			if [ $? -ne 0 ]; then
 				# EEPROM failed.
 				if is_virtual_machine; then


### PR DESCRIPTION
On systems like MSN2700-A1, that keep PSU VPD information in the PSU EEPROM, the PSU EEPROM parsing script fails to add PSU manufacturer information to the parsed file. This patch fixes the problem.

Bug: 5183998