### PR TITLE
hw-mgmt: scripts: Add fan/psu soft-hotplug.

### DIFF
--- a/usr/lib/udev/rules.d/50-hw-management-events.rules
+++ b/usr/lib/udev/rules.d/50-hw-management-events.rules
@@ -641,8 +641,11 @@ SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/MLNXBF49:00/i2c_mlxcpld*/i2c-*/i
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/MLNXBF49:00/i2c_mlxcpld*/i2c-*/i2c-*/*-*/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-chassis-events.sh rm voltmonX %S %p"
 
 # any temp sensor on AMD CPU systems without i2c_mlxcpld driver
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-004[c-f]/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add tempX %S %p"
-SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-004[c-f]/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm tempX %S %p"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-004[8-f]/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add tempX %S %p"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-004[8-f]/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm tempX %S %p"
+# any PSU on AMD CPU systems without i2c_mlxcpld driver
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-005[8-c]/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-thermal-events.sh add psuX %p %k %S %n"
+SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-005[8-c]/hwmon/hwmon*", ACTION=="remove", RUN+="/usr/bin/hw-management-thermal-events.sh rm psuX %p %k %S %n"
 
 # any voltmon on AMD CPU systems without i2c_mlxcpld driver
 SUBSYSTEM=="hwmon", DEVPATH=="/devices/platform/AMDI*:*/i2c-*/i2c-*/*-*/hwmon/hwmon*", ACTION=="add", RUN+="/usr/bin/hw-management-chassis-events.sh add voltmonX %S %p"

--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -535,12 +535,27 @@ function set_fpga_combined_version()
 	echo "$str" > "$path"/system/fpga
 }
 
+# Input parameters:
+# 1 - attribute
+# 2 - event
+# 3 - sysfs path
+# 4 - device path
 function handle_hotplug_fan_event()
 {
 	local attribute=$1
 	local event=$2
 	local bus=
 	local addr=
+
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"attr:$attribute evt:$event sysfs:$3 device:$4 entering..."
+
+	if [ -n "$3" ] && [ -n "$4" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"attr:$attribute init_hotplug_sysfs_event $3$4"
+		init_hotplug_sysfs_event "$3$4" "$attribute" \
+					"$thermal_path/${attribute}_status" "$attribute"
+	fi
 
 	case "$dmi_board_name" in
 	VMOD0014)
@@ -639,6 +654,58 @@ function handle_hotplug_psu_event()
 	fi
 }
 
+# Input parameters:
+# 1 - attribute (psuN name used for config/dummy paths)
+# 2 - event
+# 3 - sysfs path
+# 4 - device path
+# example: handle_soft_hotplug_pwr_event "psu1" 1 "/sys" "/bus/i2c/devices/"
+function handle_soft_hotplug_pwr_event()
+{
+	local psu_name=$1
+	local event=$2
+	local psu_bus_raw
+	local psu_addr_raw
+	local psu_addr_hex
+	local psu_driver
+
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"psu:$psu_name evt:$event entering..."
+
+	# hotplug initialization logic:
+	# 1. Get psu i2c bus and address
+	# 2. get device driver from devtree (based on device i2c bus and address)
+	# 3. Connect/disconnect psu driver
+	# 3.1 don't connect if psu already connected
+	# EEPROM is attached later by hw-management-thermal-events.sh on PSU hwmon add
+	if [ -f "${config_path}/${psu_name}_i2c_addr" ]; then
+		psu_addr_raw=$(< "${config_path}/${psu_name}_i2c_addr") || true
+		psu_bus_raw=$(< "${config_path}/.${psu_name}_i2c_bus") || true
+	fi
+
+	if [ -n "$psu_bus_raw" ] && [ -n "$psu_addr_raw" ]; then
+		psu_addr_hex=$(i2c_config_addr_to_hex "$psu_addr_raw")
+		psu_driver=$(get_devtree_device_driver_name "$psu_bus_raw" "$psu_addr_hex")
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"psu:$psu_name bus:$psu_bus_raw addr:$psu_addr_hex driver:$psu_driver"
+		# if psu driver is not empty, then connect/disconnect psu driver
+		if [ -n "$psu_driver" ]; then
+			if [ "$event" -eq 1 ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"psu:$psu_name connect $psu_driver $psu_addr_hex bus:$psu_bus_raw"
+				connect_device "$psu_driver" "$psu_addr_hex" "$psu_bus_raw"
+			else
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"psu:$psu_name disconnect $psu_addr_hex bus:$psu_bus_raw"
+				disconnect_device "$psu_addr_hex" "$psu_bus_raw"
+			fi
+		fi
+	else
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"psu:$psu_name skip: missing i2c bus/addr config"
+	fi
+}
+
 function handle_hotplug_event()
 {
 	local attribute
@@ -706,6 +773,52 @@ function handle_hotplug_event()
 		;;
 	psu*)
 		handle_hotplug_psu_event "$attribute" "$event"
+		;;
+	*)
+		;;
+	esac
+}
+
+function handle_soft_hotplug_event()
+{
+	local attribute
+	local event
+	local sysfs_path
+	local device_path
+
+	attribute=$(echo "$1" | awk '{print tolower($0)}')
+	event=$2
+	sysfs_path=$3
+	device_path=$4
+
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"attr:$attribute evt:$event sysfs:$sysfs_path device:$device_path entering..."
+
+	if [ -f "$events_path"/"$attribute" ]; then
+		echo "$event" > "$events_path"/"$attribute"
+		log_info "Event ${event} is received for attribute ${attribute}"
+	fi
+
+	case "$attribute" in
+	fan*)
+		print_function_call "$0" "${FUNCNAME[0]}" "attr:$attribute dispatch fan"
+		handle_hotplug_fan_event "$attribute" "$event" "$sysfs_path" "$device_path"
+		;;
+	psu*)
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"attr:$attribute init_hotplug_sysfs_event $sysfs_path$device_path"
+		init_hotplug_sysfs_event "$sysfs_path$device_path" "$attribute" \
+			"$thermal_path/${attribute}_status" "$attribute"
+		;;
+	pwr*)
+		local pwr_index
+		pwr_index=$(echo "$attribute" | cut -c 4-)
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"attr:$attribute dispatch pwr index:$pwr_index"
+		init_hotplug_sysfs_event "$sysfs_path$device_path" "$attribute" \
+			"$thermal_path/psu${pwr_index}_pwr_status" "$attribute"
+
+		handle_soft_hotplug_pwr_event "psu${pwr_index}" "$event" "$sysfs_path" "$device_path"
 		;;
 	*)
 		;;
