### PR TITLE
hw-mgmt: scripts: Validate cable cartridge FRU on init

### DIFF
--- a/Documentation/CHANGELOG_User_Manual.md
+++ b/Documentation/CHANGELOG_User_Manual.md
@@ -1,11 +1,28 @@
 # User Manual Changelog
 
 **Document:** Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md  
-**Last Updated:** August 17, 2026
+**Last Updated:** August 26, 2026
 
 ---
 
 ## Change History
+
+### Rev. 3.2.9 - August 26, 2026
+
+#### Added: Cable cartridge FRU validity
+
+**Affected platforms:** N51XX_LD and N61XX_LD (VMOD0021, VMOD0023). Other platforms with cable cartridge EEPROMs parse them through a different path and are unaffected.
+
+**User manual updates:**
+
+| Area | Change |
+|------|--------|
+| §3.1.61 | **`config/cable_cartridge<n>_valid`**: `1` FRU valid, `0` FRU invalid, absent when the check did not run or the cartridge was removed |
+
+**Validation source:** `usr/usr/bin/hw-management-chassis-events.sh`
+(`validate_cartridge_fru()`).
+
+---
 
 ### Rev. 3.2.8 - August 25, 2026
 

--- a/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
+++ b/Documentation/Chassis_Management_for_NVIDIA_Switch_Systems_with_Sysfs_rev.3.2.md
@@ -2,7 +2,7 @@
 
 ![NVIDIA Logo](images/logo.png)
 
-Rev. 3.2.7
+Rev. 3.2.8
 
 ## Table of Contents
 
@@ -76,6 +76,7 @@ Rev. 3.2.7
 | 3.1.58 | Core 1 Temperature ID | 37 |
 | 3.1.59 | Read PDB Hotswap Scale Factor | 37 |
 | 3.1.60 | Read LED Control Type Map | 38 |
+| 3.1.61 | Cable Cartridge FRU Validity | 38 |
 | 3.2 | BIOS Control | 38 |
 | 3.2.1 | BIOS Status | 38 |
 | 3.2.2 | BIOS Start Retry | 38 |
@@ -409,6 +410,7 @@ Rev. 3.2.7
 
 | Revision | Date | Description |
 |----------|------|-------------|
+| 3.2.8 | August 2026 | §3.1.61 `config/cable_cartridge<n>_valid`: IPMI FRU check result per cable cartridge (N51XX_LD / N61XX_LD) |
 | 3.2.7 | August 2026 | §3.1.60 `config/led_control_type` platform LED owner map; §3.16.28 `led/led_<name>_control` (`led_sw` / `led_hw` / `led_hw_sw`); glob masks `*` and `?` |
 | 3.2.6 | June 2026 | §3.1.59 and §3.4 PDB hotswap scale (SN6600_LD / lm5066i); §3.24 AST2700 BMC reset cause tree; §3.25 BMC A2D leakage runtime layout; N6300_LD (HI185) platform notes; §3.18 cpu_shutdown_req hw-mgmt polling note |
 | 3.2.5 | June 2026 | §2.2 HI189 BMC peripheral table; §3.3.7–§3.3.8 BMC EEPROM bodies; §3.20 BMC stack tags and CPU-on-BMC thermal cross-refs; §3.23 BMC status bodies (present, bmc_to_cpu_ctrl, MCTP) |
