### PR TITLE
hw-mgmt: scripts: add function-call traces for start and udev debug

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -604,6 +604,7 @@ function handle_hotplug_dpu_event()
     local attribute
     local dpu_event_path
 
+    print_function_call "$0" "${FUNCNAME[0]}" "attr:$1 evt:$2"
     attribute=$(echo "$1" | awk '{print tolower($0)}')
     event=$2
     dpu_i2c_path=$(echo "$3""$4" | rev | cut -d'/' -f4- | rev)
@@ -628,6 +629,7 @@ function handle_hotplug_psu_event()
 	local psu_is_dummy
 	local dummy_psus_supported=$(< ${config_path}/dummy_psus_supported)
 
+	print_function_call "$0" "${FUNCNAME[0]}" "psu:$psu_name evt:$event"
 	psu_name=$(echo ${psu_name} | awk '{print tolower($0)}')
 	if [ ${dummy_psus_supported} -eq 1 ]; then
 		if [ $event -eq 1 ]; then
@@ -635,6 +637,8 @@ function handle_hotplug_psu_event()
 			psu_addr=$(< "${config_path}/${psu_name}_i2c_addr")
 			psu_bus=$(< "${config_path}/${psu_name}_i2c_bus")
 			if [ -z "$psu_bus" ] || [ -z "$psu_addr" ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"psu:$psu_name skip missing bus/addr"
 				return
 			fi
 			# Normalize to 2-digit hex (strip "0x"), matching sysfs i2c naming
@@ -649,6 +653,8 @@ function handle_hotplug_psu_event()
 				sleep 1
 			done
 			if [ ${psu_is_dummy} -eq 1 ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"psu:$psu_name marked dummy bus:$psu_bus addr:$psu_addr"
 				touch ${config_path}/${psu_name}_is_dummy
 			fi
 		else
@@ -720,6 +726,7 @@ function handle_hotplug_event()
 	attribute=$(echo "$1" | awk '{print tolower($0)}')
 	event=$2
 
+	print_function_call "$0" "${FUNCNAME[0]}" "attr:$attribute evt:$event"
 	if [ -f "$events_path"/"$attribute" ]; then
 		echo "$event" > "$events_path"/"$attribute"
 		log_info "Event ${event} is received for attribute ${attribute}"
@@ -1057,18 +1064,22 @@ if [ "$1" == "add" ]; then
 	   [ "$2" == "hotswap" ] || [ "$2" == "pmbus" ]; then
 		# Get i2c voltmon prefix.
 		prefix=$(get_i2c_busdev_name "$2" "$4")
+		print_function_call "$0" "add" "voltmon $2 prefix:$prefix"
 		if [[ $prefix == "undefined" ]] && [[ $5 != "dpu" ]];
 		then
+			print_function_call "$0" "add" "voltmon skip undefined $2 $4"
 			exit
 		fi
 		# ignore sensors started with "psu"
 		if [[ "$prefix" == "psu"* ]]; then
+			print_function_call "$0" "add" "voltmon skip psu prefix:$prefix"
 			exit
 		fi
 		# Voltmon MUST have at least one input.
 		# Filtering device that doesn't have it.
 		if [ ! -f "$3""$4"/in1_input ]; 
 		then
+			print_function_call "$0" "add" "voltmon skip no in1_input prefix:$prefix"
 			exit
 		fi
 
@@ -1268,6 +1279,7 @@ if [ "$1" == "add" ]; then
 		# In newer switches the LED color is amber. This is a workaround
 		# to avoid driver changes.
 		color=$(echo "$5" | cut -d':' -f3)
+		print_function_call "$0" "add" "led name:$name color:$color"
 		if [ "$color" == "orange" ]; then
 			color="amber"
 		fi
@@ -1291,6 +1303,7 @@ if [ "$1" == "add" ]; then
 		$led_path/led_"$name"_state
 	fi
 	if [ "$2" == "regio" ]; then
+		print_function_call "$0" "add" "regio $3$4"
 		reset_attr_num=$(< $config_path/reset_attr_num)
 		reset_attrr_count=0
 		linecard=0
@@ -1389,6 +1402,7 @@ if [ "$1" == "add" ]; then
 		if [ ! -f "$3""$4"/eeprom ]; then
 			exit
 		fi
+		print_function_call "$0" "add" "eeprom $3$4"
 		busdir="$3""$4"
 		busfolder=$(basename "$busdir")
 		bus="${busfolder:0:${#busfolder}-5}"
@@ -1405,6 +1419,7 @@ if [ "$1" == "add" ]; then
 		input_bus_num=$(echo "$3""$4" | xargs dirname | xargs dirname | xargs basename | cut -d"-" -f2)
 		driver_dir=$(echo "$3""$4" | xargs dirname | xargs dirname)/"$input_bus_num"-00"$mlxreg_lc_addr"
 		eeprom_name=$(find_eeprom_name "$bus" "$addr" "$parentbus" "$input_bus_num")
+		print_function_call "$0" "add" "eeprom name:$eeprom_name bus:$bus addr:$addr"
 		if [ -d "$driver_dir" ]; then
 			driver_name=$(< "$driver_dir"/name)
 			if [ "$driver_name" == "mlxreg-lc" ]; then
@@ -1496,10 +1511,12 @@ if [ "$1" == "add" ]; then
 		esac
 	fi
 	if [ "$2" == "cpld" ]; then
+		print_function_call "$0" "add" "cpld $3$4"
 		asic_cpld_add_handler "${3}${4}"
 	fi
 	if [ "$2" == "watchdog" ]; then
 		wd_type=$(< "$3""$4"/identity)
+		print_function_call "$0" "add" "watchdog $wd_type"
 		case $wd_type in
 			mlx-wdt-*)
 				wd_sub="$(echo "$wd_type" | cut -c 9-)"
@@ -1522,6 +1539,7 @@ if [ "$1" == "add" ]; then
 	fi
 	# Creating dpu folders hierarchy upon dpu udev add event.
 	if [ "$2" == "dpu" ]; then
+		print_function_call "$0" "add" "dpu $3$4"
 		case $dmi_sku in
 		HI160)
 			slot_num=$(find_dpu_slot "$3$4")
