### PR TITLE
hw-mgmt: scripts: Prefer HTTP for NOS-BMC Redfish communication

### DIFF
--- a/tests/offline/test_hw_management_redfish_client.py
+++ b/tests/offline/test_hw_management_redfish_client.py
@@ -143,7 +143,7 @@ class TestRedfishClientCommandBuilders:
         cmd = basic_redfish_client._RedfishClient__build_login_cmd('********')
         assert cmd.startswith(RedfishClient._CFG_LOGIN_PREFIX)
         assert 'request = POST' in cmd
-        assert 'https://10.0.1.1/login' in cmd
+        assert 'http://10.0.1.1/login' in cmd
         assert 'username' in cmd and 'admin' in cmd
         assert 'password' in cmd and '********' in cmd
 
@@ -153,7 +153,7 @@ class TestRedfishClientCommandBuilders:
         cmd = basic_redfish_client._RedfishClient__build_get_cmd('/redfish/v1/test')
         assert 'request = GET' in cmd
         assert 'header = "X-Auth-Token: test_token_123"' in cmd
-        assert 'https://10.0.1.1/redfish/v1/test' in cmd
+        assert 'http://10.0.1.1/redfish/v1/test' in cmd
 
     def test_medium_build_fw_update_cmd(self, basic_redfish_client):
         """Medium: Build firmware update command"""
@@ -179,7 +179,7 @@ class TestRedfishClientCommandBuilders:
         data = {'key1': 'value1', 'key2': 123}
         cmd = basic_redfish_client._RedfishClient__build_post_cmd('/test/uri', data)
         assert 'request = POST' in cmd
-        assert 'https://10.0.1.1/test/uri' in cmd
+        assert 'http://10.0.1.1/test/uri' in cmd
         assert 'key1' in cmd and 'value1' in cmd
 
     def test_complex_build_set_force_update_true(self, basic_redfish_client):
@@ -506,6 +506,148 @@ class TestRedfishClientExecCurl:
         captured = capsys.readouterr()
         assert 'Execute cURL command:' in captured.err
         assert 'test_token' not in captured.err
+
+
+class TestRedfishClientHttpScheme:
+    """HTTP is default; HTTPS is used only when HTTP is unreachable."""
+
+    def test_default_scheme_is_http(self, basic_redfish_client):
+        assert basic_redfish_client._RedfishClient__scheme == RedfishClient.SCHEME_HTTP
+
+    def test_http_success_does_not_fallback(
+            self, basic_redfish_client, mock_subprocess):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            mock_curl_stdout('{"token": "tok"}'), b'')
+        mock_process.returncode = 0
+        mock_subprocess.Popen.return_value = mock_process
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+        stdin = mock_process.communicate.call_args.kwargs['input']
+        assert b'url = "http://' in stdin
+        assert b'https://' not in stdin
+        assert mock_subprocess.Popen.call_count == 1
+
+    def test_https_fallback_when_http_unreachable(
+            self, basic_redfish_client, mock_subprocess):
+        http_fail = MagicMock()
+        http_fail.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        http_fail.returncode = 7
+        https_ok = MagicMock()
+        https_ok.communicate.return_value = (
+            mock_curl_stdout('{"token": "tok"}'), b'')
+        https_ok.returncode = 0
+        mock_subprocess.Popen.side_effect = [http_fail, https_ok]
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_OK
+        assert basic_redfish_client.get_token() == 'tok'
+        assert basic_redfish_client._RedfishClient__scheme == 'https'
+        assert b'url = "http://' in http_fail.communicate.call_args.kwargs['input']
+        assert b'url = "https://' in https_ok.communicate.call_args.kwargs['input']
+
+    def test_https_fallback_both_fail_keeps_http_default(
+            self, basic_redfish_client, mock_subprocess):
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        mock_process.returncode = 7
+        mock_subprocess.Popen.return_value = mock_process
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_CURL_FAILURE
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+        assert mock_subprocess.Popen.call_count == 2
+
+    def test_fallback_stays_armed_after_http_worked(
+            self, basic_redfish_client, mock_subprocess):
+        """BMC firmware may go HTTPS-only mid-life; fallback must still fire."""
+        http_ok = MagicMock()
+        http_ok.communicate.return_value = (
+            mock_curl_stdout('{"token": "tok"}'), b'')
+        http_ok.returncode = 0
+        http_dead = MagicMock()
+        http_dead.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        http_dead.returncode = 7
+        https_ok = MagicMock()
+        https_ok.communicate.return_value = (mock_curl_stdout('{}'), b'')
+        https_ok.returncode = 0
+        mock_subprocess.Popen.side_effect = [http_ok, http_dead, https_ok]
+
+        assert basic_redfish_client.login() == RedfishClient.ERR_CODE_OK
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+
+        cfg = basic_redfish_client._RedfishClient__build_get_cmd('/redfish/v1/x')
+        ret, output, _error = basic_redfish_client.exec_curl_cmd(cfg)
+        assert ret == 0
+        assert output == '{}'
+        assert basic_redfish_client._RedfishClient__scheme == 'https'
+        assert b'url = "https://' in https_ok.communicate.call_args.kwargs['input']
+
+    @pytest.mark.parametrize('curl_rc, err', [
+        (28, b'curl: (28) Operation timed out'),
+        (52, b'curl: (52) Empty reply from server'),
+        (55, b'curl: (55) Failed sending data to the peer'),
+        (56, b'curl: (56) Recv failure: Connection reset by peer'),
+    ])
+    def test_no_resend_when_request_may_have_been_delivered(
+            self, basic_redfish_client, mock_subprocess, curl_rc, err):
+        """A lost reply must not replay a mutation on the other scheme."""
+        basic_redfish_client._RedfishClient__token = 'tok'
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (b'', err)
+        mock_process.returncode = curl_rc
+        mock_subprocess.Popen.return_value = mock_process
+
+        cfg = basic_redfish_client._build_change_user_password_cmd(
+            'admin', 'new-pass')
+        ret, _out, _err = basic_redfish_client.exec_curl_cmd(cfg)
+
+        assert ret == RedfishClient.ERR_CODE_CURL_FAILURE
+        assert mock_subprocess.Popen.call_count == 1
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+
+    def test_alt_scheme_kept_when_it_answers_with_error(
+            self, basic_redfish_client, mock_subprocess):
+        """A reply over the alternate scheme marks it as the live endpoint."""
+        http_dead = MagicMock()
+        http_dead.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        http_dead.returncode = 7
+        https_timeout = MagicMock()
+        https_timeout.communicate.return_value = (
+            b'', b'curl: (28) Operation timed out')
+        https_timeout.returncode = 28
+        mock_subprocess.Popen.side_effect = [http_dead, https_timeout]
+
+        ret = basic_redfish_client.login()
+        assert ret == RedfishClient.ERR_CODE_CURL_FAILURE
+        assert basic_redfish_client._RedfishClient__scheme == 'https'
+
+    def test_https_client_returns_to_http_when_https_dies(
+            self, basic_redfish_client, mock_subprocess):
+        """Fallback works in both directions, not only http -> https."""
+        basic_redfish_client._RedfishClient__scheme = 'https'
+        basic_redfish_client._RedfishClient__token = 'tok'
+        https_dead = MagicMock()
+        https_dead.communicate.return_value = (
+            b'', b'curl: (7) Failed to connect')
+        https_dead.returncode = 7
+        http_ok = MagicMock()
+        http_ok.communicate.return_value = (mock_curl_stdout('{}'), b'')
+        http_ok.returncode = 0
+        mock_subprocess.Popen.side_effect = [https_dead, http_ok]
+
+        cfg = basic_redfish_client._RedfishClient__build_get_cmd('/redfish/v1/x')
+        ret, output, _error = basic_redfish_client.exec_curl_cmd(cfg)
+        assert ret == 0
+        assert output == '{}'
+        assert basic_redfish_client._RedfishClient__scheme == 'http'
+        assert b'url = "http://' in http_ok.communicate.call_args.kwargs['input']
 
 
 # =============================================================================

