### PR TITLE
hw-mgmt: services: Add NVMe shutdown hook for no-BMC platforms

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -46,6 +46,11 @@ ifeq ($(with_host),1)
 	cp usr/usr/local/bin/* debian/$(pname)/usr/local/bin
 	dh_installdirs -p$(pname) etc/logrotate.d
 	cp usr/etc/logrotate.d/* debian/$(pname)/etc/logrotate.d
+	dh_installdirs -p$(pname) etc/default
+	cp usr/etc/default/hw-management-nvme-shutdown debian/$(pname)/etc/default/
+	dh_installdirs -p$(pname) lib/systemd/system-shutdown
+	install -m 755 usr/usr/bin/hw-management-nvme-shutdown-hook.sh \
+		debian/$(pname)/lib/systemd/system-shutdown/hw-management-nvme-shutdown
 	dh_installdirs -p$(pname) etc/bash_completion.d
 	cp usr/etc/bash_completion.d/* debian/$(pname)/etc/bash_completion.d
 ifeq ($(DEB_HOST_ARCH),arm64)

--- a/rpm/hw-management.spec
+++ b/rpm/hw-management.spec
@@ -61,8 +61,10 @@ mkdir -p $RPM_BUILD_ROOT/etc/modprobe.d
 mkdir -p $RPM_BUILD_ROOT/etc/hw-management-thermal
 mkdir -p $RPM_BUILD_ROOT/usr/bin
 mkdir -p $RPM_BUILD_ROOT/usr/local/bin
+mkdir -p $RPM_BUILD_ROOT/etc/default
 mkdir -p $RPM_BUILD_ROOT/lib/udev/rules.d
 mkdir -p $RPM_BUILD_ROOT/lib/systemd/system
+mkdir -p $RPM_BUILD_ROOT/lib/systemd/system-shutdown
 mkdir -p $RPM_BUILD_ROOT/usr/share/doc/hw-management
 mkdir -p $RPM_BUILD_ROOT/usr/share/man/man1
 mkdir -p $RPM_BUILD_ROOT/usr/share/man/man8
@@ -128,6 +130,13 @@ install -m 0755 usr/usr/bin/hw-management-power-helper.sh $RPM_BUILD_ROOT/usr/bi
 install -m 0755 usr/usr/bin/hw-management-ps-vpd.sh $RPM_BUILD_ROOT/usr/bin/hw-management-ps-vpd.sh
 install -m 0755 usr/usr/bin/hw-management-ready.sh $RPM_BUILD_ROOT/usr/bin/hw-management-ready.sh
 install -m 0755 usr/usr/bin/hw-management-start-post.sh $RPM_BUILD_ROOT/usr/bin/hw-management-start-post.sh
+install -m 0755 usr/usr/bin/hw-management-nvme-shutdown.sh $RPM_BUILD_ROOT/usr/bin/hw-management-nvme-shutdown.sh
+install -m 0755 usr/usr/bin/hw-management-nvme-shutdown-hook.sh $RPM_BUILD_ROOT/usr/bin/hw-management-nvme-shutdown-hook.sh
+install -m 0755 usr/usr/bin/hw-management-nvme-shutdown-condition.sh $RPM_BUILD_ROOT/usr/bin/hw-management-nvme-shutdown-condition.sh
+install -m 0755 usr/usr/bin/hw-management-nvme-shutdown-setup.sh $RPM_BUILD_ROOT/usr/bin/hw-management-nvme-shutdown-setup.sh
+install -m 0644 usr/etc/default/hw-management-nvme-shutdown $RPM_BUILD_ROOT/etc/default/hw-management-nvme-shutdown
+install -m 0755 usr/usr/bin/hw-management-nvme-shutdown-hook.sh \
+	$RPM_BUILD_ROOT/lib/systemd/system-shutdown/hw-management-nvme-shutdown
 install -m 0755 usr/usr/bin/hw-management-thermal-events.sh $RPM_BUILD_ROOT/usr/bin/hw-management-thermal-events.sh
 install -m 0755 usr/usr/bin/hw-management-vpd-parser.py $RPM_BUILD_ROOT/usr/bin/hw-management-vpd-parser.py
 install -m 0755 usr/usr/bin/hw-management-wd.sh $RPM_BUILD_ROOT/usr/bin/hw-management-wd.sh
@@ -234,6 +243,12 @@ chmod 0644 $RPM_BUILD_ROOT/usr/share/man/man8/hw-management.service.8.gz
 %attr(0755, root, root) "/usr/bin/hw-management-ps-vpd.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-ready.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-start-post.sh"
+%attr(0755, root, root) "/usr/bin/hw-management-nvme-shutdown.sh"
+%attr(0755, root, root) "/usr/bin/hw-management-nvme-shutdown-hook.sh"
+%attr(0755, root, root) "/usr/bin/hw-management-nvme-shutdown-condition.sh"
+%attr(0755, root, root) "/usr/bin/hw-management-nvme-shutdown-setup.sh"
+%config %attr(0644, root, root) "/etc/default/hw-management-nvme-shutdown"
+%attr(0755, root, root) "/lib/systemd/system-shutdown/hw-management-nvme-shutdown"
 %attr(0755, root, root) "/usr/bin/hw-management-thermal-events.sh"
 %attr(0755, root, root) "/usr/bin/hw-management-wd.sh"
 %attr(0755, root, root) "/usr/bin/hw-management.sh"

--- a/usr/etc/default/hw-management-nvme-shutdown
+++ b/usr/etc/default/hw-management-nvme-shutdown
@@ -1,0 +1,18 @@
+# Configuration for hw-management NVMe shutdown hook (software-only, no-BMC).
+#
+# Installed as /usr/lib/systemd/system-shutdown/hw-management-nvme-shutdown.
+# Runs in the final systemd-shutdown phase, after umount and service teardown,
+# immediately before the kernel poweroff/reboot path (pm_power_off / CPLD halt).
+#
+# Eligibility (cached at boot; read at shutdown from
+# /var/lib/hw-management/nvme-shutdown-enabled):
+#   - NVMe block devices exist under /dev/nvme*, and
+#   - BMC is absent: bmc_present and gp_bmc_presnt are 0 or missing, and
+#     the host SKU is not a known BMC platform (HI180/HI193 and related).
+#
+# Total wall-clock budget for the hook (seconds). Each blocking step
+# (sync, flushbufs, SHN wait) uses remaining time until this deadline.
+NVME_SHUTDOWN_TIMEOUT_SEC=120
+
+# Max time to wait for NVMe controller shutdown (seconds).
+NVME_SHUTDOWN_WAIT_SEC=10

--- a/usr/usr/bin/hw-management-nvme-shutdown-condition.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown-condition.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Return 0 when the NVMe shutdown hook should run:
+#   - NVMe block devices are present under /dev/nvme*
+#   - platform has no BMC (software-only shutdown path)
+#
+# Do not treat a 0 reading of bmc_present as proof of no BMC: on some
+# BMC hosts (e.g. HI180) that GPIO is a false negative. Skip known BMC
+# SKUs even when bmc_present/gp_bmc_presnt read 0 or are missing.
+#
+# Return 1 to skip.
+#
+# At systemd-shutdown time /var/run/hw-management is usually gone, so a flag
+# cached at boot in /var/lib/hw-management/nvme-shutdown-enabled is used.
+##################################################################################
+
+set -euo pipefail
+
+readonly LOGGER_TAG="hw-management-nvme-shutdown"
+readonly HW_MGMT_SYSTEM=/var/run/hw-management/system
+readonly FLAG_DIR=/var/lib/hw-management
+readonly FLAG_FILE=$FLAG_DIR/nvme-shutdown-enabled
+
+log_dbg() { logger -t "$LOGGER_TAG" -p user.debug -- "$@"; }
+
+read_attr() {
+	local path=$1
+
+	[ -f "$path" ] || return 1
+	tr -d '[:space:]' <"$path"
+}
+
+# Host DMI product_sku values for BMC-equipped L1 systems. Presence of
+# cpu_shutdown_req / cpu_power_off_ready sysfs is NOT used: mlx-platform
+# exports those on no-BMC boards as well.
+bmc_sku_platform() {
+	local sku
+
+	sku=$(read_attr /sys/devices/virtual/dmi/id/product_sku 2>/dev/null) || \
+		sku=$(read_attr "$HW_MGMT_SYSTEM/sku" 2>/dev/null) || \
+		sku=""
+
+	case "$sku" in
+	HI180|HI181|HI182|HI183|HI185|HI186|HI187|HI188|HI193|HI194|HI195|HI197|HI199|HI200|HI201)
+		log_dbg "BMC SKU $sku, skip NVMe shutdown hook"
+		return 0
+		;;
+	esac
+	return 1
+}
+
+bmc_is_present() {
+	local path val
+
+	if bmc_sku_platform; then
+		return 0
+	fi
+
+	for path in \
+		"$HW_MGMT_SYSTEM/bmc_present" \
+		/sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/gp_bmc_presnt
+	do
+		val=$(read_attr "$path" 2>/dev/null) || continue
+		case "$val" in
+		1)
+			log_dbg "BMC present ($path=1), skip NVMe shutdown hook"
+			return 0
+			;;
+		esac
+	done
+
+	return 1
+}
+
+nvme_block_devices_exist() {
+	local dev
+
+	for dev in /dev/nvme*; do
+		[ -b "$dev" ] || continue
+		return 0
+	done
+
+	return 1
+}
+
+nvme_storage_configured() {
+	if nvme_block_devices_exist; then
+		return 0
+	fi
+
+	log_dbg "No NVMe block devices under /dev/nvme*, skip hook"
+	return 1
+}
+
+evaluate_platform_eligibility() {
+	if bmc_is_present; then
+		return 1
+	fi
+
+	if ! nvme_storage_configured; then
+		return 1
+	fi
+
+	return 0
+}
+
+read_cached_eligibility() {
+	local val
+
+	val=$(read_attr "$FLAG_FILE" 2>/dev/null) || return 1
+	[ "$val" -eq 1 ]
+}
+
+main() {
+	if [ ! -d "$HW_MGMT_SYSTEM" ]; then
+		if read_cached_eligibility; then
+			exit 0
+		fi
+		log_dbg "hw-management tree absent and cache disabled, skip hook"
+		exit 1
+	fi
+
+	if evaluate_platform_eligibility; then
+		exit 0
+	fi
+
+	exit 1
+}
+
+main "$@"

--- a/usr/usr/bin/hw-management-nvme-shutdown-hook.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown-hook.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# systemd-shutdown(8) hook: runs in the final userspace phase, after services
+# are stopped and filesystems are unmounted, immediately before the kernel
+# poweroff/reboot path (pm_power_off / CPLD halt on no-BMC platforms).
+#
+# Argument: poweroff | halt | reboot | kexec
+##################################################################################
+
+set -euo pipefail
+
+if [ -f /etc/default/hw-management-nvme-shutdown ]; then
+	# shellcheck disable=SC1091
+	. /etc/default/hw-management-nvme-shutdown
+fi
+
+readonly NVME_SHUTDOWN_TIMEOUT_SEC="${NVME_SHUTDOWN_TIMEOUT_SEC:-120}"
+
+if command -v timeout >/dev/null 2>&1; then
+	exec timeout --foreground "${NVME_SHUTDOWN_TIMEOUT_SEC}" \
+		/usr/bin/hw-management-nvme-shutdown.sh "$@"
+fi
+
+exec /usr/bin/hw-management-nvme-shutdown.sh "$@"

--- a/usr/usr/bin/hw-management-nvme-shutdown-setup.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown-setup.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Cache NVMe shutdown hook eligibility at boot. The hook under
+# /usr/lib/systemd/system-shutdown/ reads this flag because
+# /var/run/hw-management is gone in the final shutdown phase.
+##################################################################################
+
+set -euo pipefail
+
+readonly FLAG_DIR=/var/lib/hw-management
+readonly FLAG_FILE=$FLAG_DIR/nvme-shutdown-enabled
+readonly LOGGER_TAG="hw-management-nvme-shutdown"
+
+log_msg() { logger -t "$LOGGER_TAG" -p user.notice -- "$@"; }
+
+mkdir -p "$FLAG_DIR"
+
+if /usr/bin/hw-management-nvme-shutdown-condition.sh; then
+	echo 1 >"$FLAG_FILE"
+	log_msg "NVMe shutdown hook enabled (no-BMC platform with NVMe storage)"
+else
+	echo 0 >"$FLAG_FILE"
+	log_msg "NVMe shutdown hook disabled (BMC present, SATA, or no NVMe)"
+fi

--- a/usr/usr/bin/hw-management-nvme-shutdown.sh
+++ b/usr/usr/bin/hw-management-nvme-shutdown.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+##################################################################################
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Software-only NVMe quiesce for no-BMC platforms during system shutdown.
+# No CPLD or cpu_power_off_ready interaction.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. Neither the names of the copyright holders nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##################################################################################
+
+set -euo pipefail
+
+if [ -f /etc/default/hw-management-nvme-shutdown ]; then
+	# shellcheck disable=SC1091
+	. /etc/default/hw-management-nvme-shutdown
+fi
+
+readonly LOGGER_TAG="hw-management-nvme-shutdown"
+readonly NVME_SHUTDOWN_TIMEOUT_SEC="${NVME_SHUTDOWN_TIMEOUT_SEC:-120}"
+readonly NVME_SHUTDOWN_WAIT_SEC="${NVME_SHUTDOWN_WAIT_SEC:-10}"
+# Leave 1s so the completion log can run before the hook's outer timeout.
+readonly NVME_SHUTDOWN_TAIL_SEC=1
+
+NVME_DEADLINE_SEC=0
+NVME_SHUTDOWN_CTRLS=()
+
+log_msg()  { logger -t "$LOGGER_TAG" -p user.notice -- "$@"; }
+log_warn() { logger -t "$LOGGER_TAG" -p user.warning -- "$@"; }
+
+deadline_init() {
+	NVME_DEADLINE_SEC=$((SECONDS + NVME_SHUTDOWN_TIMEOUT_SEC))
+}
+
+remaining_sec() {
+	local r=$((NVME_DEADLINE_SEC - SECONDS - NVME_SHUTDOWN_TAIL_SEC))
+
+	[ "$r" -gt 0 ] || r=0
+	echo "$r"
+}
+
+# Run a blocking command with the remaining deadline. Never trip set -e.
+run_bounded() {
+	local rem
+
+	rem=$(remaining_sec)
+	if [ "$rem" -lt 1 ]; then
+		log_warn "deadline reached; skip: $*"
+		return 0
+	fi
+	if command -v timeout >/dev/null 2>&1; then
+		timeout --foreground "$rem" "$@" || \
+			log_warn "timed out or failed (${rem}s): $*"
+	else
+		"$@" || log_warn "failed: $*"
+	fi
+	return 0
+}
+
+nvme_controllers() {
+	local ctrl
+	for ctrl in /sys/class/nvme/nvme*; do
+		[ -d "$ctrl" ] || continue
+		printf '%s\n' "$ctrl"
+	done
+}
+
+nvme_controller_state() {
+	local ctrl=$1 name state_path
+
+	name=$(basename "$ctrl")
+	for state_path in \
+		"$ctrl/state" \
+		"$ctrl/$name/state"
+	do
+		if [ -f "$state_path" ]; then
+			cat "$state_path"
+			return 0
+		fi
+	done
+
+	echo "unknown"
+}
+
+nvme_state_is_pending() {
+	case "$1" in
+		live|resetting|connecting|deleting|deleting_noio)
+			return 0
+			;;
+	esac
+	return 1
+}
+
+flush_block_devices() {
+	local dev
+	local -a devs
+
+	# Namespaces only; partition flush is redundant with nvmeXnY.
+	shopt -s nullglob
+	devs=(/dev/nvme*n*)
+	shopt -u nullglob
+
+	for dev in "${devs[@]}"; do
+		[ -b "$dev" ] || continue
+		case "$dev" in
+		*p[0-9]*) continue ;;
+		esac
+		[ "$(remaining_sec)" -ge 1 ] || {
+			log_warn "deadline reached; skip remaining flushbufs"
+			return 0
+		}
+		run_bounded blockdev --flushbufs "$dev"
+	done
+}
+
+request_nvme_shutdown() {
+	local ctrl name
+
+	NVME_SHUTDOWN_CTRLS=()
+
+	while IFS= read -r ctrl; do
+		[ -n "$ctrl" ] || continue
+		name=$(basename "$ctrl")
+		if [ ! -f "$ctrl/shutdown" ]; then
+			continue
+		fi
+		log_msg "Requesting NVMe shutdown: $name"
+		if echo 1 >"$ctrl/shutdown" 2>/dev/null; then
+			NVME_SHUTDOWN_CTRLS+=("$ctrl")
+		else
+			log_warn "Failed to write $ctrl/shutdown"
+		fi
+	done < <(nvme_controllers)
+}
+
+wait_nvme_shutdown() {
+	local ctrl name state elapsed=0 pending rem wait_cap
+
+	if [ "${#NVME_SHUTDOWN_CTRLS[@]}" -eq 0 ]; then
+		return 0
+	fi
+
+	wait_cap=$NVME_SHUTDOWN_WAIT_SEC
+	[ "$wait_cap" -ge 1 ] || wait_cap=1
+
+	while :; do
+		rem=$(remaining_sec)
+		if [ "$rem" -lt 1 ]; then
+			log_warn "deadline reached during NVMe shutdown wait"
+			return 0
+		fi
+		if [ "$elapsed" -ge "$wait_cap" ]; then
+			log_warn "NVMe shutdown wait timed out after ${wait_cap}s"
+			return 0
+		fi
+
+		pending=0
+		for ctrl in "${NVME_SHUTDOWN_CTRLS[@]}"; do
+			name=$(basename "$ctrl")
+			state=$(nvme_controller_state "$ctrl")
+
+			if nvme_state_is_pending "$state"; then
+				pending=1
+				log_msg "$name state=$state (waiting)"
+			else
+				log_msg "$name state=$state"
+			fi
+		done
+
+		[ "$pending" -eq 0 ] && return 0
+		run_bounded sleep 1
+		elapsed=$((elapsed + 1))
+	done
+}
+
+main() {
+	local requested action="${1:-unknown}"
+
+	if ! /usr/bin/hw-management-nvme-shutdown-condition.sh; then
+		exit 0
+	fi
+
+	mapfile -t _nvme_ctrls < <(nvme_controllers)
+	if [ "${#_nvme_ctrls[@]}" -eq 0 ]; then
+		log_warn "No NVMe controllers in sysfs"
+		exit 0
+	fi
+
+	deadline_init
+	log_msg "Starting software-only NVMe shutdown (action=${action} " \
+		"timeout=${NVME_SHUTDOWN_TIMEOUT_SEC}s)"
+
+	run_bounded sync
+	flush_block_devices
+
+	if [ "$(remaining_sec)" -ge 1 ]; then
+		request_nvme_shutdown
+		requested="${#NVME_SHUTDOWN_CTRLS[@]}"
+		if [ "$requested" -gt 0 ]; then
+			wait_nvme_shutdown
+		else
+			log_warn "No controller accepted shutdown request; " \
+				"relying on sync/flush only"
+		fi
+	else
+		log_warn "deadline reached; skip NVMe shutdown request"
+	fi
+
+	run_bounded sync
+
+	log_msg "Software-only NVMe shutdown completed"
+}
+
+main "$@"

--- a/usr/usr/bin/hw-management-start-post.sh
+++ b/usr/usr/bin/hw-management-start-post.sh
@@ -280,3 +280,8 @@ fi
 
 # double check fan_dir present and initialize it
 set_fan_direction_for_all_fans 0
+
+# Enable NVMe shutdown hook only on no-BMC platforms with NVMe storage.
+if [ -x /usr/bin/hw-management-nvme-shutdown-setup.sh ]; then
+	/usr/bin/hw-management-nvme-shutdown-setup.sh
+fi


### PR DESCRIPTION
On systems without BMC, mlxplat_poweroff() asserts CPLD halt during kernel shutdown. SSD/aux power can drop before NVMe flush completes, and there is no cpu_power_off_ready handshake.

Add a systemd-shutdown hook that syncs and flushes NVMe namespaces (and optional sysfs shutdown if present). Cache eligibility at boot in /var/lib/hw-management/nvme-shutdown-enabled. Enable only when NVMe is present and BMC is absent; skip known BMC SKUs even when bmc_present reads 0 (HI180 false negative). Bound runtime to 120s.