@@ -1541,6 +1559,7 @@ if [ "$1" == "add" ]; then
 	fi
 	# Creating lc folders hierarchy upon line card udev add event.
 	if [ "$2" == "linecard" ]; then
+		print_function_call "$0" "add" "linecard $3$4"
 		input_bus_num=$(echo "$3""$4" | xargs basename | cut -d"-" -f1)
 		find_linecard_num "$input_bus_num"
 		if [ ! -d "$hw_management_path"/lc"$linecard_num" ]; then
@@ -1559,6 +1578,7 @@ if [ "$1" == "add" ]; then
 	fi
 	# Create i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
+		print_function_call "$0" "add" "i2c_bus $4"
 		log_info "I2C bus $4 connected."
 		handle_i2cbus_dev_action $4 "add"
 	fi
@@ -1767,6 +1787,7 @@ else
 		rm -f $led_path/led_"$name"_control
 	fi
 	if [ "$2" == "regio" ]; then
+		print_function_call "$0" "remove" "regio $3$4"
 		# Detect if it belongs to line card or to main board or to dpu.
 		# For main board dirname mlxreg-io, for line card - mlxreg-io.{bus_num}.
 		driver_dir=$(echo "$3""$4" | xargs dirname| xargs dirname| xargs basename)
@@ -1854,6 +1875,7 @@ else
 	fi
 	# Clear dpu folders upon line card udev rm event.
 	if [ "$2" == "dpu" ]; then
+		print_function_call "$0" "remove" "dpu $3$4"
 		case $dmi_sku in
 		HI160)
 			slot_num=$(find_dpu_slot "$3$4")
@@ -1885,6 +1907,7 @@ else
 	# Remove i2c bus.
 	if [ "$2" == "i2c_bus" ]; then
 		log_info "I2C bus $4 removed."
+		print_function_call "$0" "remove" "i2c_bus $4"
 		handle_i2cbus_dev_action $4 "remove"
 	fi
 	# Removed i2c links.

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -246,6 +246,7 @@ check_cpu_type()
 		if [ "$cpu_pn" == "$BF3_CPU" ] || [ "$cpu_pn" == "$ARMv7_CPU" ]; then
 			cpu_type=$cpu_pn
 			echo $cpu_type > $config_path/cpu_type
+			print_function_call "$0" "${FUNCNAME[0]}" "cpu_type:$cpu_type"
 			return 0
 		fi
 
@@ -256,6 +257,7 @@ check_cpu_type()
 	else
 		cpu_type=$(cat $config_path/cpu_type)
 	fi
+	print_function_call "$0" "${FUNCNAME[0]}" "cpu_type:$cpu_type"
 }
 
 find_i2c_bus()
@@ -294,12 +296,16 @@ find_i2c_bus()
                 esac
 
                 echo $i2c_bus_offset > $config_path/i2c_bus_offset
+                print_function_call "$0" "${FUNCNAME[0]}" \
+			"i2c_bus_offset:$i2c_bus_offset sku:$sku"
                 return
             fi
         fi
     done
 
     log_err "I2C infrastructure is not created"
+    print_function_call "$0" "${FUNCNAME[0]}" \
+	"I2C infrastructure is not created bus_min:$bus_min bus_max:$bus_max"
     exit 0
 }
 
@@ -399,6 +405,7 @@ consume_tc_saved_state()
 	rm -f "$tc_state_file"
 	case $state in
 		started)
+			print_function_call "$0" "${FUNCNAME[0]}" "state:started"
 			printf '%s\n' "$state"
 			;;
 	esac
