### PR TITLE
hw-mgmt: scripts: Prefer HTTP for NOS-BMC Redfish communication

### DIFF
--- a/tests/offline/test_hw_management_redfish_client.py
+++ b/tests/offline/test_hw_management_redfish_client.py
@@ -143,7 +143,7 @@ class TestRedfishClientCommandBuilders:
         cmd = basic_redfish_client._RedfishClient__build_login_cmd('********')
         assert cmd.startswith(RedfishClient._CFG_LOGIN_PREFIX)
         assert 'request = POST' in cmd
-        assert 'https://10.0.1.1/login' in cmd
+        assert 'http://10.0.1.1/login' in cmd
         assert 'username' in cmd and 'admin' in cmd
         assert 'password' in cmd and '********' in cmd
 
@@ -153,7 +153,7 @@ class TestRedfishClientCommandBuilders:
         cmd = basic_redfish_client._RedfishClient__build_get_cmd('/redfish/v1/test')
         assert 'request = GET' in cmd
         assert 'header = "X-Auth-Token: test_token_123"' in cmd
-        assert 'https://10.0.1.1/redfish/v1/test' in cmd
+        assert 'http://10.0.1.1/redfish/v1/test' in cmd
 
     def test_medium_build_fw_update_cmd(self, basic_redfish_client):
         """Medium: Build firmware update command"""
@@ -179,7 +179,7 @@ class TestRedfishClientCommandBuilders:
         data = {'key1': 'value1', 'key2': 123}
         cmd = basic_redfish_client._RedfishClient__build_post_cmd('/test/uri', data)
         assert 'request = POST' in cmd
-        assert 'https://10.0.1.1/test/uri' in cmd
+        assert 'http://10.0.1.1/test/uri' in cmd
         assert 'key1' in cmd and 'value1' in cmd
 
     def test_complex_build_set_force_update_true(self, basic_redfish_client):
@@ -506,6 +506,63 @@ class TestRedfishClientExecCurl:
         captured = capsys.readouterr()
         assert 'Execute cURL command:' in captured.err
         assert 'test_token' not in captured.err
+
+
+class TestRedfishClientHttpScheme:
+    """HTTP is default; HTTPS is used only when HTTP is unreachable."""
+
+    def test_default_scheme_is_http(self, basic_redfish_client):
+        assert basic_redfish_client._RedfishClient__scheme == RedfishClient.SCHEME_HTTP
+        assert not basic_redfish_client._RedfishClient__scheme_resolved
+
+    def test_http_success_does_not_fallback(
+            self, basic_redfish_client, mock_subprocess):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            mock_curl_stdout('{"token": "tok"}'), b'')
+        mock_process.returncode = 0
+        mock_subprocess.Popen.return_value = mock_process
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+        stdin = mock_process.communicate.call_args.kwargs['input']
+        assert b'url = "http://' in stdin
+        assert b'https://' not in stdin
+        assert mock_subprocess.Popen.call_count == 1
+
+    def test_https_fallback_when_http_unreachable(
+            self, basic_redfish_client, mock_subprocess):
+        http_fail = MagicMock()
+        http_fail.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        http_fail.returncode = 7
+        https_ok = MagicMock()
+        https_ok.communicate.return_value = (
+            mock_curl_stdout('{"token": "tok"}'), b'')
+        https_ok.returncode = 0
+        mock_subprocess.Popen.side_effect = [http_fail, https_ok]
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert basic_redfish_client.get_token() == 'tok'
+        assert basic_redfish_client._RedfishClient__scheme == 'https'
+        assert b'url = "http://' in http_fail.communicate.call_args.kwargs['input']
+        assert b'url = "https://' in https_ok.communicate.call_args.kwargs['input']
+
+    def test_https_fallback_both_fail_keeps_http_default(
+            self, basic_redfish_client, mock_subprocess):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        mock_process.returncode = 7
+        mock_subprocess.Popen.return_value = mock_process
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_CURL_FAILURE
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+        assert not basic_redfish_client._RedfishClient__scheme_resolved
+        assert mock_subprocess.Popen.call_count == 2
 
 
 # =============================================================================

