### PR TITLE
hw-mgmt: thermal: Fix thermal data for SN2201_M

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
@@ -1,5 +1,5 @@
  {
-	"name": "msn2201",
+	"name": "msn2201m",
 	"tc_version": "2.5",
 	"dmin" : {
 		"C2P": {
@@ -32,7 +32,7 @@
 	"dev_parameters" : {
 		"asic\\d*":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":70},
 		"(cpu_pack|cpu_core\\d+)": {"pwm_min": 20, "pwm_max" : 100,  "val_min": "!70000", "val_max": "!95000", "poll_time": 3, "sensor_read_error":70},
-		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "val_max_clamp": 65000, "poll_time": 20,
+		"module\\d+":     {"pwm_min": 30, "pwm_max" : 71, "val_min":60000, "val_max":80000, "val_min_offset": -10000, "val_max_offset": 0, "poll_time": 20,
 						   "reg_extra_param": {"increase_step" : 5, "decrease_step": 0.1, "Iterm_down_trh": -10,
                                          	   "val_up_trh" : 1, "val_down_trh": 3, "range": 3}},
 		"sensor_amb":     {"pwm_min": 20, "pwm_max" : 50, "val_min": 30000, "val_max": 50000, "poll_time": 30},


### PR DESCRIPTION
Drop the 65C module Tmax clamp so PWM follows val_max (80C) with
the existing val_max_offset on MSN2201 busbar systems.

Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