--- a/usr/usr/bin/hw_management_redfish_client.py
+++ b/usr/usr/bin/hw_management_redfish_client.py
@@ -62,6 +62,25 @@ class RedfishClient:
     DEFAULT_GET_TIMEOUT = 3
     _CFG_LOGIN_PREFIX = '# hw-mgmt-redfish: login\n'
     _CURL_HTTP_TRAILER_RE = re.compile(r'\nHTTP Status Code: (\d+)\Z')
+    # BMC is moving to HTTP-only. Start with HTTP; switch to the other scheme
+    # whenever the BMC refuses connections on the one in use.
+    SCHEME_HTTP = 'http'
+    SCHEME_HTTPS = 'https'
+    _ALT_SCHEME = {SCHEME_HTTP: SCHEME_HTTPS, SCHEME_HTTPS: SCHEME_HTTP}
+    _URL_SCHEME_RE = re.compile(r'(url = ")https?://')
+    # cURL exit codes that prove the request never reached the BMC application:
+    # proxy/host resolution, TCP connect and TLS handshake failures. Only these
+    # allow a resend on the other scheme. Codes like 28 (timeout), 52 (empty
+    # reply), 55/56 (send/recv error) can happen after the BMC already applied
+    # a POST or PATCH, so resending them could duplicate the mutation.
+    _CURL_RC_NO_CONNECTION = frozenset((
+        5,   # CURLE_COULDNT_RESOLVE_PROXY
+        6,   # CURLE_COULDNT_RESOLVE_HOST
+        7,   # CURLE_COULDNT_CONNECT
+        35,  # CURLE_SSL_CONNECT_ERROR
+        51,  # CURLE_PEER_FAILED_VERIFICATION
+        60,  # CURLE_SSL_CACERT
+    ))
 
     # Redfish URIs
     REDFISH_URI_FW_INVENTORY = '/redfish/v1/UpdateService/FirmwareInventory'
@@ -90,6 +109,7 @@ class RedfishClient:
         self.__user = user
         self.__password = password
         self.__token = None
