### PR TITLE
hw-mgmt: examples: Add BOM record examples for HI194 system

### DIFF
--- a/bmc/examples/HI194/hw-management-bmc-bom.json
+++ b/bmc/examples/HI194/hw-management-bmc-bom.json
@@ -1,0 +1,154 @@
+{
+    "swb": [
+        {
+            "key": "24c512_0",
+            "spec": "24c512 0x51 27 swb_info"
+        },
+        {
+            "key": "24c512_1",
+            "spec": "24c512 0x51 30 swb2_info"
+        },
+        {
+            "key": "lm5066i_0",
+            "spec": "lm5066i 0x12 21 pdb_hotswap1"
+        },
+        {
+            "key": "lm5066i_1",
+            "spec": "lm5066i 0x12 28 pdb_hotswap2"
+        },
+        {
+            "key": "mp29816_0",
+            "spec": "mp29816 0x66 22 voltmon1"
+        },
+        {
+            "key": "mp29816_1",
+            "spec": "mp29816 0x68 22 voltmon2"
+        },
+        {
+            "key": "mp29816_10",
+            "spec": "mp29816 0x68 32 voltmon11"
+        },
+        {
+            "key": "mp29816_11",
+            "spec": "mp29816 0x6c 32 voltmon12"
+        },
+        {
+            "key": "mp29816_2",
+            "spec": "mp29816 0x6c 22 voltmon3"
+        },
+        {
+            "key": "mp29816_3",
+            "spec": "mp29816 0x66 29 voltmon4"
+        },
+        {
+            "key": "mp29816_4",
+            "spec": "mp29816 0x68 29 voltmon5"
+        },
+        {
+            "key": "mp29816_5",
+            "spec": "mp29816 0x6c 29 voltmon6"
+        },
+        {
+            "key": "mp29816_6",
+            "spec": "mp29816 0x66 31 voltmon7"
+        },
+        {
+            "key": "mp29816_7",
+            "spec": "mp29816 0x68 31 voltmon8"
+        },
+        {
+            "key": "mp29816_8",
+            "spec": "mp29816 0x6c 31 voltmon9"
+        },
+        {
+            "key": "mp29816_9",
+            "spec": "mp29816 0x66 32 voltmon10"
+        },
+        {
+            "key": "mp5926_0",
+            "spec": "mp5926 0x12 21 pdb_hotswap1"
+        },
+        {
+            "key": "mp5926_1",
+            "spec": "mp5926 0x12 28 pdb_hotswap2"
+        },
+        {
+            "key": "xdpe1a2g7_0",
+            "spec": "xdpe1a2g7 0x66 22 voltmon1"
+        },
+        {
+            "key": "xdpe1a2g7_1",
+            "spec": "xdpe1a2g7 0x68 22 voltmon2"
+        },
+        {
+            "key": "xdpe1a2g7_10",
+            "spec": "xdpe1a2g7 0x68 32 voltmon11"
+        },
+        {
+            "key": "xdpe1a2g7_11",
+            "spec": "xdpe1a2g7 0x6c 32 voltmon12"
+        },
+        {
+            "key": "xdpe1a2g7_12",
+            "spec": "xdpe1a2g7 0x5c 22 pwr_conv1"
+        },
+        {
+            "key": "xdpe1a2g7_13",
+            "spec": "xdpe1a2g7 0x5c 31 pwr_conv2"
+        },
+        {
+            "key": "xdpe1a2g7_2",
+            "spec": "xdpe1a2g7 0x6c 22 voltmon3"
+        },
+        {
+            "key": "xdpe1a2g7_3",
+            "spec": "xdpe1a2g7 0x66 29 voltmon4"
+        },
+        {
+            "key": "xdpe1a2g7_4",
+            "spec": "xdpe1a2g7 0x68 29 voltmon5"
+        },
+        {
+            "key": "xdpe1a2g7_5",
+            "spec": "xdpe1a2g7 0x6c 29 voltmon6"
+        },
+        {
+            "key": "xdpe1a2g7_6",
+            "spec": "xdpe1a2g7 0x66 31 voltmon7"
+        },
+        {
+            "key": "xdpe1a2g7_7",
+            "spec": "xdpe1a2g7 0x68 31 voltmon8"
+        },
+        {
+            "key": "xdpe1a2g7_8",
+            "spec": "xdpe1a2g7 0x6c 31 voltmon9"
+        },
+        {
+            "key": "xdpe1a2g7_9",
+            "spec": "xdpe1a2g7 0x66 32 voltmon10"
+        }
+    ],
+    "platform": [
+        {
+            "key": "24c512_1",
+            "spec": "24c512 0x51 1 vpd_info"
+        },
+        {
+            "key": "mp2845_0",
+            "spec": "mp2845 0x69 17 comex_voltmon1"
+        },
+        {
+            "key": "mp2975_1",
+            "spec": "mp2975 0x6a 17 comex_voltmon2"
+        },
+        {
+            "key": "spd5118_0",
+            "spec": "spd5118 0x52 19 somdimm_temp1"
+        },
+        {
+            "key": "spd5118_1",
+            "spec": "spd5118 0x53 19 somdimm_temp2"
+        }
+    ]
+}

