### PR TITLE
hw-mgmt: sensors: ignore PSU hotspot temperatures on SN5640 and SN5610.

### DIFF
--- a/usr/etc/hw-management-sensors/sn5640_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn5640_sensors.conf
@@ -379,6 +379,10 @@ chip "xdpe1a2g7b-i2c-*-6e"
     ignore curr6
 
 # Power supplies
+# PSU FW reports the ambient thresholds (OTW 63C / OTP 68C) on all three temperature
+# sensors, while the hotspot sensors are rated 105C/120C and 120C/125C. The dps460
+# driver has no PMBus page support, so the per-page thresholds cannot be fetched and
+# temp2/temp3 raise false alarms above 68C. Ignore them until page-aware FW+driver.
 chip "dps460-i2c-*-59"
     label in1 "PSU-1(L) 220V Rail (in)"
     ignore in2
@@ -387,8 +391,8 @@ chip "dps460-i2c-*-59"
     ignore fan3
     label fan1 "PSU-1(L) Fan 1"
     label temp1 "PSU-1(L) Temp 1"
-    label temp2 "PSU-1(L) Temp 2"
-    label temp3 "PSU-1(L) Temp 3"
+    ignore temp2
+    ignore temp3
     label power1 "PSU-1(L) 220V Rail Pwr (in)"
     label power2 "PSU-1(L) 12V Rail Pwr (out)"
     label curr1 "PSU-1(L) 220V Rail Curr (in)"
@@ -401,8 +405,8 @@ chip "dps460-i2c-*-58"
     ignore fan3
     label fan1 "PSU-2(L) Fan 1"
     label temp1 "PSU-2(L) Temp 1"
-    label temp2 "PSU-2(L) Temp 2"
-    label temp3 "PSU-2(L) Temp 3"
+    ignore temp2
+    ignore temp3
     label power1 "PSU-2(L) 220V Rail Pwr (in)"
     label power2 "PSU-2(L) 12V Rail Pwr (out)"
     label curr1 "PSU-2(L) 220V Rail Curr (in)"
@@ -415,8 +419,8 @@ chip "dps460-i2c-*-5b"
     ignore fan3
     label fan1 "PSU-3(R) Fan 1"
     label temp1 "PSU-3(R) Temp 1"
-    label temp2 "PSU-3(R) Temp 2"
-    label temp3 "PSU-3(R) Temp 3"
+    ignore temp2
+    ignore temp3
     label power1 "PSU-3(R) 220V Rail Pwr (in)"
     label power2 "PSU-3(R) 12V Rail Pwr (out)"
     label curr1 "PSU-3(R) 220V Rail Curr (in)"
@@ -429,8 +433,8 @@ chip "dps460-i2c-*-5a"
     ignore fan3
     label fan1 "PSU-4(R) Fan 1"
     label temp1 "PSU-4(R) Temp 1"
-    label temp2 "PSU-4(R) Temp 2"
-    label temp3 "PSU-4(R) Temp 3"
+    ignore temp2
+    ignore temp3
     label power1 "PSU-4(R) 220V Rail Pwr (in)"
     label power2 "PSU-4(R) 12V Rail Pwr (out)"
     label curr1 "PSU-4(R) 220V Rail Curr (in)"

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -861,9 +861,16 @@ if [ "$1" == "add" ]; then
 		check_n_link "$5""$3"/temp1_input $thermal_path/"$psu_name"_temp1
 		check_n_link "$5""$3"/temp1_max $thermal_path/"$psu_name"_temp1_max
 		check_n_link "$5""$3"/temp1_max_alarm $alarm_path/"$psu_name"_temp1_max_alarm
-		check_n_link "$5""$3"/temp2_input $thermal_path/"$psu_name"_temp2
-		check_n_link "$5""$3"/temp2_max $thermal_path/"$psu_name"_temp2_max
-		check_n_link "$5""$3"/temp2_max_alarm $alarm_path/"$psu_name"_temp2_max_alarm
+		# SN5640 (HI171) and SN5610 (HI172) PSU FW reports the ambient thresholds
+		# (OTW 63C / OTP 68C) for the hotspot sensors too, while temp2 is rated
+		# 105C/120C. The dps460 driver has no PMBus page support, so the real
+		# per-page limits can't be fetched, and the FW-driven alarm bit asserts
+		# above 68C. Don't expose the sensor until page-aware FW and driver.
+		if [[ $dmi_sku != "HI171" && $dmi_sku != "HI172" ]]; then
+			check_n_link "$5""$3"/temp2_input $thermal_path/"$psu_name"_temp2
+			check_n_link "$5""$3"/temp2_max $thermal_path/"$psu_name"_temp2_max
+			check_n_link "$5""$3"/temp2_max_alarm $alarm_path/"$psu_name"_temp2_max_alarm
+		fi
 		check_n_link "$5""$3"/fan1_alarm $alarm_path/"$psu_name"_fan1_alarm
 		check_n_link "$5""$3"/power1_alarm $alarm_path/"$psu_name"_power1_alarm
 		check_n_link "$5""$3"/fan1_input $thermal_path/"$psu_name"_fan1_speed_get


### PR DESCRIPTION
PSU FW on SN5640 (HI171) and SN5610 (HI172) reports the ambient thresholds (OTW 63C / OTP 68C) for all three PSU temperature sensors, while the primary and secondary hotspot sensors are rated 105C/120C and 120C/125C respectively. The dps460 driver has no PMBus page support, so even FW that exposes per-page thresholds cannot be read correctly, and the hotspot sensors raise false alarms once they pass 68C.

Ignore temp2/temp3 for the PSU chips in sn5640_sensors.conf, shared by both SKUs, and skip the psu*_temp2 attribute group in the hw-management sysfs tree, where the same wrong threshold shows up as psu*_temp2_max and as an asserted psu*_temp2_max_alarm. The alarm bit is computed by the PSU itself, so it cannot be corrected on the host side. The teardown path needs no change, as check_n_unlink tolerates absent links.

Bug: 5125814