### PR TITLE
hw-mgmt: sensors: Fix MP2975 DDR voltage regulator current labels

### DIFF
--- a/usr/etc/hw-management-sensors/sn66xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn66xxld_sensors.conf
@@ -448,10 +448,10 @@ chip "mp2975-i2c-*-6a"
     label power2 "DDR PMIC VDD_MEMIO Pwr (out1)"
     label power3 "DDR PMIC VDD_MEM Pwr (out2)"
     label curr1 "DDR PMIC VDD_MEM Curr (in)"
-    label curr2 "DDR PMIC VDD_MEM Curr (out)"
+    label curr2 "DDR PMIC VDD_MEMIO Curr (out1)"
     ignore curr3
     ignore curr4
-    ignore curr5
+    label curr5 "DDR PMIC VDD_MEM Curr (out2)"
     ignore curr6
 
 # Management board DDR temperature sensors

--- a/usr/etc/hw-management-sensors/sn68xxld_sensors.conf
+++ b/usr/etc/hw-management-sensors/sn68xxld_sensors.conf
@@ -382,10 +382,10 @@ chip "mp2975-i2c-*-6a"
     label power2 "DDR PMIC VDD_MEMIO Pwr (out1)"
     label power3 "DDR PMIC VDD_MEM Pwr (out2)"
     label curr1 "DDR PMIC VDD_MEM Curr (in)"
-    label curr2 "DDR PMIC VDD_MEM Curr (out)"
+    label curr2 "DDR PMIC VDD_MEMIO Curr (out1)"
     ignore curr3
     ignore curr4
-    ignore curr5
+    label curr5 "DDR PMIC VDD_MEM Curr (out2)"
     ignore curr6
 
 # Management board DDR temperature sensors


### PR DESCRIPTION
The DDR voltage regulator of SN6600_LD/SN68XX_LD is an mp2975 device driving two rails. Its curr2 attribute is the output current of the first rail, but was named after the second one, while curr5, the output current of the second rail, was ignored. The remaining current attributes are the per phase currents of the two rails. Label the output current of each rail after the rail it belongs to, as already done for the voltages and the powers.

Bug: 5269629