--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -62,6 +62,10 @@ class RedfishClient:
     DEFAULT_GET_TIMEOUT = 3
     _CFG_LOGIN_PREFIX = '# hw-mgmt-redfish: login\n'
     _CURL_HTTP_TRAILER_RE = re.compile(r'\nHTTP Status Code: (\d+)\Z')
+    # BMC is moving to HTTP-only. Prefer HTTP; fall back to HTTPS if HTTP is down.
+    SCHEME_HTTP = 'http'
+    SCHEME_HTTPS = 'https'
+    _URL_SCHEME_RE = re.compile(r'(url = ")https?://')
 
     # Redfish URIs
     REDFISH_URI_FW_INVENTORY = '/redfish/v1/UpdateService/FirmwareInventory'
@@ -90,6 +94,8 @@ class RedfishClient:
         self.__user = user
         self.__password = password
         self.__token = None
+        self.__scheme = RedfishClient.SCHEME_HTTP
+        self.__scheme_resolved = False
 
     def get_token(self):
         return self.__token
@@ -109,7 +115,31 @@ class RedfishClient:
         return val.replace('\\', '\\\\').replace('"', '\\"')
 
     def __curl_redfish_url(self, path_without_scheme):
-        return f'https://{self.__svr_ip}{path_without_scheme}'
+        return f'{self.__scheme}://{self.__svr_ip}{path_without_scheme}'
+
+    def __apply_scheme_to_curl_config(self, curl_config):
+        return RedfishClient._URL_SCHEME_RE.sub(
+            r'\1' + self.__scheme + '://', curl_config, count=1)
+
+    def __try_https_fallback(self, curl_config, ret, output_str, error_str):
+        '''If HTTP is unreachable, retry once over HTTPS and remember the winner.'''
+        if ret != RedfishClient.ERR_CODE_CURL_FAILURE:
+            self.__scheme_resolved = True
+            return (curl_config, ret, output_str, error_str)
+
+        if self.__scheme_resolved or self.__scheme != RedfishClient.SCHEME_HTTP:
+            return (curl_config, ret, output_str, error_str)
+
+        self.__scheme = RedfishClient.SCHEME_HTTPS
+        ret_https, out_https, err_https = self.__exec_curl_cmd_internal(
+            curl_config)
+        if ret_https != RedfishClient.ERR_CODE_CURL_FAILURE:
+            self.__scheme_resolved = True
+            return (self.__apply_scheme_to_curl_config(curl_config),
+                    ret_https, out_https, err_https)
+
+        self.__scheme = RedfishClient.SCHEME_HTTP
+        return (curl_config, ret, output_str, error_str)
 
     def __curl_config_auth_header_line(self):
         return (
@@ -387,6 +417,7 @@ class RedfishClient:
     '''
 
     def __exec_curl_cmd_internal(self, curl_config):
+        curl_config = self.__apply_scheme_to_curl_config(curl_config)
 
         task_mon = RedfishClient.REDFISH_URI_TASKS in curl_config
         if not task_mon:
@@ -465,6 +496,8 @@ class RedfishClient:
             return (RedfishClient.ERR_CODE_NOT_LOGIN, 'Not login', 'Not login')
 
         ret, output_str, error_str = self.__exec_curl_cmd_internal(curl_config)
+        curl_config, ret, output_str, error_str = self.__try_https_fallback(
+            curl_config, ret, output_str, error_str)
 
         is_empty_response = ((ret == 0) and (len(output_str) == 0))
 


### PR DESCRIPTION
Use HTTP (port 80) by default for internal CPU-BMC Redfish. Retry
HTTPS only if HTTP is unreachable, so mixed BMC firmware still works
while HTTPS is being removed. Internal HTTPS did not verify
certificates and would break if mTLS is enabled on external interfaces.

FR: 5064006
