### PR TITLE
hw-mgmt: scripts: Fix reset attributes counter initialization

### DIFF
--- a/usr/usr/bin/hw-management-chassis-events.sh
+++ b/usr/usr/bin/hw-management-chassis-events.sh
@@ -1171,8 +1171,12 @@ if [ "$1" == "add" ]; then
 		$led_path/led_"$name"_state
 	fi
 	if [ "$2" == "regio" ]; then
-		reset_attr_num=$(< $config_path/reset_attr_num)
-		reset_attrr_count=0
+		if [ -f "$config_path/reset_attr_num" ]; then
+			reset_attr_num=$(< $config_path/reset_attr_num)
+		else
+			reset_attr_num=0
+		fi
+		reset_attr_count=0
 		linecard=0
 		# Detect if it belongs to line card or to main board or to dpu.
 		# For main board dirname mlxreg-io, for linecard - mlxreg-io.{bus_num}.


### PR DESCRIPTION
The regio event handler initializes reset_attrr_count, while the counter incremented by check_reset_attrs() is reset_attr_count, so the counter is never initialized and the misspelled variable is never read.

It happens to work today because every udev event is handled by a separate process, in which an unset variable evaluates to zero. Should the handler ever run twice in the same process, the counter would keep climbing past reset_attr_num and reset_attr_ready would never be set.

Read reset_attr_num only if the configuration attribute exists. It is set by all the currently supported systems, but a system leaving it out made the handler complain about the missing file and then about a missing operand in the comparison, once per reset attribute.

Bug: 5269665