@@ -943,6 +1056,10 @@ if [ "$1" == "add" ]; then
 		prefix=$(get_i2c_busdev_name "$2" "$4")
 		if [[ $prefix == "undefined" ]] && [[ $5 != "dpu" ]];
 		then
+			exit
+		fi
+		# ignore sensors started with "psu"
+		if [[ "$prefix" == "psu"* ]]; then
 			exit
 		fi
 		# Voltmon MUST have at least one input.
@@ -1452,6 +1569,12 @@ elif [ "$1" == "hotplug-event" ]; then
 		exit 0
 	fi
 	handle_hotplug_event "${2}" "${3}"
+elif [ "$1" == "soft-hotplug-event" ]; then
+	# Don't process udev events until service is started and directories are created
+	if [ ! -f ${udev_ready} ]; then
+		exit 0
+	fi
+	handle_soft_hotplug_event "${2}" "${3}" "${4}" "${5}"
 elif [ "$1" == "hotplug-dpu-event" ]; then
 	# Don't process udev events until service is started and directories are created
 	if [ ! -f ${udev_ready} ]; then

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -610,6 +610,19 @@ unlock_service_state_change_update_and_match()
 	/usr/bin/flock -u ${LOCKFD}
 }
 
+# Normalize I2C address from config (59 or 0x59) to 0xNN for connect_device/disconnect_device.
+# $1 - raw address from config (59 or 0x59).
+# Prints normalized address on stdout (e.g. 0x59). Zero-pads a single hex digit (5 -> 0x05).
+i2c_config_addr_to_hex() {
+	local raw="$1"
+	local val="${raw,,}"   # convert to lowercase
+	val="${val#0x}"
+	if [ ${#val} -eq 1 ]; then
+		val="0${val}"
+	fi
+	printf '0x%s\n' "$val"
+}
+
 # Check if module is loaded
 # $1 - module name
 # return 0 if module is loaded, 1 otherwise
@@ -887,6 +900,33 @@ function get_i2c_busdev_name()
 	fi
 
 	echo "$dev_name"
+}
+
+# Get device driver name from devtree based on device i2c bus and address
+# $1 - device i2c bus
+# $2 - device i2c address
+# return device driver name if match is found or empty string in other case.
+get_devtree_device_driver_name()
+{
+	local i2c_bus=$1
+	local i2c_address=$2
+
+	if [ -f "$devtree_file" ]; then
+		declare -a devtree_table=($(<"$devtree_file"))
+	else
+		echo ""
+		return
+	fi
+
+	for ((i=0; i<${#devtree_table[@]}; i+=4)); do
+		if [ "$i2c_bus" == "${devtree_table[i+2]}" ] && [ "$i2c_address" == "${devtree_table[i+1]}" ];
+		then
+			echo "${devtree_table[i]}"
+			return
+		fi
+	done
+
+	echo ""
 }
 
 find_dpu_slot_from_i2c_bus()

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -349,7 +349,7 @@ if [ "$1" == "add" ]; then
 			check_n_link "$3""$4"/temp2_input $thermal_path/cx_amb
 		else
 			therml_sensor_name=$(get_i2c_busdev_name "$2" "$4")
-			if [[ $therml_sensor_name == "undefined" ]];
+			if [[ $therml_sensor_name == "undefined" ]] || [[ $therml_sensor_name == "tempX" ]];
 			then
 				exit
 			fi
@@ -827,11 +827,16 @@ if [ "$1" == "add" ]; then
 	if [ "$2" == "psu1" ] || [ "$2" == "psu2" ] ||
 	   [ "$2" == "psu3" ] || [ "$2" == "psu4" ] ||
 	   [ "$2" == "psu5" ] || [ "$2" == "psu6" ] ||
-	   [ "$2" == "psu7" ] || [ "$2" == "psu8" ]; then
+	   [ "$2" == "psu7" ] || [ "$2" == "psu8" ] ||
+	   [ "$2" == "psuX" ]; then
 		if [[ $dmi_sku == "HI138" ]] || [[ $dmi_sku == "HI139" ]]; then
 			exit 0
 		fi
-		psu_name="$2"
+		psu_name=$(get_i2c_busdev_name "$2" "$3")
+		if [[ $psu_name == "undefined" ]] || [[ $psu_name == "psuX" ]];
+		then
+			exit
+		fi
 		# SN5600, SN5400 systems have PSU2 with I2C address 0x5a. In udev rules 0x5a corresponds to psu4.
 		if [[ ( $dmi_sku == "HI144" || $dmi_sku == "HI147" ) && "$2" == "psu4" ]]; then
 			psu_name="psu2"
@@ -847,7 +852,7 @@ if [ "$1" == "add" ]; then
 			exit 0
 		fi
 		# Allow PS controller to stabilize
-		retry_helper "ls" 0.2 20 "$2 takes too long to init" "$5""$3"/in1_input
+		retry_helper "ls" 0.2 20 "$psu_name takes too long to init" "$5""$3"/in1_input
 		sleep 1
 		# Set I2C bus for psu
 		echo "$bus" > $config_path/"$psu_name"_i2c_bus
@@ -1163,7 +1168,13 @@ elif [ "$1" == "change" ]; then
 	fi
 else
 	case "$2" in
-		fan_amb | port_amb | cx_amb | lrl_amb | swb_amb | cpu_amb | pdb_temp1 | pdb_temp2)
+		fan_amb | port_amb | cx_amb | lrl_amb | swb_amb | cpu_amb | pdb_temp1 | pdb_temp2 | tempX)
+
+		sensor_name=$(get_i2c_busdev_name "$2" "$4")
+		if [[ $sensor_name == "undefined" ]] || [[ $sensor_name == "tempX" ]];
+		then
+			exit
+		fi
 		# Verify if this is COMEX sensor
 		find_i2c_bus
 		i2c_comex_mon_bus_default=$(< $i2c_comex_mon_bus_default_file)
@@ -1188,7 +1199,7 @@ else
 		elif [ "$bus" == "$cx_i2c_bus" ]; then
 			unlink $thermal_path/cx_amb
 		else
-			unlink $thermal_path/"$2"
+			unlink $thermal_path/"$sensor_name"
 		fi
 		;;
 	esac
@@ -1388,8 +1399,13 @@ else
 	if [ "$2" == "psu1" ] || [ "$2" == "psu2" ] ||
 	   [ "$2" == "psu3" ] || [ "$2" == "psu4" ] ||
 	   [ "$2" == "psu5" ] || [ "$2" == "psu6" ] ||
-	   [ "$2" == "psu7" ] || [ "$2" == "psu8" ]; then
-		psu_name="$2"
+	   [ "$2" == "psu7" ] || [ "$2" == "psu8" ] ||
+	   [ "$2" == "psuX" ]; then
+		psu_name=$(get_i2c_busdev_name "$2" "$3")
+		if [[ $psu_name == "undefined" ]] || [[ $psu_name == "psuX" ]];
+		then
+			exit
+		fi
 		# SN5600, SN5400 systems have PSU2 with I2C address 0x5a. In udev rules 0x5a corresponds to psu4.
 		if [[ ( $dmi_sku == "HI144" || $dmi_sku == "HI147" ) && "$2" == "psu4" ]]; then
 			psu_name="psu2"
@@ -1415,22 +1431,29 @@ else
 		# Remove thermal attributes
 		check_n_unlink $thermal_path/"$psu_name"_temp
 		check_n_unlink $thermal_path/"$psu_name"_temp_max
-		check_n_unlink $thermal_path/"$psu_name"_temp_alarm
-		check_n_unlink $thermal_path/"$psu_name"_temp_max_alarm
+		check_n_unlink $alarm_path/"$psu_name"_temp_alarm
+		check_n_unlink $alarm_path/"$psu_name"_temp_max_alarm
+		check_n_unlink $thermal_path/"$psu_name"_temp1
+		check_n_unlink $thermal_path/"$psu_name"_temp1_max
+		check_n_unlink $alarm_path/"$psu_name"_temp1_alarm
+		check_n_unlink $alarm_path/"$psu_name"_temp1_max_alarm
 		check_n_unlink $thermal_path/"$psu_name"_temp2
 		check_n_unlink $thermal_path/"$psu_name"_temp2_max
-		check_n_unlink $thermal_path/"$psu_name"_temp2_max_alarm
+		check_n_unlink $alarm_path/"$psu_name"_temp2_max_alarm
 		check_n_unlink $thermal_path/"$psu_name"_fan1_speed_get
 		check_n_unlink $alarm_path/"$psu_name"_fan1_alarm
 		check_n_unlink $alarm_path/"$psu_name"_power1_alarm
 
 		# Remove power attributes
 		psu_disconnect_power_sensor "$psu_name"_volt_in
+		psu_disconnect_power_sensor "$psu_name"_volt_out
 		psu_disconnect_power_sensor "$psu_name"_volt
 		psu_disconnect_power_sensor "$psu_name"_volt_out2
 		psu_disconnect_power_sensor "$psu_name"_power_in
+		psu_disconnect_power_sensor "$psu_name"_power_out
 		psu_disconnect_power_sensor "$psu_name"_power
 		psu_disconnect_power_sensor "$psu_name"_curr_in
+		psu_disconnect_power_sensor "$psu_name"_curr_out
 		psu_disconnect_power_sensor "$psu_name"_curr
 
 		rm -f $eeprom_path/"$psu_name"_vpd

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -3283,10 +3283,13 @@ set_config_data()
 {
 	local asic_num=0
 	for ((idx=1; idx<=psu_count; idx+=1)); do
-		# if psuX_i2c_bus variable is set - add file psuX_i2c_bus to config_path
+		# if psuX_i2c_bus variable is set - add file .psuX_i2c_bus to config_path
 		local psu_i2c_bus=psu"$idx"_i2c_bus
 		if [ ${!psu_i2c_bus} ]; then
-			echo ${!psu_i2c_bus} > $config_path/psu"$idx"_i2c_bus
+			# Add psu i2c bus configuration for user. This file can be removed in PSU unplug event.
+		    echo ${!psu_i2c_bus} > $config_path/psu"$idx"_i2c_bus
+			# Add hidden psu i2c bus configuration for internal hw-management use (static file)
+			echo ${!psu_i2c_bus} > $config_path/.psu"$idx"_i2c_bus
 		fi
 		psu_i2c_addr=psu"$idx"_i2c_addr
 		echo ${!psu_i2c_addr} > $config_path/psu"$idx"_i2c_addr
@@ -3991,7 +3994,7 @@ map_dummy_psus()
 
 	for ((psu_idx=1; psu_idx <= psu_count; psu_idx+=1)); do
 		# Bus/addr from set_config_data() in hw-management.sh
-		psu_bus=$(< "${config_path}/psu${psu_idx}_i2c_bus")
+		psu_bus=$(< "${config_path}/.psu${psu_idx}_i2c_bus")
 		psu_addr=$(< "${config_path}/psu${psu_idx}_i2c_addr")
 
 		# psuX_i2c_bus is optional; set_config_data() writes it only when set


### PR DESCRIPTION
Refactor fan/psu hotplug for AMD platforms and software PWR events.
Not powered PSUs cannot speak I2C, so the PSU driver is bound on pwr.

1. Widen AMD temp udev match to 0x48-0x4f and add AMD psuX hwmon rules
2. Add PSU driver connect/disconnect on pwr (soft-hotplug-event; udev later)
3. Store static PSU I2C bus as .psuN_i2c_bus; resolve psuX/tempX from devtree

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
