### PR TITLE
hw-mgmt: thermal: Make FAN relax time configurable per platform

### DIFF
--- a/usr/etc/hw-management-thermal/tc_config_msn2201.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201.json
@@ -36,7 +36,8 @@
 			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}},
 		"P2C": {
 			"0" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10},
-			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}}
+			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}},
+		"relax_time": 20
 	},
 	"dev_parameters" : {
 		"asic\\d*":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":70},

--- a/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
+++ b/usr/etc/hw-management-thermal/tc_config_msn2201_busbar.json
@@ -27,7 +27,8 @@
 			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}},
 		"P2C": {
 			"0" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10},
-			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}}
+			"1" : {"rpm_min":1983, "rpm_max":22000, "slope": 227, "pwm_min" : 10, "pwm_max_reduction" : 10}},
+		"relax_time": 20
 	},
 	"dev_parameters" : {
 		"asic\\d*":           {"pwm_min": 20, "pwm_max" : 100, "val_min":"!70000", "val_max":"!105000", "poll_time": 3, "sensor_read_error":70},

--- a/usr/usr/bin/hw_management_thermal_control.py
+++ b/usr/usr/bin/hw_management_thermal_control.py
@@ -167,6 +167,7 @@ class CONST:
     # FAN calibration
     # Time for FAN rotation stabilize after change
     FAN_RELAX_TIME = 10
+    # Minimum PWM change required to activate FAN relaxation after a PWM update
     FAN_RELAX_PWM_JUMP_MIN = 4
 
     FAN_SHUTDOWN_ENA = "1"
@@ -2224,7 +2225,7 @@ class psu_fan_sensor(system_device):
         #  UNKNOWN P2C        False
         #  UNKNOWN UNKNOWN    False
         if (self.system_flow_dir == CONST.C2P and self.fan_dir == CONST.P2C) or \
-            (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
+                (self.system_flow_dir == CONST.P2C and self.fan_dir == CONST.C2P):
             self.append_fault(CONST.DIRECTION)
 
         if self.fread_err.check_err():
@@ -2332,7 +2333,7 @@ class fan_sensor(system_device):
         self.val_max_def = self.get_file_val("thermal/fan{}_max".format(self.tacho_idx), CONST.RPM_MIN_MAX["val_max"])
         self.is_calibrated = False
 
-        self.rpm_relax_timeout = CONST.FAN_RELAX_TIME * 1000
+        self.rpm_relax_timeout = self.fan_param.get("relax_time", CONST.FAN_RELAX_TIME) * 1000
         self.rpm_relax_timestamp = current_milli_time() + self.rpm_relax_timeout
         self.name = "{}:{}".format(self.name, list(range(self.tacho_idx, self.tacho_idx + self.tacho_cnt)))
         self.pwm_set = self.read_pwm(CONST.PWM_MIN)

--- a/usr/usr/bin/hw_management_thermal_control_2_5.py
+++ b/usr/usr/bin/hw_management_thermal_control_2_5.py
@@ -173,6 +173,7 @@ class CONST:
     # FAN calibration
     # Time for FAN rotation stabilize after change
     FAN_RELAX_TIME = 10
+    # Minimum PWM change required to activate FAN relaxation after a PWM update
     FAN_RELAX_PWM_JUMP_MIN = 4
 
     FAN_SHUTDOWN_ENA = "1"
@@ -2703,7 +2704,7 @@ class fan_sensor(system_device):
         self.val_max_def = self.get_file_val("thermal/fan{}_max".format(self.tacho_idx), CONST.RPM_MIN_MAX["val_max"])
         self.is_calibrated = False
 
-        self.rpm_relax_timeout = CONST.FAN_RELAX_TIME * 1000
+        self.rpm_relax_timeout = self.fan_param.get("relax_time", CONST.FAN_RELAX_TIME) * 1000
         self.rpm_relax_timestamp = current_milli_time() + self.rpm_relax_timeout
         self.name = "{}:{}".format(self.name, list(range(self.tacho_idx, self.tacho_idx + self.tacho_cnt)))
         self.pwm_set = self.read_pwm(CONST.PWM_MIN)


### PR DESCRIPTION
TC compare  expected and current FAN speed, but fans cannot stabilize
immediately (HW specific). Dut to this HW specific, TC waits for
the FAN speed to stabilize. The default stabilization time is 10s, but
for some FAN types it is not enough. If the FAN speed is not stabilized
at timeout, TC can raise an error condition.

On SN2201(M) FANsi stabilisation is slower than usual, so the default
timeout (10sec) is not enough.

This commit adds a configurable "relax_time" parameter and sets it to
20s for msn2201 / msn2201m.

Bug SW: 5245926
Signed-off-by: Oleksandr Shamray <oleksandrs@nvidia.com>
