### PR TITLE
hw-mgmt: thermal: SPC1: Add fallback in case if I2C ASIC driver failure

### DIFF
--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -1776,36 +1776,101 @@ get_asic_mlxreg_dev()
 	return 1
 }
 
+# True for Spectrum-1 chassis (mlxsw_minimal I2C ASIC). Matches check_system().
+is_spc1_system()
+{
+	local bt product cpu
+
+	[ -f "$board_type_file" ] && bt=$(< "$board_type_file") || bt="Unknown"
+	case $bt in
+	VMOD0001|VMOD0002|VMOD0003|VMOD0004|VMOD0009|VMOD0014)
+		return 0
+		;;
+	esac
+
+	[ -f "$pn_file" ] && product=$(< "$pn_file") || product=""
+	case $product in
+	MSN27002|MSB78002|MSN24102|MSN274*|MSN21*|MSN24*|MSN27*|MSB*|MSX*|MSN201*|SN2201*)
+		return 0
+		;;
+	esac
+
+	if [ -f "$config_path/cpu_type" ] && \
+	   grep -q "Mellanox Technologies" /sys/devices/virtual/dmi/id/chassis_vendor 2>/dev/null; then
+		cpu=$(< "$config_path/cpu_type")
+		case $cpu in
+		"$IVB_CPU"|"$RNG_CPU")
+			return 0
+			;;
+		esac
+	fi
+	return 1
+}
+
+# Read a mlxreg-io reset_* attribute from $system_path or the hwmon source.
+# Chipup can race regio udev linking into $system_path.
+_hw_mgmt_reset_attr_is_set()
+{
+	local name="$1"
+	local f
+
+	if [ -e "$system_path/$name" ] && \
+	   [ "$(cat "$system_path/$name" 2>/dev/null)" = "1" ]; then
+		return 0
+	fi
+
+	for f in /sys/devices/platform/mlxplat/mlxreg-io/hwmon/hwmon*/"$name"; do
+		[ -e "$f" ] || continue
+		if [ "$(cat "$f" 2>/dev/null)" = "1" ]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Cold power-cycle: recovery is another reboot, not MFSC PWM.
+# Warm reboot: COMEX/CPU reset (Linux reboot) or reset_platform.
+is_spc1_warm_reboot()
+{
+	local cold
+
+	is_spc1_system || return 1
+
+	for cold in reset_aux_pwr_or_ref reset_aux_pwr_or_fu \
+		    reset_aux_pwr_or_reload reset_long_pb reset_long_pwr_pb \
+		    reset_ac_pwr_fail; do
+		if _hw_mgmt_reset_attr_is_set "$cold"; then
+			return 1
+		fi
+	done
+
+	_hw_mgmt_reset_attr_is_set reset_from_comex && return 0
+	_hw_mgmt_reset_attr_is_set reset_platform && return 0
+	return 1
+}
+
 # After mlxsw_minimal chipup has failed, thermal/asic and thermal/pwm1 are
-# typically missing, so thermal control never latches emergency and never
-# calls write_pwm_mlxreg(). Force PWM 100% here:
-# - thermal/pwm1 if it still exists (CPLD or leftover ASIC hwmon)
-# - otherwise MFSC via mlxreg for the failed ASIC when tc_config enables
-#   ASIC PWM control
+# not created (SPC1 PWM comes from ASIC hwmon). Thermal control never
+# latches emergency and never calls write_pwm_mlxreg(), so ASIC PWM stays
+# at the HW default (~60%). Program MFSC via mlxreg for the failed ASIC.
+# Scope: SPC1 after a warm (COMEX/CPU) reboot only. Cold reboot recovery
+# is another reboot; other platforms must not get these register writes.
 # $1: ASIC index from chipup (0- or 1-based; 0 means first ASIC)
 # $2: optional mlxreg device, PCI BDF, or sxcore PCI sysfs path
 set_asic_pwm_full_speed_on_chipup_fail()
 {
 	local asic_index
 	local explicit_dev="$2"
-	local pwm_link="$thermal_path/pwm1"
-	local tc_cfg="$config_path/tc_config.json"
 	local mt_dev=""
 	local mlxreg_rc=0
 	local mst_devdir="${HW_MGMT_MST_DEVDIR:-/dev/mst}"
 
-	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
-
-	if [ -e "$pwm_link" ]; then
-		echo 255 > "$pwm_link"
-		log_info "Set PWM to maximum speed via sysfs after chipup failure."
-		return 0
-	fi
-
-	if [ ! -f "$tc_cfg" ] || ! grep -q '"pwm_control"[[:space:]]*:[[:space:]]*true' "$tc_cfg"; then
-		log_info "Chipup failed and PWM sysfs is missing; ASIC PWM control is not configured."
+	if ! is_spc1_warm_reboot; then
+		log_info "Skip PWM fallback after chipup failure: not SPC1 warm reboot."
 		return 1
 	fi
+
+	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
 
 	if ! command -v mlxreg >/dev/null 2>&1; then
 		log_err "mlxreg is not available; cannot set PWM after chipup failure."

--- a/usr/usr/bin/hw-management-helpers.sh
+++ b/usr/usr/bin/hw-management-helpers.sh
@@ -1662,3 +1662,184 @@ function set_fan_direction_for_all_fans()
 	done
 	print_function_call "$0" "${FUNCNAME[0]}" "Finished"
 }
+
+# Normalize PCI BDF to bus:dev.func without domain (03:00.0).
+_hw_mgmt_pci_bdf_short()
+{
+	local pci_id="$1"
+
+	pci_id=$(echo "$pci_id" | tr -d '[:space:]')
+	pci_id="${pci_id#0000:}"
+	echo "$pci_id"
+}
+
+# Chipup callers mix 0-based and 1-based indexes. sxcore uses
+# "chipup 0 <pci_path>"; autochipup/hotplug use 1..N. Config files are
+# 1-based (asic1_pci_bus_id). Map 0/empty to 1.
+_hw_mgmt_normalize_asic_index()
+{
+	local idx="${1:-1}"
+
+	if [ -z "$idx" ] || [ "$idx" -eq 0 ] 2>/dev/null; then
+		echo 1
+		return
+	fi
+	echo "$idx"
+}
+
+# Extract a PCI BDF from a chipup argument: BDF, pci-BDF, or sysfs path
+# ending in 0000:bb:dd.f (sxcore passes %S/%p).
+_hw_mgmt_extract_pci_bdf()
+{
+	local arg="$1"
+	local base
+
+	[ -n "$arg" ] || return 1
+	base=$(basename "$arg")
+	base="${base#pci-}"
+	echo "$base" | grep -E -q '^([0-9A-Fa-f]{4}:)?[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f]$' || return 1
+	_hw_mgmt_pci_bdf_short "$base"
+}
+
+# Resolve mlxreg -d target for ASIC index $1 (0- or 1-based).
+# Optional $2: explicit /dev/mst path (tests) or PCI BDF/sysfs path from
+# chipup $3. Match /sys/class/mst to config/asicN_pci_bus_id (1-based) so a
+# multi-ASIC chipup failure programs the ASIC that failed, not the first
+# pciconf0. If no mst node matches, pass the PCI BDF to mlxreg.
+get_asic_mlxreg_dev()
+{
+	local asic_index
+	local arg2="$2"
+	local pci_id pci_short mst_sysfs mst_devdir mst_name pci_link pci_tail extracted
+	local asic_num=1
+	local match=""
+
+	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
+
+	if [ -n "$arg2" ]; then
+		if extracted=$(_hw_mgmt_extract_pci_bdf "$arg2"); then
+			pci_id=$extracted
+			pci_short=$extracted
+		else
+			echo "$arg2"
+			return 0
+		fi
+	fi
+
+	[ -f "$config_path/asic_num" ] && asic_num=$(< "$config_path/asic_num")
+
+	if [ -z "$pci_short" ] && [ -f "$config_path/asic${asic_index}_pci_bus_id" ]; then
+		pci_id=$(_hw_mgmt_pci_bdf_short "$(< "$config_path/asic${asic_index}_pci_bus_id")")
+		pci_short=$pci_id
+	fi
+
+	mst_sysfs="${HW_MGMT_MST_SYSFS:-/sys/class/mst}"
+	mst_devdir="${HW_MGMT_MST_DEVDIR:-/dev/mst}"
+
+	if [ -n "$pci_short" ] && [ -d "$mst_sysfs" ]; then
+		for mst_name in "$mst_sysfs"/*; do
+			[ -e "$mst_name" ] || continue
+			pci_link=$(readlink -f "$mst_name/device" 2>/dev/null)
+			if [ -z "$pci_link" ] && [ -f "$mst_name/uevent" ]; then
+				pci_link=$(sed -n 's/^PCI_SLOT_NAME=//p' "$mst_name/uevent")
+			fi
+			[ -n "$pci_link" ] || continue
+			pci_tail=$(_hw_mgmt_pci_bdf_short "$(basename "$pci_link")")
+			if [ "$pci_tail" = "$pci_short" ]; then
+				match="$mst_devdir/$(basename "$mst_name")"
+				break
+			fi
+		done
+	fi
+
+	if [ -n "$match" ]; then
+		echo "$match"
+		return 0
+	fi
+
+	# mlxreg accepts a PCI BDF when the mst char device is missing.
+	if [ -n "$pci_short" ]; then
+		echo "$pci_id"
+		return 0
+	fi
+
+	# Last resort for a single-ASIC system only. Never pick the first
+	# pciconf0 when more than one ASIC is present.
+	if [ "$asic_num" -eq 1 ]; then
+		match=$(find "$mst_devdir" -maxdepth 1 -name '*_pciconf0' 2>/dev/null | head -n 1)
+		if [ -n "$match" ]; then
+			echo "$match"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+# After mlxsw_minimal chipup has failed, thermal/asic and thermal/pwm1 are
+# typically missing, so thermal control never latches emergency and never
+# calls write_pwm_mlxreg(). Force PWM 100% here:
+# - thermal/pwm1 if it still exists (CPLD or leftover ASIC hwmon)
+# - otherwise MFSC via mlxreg for the failed ASIC when tc_config enables
+#   ASIC PWM control
+# $1: ASIC index from chipup (0- or 1-based; 0 means first ASIC)
+# $2: optional mlxreg device, PCI BDF, or sxcore PCI sysfs path
+set_asic_pwm_full_speed_on_chipup_fail()
+{
+	local asic_index
+	local explicit_dev="$2"
+	local pwm_link="$thermal_path/pwm1"
+	local tc_cfg="$config_path/tc_config.json"
+	local mt_dev=""
+	local mlxreg_rc=0
+	local mst_devdir="${HW_MGMT_MST_DEVDIR:-/dev/mst}"
+
+	asic_index=$(_hw_mgmt_normalize_asic_index "$1")
+
+	if [ -e "$pwm_link" ]; then
+		echo 255 > "$pwm_link"
+		log_info "Set PWM to maximum speed via sysfs after chipup failure."
+		return 0
+	fi
+
+	if [ ! -f "$tc_cfg" ] || ! grep -q '"pwm_control"[[:space:]]*:[[:space:]]*true' "$tc_cfg"; then
+		log_info "Chipup failed and PWM sysfs is missing; ASIC PWM control is not configured."
+		return 1
+	fi
+
+	if ! command -v mlxreg >/dev/null 2>&1; then
+		log_err "mlxreg is not available; cannot set PWM after chipup failure."
+		return 1
+	fi
+
+	if [ -z "$explicit_dev" ] && [ ! -d "$mst_devdir" ] && \
+	   [ -z "${HW_MGMT_MST_DEVDIR:-}" ] && command -v mst >/dev/null 2>&1; then
+		mst start >/dev/null 2>&1
+		sleep 2
+	fi
+
+	mt_dev=$(get_asic_mlxreg_dev "$1" "$explicit_dev")
+	if [ -z "$mt_dev" ]; then
+		log_err "ASIC $asic_index mst/PCI device is not available; cannot set PWM after chipup failure."
+		return 1
+	fi
+
+	# mlxreg prompts for confirmation; same pattern as thermal write_pwm_mlxreg().
+	if command -v timeout >/dev/null 2>&1; then
+		yes | timeout 3 mlxreg -d "$mt_dev" --reg_name MFSC \
+			--indexes pwm=0x0 --set pwm_duty_cycle=0xff >/dev/null 2>&1
+		mlxreg_rc=$?
+	else
+		yes | mlxreg -d "$mt_dev" --reg_name MFSC \
+			--indexes pwm=0x0 --set pwm_duty_cycle=0xff >/dev/null 2>&1
+		mlxreg_rc=$?
+	fi
+
+	if [ "$mlxreg_rc" -ne 0 ]; then
+		log_err "Failed to set PWM to maximum speed via mlxreg after chipup failure (asic=$asic_index dev=$mt_dev rc=$mlxreg_rc)."
+		return 1
+	fi
+
+	log_info "Set PWM to maximum speed via mlxreg after chipup failure (asic=$asic_index dev=$mt_dev)."
+	return 0
+}

--- a/usr/usr/bin/hw-management-thermal-events.sh
+++ b/usr/usr/bin/hw-management-thermal-events.sh
@@ -1090,6 +1090,8 @@ if [ "$1" == "add" ]; then
 		if [ ${minimal_unsupported} -eq 0 ] && [ ! -d /sys/module/mlxsw_minimal ]; then
 			modprobe mlxsw_minimal
 		fi
+		# sxcore uses 0-based ASIC index; chipup maps 0 to asic1_* and
+		# uses $3 (%S/%p PCI path) to identify the failed ASIC.
 		/usr/bin/hw-management.sh chipup 0 "$4/$5"
 		set_asic_ready "$4/$5" 1
 	fi

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -4324,12 +4324,14 @@ case $ACTION in
 			done
 			stop_chipup_i2c_trace
 			log_info "chipup failed for ASIC $asic_index"
-			# thermal/pwm1 and thermal/asic are not created when
-			# mlxsw_minimal probe fails, so TC will not enforce
-			# full speed. Set PWM 100% on the ASIC that failed
-			# chipup via sysfs or mlxreg MFSC. Pass $3 (PCI path
-			# from sxcore) so index 0 still resolves a target.
-			set_asic_pwm_full_speed_on_chipup_fail "$asic_index" "$3"
+			# PWM 100% fallback is only for SPC1 after a warm
+			# (COMEX/CPU) reboot. Cold reboot recovery is another
+			# reboot; other chipup paths must not write MFSC.
+			# Pass $3 (PCI path from sxcore) so index 0 still
+			# resolves a target.
+			if is_spc1_warm_reboot; then
+				set_asic_pwm_full_speed_on_chipup_fail "$asic_index" "$3"
+			fi
 		fi
 	;;
 	chipdown)

--- a/usr/usr/bin/hw-management.sh
+++ b/usr/usr/bin/hw-management.sh
@@ -4324,6 +4324,12 @@ case $ACTION in
 			done
 			stop_chipup_i2c_trace
 			log_info "chipup failed for ASIC $asic_index"
+			# thermal/pwm1 and thermal/asic are not created when
+			# mlxsw_minimal probe fails, so TC will not enforce
+			# full speed. Set PWM 100% on the ASIC that failed
+			# chipup via sysfs or mlxreg MFSC. Pass $3 (PCI path
+			# from sxcore) so index 0 still resolves a target.
+			set_asic_pwm_full_speed_on_chipup_fail "$asic_index" "$3"
 		fi
 	;;
 	chipdown)


### PR DESCRIPTION
  Cherry-pick of #2890 onto V.7.0070.1000_BR.
  
  This change is only for SPC1 based systems. After mlxsw_minimal chipup fails, thermal sysfs PWM is missing and TC cannot force full speed. Set PWM to 100% via mlxreg MFSC.
  
  The reason of these failures might be HW issue: system before re-spin, bad serial cable. Or in some rare case problem with I2C communication from CPU to SPC1.
  In case the problem with the serial cable - the suggestion to replace the cable by cables recommended by Nvidia.
  
  It was agreed on the following SW approach:
  In case issue happened after cold reboot - just reboot system again.
  In case issue happened after warm reboot - need to change code and set PWM to 100%, so it will stay at full speed with no changes.
  
  Bug #4966961
  
  Cherry-picked commits:
  - 4f45eb61 hw-mgmt: thermal: SPC1: Add fallback in case if I2C ASIC driver failure
  - 82cbe829 hw-mgmt: thermal: Limit chipup PWM fallback to SPC1 warm reboot 