+        self.__scheme = RedfishClient.SCHEME_HTTP
 
     def get_token(self):
         return self.__token
@@ -109,7 +129,45 @@ class RedfishClient:
         return val.replace('\\', '\\\\').replace('"', '\\"')
 
     def __curl_redfish_url(self, path_without_scheme):
-        return f'https://{self.__svr_ip}{path_without_scheme}'
+        return f'{self.__scheme}://{self.__svr_ip}{path_without_scheme}'
+
+    def __apply_scheme_to_curl_config(self, curl_config):
+        return RedfishClient._URL_SCHEME_RE.sub(
+            r'\1' + self.__scheme + '://', curl_config, count=1)
+
+    @staticmethod
+    def __curl_rc_proves_no_connection(curl_rc):
+        return curl_rc in RedfishClient._CURL_RC_NO_CONNECTION
+
+    def __try_alt_scheme_fallback(self, curl_config, ret, output_str,
+                                  error_str, curl_rc):
+        '''Retry once on the other scheme when curl never reached the BMC.
+
+        BMC firmware may move between HTTP-only and HTTPS-only at any time,
+        so this stays armed for the whole client lifetime instead of latching
+        on the first scheme that worked. The scheme in use is kept sticky, so
+        a reachable BMC costs no extra curl invocation.
+
+        Resending is only safe when curl failed before delivering the request
+        (see _CURL_RC_NO_CONNECTION), otherwise a POST or PATCH the BMC has
+        already applied would be replayed on the other scheme.
+        '''
+        if not self.__curl_rc_proves_no_connection(curl_rc):
+            return (ret, output_str, error_str)
+
+        prev_scheme = self.__scheme
+        self.__scheme = RedfishClient._ALT_SCHEME[prev_scheme]
+        ret_alt, out_alt, err_alt, rc_alt = self.__exec_curl_cmd_internal(
+            curl_config)
+        # Any reply, including an error one, means this scheme is the live
+        # endpoint, so keep it and report its result.
+        if not self.__curl_rc_proves_no_connection(rc_alt):
+            return (ret_alt, out_alt, err_alt)
+
+        # BMC unreachable on both schemes: keep the previous one so a
+        # transient outage does not flip the client onto a dead scheme.
+        self.__scheme = prev_scheme
+        return (ret, output_str, error_str)
 
     def __curl_config_auth_header_line(self):
         return (
@@ -383,10 +441,12 @@ class RedfishClient:
         return (curl_output, None)
 
     '''
-    Execute cURL command and return the output and error messages
+    Execute cURL command and return the output, error messages and the raw
+    cURL exit code (needed to tell a failed connect from a lost reply).
     '''
 
     def __exec_curl_cmd_internal(self, curl_config):
+        curl_config = self.__apply_scheme_to_curl_config(curl_config)
 
         task_mon = RedfishClient.REDFISH_URI_TASKS in curl_config
         if not task_mon:
@@ -408,7 +468,8 @@ class RedfishClient:
         output, error = process.communicate(input=stdin_bytes)
         output_decoded = output.decode('utf-8')
         error_str = error.decode('utf-8')
-        ret = process.returncode
+        curl_rc = process.returncode
+        ret = curl_rc
 
         if ret > 0:
             ret = RedfishClient.ERR_CODE_CURL_FAILURE
@@ -421,7 +482,7 @@ class RedfishClient:
             if match:
                 error_str = match.group(1)
 
-        return (ret, output_str, error_str)
+        return (ret, output_str, error_str, curl_rc)
 
     def __update_token_in_curl_config(self, curl_config):
         if self.__token is None:
@@ -464,7 +525,10 @@ class RedfishClient:
         if (not self.has_login()) and (not is_login_cmd):
             return (RedfishClient.ERR_CODE_NOT_LOGIN, 'Not login', 'Not login')
 
-        ret, output_str, error_str = self.__exec_curl_cmd_internal(curl_config)
+        ret, output_str, error_str, curl_rc = self.__exec_curl_cmd_internal(
+            curl_config)
+        ret, output_str, error_str = self.__try_alt_scheme_fallback(
+            curl_config, ret, output_str, error_str, curl_rc)
 
         is_empty_response = ((ret == 0) and (len(output_str) == 0))
 
@@ -476,8 +540,8 @@ class RedfishClient:
             ret = self.login()
             if ret == RedfishClient.ERR_CODE_OK:
                 curl_retry = self.__update_token_in_curl_config(curl_config)
-                ret, output_str, error_str = self.__exec_curl_cmd_internal(
-                    curl_retry)
+                ret, output_str, error_str, _rc = \
+                    self.__exec_curl_cmd_internal(curl_retry)
             elif ret == RedfishClient.ERR_CODE_BAD_CREDENTIAL:
                 self.__token = None
                 return (ret, 'Bad credential', 'Bad credential')


### PR DESCRIPTION
Use HTTP (port 80) by default for internal CPU-BMC Redfish. Retry
HTTPS only if HTTP is unreachable, so mixed BMC firmware still works
while HTTPS is being removed. Internal HTTPS did not verify
certificates and would break if mTLS is enabled on external interfaces.

FR: 5064006