@@ -1990,6 +1992,48 @@ uses `led_hw_sw`.
 ```bash
 cat $bsp_path/config/led_control_type
 # fan led_sw psu led_sw status led_sw
+```
+
+### Cable Cartridge FRU Validity
+
+**Stack:** Host
+
+**Node name:** `$bsp_path/config/cable_cartridge<cartridge number>_valid`
+
+**Description:** Result of the IPMI FRU check run on the cable cartridge EEPROM
+at init. The BMC reads the same EEPROM and programs the rack id, topology id,
+switch tray id and slot id into the switch board CPLD without validating it,
+so this node reports whether that source data can be trusted.
+
+Written by `validate_cartridge_fru()` in `hw-management-chassis-events.sh` after
+`ipmi-fru` parses `eeprom/cable_cartridge<n>_eeprom`. `ipmi-fru` exits 0 even
+for a broken FRU, so the verdict comes from its output: a `FRU Error` line, or a
+missing board serial number or chassis custom info field, gives 0. Failures are
+also reported to syslog.
+
+Created on the N51XX_LD and N61XX_LD families only. Other platforms that have
+cable cartridge EEPROMs parse them through a different path and do not get this
+node. It is also absent when `ipmi-fru` is not installed.
+
+The node is created when the cartridge EEPROM appears and removed when the
+cartridge is removed, so it never reports a verdict for an empty slot.
+
+One node per cartridge, so the count follows `config/cartridge_counter`, which
+is platform dependent: 4 on N6100_LD (HI180), N6300_LD (HI185), N5110_LD (HI166)
+and N5100_LD (HI167/HI170), and 2 on N5112_LD (HI169).
+
+**Access:** Read only
+
+**Release version:** 3.2.8
+
+**Arguments:**
+| Name | Data type | Values |
+|------|-----------|--------|
+| Validity | Integer | 1 - FRU valid, 0 - FRU invalid |
+
+**Example:** Check cable cartridge 1 FRU validity:
+```bash
+cat $bsp_path/config/cable_cartridge1_valid
 ```
 
 ## BIOS Control

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -495,6 +495,29 @@ get_fan_direction_by_vpd()
 	return $dir
 }
 
+validate_cartridge_fru()
+{
+	local cartridge_name=$1
+	local fru_data_file="$eeprom_path/${cartridge_name}_data"
+	local valid_file="$config_path/${cartridge_name%%_eeprom*}_valid"
+	local fru_error
+
+	# ipmi-fru returns 0 even for a broken FRU, so only its output tells us.
+	# The BMC reads these two fields to program the CPLD, so both must be there.
+	fru_error=$(grep -m1 -o "FRU Error.*" "$fru_data_file" 2>/dev/null)
+	if [ -n "$fru_error" ]; then
+		echo 0 > "$valid_file"
+		log_err "$cartridge_name: $fru_error"
+	elif ! grep -q "FRU Board Serial Number" "$fru_data_file" 2>/dev/null ||
+		! grep -q "FRU Chassis Custom Info" "$fru_data_file" 2>/dev/null; then
+		echo 0 > "$valid_file"
+		log_err "$cartridge_name: FRU missing board serial or chassis custom info"
+	else
+		echo 1 > "$valid_file"
+		log_info "$cartridge_name: FRU valid"
+	fi
+}
+
 function set_fpga_combined_version()
 {
 	path="$1"
@@ -1321,6 +1344,9 @@ if [ "$1" == "add" ]; then
 			if [ "$dmi_board_name" == "VMOD0021" ] || [ "$dmi_board_name" == "VMOD0023" ]; then
 				if command -v ipmi-fru 2>&1 >/dev/null; then
 					ipmi-fru --fru-file="$eeprom_path"/"$eeprom_name" > "$eeprom_path"/"$eeprom_name"_data
+					validate_cartridge_fru "$eeprom_name"
+				else
+					log_info "$eeprom_name: ipmi-fru not found, FRU not validated"
 				fi
 			else
 				eeprom_vpd_filename=${eeprom_name/"_eeprom"/"_data"}
@@ -1682,6 +1708,9 @@ else
 				;;
 			vpd*)
 				rm -f $eeprom_path/vpd_parsed
+				;;
+			cable_cartridge*)
+				rm -f $config_path/"${eeprom_name%%_eeprom*}"_valid
 				;;
 			*)
 				;;


### PR DESCRIPTION
bmc read the cbc eeprom and wrote its rack id, slot, tray and topology from cbc eeprom, but made no validation since bmc doesn't use ipmi_fru tool (it uses customized parser that makes no validation like checksum). so it might have written corrupted data to cpld that asic would have read.
Added validation in chassis event script that checks for the cbc eeprom that hw-mgmt is reading (using ipmi_fru tool), new file is created for each cbc:  cable_cartridge<n>_valid that contains 0 if corrupted and 1 if correct, so nos can use  Added info and error logs as well.