--- a/examples/HI194/hw-management-bom.json
+++ b/examples/HI194/hw-management-bom.json
@@ -1,0 +1,154 @@
+{
+    "swb": [
+        {
+            "key": "24c512_0",
+            "spec": "24c512 0x51 13 swb_info"
+        },
+        {
+            "key": "24c512_1",
+            "spec": "24c512 0x51 29 swb2_info"
+        },
+        {
+            "key": "lm5066i_0",
+            "spec": "lm5066i 0x12 6 pdb_hotswap1"
+        },
+        {
+            "key": "lm5066i_1",
+            "spec": "lm5066i 0x12 22 pdb_hotswap2"
+        },
+        {
+            "key": "mp29816_0",
+            "spec": "mp29816 0x66 7 voltmon1"
+        },
+        {
+            "key": "mp29816_1",
+            "spec": "mp29816 0x68 7 voltmon2"
+        },
+        {
+            "key": "mp29816_10",
+            "spec": "mp29816 0x68 55 voltmon11"
+        },
+        {
+            "key": "mp29816_11",
+            "spec": "mp29816 0x6c 55 voltmon12"
+        },
+        {
+            "key": "mp29816_2",
+            "spec": "mp29816 0x6c 7 voltmon3"
+        },
+        {
+            "key": "mp29816_3",
+            "spec": "mp29816 0x66 23 voltmon4"
+        },
+        {
+            "key": "mp29816_4",
+            "spec": "mp29816 0x68 23 voltmon5"
+        },
+        {
+            "key": "mp29816_5",
+            "spec": "mp29816 0x6c 23 voltmon6"
+        },
+        {
+            "key": "mp29816_6",
+            "spec": "mp29816 0x66 39 voltmon7"
+        },
+        {
+            "key": "mp29816_7",
+            "spec": "mp29816 0x68 39 voltmon8"
+        },
+        {
+            "key": "mp29816_8",
+            "spec": "mp29816 0x6c 39 voltmon9"
+        },
+        {
+            "key": "mp29816_9",
+            "spec": "mp29816 0x66 55 voltmon10"
+        },
+        {
+            "key": "mp5926_0",
+            "spec": "mp5926 0x12 6 pdb_hotswap1"
+        },
+        {
+            "key": "mp5926_1",
+            "spec": "mp5926 0x12 22 pdb_hotswap2"
+        },
+        {
+            "key": "xdpe1a2g7_0",
+            "spec": "xdpe1a2g7 0x66 7 voltmon1"
+        },
+        {
+            "key": "xdpe1a2g7_1",
+            "spec": "xdpe1a2g7 0x68 7 voltmon2"
+        },
+        {
+            "key": "xdpe1a2g7_10",
+            "spec": "xdpe1a2g7 0x68 55 voltmon11"
+        },
+        {
+            "key": "xdpe1a2g7_11",
+            "spec": "xdpe1a2g7 0x6c 55 voltmon12"
+        },
+        {
+            "key": "xdpe1a2g7_12",
+            "spec": "xdpe1a2g7 0x5c 7 pwr_conv1"
+        },
+        {
+            "key": "xdpe1a2g7_13",
+            "spec": "xdpe1a2g7 0x5c 39 pwr_conv2"
+        },
+        {
+            "key": "xdpe1a2g7_2",
+            "spec": "xdpe1a2g7 0x6c 7 voltmon3"
+        },
+        {
+            "key": "xdpe1a2g7_3",
+            "spec": "xdpe1a2g7 0x66 23 voltmon4"
+        },
+        {
+            "key": "xdpe1a2g7_4",
+            "spec": "xdpe1a2g7 0x68 23 voltmon5"
+        },
+        {
+            "key": "xdpe1a2g7_5",
+            "spec": "xdpe1a2g7 0x6c 23 voltmon6"
+        },
+        {
+            "key": "xdpe1a2g7_6",
+            "spec": "xdpe1a2g7 0x66 39 voltmon7"
+        },
+        {
+            "key": "xdpe1a2g7_7",
+            "spec": "xdpe1a2g7 0x68 39 voltmon8"
+        },
+        {
+            "key": "xdpe1a2g7_8",
+            "spec": "xdpe1a2g7 0x6c 39 voltmon9"
+        },
+        {
+            "key": "xdpe1a2g7_9",
+            "spec": "xdpe1a2g7 0x66 55 voltmon10"
+        }
+    ],
+    "platform": [
+        {
+            "key": "24c512_1",
+            "spec": "24c512 0x51 1 vpd_info"
+        },
+        {
+            "key": "mp2845_0",
+            "spec": "mp2845 0x69 5 comex_voltmon1"
+        },
+        {
+            "key": "mp2975_1",
+            "spec": "mp2975 0x6a 5 comex_voltmon2"
+        },
+        {
+            "key": "spd5118_0",
+            "spec": "spd5118 0x52 10 somdimm_temp1"
+        },
+        {
+            "key": "spd5118_1",
+            "spec": "spd5118 0x53 10 somdimm_temp2"
+        }
+    ]
+}

--- a/examples/HI194/hw-management-i2c-mux-tree.conf
+++ b/examples/HI194/hw-management-i2c-mux-tree.conf
@@ -1,0 +1,11 @@
+chan_id	CPU bus	BMC bus	Name
+2	5	17	comex_voltmon1,comex_voltmon2
+3	6	21	pdb_hotswap1
+4	7	22	voltmon1,voltmon2,voltmon3,pwr_conv1
+7	10	19	somdimm_temp1,somdimm_temp2
+10	13	27	swb_info
+19	22	28	pdb_hotswap2
+20	23	29	voltmon4,voltmon5,voltmon6
+26	29	30	swb2_info
+36	39	31	voltmon7,voltmon8,voltmon9,pwr_conv2
+52	55	32	voltmon10,voltmon11,voltmon12


### PR DESCRIPTION
Add host and BMC SMBIOS BOM JSON examples and the I2C mux-tree map for HI194 (N7200_LD), taken from the HI194 I2C device table. CPU and BMC bus numbers follow the HI193 mapping for now and can be updated once the HI194 map is confirmed. Cartridge EEPROMs are not included; they are not connected over I2C on this platform.