@@ -441,6 +448,7 @@ check_host_usb0_managed_by_nos()
 # This function create or cleans sysfs monitor helper files.
 init_sysfs_monitor_timestamp_files()
 {
+    print_function_call "$0" "${FUNCNAME[0]}" "entering..."
     SYSFS_MONITOR_FILES=(
         "$SYSFS_MONITOR_RESET_FILE_A"
         "$SYSFS_MONITOR_RESET_FILE_B"
@@ -671,8 +679,13 @@ connect_device()
 				# We know that sleep is not accurate. But it is acceptable for this use case.
 				sleep "$step_sec"
 			done
+			print_function_call "$0" "${FUNCNAME[0]}" \
+				"bind timeout driver:$1 addr:$2 bus:$bus"
 			return 1
 		fi
+	else
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"skip: missing i2c-$bus/new_device driver:$1 addr:$2"
 	fi
 
 	return 0
@@ -687,6 +700,7 @@ disconnect_device()
 		
 		if [ -d /sys/bus/i2c/devices/$bus-00"$addr" ] ||
 		   [ -d /sys/bus/i2c/devices/$bus-000"$addr" ]; then
+			print_function_call "$0" "${FUNCNAME[0]}" "addr:$1 bus:$bus"
 			echo "$1" > /sys/bus/i2c/devices/i2c-$bus/delete_device
 			return $?
 		fi
@@ -725,6 +739,8 @@ function retry_helper()
 	if [ ! -z "$$user_log" ]; then
 		log_err "$user_log"
 	fi
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"failed func:$user_func retries:$retry_cnt log:$user_log param:$user_param"
 
 	return 1
 }
@@ -744,6 +760,7 @@ psu_set_fan_speed()
 	local fan_command=$(< $config_path/fan_command)
 	local speed=$2
 
+	print_function_call "$0" "${FUNCNAME[0]}" "psu:$1 speed:$speed bus:$bus addr:$addr"
 	# Set fan speed units (percentage or RPM)
 	i2cset -f -y "$bus" "$addr" "$fan_config_command" "$fan_speed_units" bp
 
@@ -759,6 +776,7 @@ set_fan_speed_limits()
 
 	# If fan not ready - nothing to do, return
 	if [ ! -f $thermal_path/"$fan_name"_speed_get ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "$fan_name skip: speed_get missing"
 		return
 	fi
 
@@ -784,9 +802,12 @@ set_fan_speed_limits()
 
 	# Set fan speed limits. Check if exists separate Front/Rear fan speed limits.
 	if [ -f "$config_path/$fan_min_fname" ] && [ -f "$config_path/$fan_max_fname" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"$fan_name min:$fan_min_fname max:$fan_max_fname"
 		check_n_link "$config_path"/"$fan_min_fname" "$thermal_path"/"$fan_name"_min
 		check_n_link "$config_path"/"$fan_max_fname" "$thermal_path"/"$fan_name"_max
 	else
+		print_function_call "$0" "${FUNCNAME[0]}" "$fan_name using default fan_min/max_speed"
 		check_n_link "$config_path"/fan_min_speed "$thermal_path"/"$fan_name"_min
 		check_n_link "$config_path"/fan_max_speed "$thermal_path"/"$fan_name"_max
 	fi
@@ -810,9 +831,11 @@ function handle_i2cbus_dev_action()
 	i2c_busdev_path=$1
 	i2c_busdev_action=$2
 
+	print_function_call "$0" "${FUNCNAME[0]}" "path:$i2c_busdev_path action:$i2c_busdev_action"
 	# Check if we have devices list which should be connected to dynamic i2c buses.
 	if [ ! -f $config_path/i2c_bus_connect_devices ];
 	then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: no i2c_bus_connect_devices"
 		return
 	fi
 
@@ -820,6 +843,7 @@ function handle_i2cbus_dev_action()
 	i2cbus_regex="i2c-([0-9]+)$"
 	[[ $i2c_busdev_path =~ $i2cbus_regex ]]
 	if [[ "${#BASH_REMATCH[@]}" != 2 ]]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: bus index not matched path:$i2c_busdev_path"
 		return
 	else
 		i2cbus="${BASH_REMATCH[1]}"
@@ -835,9 +859,13 @@ function handle_i2cbus_dev_action()
 		if [ $i2cbus == "${dynamic_i2c_bus_connect_table[i+2]}" ];
 		then
 			if [ "$i2c_busdev_action" == "add" ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"add ${dynamic_i2c_bus_connect_table[i]} ${dynamic_i2c_bus_connect_table[i+1]} bus:$i2cbus"
 				connect_device "${dynamic_i2c_bus_connect_table[i]}" "${dynamic_i2c_bus_connect_table[i+1]}" \
 					"${dynamic_i2c_bus_connect_table[i+2]}"
 			elif [ "$i2c_busdev_action" == "remove" ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"remove ${dynamic_i2c_bus_connect_table[i+1]} bus:$i2cbus"
 				diconnect_device "${dynamic_i2c_bus_connect_table[i]}" "${dynamic_i2c_bus_connect_table[i+1]}" \
 					"${dynamic_i2c_bus_connect_table[i+2]}"
 			fi
@@ -886,6 +914,8 @@ function get_i2c_busdev_name()
 			then
 				dev_name="${dynamic_i2c_bus_connect_table[i+3]}"
 				if [ $dev_name == "NA" ]; then 
+					print_function_call "$0" "${FUNCNAME[0]}" \
+						"NA bus:$i2cbus addr:$i2caddr path:$i2c_busdev_path"
 					echo "undefined"
 				else
 					echo "$dev_name"
@@ -899,6 +929,7 @@ function get_i2c_busdev_name()
 	# returning passed "devname" name or "undefined" in case if passed '{devtype}X"
 	if [ ${dev_name:0-1} == "X" ];
 	then
+		print_function_call "$0" "${FUNCNAME[0]}" "undefined suffixX name:$1 path:$i2c_busdev_path"
 		dev_name="undefined"
 	fi
 
@@ -917,6 +948,7 @@ get_devtree_device_driver_name()
 	if [ -f "$devtree_file" ]; then
 		declare -a devtree_table=($(<"$devtree_file"))
 	else
+		print_function_call "$0" "${FUNCNAME[0]}" "no devtree bus:$i2c_bus addr:$i2c_address"
 		echo ""
 		return
 	fi
@@ -973,6 +1005,8 @@ create_hotplug_smart_switch_event_files()
 	local dpu2host_event_file="$1"
 	local dpu_event_file="$2"
 
+	print_function_call "$0" "${FUNCNAME[0]}" "dpu2host:$dpu2host_event_file dpu:$dpu_event_file"
+
 	declare -a dpu2host_event_table="($(< $dpu2host_event_file))"
 	declare -a dpu_event_table="($(< $dpu_event_file))"
 
@@ -1013,10 +1047,14 @@ init_hotplug_sysfs_event()
 	local src="${hwmon_path}/${attr}"
 
 	if [ ! -f "$src" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"missing $src attr:$attr event:$event_name"
 		return 1
 	fi
 	check_n_link "$src" "$status_link"
 	event=$(< "$status_link")
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"attr:$attr event:$event_name val:$event link:$status_link"
 	if [ "$event" -eq 1 ]; then
 		echo 1 > "$events_path/$event_name"
 	fi
@@ -1038,6 +1076,7 @@ deinit_hotplug_sysfs_event()
 	local status_link="$3"
 	local event_name="$4"
 
+	print_function_call "$0" "${FUNCNAME[0]}" "attr:$attr event:$event_name"
 	check_n_unlink "$status_link"
 	echo 0 > "$events_path/$event_name"
 }
@@ -1053,6 +1092,7 @@ init_hotplug_dpu_events()
 	local plat_drv_path="/sys/devices/platform/mlxplat/i2c_mlxcpld.1/i2c-1"
 	local hwmon_path="mlxreg-hotplug.$slot_num/hwmon/hwmon*"
 
+	print_function_call "$0" "${FUNCNAME[0]}" "slot:$slot_num file:$event_file"
 	declare -a event_table="($(< $event_file))"
 
 	if [ $slot_num -ne 0 ]; then
@@ -1084,6 +1124,7 @@ deinit_hotplug_dpu_events()
 	local slot_num="$2"
 	local s_path
 
+	print_function_call "$0" "${FUNCNAME[0]}" "slot:$slot_num file:$event_file"
 	declare -a event_table="($(< $event_file))"
 
 	if [ $slot_num -ne 0 ]; then
@@ -1101,7 +1142,9 @@ connect_underlying_devices()
 {
 	local bus="$1"
 
+	print_function_call "$0" "${FUNCNAME[0]}" "bus:$bus"
 	if [ ! -f $config_path/i2c_underlying_devices ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: no i2c_underlying_devices bus:$bus"
 		return
 	fi
 
@@ -1120,7 +1163,9 @@ disconnect_underlying_devices()
 {
 	local bus="$1"
 
+	print_function_call "$0" "${FUNCNAME[0]}" "bus:$bus"
 	if [ ! -f $config_path/i2c_underlying_devices ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: no i2c_underlying_devices bus:$bus"
 		return
 	fi
 
@@ -1140,7 +1185,9 @@ connect_dynamic_board_devices()
 	local board_name="$1"
 	local device_connect_retry=2
 
+	print_function_call "$0" "${FUNCNAME[0]}" "board:$board_name"
 	if [ ! -f "$dynamic_boards_path"/"$board_name" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: missing $dynamic_boards_path/$board_name"
 		return
 	fi
 
@@ -1151,6 +1198,8 @@ connect_dynamic_board_devices()
 			connect_device "${board_connect_table[i]}" "${board_connect_table[i+1]}" \
 					"${board_connect_table[i+2]}"
 			if [ $? -eq 0 ]; then
+				print_function_call "$0" "${FUNCNAME[0]}" \
+					"ok ${board_connect_table[i]} ${board_connect_table[i+1]} bus:${board_connect_table[i+2]} tries:$((j+1))"
 				break;
 			fi
 			disconnect_device "${board_connect_table[i+1]}" "${board_connect_table[i+2]}"
@@ -1162,7 +1211,9 @@ disconnect_dynamic_board_devices()
 {
 	local board_name="$1"
 
+	print_function_call "$0" "${FUNCNAME[0]}" "board:$board_name"
 	if [ ! -f "$dynamic_boards_path"/"$board_name" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: missing $dynamic_boards_path/$board_name"
 		return
 	fi
 
@@ -1178,9 +1229,11 @@ load_dpu_sensors()
 	local dpu_num=$1
 	local dpu_ready
 
+	print_function_call "$0" "${FUNCNAME[0]}" "dpu:$dpu_num"
 	if [ -f $hw_management_path/system/dpu${dpu_num}_ready ]; then
 		dpu_ready=$(< $hw_management_path/system/dpu${dpu_num}_ready)
 		if [ ${dpu_ready} -eq 1 ]; then
+			print_function_call "$0" "${FUNCNAME[0]}" "dpu:$dpu_num ready, connecting"
 			if [ -e "$devtree_file" ]; then
 				connect_dynamic_board_devices "dpu_board""$dpu_num"
 			fi
@@ -1220,6 +1273,7 @@ get_ui_tree_archive_file()
 # hw-management-start-post.sh
 check_and_recreate_dpu_devices()
 {
+	print_function_call "$0" "${FUNCNAME[0]}" "entering..."
 	for bus in {18..21}; do
 		if ! ls /sys/bus/i2c/devices/${bus}-0068/mlxreg-io* >/dev/null 2>&1; then
 			log_info "Device mlxreg-io* not found on i2c-$bus. Recreating device..."
@@ -1238,6 +1292,7 @@ run_fixup_script()
 	local status
 	local stage=$1
 
+	print_function_call "$0" "${FUNCNAME[0]}" "stage:$stage"
 	if [ -x ${fixup_hook_script} ] && [ -s ${fixup_hook_script} ]; then
 		${fixup_hook_script} $stage
 		status=$?
@@ -1252,9 +1307,12 @@ check_asic_chipup_status()
 
 	if [ -f "$asic_chipup_status" ]; then
 		chipup_status=$(< "$asic_chipup_status")
+		print_function_call "$0" "${FUNCNAME[0]}" "status:$chipup_status"
 		if [ $chipup_status -eq 1 ]; then
 			return 0
 		fi
+	else
+		print_function_call "$0" "${FUNCNAME[0]}" "missing $asic_chipup_status"
 	fi
 	return 1
 }
@@ -1275,6 +1333,7 @@ set_sodimm_temp_limits()
 	# JC42 driver is not relevant on systems with DDR5 DRAM
 	case $cpu_type in
 		$BDW_CPU|$BF3_CPU|$AMD_V3000_CPU|$AMD_FRNG_CPU)
+			print_function_call "$0" "${FUNCNAME[0]}" "skip cpu_type:$cpu_type"
 			return 0
 			;;
 		*)
@@ -1290,6 +1349,7 @@ set_sodimm_temp_limits()
 				[[ -d /sys/bus/i2c/drivers/jc42 ]] && break
 			done
 		else
+			print_function_call "$0" "${FUNCNAME[0]}" "jc42 modprobe failed rc:$rc"
 			return 1
 		fi
 	fi
@@ -1304,6 +1364,7 @@ set_sodimm_temp_limits()
 		echo "$SODIMM_TEMP_HYST" > "$temp_sens"/hwmon/hwmon*/temp1_crit_hyst
 	done
 
+	print_function_call "$0" "${FUNCNAME[0]}" "limits applied"
 	return 0
 }
 
@@ -1318,12 +1379,14 @@ I2C_TRACE_LOG="/var/log/hw-mgmt-i2c-trace.log"
 I2C_TRACE_BUF_SIZE_KB=1024
 start_i2c_trace() {
 	if [ ! -d "$KERN_TRACE_FS/events/i2c" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: no i2c trace events"
 		return
 	fi
 
 	# Already running: do not reconfigure (another tool may have enabled it with
 	# different buffer/filters; re-applying could fight that consumer).
 	if [ "$(< "$KERN_TRACE_FS"/events/i2c/enable)" -eq 1 ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: already running"
 		return
 	fi
 
@@ -1341,16 +1404,19 @@ start_i2c_trace() {
 	echo "adapter_nr!=1" > "$KERN_TRACE_FS"/events/i2c/i2c_reply/filter  2>/dev/null || true
 	# enable (start)i2c trace
 	echo 1 > "$KERN_TRACE_FS"/events/i2c/enable
+	print_function_call "$0" "${FUNCNAME[0]}" "started"
 }
 
 # Stop i2c trace
 stop_i2c_trace() {
 	# check if i2c trace available
 	if [ ! -f "$KERN_TRACE_FS"/events/i2c/enable ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: no i2c enable"
 		return
 	fi
 	# check if trace is running (/sys/kernel/debug/tracing/events/i2c/enable == 1)
 	if [ "$(cat "$KERN_TRACE_FS"/events/i2c/enable)" -eq 0 ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: not running"
 		return
 	fi
 	# disable (stop) i2c trace
@@ -1359,6 +1425,7 @@ stop_i2c_trace() {
 	cat "$KERN_TRACE_FS"/trace >> "$I2C_TRACE_LOG"
 	# clear i2c trace buffer
 	echo 0 > "$KERN_TRACE_FS"/trace
+	print_function_call "$0" "${FUNCNAME[0]}" "stopped saved:$I2C_TRACE_LOG"
 }
 
 # Snapshot the boot-wide (top-level) I2C trace buffer into the trace log, tagged
@@ -1384,6 +1451,7 @@ save_i2c_trace_on_failure() {
 	# Clear so the tracer continues with a fresh, bounded window (and the final
 	# stop_i2c_trace dump does not duplicate what we just saved).
 	echo 0 > "$KERN_TRACE_FS"/trace 2>/dev/null
+	print_function_call "$0" "${FUNCNAME[0]}" "saved reason:$reason"
 }
 
 # Chipup I2C tracer.
@@ -1412,6 +1480,7 @@ start_chipup_i2c_trace() {
 	CHIPUP_I2C_TRACE_INSTANCE="$KERN_TRACE_FS/instances/hwmgmt_chipup_${asic_index}"
 
 	if [ ! -d "$KERN_TRACE_FS/events/i2c" ]; then
+		print_function_call "$0" "${FUNCNAME[0]}" "skip: no i2c events asic:$asic_index"
 		return
 	fi
 
@@ -1425,6 +1494,8 @@ start_chipup_i2c_trace() {
 	elif [ "$(cat "$KERN_TRACE_FS"/events/i2c/enable 2>/dev/null)" = "0" ]; then
 		CHIPUP_TRACE_DIR="$KERN_TRACE_FS"
 	else
+		print_function_call "$0" "${FUNCNAME[0]}" \
+			"skip: boot tracer busy asic:$asic_index"
 		return
 	fi
 
@@ -1435,6 +1506,7 @@ start_chipup_i2c_trace() {
 	echo "$I2C_TRACE_BUF_SIZE_KB" > "$CHIPUP_TRACE_DIR"/buffer_size_kb 2>/dev/null || true
 	echo "$CHIPUP_I2C_TRACE_FILTER" > "$CHIPUP_TRACE_DIR"/events/i2c/filter 2>/dev/null || true
 	echo 1 > "$CHIPUP_TRACE_DIR"/events/i2c/enable 2>/dev/null
+	print_function_call "$0" "${FUNCNAME[0]}" "started asic:$asic_index dir:$CHIPUP_TRACE_DIR"
 }
 
 # Append the current chipup trace buffer to the log and clear it (called
@@ -1444,6 +1516,7 @@ save_chipup_i2c_trace() {
 	local attempt="${1:-}"
 
 	[ -n "$CHIPUP_TRACE_DIR" ] || return
+	print_function_call "$0" "${FUNCNAME[0]}" "attempt:${attempt:-na} dir:$CHIPUP_TRACE_DIR"
 	if [ -n "$attempt" ]; then
 		echo "# --- chipup attempt ${attempt} ---" >> /var/log/chipup_i2c_trace_log
 	fi
@@ -1454,6 +1527,7 @@ save_chipup_i2c_trace() {
 # Stop the chipup tracer and release the dedicated instance (if one was used).
 stop_chipup_i2c_trace() {
 	[ -n "$CHIPUP_TRACE_DIR" ] || return
+	print_function_call "$0" "${FUNCNAME[0]}" "dir:$CHIPUP_TRACE_DIR"
 	echo 0 > "$CHIPUP_TRACE_DIR"/events/i2c/enable 2>/dev/null
 	if [ "$CHIPUP_TRACE_DIR" = "$CHIPUP_I2C_TRACE_INSTANCE" ]; then
 		rmdir "$CHIPUP_I2C_TRACE_INSTANCE" 2>/dev/null || true
@@ -1840,6 +1914,8 @@ get_asic_mlxreg_dev()
 		fi
 	fi
 
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"unresolved asic_index:$1 pci:$pci_short asic_num:$asic_num"
 	return 1
 }
 
@@ -1862,6 +1938,7 @@ set_asic_pwm_full_speed_on_chipup_fail()
 	local mst_devdir="${HW_MGMT_MST_DEVDIR:-/dev/mst}"
 
 	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
+	print_function_call "$0" "${FUNCNAME[0]}" "asic:$asic_index dev:$explicit_dev"
 
 	if [ -e "$pwm_link" ]; then
 		echo 255 > "$pwm_link"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -286,6 +286,7 @@ function set_asic_ready()
 	sysfs_picdev_path=$1
 	state=$2
 	[ -f "$config_path/asic_num" ] && asic_num=$(< $config_path/asic_num)
+	print_function_call "$0" "${FUNCNAME[0]}" "path:$sysfs_picdev_path state:$state asic_num:$asic_num"
 	if [ $asic_num -gt 1 ]; then
 		pci_bus="${sysfs_picdev_path: -7}"
 		for ((asic_id=1; asic_id<=asic_num; asic_id+=1)); do
@@ -335,6 +336,7 @@ if [ "$1" == "add" ]; then
 			asic_i2c_bus_id=$(< $config_path/asic"$i"_i2c_bus_id)
 			asic_bus=$((asic_i2c_bus_id+i2c_bus_offset))
 			if [ "$bus" == "$asic_bus" ]; then
+				print_function_call "$0" "add" "amb skip asic bus:$bus $2"
 				exit 0
 			fi
 		done
@@ -359,6 +361,7 @@ if [ "$1" == "add" ]; then
 	esac
 	if [ "$2" == "switch" ]; then
 		name=$(< "$3""$4"/name)
+		print_function_call "$0" "add" "switch name:$name"
 		if [[ $name != *"nvme"* ]]; then
 			get_lc_id_hwmon "$3$4"
 			lc_number=$?
@@ -442,6 +445,7 @@ if [ "$1" == "add" ]; then
 				for ((i=1; i<=$(<$config_path/max_tachos); i+=1)); do
 					set_fan_speed_limits fan"$i"
 				done
+				print_function_call "$0" "add" "switch mlxsw asic ready pwm:$(< "$tpath"/pwm1 2>/dev/null)"
 				set_asic_ready "$3""$4" 1
 			fi
 
@@ -522,11 +526,13 @@ if [ "$1" == "add" ]; then
 
 	if [ "$2" == "regfan" ]; then
 		name=$(< "$3""$4"/name)
+		print_function_call "$0" "add" "regfan name:$name"
 		echo "$name" > $config_path/cooling_name
 		check_n_link "$3""$4"/pwm1 $thermal_path/pwm1
 		pwm_level=$(< "$thermal_path/pwm1")
 		# If PWM level less then minimum then set it to default value
 		if [ $pwm_level -lt $pwm_min_level ]; then
+			print_function_call "$0" "add" "regfan pwm $pwm_level -> $pwm_min_level"
 			echo $pwm_min_level > $thermal_path/pwm1
 		fi
 		for ((i=1; i<=max_pwm; i+=1)); do
@@ -554,6 +560,7 @@ if [ "$1" == "add" ]; then
 	fi
 	if [ "$2" == "thermal_zone" ]; then
 		zonetype=$(< "$3""$4"/type)
+		[ "$zonetype" == "mlxsw" ] && print_function_call "$0" "add" "thermal_zone $zonetype"
 		get_lc_id_tz "$zonetype"
 		lc_number=$?
 		if [ "$lc_number" -ne 0 ]; then
@@ -709,6 +716,7 @@ if [ "$1" == "add" ]; then
 	fi
 	# Max index of SN2201 cputemp is 14.
 	if [ "$2" == "cputemp" ]; then
+		print_function_call "$0" "add" "cputemp $3$4"
 		for i in {1..16}; do
 			if [ -f "$3""$4"/temp"$i"_input ]; then
 				if [ $i -eq 1 ]; then
@@ -829,12 +837,15 @@ if [ "$1" == "add" ]; then
 	   [ "$2" == "psu5" ] || [ "$2" == "psu6" ] ||
 	   [ "$2" == "psu7" ] || [ "$2" == "psu8" ] ||
 	   [ "$2" == "psuX" ]; then
+		print_function_call "$0" "add" "psu $2 $3"
 		if [[ $dmi_sku == "HI138" ]] || [[ $dmi_sku == "HI139" ]]; then
+			print_function_call "$0" "add" "psu skip sku:$dmi_sku $2"
 			exit 0
 		fi
 		psu_name=$(get_i2c_busdev_name "$2" "$3")
 		if [[ $psu_name == "undefined" ]] || [[ $psu_name == "psuX" ]];
 		then
+			print_function_call "$0" "add" "psu skip name:$psu_name $2 $3"
 			exit
 		fi
 		# SN5600, SN5400 systems have PSU2 with I2C address 0x5a. In udev rules 0x5a corresponds to psu4.
@@ -849,6 +860,7 @@ if [ "$1" == "add" ]; then
 		bus="${busfolder:0:${#busfolder}-5}"
 		# Verify if this is COMEX device
 		if [ "$bus" == "$comex_bus" ]; then
+			print_function_call "$0" "add" "psu skip comex bus:$bus $2"
 			exit 0
 		fi
 		# Allow PS controller to stabilize
@@ -856,6 +868,7 @@ if [ "$1" == "add" ]; then
 		sleep 1
 		# Set I2C bus for psu
 		echo "$bus" > $config_path/"$psu_name"_i2c_bus
+		print_function_call "$0" "add" "psu linked name:$psu_name bus:$bus"
 
 		# Add thermal attributes
 		check_n_link "$5""$3"/temp1_input $thermal_path/"$psu_name"_temp1
@@ -1082,6 +1095,7 @@ if [ "$1" == "add" ]; then
 
 	fi
 	if [ "$2" == "sxcore" ]; then
+		print_function_call "$0" "add" "sxcore $4/$5"
 		if [ -f "$config_path"/minimal_unsupported ]; then
 			minimal_unsupported=$(< $config_path/minimal_unsupported)
 		fi
@@ -1124,6 +1138,7 @@ if [ "$1" == "add" ]; then
 		fi
 	fi
 	if [ "$2" == "dpu" ]; then
+		print_function_call "$0" "add" "dpu $3$4"
 		case $dmi_sku in
 		HI160)
 			# DPU event, replace output folder.
@@ -1141,12 +1156,16 @@ if [ "$1" == "add" ]; then
 
 elif [ "$1" == "change" ]; then
 	if [ "$2" == "hotplug_asic" ]; then
+		print_function_call "$0" "change" "hotplug_asic $3 index:$6"
 		if [ -d /sys/module/mlxsw_pci ]; then
+			print_function_call "$0" "change" "hotplug_asic skip mlxsw_pci"
 			exit 0
 		fi
 		asic_index="$6"
 		asic_num=$(< $config_path/asic_num)
 		if [ "$asic_num" -lt "$asic_index" ]; then
+			print_function_call "$0" "change" \
+				"hotplug_asic skip index:$asic_index asic_num:$asic_num"
 			exit 0
 		fi
 		if [ "$3" == "up" ]; then
@@ -1158,11 +1177,16 @@ elif [ "$1" == "change" ]; then
 			fi
 			# Run automatic chipup based on ASIC health event only in special CI/verification OSes.
 			if [ -f /etc/autochipup ]; then
+				print_function_call "$0" "change" "hotplug_asic autochipup index:$asic_index"
 				asic_chipup_completed=$(< $config_path/asic_chipup_completed)
 				[ ${asic_chipup_completed} -eq 0 ] && sleep 3
 				/usr/bin/hw-management.sh chipup "$asic_index"
+			else
+				print_function_call "$0" "change" \
+					"hotplug_asic up no autochipup index:$asic_index"
 			fi
 		elif [ "$3" == "down" ]; then
+			print_function_call "$0" "change" "hotplug_asic chipdown index:$asic_index"
 			/usr/bin/hw-management.sh chipdown "$asic_index"
 		fi
 	fi
@@ -1205,6 +1229,7 @@ else
 	esac
 	if [ "$2" == "switch" ]; then
 		name=$(< "$3""$4"/name)
+		print_function_call "$0" "remove" "switch name:$name"
 		if [[ $name != *"nvme"* ]]; then
 			[ -f "$config_path/stopping" ] && stopping=$(< $config_path/stopping)
 			if [ "$stopping" ] &&  [ "$stopping" = "1" ]; then
@@ -1280,6 +1305,7 @@ else
 		fi
 	fi
 	if [ "$2" == "regfan" ]; then
+		print_function_call "$0" "remove" "regfan $3$4"
 		for ((i=1; i<=max_pwm; i+=1)); do
 			if [ -L $thermal_path/pwm"$i" ]; then
 				unlink $thermal_path/pwm"$i"
@@ -1326,6 +1352,7 @@ else
 		check_n_unlink $thermal_path/highest_thermal_zone
 	fi
 	if [ "$2" == "hotplug" ]; then
+		print_function_call "$0" "remove" "hotplug $3$4"
 		for ((i=1; i<=max_tachos; i+=1)); do
 			check_n_unlink $thermal_path/fan"$i"_status
 		done
@@ -1371,6 +1398,7 @@ else
 		deinit_hotplug_dpu_events "$dpu2host_events_file" 0
 	fi
 	if [ "$2" == "cputemp" ]; then
+		print_function_call "$0" "remove" "cputemp"
 		unlink $thermal_path/cpu_pack
 		unlink $thermal_path/cpu_pack_crit
 		unlink $thermal_path/cpu_pack_max
@@ -1401,6 +1429,7 @@ else
 	   [ "$2" == "psu5" ] || [ "$2" == "psu6" ] ||
 	   [ "$2" == "psu7" ] || [ "$2" == "psu8" ] ||
 	   [ "$2" == "psuX" ]; then
+		print_function_call "$0" "remove" "psu $2 $3"
 		psu_name=$(get_i2c_busdev_name "$2" "$3")
 		if [[ $psu_name == "undefined" ]] || [[ $psu_name == "psuX" ]];
 		then
@@ -1467,10 +1496,12 @@ else
 		fi
 	fi
 	if [ "$2" == "sxcore" ]; then
+		print_function_call "$0" "remove" "sxcore $4/$5"
 		/usr/bin/hw-management.sh chipdown 0 "$4/$5"
 		set_asic_ready "$4/$5" 0
 	fi
 	if [ "$2" == "dpu" ]; then
+		print_function_call "$0" "remove" "dpu $3$4"
 		case ${dmi_sku} in
 		HI160)
 			# DPU event, replace output folder.

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -674,6 +674,7 @@ sn6600_named_busses=(asic1 5 pwr 4 vr1 16 vr2 17 vpd 1 cpu-vr 6)
 sn68xxld_named_busses=(asic1 4 pwr1 6 vr1 15 vpd 1 cpu-vr 5)
 
 ACTION=$1
+print_function_call "$0" "main" "ACTION=$ACTION $2 $3"
 
 if [ "$board_type" == "VMOD0014" ]; then
 	i2c_bus_max=14
@@ -3233,9 +3234,18 @@ check_system()
 {
 	local json_file
 
+	# restart runs do_stop then do_start in one process; both call
+	# check_system which appends to these globals. Reset so devices are
+	# not connected or disconnected twice.
+	connect_table=()
+	named_busses=()
+
+	print_function_call "$0" "${FUNCNAME[0]}" "sku:$sku board:$board_type"
 	if json_file=$(find_platform_json_config "$sku"); then
+		print_function_call "$0" "${FUNCNAME[0]}" "json:$json_file"
 		check_system_json "$json_file" || return 1
 	else
+		print_function_call "$0" "${FUNCNAME[0]}" "no json, using check_system_internal"
 		check_system_internal || return 1
 	fi
 	check_system_bmc_redfish_login || true
@@ -3318,6 +3328,7 @@ enable_vpd_wp()
 
 load_modules()
 {
+	print_function_call "$0" "${FUNCNAME[0]}" "cpu:$cpu_type sku:$sku"
 	# Some modules are not present in all the kernel
 	# versions. Use this function to load those modules
 	# which need to be loaded based on their availability
@@ -3428,6 +3439,7 @@ set_config_data()
 
 connect_platform()
 {
+	print_function_call "$0" "${FUNCNAME[0]}" "entering..."
 	find_i2c_bus
 	# Check if it's new or old format of connect table
 	if [ -e "$devtree_file" ]; then
@@ -3456,7 +3468,12 @@ connect_platform()
 		# ASIC chipup failures.
 		if [ "$dev_connected" -eq 0 ]; then
 			log_err "Failed to connect device ${connect_table[i]} ${connect_table[i+1]} on bus ${connect_table[i+2]} after ${device_connect_retry} attempts"
+			print_function_call "$0" "${FUNCNAME[0]}" \
+				"FAIL ${connect_table[i]} ${connect_table[i+1]} bus:${connect_table[i+2]}"
 			save_i2c_trace_on_failure "device connect failed: ${connect_table[i]} ${connect_table[i+1]} bus ${connect_table[i+2]}"
+		else
+			print_function_call "$0" "${FUNCNAME[0]}" \
+				"ok ${connect_table[i]} ${connect_table[i+1]} bus:${connect_table[i+2]} tries:$((j+1))"
 		fi
 	done
 	if [ ! -z $mctp_addr ]; then
@@ -3468,6 +3485,7 @@ connect_platform()
 
 disconnect_platform()
 {
+	print_function_call "$0" "${FUNCNAME[0]}" "entering..."
 	if [ -f $config_path/i2c_bus_offset ]; then
 		i2c_bus_offset=$(<$config_path/i2c_bus_offset)
 	fi
@@ -4142,6 +4160,7 @@ report_sed_pba_ver()
 
 do_start()
 {
+	print_function_call "$0" "${FUNCNAME[0]}" "entering..."
 	# start i2c bus trace recording
 	start_i2c_trace
 	show_hw_info
@@ -4149,10 +4168,18 @@ do_start()
 	create_symbolic_links
 	run_fixup_script pre
 	check_cpu_type
-	pre_devtr_init || exit 1
+	print_function_call "$0" "do_start" "cpu_type:$cpu_type"
+	pre_devtr_init || {
+		print_function_call "$0" "do_start" "pre_devtr_init failed"
+		exit 1
+	}
 	load_modules
 	devtr_check_smbios_device_description
-	check_system || exit 1
+	check_system || {
+		print_function_call "$0" "do_start" "check_system failed sku:$sku"
+		exit 1
+	}
+	print_function_call "$0" "do_start" "check_system done"
 	set_asic_pci_id
 	set_dpu_pci_id
 	set_sodimms
@@ -4162,19 +4189,23 @@ do_start()
 		ln -sf $lm_sensors_labels $config_path/lm_sensors_labels
 	fi
 	asic_control=$(< $config_path/asic_control) 
+	print_function_call "$0" "do_start" "asic_control:$asic_control"
 	if [[ $asic_control -ne 0 ]]; then
 		set_asic_i2c_bus
 	fi
 	touch $udev_ready
 	run_depmod_if_needed
 
+	print_function_call "$0" "do_start" "udevadm trigger add"
 	udevadm trigger --action=add
 	udevadm settle
+	print_function_call "$0" "do_start" "udevadm settle done"
 	set_sodimm_temp_limits
 	set_gpios "export"
 	create_event_files
 	hw-management-i2c-gpio-expander.sh
 	connect_platform
+	print_function_call "$0" "do_start" "connect_platform done"
 	sleep 1
 	enable_vpd_wp
 	echo 0 > $config_path/events_ready
@@ -4195,11 +4226,13 @@ do_start()
 		ln -sf /etc/sensors3.conf $config_path/lm_sensors_config
 	fi
 	/usr/bin/hw-management-exec-parser.sh
+	print_function_call "$0" "do_start" "completed"
 	log_info "Init completed."
 }
 
 do_stop()
 {
+	print_function_call "$0" "${FUNCNAME[0]}" "entering..."
 	rm -f /var/run/hw-management/exec 2>/dev/null
 	rm -fR /var/run/hw-management/exec.d 2>/dev/null
 	check_cpu_type
@@ -4221,6 +4254,7 @@ do_stop()
 		sleep 1
 		rm -fR /var/run/hw-management
 	fi
+	print_function_call "$0" "do_stop" "completed"
 }
 
 function find_asic_hwmon_path()
@@ -4239,6 +4273,8 @@ do_chip_up_down()
 	local asic_pci_bus=$3
 	local asic_i2c_bus
 
+	print_function_call "$0" "${FUNCNAME[0]}" \
+		"action:$action asic:$asic_index pci:$asic_pci_bus"
 	if [ -f "$config_path"/asic_control ]; then
 		asic_control=$(< $config_path/asic_control)
 	fi
@@ -4322,16 +4358,22 @@ do_chip_up_down()
 			echo $i2c_asic_addr > /sys/bus/i2c/devices/i2c-"$asic_i2c_bus"/delete_device
 			restore_i2c_bus_frequency_default
 		else
+			print_function_call "$0" "do_chip_up_down" \
+				"chipdown skip asic:$asic_index bus:$asic_i2c_bus addr:$i2c_asic_addr_name minimal:${minimal_unsupported:-0}"
 			unlock_service_state_change
 			return 0
 		fi
 		unlock_service_state_change_update_and_match $config_path/asic_chipup_completed -1 $config_path/asic_num $config_path/asics_init_done
 		asic_chipup_completed=$(< $config_path/asic_chipup_completed)
+		print_function_call "$0" "do_chip_up_down" \
+			"chipdown done asic:$asic_index bus:$asic_i2c_bus completed:$asic_chipup_completed"
 		;;
 	1)
 		lock_service_state_change
 		[ -f "$config_path/chipup_dis" ] && disable=$(< $config_path/chipup_dis)
 		if [ "$disable" ] && [ "$disable" -gt 0 ]; then
+			print_function_call "$0" "do_chip_up_down" \
+				"chipup skipped chipup_dis:$disable asic:$asic_index"
 			disable=$((disable-1))
 			echo $disable > $config_path/chipup_dis
 			unlock_service_state_change
@@ -4348,6 +4390,8 @@ do_chip_up_down()
 			retry_helper find_asic_hwmon_path "$chipup_test_time" "$chipup_retry_count" "chip hwmon object" /sys/bus/i2c/devices/"$asic_i2c_bus"-"$i2c_asic_addr_name"/hwmon
 			if [ $? -ne 0 ]; then
 				# chipup command failed.
+				print_function_call "$0" "do_chip_up_down" \
+					"chipup failed asic:$asic_index bus:$asic_i2c_bus"
 				unlock_service_state_change
 				return 1
 			fi
@@ -4360,6 +4404,8 @@ do_chip_up_down()
 				echo "$str" > $system_path/cpld
 			fi
 		else
+			print_function_call "$0" "do_chip_up_down" \
+				"chipup skip already-present or minimal asic:$asic_index bus:$asic_i2c_bus addr:$i2c_asic_addr_name minimal:${minimal_unsupported:-0}"
 			unlock_service_state_change
 			return 0
 		fi
@@ -4504,6 +4550,8 @@ case $ACTION in
 			start_chipup_i2c_trace "$asic_index"
 
 			while [ "$asic_chipup_rc" -ne 0 ] && [ "$asic_retry" -gt 0 ]; do
+				print_function_call "$0" "chipup" \
+					"attempt:$chipup_trace_attempt retry_left:$asic_retry asic:$asic_index"
 				do_chip_up_down 1 "$2" "$3"
 				asic_chipup_rc=$?
 				if [ "$asic_chipup_rc" -ne 0 ]; then
@@ -4515,6 +4563,7 @@ case $ACTION in
 				else
 					echo "$asic_chipup_retry" > "$config_path"/asic_chipup_counter
 					stop_chipup_i2c_trace
+					print_function_call "$0" "chipup" "success asic:$asic_index"
 					exit 0
 				fi
 


### PR DESCRIPTION
Sparse print_function_call traces in hw-management start/stop,
chipup, chassis/thermal udev handlers, and helpers. Log skip/fail and
lifecycle points to /var/log/hw-mgmt.trace.log without per-attribute spam.
Also reset connect_table and named_busses in check_system so restart does
not connect devices twice.

Board: all
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
